### PR TITLE
避免绑定秘钥失败后机器还关联着秘钥

### DIFF
--- a/pkg/compute/tasks/guest_deploy_task.go
+++ b/pkg/compute/tasks/guest_deploy_task.go
@@ -127,6 +127,17 @@ func (self *GuestDeployTask) OnDeployGuestComplete(ctx context.Context, obj db.I
 
 func (self *GuestDeployTask) OnDeployGuestCompleteFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
 	guest := obj.(*models.SGuest)
+	action, _ := self.Params.GetString("deploy_action")
+	keypair, _ := self.Params.GetString("keypair")
+	if action == "deploy" && len(keypair) >= 32 {
+		_, err := db.Update(guest, func() error {
+			guest.KeypairId = ""
+			return nil
+		})
+		if err != nil {
+			log.Errorf("unset guest %s keypair failed %v", guest.Name, err)
+		}
+	}
 	guest.SetStatus(self.UserCred, models.VM_DEPLOY_FAILED, data.String())
 	self.SetStageFailed(ctx, data.String())
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复: 关联秘钥失败后解除与主机的关系

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
