### PR TITLE
fix: make cherry_pick_pull.sh comptabile with older git not support get-url

### DIFF
--- a/scripts/cherry_pick_pull.sh
+++ b/scripts/cherry_pick_pull.sh
@@ -29,14 +29,25 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 declare -r REPO_ROOT
 cd "${REPO_ROOT}"
 
+function git_remote_get_url() {
+    git remote get-url $1 2>/dev/null
+    if [ "$?" -ne "0" ]; then
+        git config remote.$1.url 2>/dev/null
+    fi
+    if [ "$?" -ne "0" ]; then
+        echo "git fail get remote url for $1"
+        exit 1
+    fi
+}
+
 STARTINGBRANCH=$(git symbolic-ref --short HEAD)
 declare -r STARTINGBRANCH
 declare -r REBASEMAGIC="${REPO_ROOT}/.git/rebase-apply"
 DRY_RUN=${DRY_RUN:-""}
 UPSTREAM_REMOTE=${UPSTREAM_REMOTE:-upstream}
 FORK_REMOTE=${FORK_REMOTE:-origin}
-MAIN_REPO_ORG=${MAIN_REPO_ORG:-$(git remote get-url "$UPSTREAM_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $3}')}
-MAIN_REPO_NAME=${MAIN_REPO_NAME:-$(git remote get-url "$UPSTREAM_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $4}')}
+MAIN_REPO_ORG=${MAIN_REPO_ORG:-$(git_remote_get_url "$UPSTREAM_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $3}')}
+MAIN_REPO_NAME=${MAIN_REPO_NAME:-$(git_remote_get_url "$UPSTREAM_REMOTE" | awk '{gsub(/http[s]:\/\/|git@/,"")}1' | awk -F'[@:./]' 'NR==1{print $4}')}
 
 if [[ -z ${GITHUB_USER:-} ]]; then
   echo "Please export GITHUB_USER=<your-user> (or GH organization, if that's where your fork lives)"


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正cherry_pick_pull.sh在旧版本不支持get-url的git无法正常工作的问题

**是否需要 backport 到之前的 release 分支**:
NONE
