### PR TITLE
Automated cherry pick of #40: fixed an issue where waiting times were too long due to a

### DIFF
--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -752,6 +752,10 @@ func (self *SManagedVirtualizedGuestDriver) RequestRenewInstance(guest *models.S
 	}
 	//避免有些云续费后过期时间刷新比较慢问题
 	cloudprovider.WaitCreated(15*time.Second, 5*time.Minute, func() bool {
+		err := iVM.Refresh()
+		if err != nil {
+			log.Errorf("failed refresh instance %s error: %v", guest.Name, err)
+		}
 		newExipred := iVM.GetExpiredAt()
 		if newExipred.After(oldExpired) {
 			return true


### PR DESCRIPTION
Cherry pick of #40 on release/2.8.0.

#40: fixed an issue where waiting times were too long due to a