### PR TITLE
remove guest secgroup rule detail

### DIFF
--- a/pkg/compute/models/secgroups.go
+++ b/pkg/compute/models/secgroups.go
@@ -114,7 +114,7 @@ func (self *SSecurityGroup) getDesc() jsonutils.JSONObject {
 	desc := jsonutils.NewDict()
 	desc.Add(jsonutils.NewString(self.Name), "name")
 	desc.Add(jsonutils.NewString(self.Id), "id")
-	desc.Add(jsonutils.NewString(self.getSecurityRuleString("")), "security_rules")
+	//desc.Add(jsonutils.NewString(self.getSecurityRuleString("")), "security_rules")
 	return desc
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复server-list因查询安全组规则过多超时问题

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
