### PR TITLE
腾讯云使用shell格式userdata,避免和cloud-init冲突导致绑定秘钥失败

### DIFF
--- a/pkg/cloudprovider/instance.go
+++ b/pkg/cloudprovider/instance.go
@@ -29,6 +29,11 @@ type SDiskInfo struct {
 	Name        string
 }
 
+const (
+	CLOUD_SHELL  = "cloud-shell"
+	CLOUD_CONFIG = "cloud-config"
+)
+
 type SManagedVMCreateConfig struct {
 	Name                string
 	ExternalImageId     string
@@ -49,6 +54,7 @@ type SManagedVMCreateConfig struct {
 	ExternalSecgroupIds []string
 	Password            string
 	UserData            string
+	UserDataType        string
 
 	BillingCycle *billing.SBillingCycle
 }
@@ -60,12 +66,15 @@ func (vmConfig *SManagedVMCreateConfig) GetConfig(config *jsonutils.JSONDict) er
 	if publicKey, _ := config.GetString("public_key"); len(publicKey) > 0 {
 		vmConfig.PublicKey = publicKey
 	}
+	if userDataType, _ := config.GetString("user_data_type"); len(userDataType) > 0 {
+		vmConfig.UserDataType = userDataType
+	}
 
 	adminPublicKey, _ := config.GetString("admin_public_key")
 	projectPublicKey, _ := config.GetString("project_public_key")
 	oUserData, _ := config.GetString("user_data")
 
-	vmConfig.UserData = generateUserData(adminPublicKey, projectPublicKey, oUserData)
+	vmConfig.UserData = generateUserData(adminPublicKey, projectPublicKey, oUserData, vmConfig.UserDataType)
 
 	resetPassword := jsonutils.QueryBoolean(config, "reset_password", false)
 	vmConfig.Password, _ = config.GetString("password")
@@ -75,7 +84,7 @@ func (vmConfig *SManagedVMCreateConfig) GetConfig(config *jsonutils.JSONDict) er
 	return nil
 }
 
-func generateUserData(adminPublicKey, projectPublicKey, oUserData string) string {
+func generateUserData(adminPublicKey, projectPublicKey, oUserData string, userDataType string) string {
 	var oCloudConfig *cloudinit.SCloudConfig
 
 	if len(oUserData) > 0 {
@@ -96,6 +105,10 @@ func generateUserData(adminPublicKey, projectPublicKey, oUserData string) string
 
 	if oCloudConfig != nil {
 		cloudConfig.Merge(oCloudConfig)
+	}
+
+	if userDataType == CLOUD_SHELL {
+		return cloudConfig.UserDataScriptBase64()
 	}
 
 	return cloudConfig.UserDataBase64()

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -2989,6 +2989,9 @@ func (self *SGuest) GetDeployConfigOnHost(ctx context.Context, userCred mcclient
 		if err != nil {
 			return nil, fmt.Errorf("failed to get iregion for host %s error: %v", host.Name, err)
 		}
+		if self.Hypervisor == HYPERVISOR_QCLOUD { //腾讯云目前仅支持shell,否则绑定秘钥会冲突失效
+			config.Add(jsonutils.NewString(cloudprovider.CLOUD_SHELL), "user_data_type")
+		}
 		secgroupIds := jsonutils.NewArray()
 		secgroups := self.GetSecgroups()
 		for i, secgroup := range secgroups {

--- a/pkg/util/cloudinit/cloudconfig.go
+++ b/pkg/util/cloudinit/cloudconfig.go
@@ -37,6 +37,7 @@ type TSudoPolicy string
 
 const (
 	CLOUD_CONFIG_HEADER = "#cloud-config\n"
+	CLOUD_SHELL_HEADER  = "#!/usr/bin/env bash\n"
 
 	USER_SUDO_NOPASSWD = TSudoPolicy("sudo_nopasswd")
 	USER_SUDO          = TSudoPolicy("sudo")
@@ -91,6 +92,41 @@ func NewWriteFile(path string, content string, perm string, owner string, isBase
 	return f
 }
 
+func setFilePermission(path, permission, owner string) []string {
+	cmds := []string{}
+	if len(permission) > 0 {
+		cmds = append(cmds, fmt.Sprintf("chmod %s %s", permission, path))
+	}
+	if len(owner) > 0 {
+		cmds = append(cmds, fmt.Sprintf("chown %s:%s %s", owner, owner, path))
+	}
+	return cmds
+}
+
+func mkPutFileCmd(path string, content string, permission string, owner string) []string {
+	cmds := []string{}
+	cmds = append(cmds, fmt.Sprintf("mkdir -p $(dirname %s)", path))
+	cmds = append(cmds, fmt.Sprintf("cat > %s <<_END\n%s\n_END", path, content))
+	return append(cmds, setFilePermission(path, permission, owner)...)
+}
+
+func mkAppendFileCmd(path string, content string, permission string, owner string) []string {
+	cmds := []string{}
+	cmds = append(cmds, fmt.Sprintf("mkdir -p $(dirname %s)", path))
+	cmds = append(cmds, fmt.Sprintf("cat >> %s <<_END\n%s\n_END", path, content))
+	return append(cmds, setFilePermission(path, permission, owner)...)
+}
+
+func (wf *SWriteFile) ShellScripts() []string {
+	content := wf.Content
+	if wf.Encoding == "b64" {
+		_content, _ := base64.StdEncoding.DecodeString(wf.Content)
+		content = string(_content)
+	}
+
+	return mkPutFileCmd(wf.Path, content, wf.Permissions, wf.Owner)
+}
+
 func NewUser(name string) SUser {
 	u := SUser{Name: name}
 	return u
@@ -131,6 +167,30 @@ func (u *SUser) Password(passwd string) *SUser {
 	return u
 }
 
+func (u *SUser) ShellScripts() []string {
+	shells := []string{}
+
+	shells = append(shells, fmt.Sprintf("useradd -m %s || true", u.Name))
+	if len(u.Passwd) > 0 {
+		shells = append(shells, fmt.Sprintf("usermod -p '%s' %s", u.Passwd, u.Name))
+	}
+
+	home := "/" + u.Name
+	if home != "/root" {
+		home = "/home" + home
+	}
+
+	keyPath := fmt.Sprintf("%s/.ssh/authorized_keys", home)
+	shells = append(shells, mkAppendFileCmd(keyPath, strings.Join(u.SshAuthorizedKeys, "\n"), "600", u.Name)...)
+	shells = append(shells, fmt.Sprintf("chown -R %s:%s %s/.ssh", u.Name, u.Name, home))
+
+	if !utils.IsInStringArray(u.Sudo, []string{"", "False"}) {
+		shells = append(shells, mkPutFileCmd("/etc/sudoers.d/"+u.Name, fmt.Sprintf("%s	%s", u.Name, u.Sudo), "", "")...)
+	}
+
+	return shells
+}
+
 func (conf *SCloudConfig) UserData() string {
 	var buf bytes.Buffer
 	jsonConf := jsonutils.Marshal(conf)
@@ -139,8 +199,30 @@ func (conf *SCloudConfig) UserData() string {
 	return buf.String()
 }
 
+func (conf *SCloudConfig) UserDataScript() string {
+	shells := []string{}
+	for _, u := range conf.Users {
+		shells = append(shells, u.ShellScripts()...)
+	}
+	shells = append(shells, conf.Runcmd...)
+
+	for _, pkg := range conf.Packages {
+		shells = append(shells, "which yum &>/dev/null && yum install -y "+pkg)
+		shells = append(shells, "which apt-get &>/dev/null && apt-get install -y "+pkg)
+	}
+	for _, wf := range conf.WriteFiles {
+		shells = append(shells, wf.ShellScripts()...)
+	}
+	return CLOUD_SHELL_HEADER + strings.Join(shells, "\n")
+}
+
 func (conf *SCloudConfig) UserDataBase64() string {
 	data := conf.UserData()
+	return base64.StdEncoding.EncodeToString([]byte(data))
+}
+
+func (conf *SCloudConfig) UserDataScriptBase64() string {
+	data := conf.UserDataScript()
 	return base64.StdEncoding.EncodeToString([]byte(data))
 }
 

--- a/pkg/util/cloudinit/cloudconfig_test.go
+++ b/pkg/util/cloudinit/cloudconfig_test.go
@@ -60,4 +60,5 @@ func TestSCloudConfig_UserData(t *testing.T) {
 			t.Errorf("userData not equal to userData2")
 		}
 	}
+	t.Log(config2.UserDataScript())
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复腾讯云因userdata格式问题导致绑定秘钥显示成功但未生效的问题.

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0