### PR TITLE
Update dhcp.go

### DIFF
--- a/pkg/baremetal/pxe/dhcp.go
+++ b/pkg/baremetal/pxe/dhcp.go
@@ -45,7 +45,7 @@ type DHCPHandler struct {
 	netConfig *types.SNetworkConfig
 }
 
-func (h *DHCPHandler) ServeDHCP(pkt dhcp.Packet, _ *net.UDPAddr, _ *net.Interface) (dhcp.Packet, error) {
+func (h DHCPHandler) ServeDHCP(pkt dhcp.Packet, _ *net.UDPAddr, _ *net.Interface) (dhcp.Packet, error) {
 	//log.V(4).Debugf("[DHCP] request: %s", pkt.DebugString())
 	err := h.parsePacket(pkt)
 	if err != nil {


### PR DESCRIPTION
去掉 DHCPHandler 指针，修复 pxe dhcp 时 baremetal 网卡信息错误的bug