### PR TITLE
cloud provider update status should clear scheduler cache

### DIFF
--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -863,11 +863,13 @@ func (provider *SCloudprovider) markProviderDisconnected(ctx context.Context, us
 	if err != nil {
 		return err
 	}
-	return provider.SetStatus(userCred, CLOUD_PROVIDER_DISCONNECTED, "not a subaccount")
+	provider.SetStatus(userCred, CLOUD_PROVIDER_DISCONNECTED, "not a subaccount")
+	return provider.ClearSchedDescCache()
 }
 
 func (provider *SCloudprovider) markProviderConnected(ctx context.Context, userCred mcclient.TokenCredential) error {
-	return provider.SetStatus(userCred, CLOUD_PROVIDER_CONNECTED, "")
+	provider.SetStatus(userCred, CLOUD_PROVIDER_CONNECTED, "")
+	return provider.ClearSchedDescCache()
 }
 
 func (provider *SCloudprovider) prepareCloudproviderRegions(ctx context.Context, userCred mcclient.TokenCredential) ([]SCloudproviderregion, error) {
@@ -996,5 +998,22 @@ func (self *SCloudprovider) StartCloudproviderDeleteTask(ctx context.Context, us
 	}
 	self.SetStatus(userCred, CLOUD_PROVIDER_START_DELETE, "StartCloudproviderDeleteTask")
 	task.ScheduleRun(nil)
+	return nil
+}
+
+func (self *SCloudprovider) ClearSchedDescCache() error {
+	hosts := make([]SHost, 0)
+	q := HostManager.Query().Equals("manager_id", self.Id)
+	err := db.FetchModelObjects(HostManager, q, &hosts)
+	if err != nil {
+		return err
+	}
+	for i := range hosts {
+		err := hosts[i].ClearSchedDescCache()
+		if err != nil {
+			log.Errorf("host CleanHostSchedCache error: %v", err)
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -28,6 +28,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/quotas"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
+	"yunion.io/x/onecloud/pkg/cloudcommon/policy"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/options"
 	"yunion.io/x/onecloud/pkg/compute/sshkeys"
@@ -938,7 +939,7 @@ func (manager *SGuestManager) ValidateCreateData(ctx context.Context, userCred m
 
 		if len(durationStr) > 0 {
 
-			if !userCred.IsAdminAllow(consts.GetServiceType(), manager.KeywordPlural(), "renew") {
+			if !userCred.IsAdminAllow(consts.GetServiceType(), manager.KeywordPlural(), policy.PolicyActionPerform, "renew") {
 				return nil, httperrors.NewForbiddenError("only admin can create prepaid resource")
 			}
 


### PR DESCRIPTION
rbact issue prevent admin from creating prepaid vm

**这个 PR 实现什么功能/修复什么问题**:
修正：
1. cloud provider更新状态后需要刷新scheduler cache
2. 修正无法创建包年包月资源的权限问题

**是否需要 backport 到之前的 release 分支**:
- release/2.7.0
- release/2.8.0

