### PR TITLE
reduce cloud sync workload

### DIFF
--- a/pkg/cloudcommon/agent/doc.go
+++ b/pkg/cloudcommon/agent/doc.go
@@ -1,0 +1,1 @@
+package agent // import "yunion.io/x/onecloud/pkg/cloudcommon/agent"

--- a/pkg/cloudcommon/db/taskman/tasks.go
+++ b/pkg/cloudcommon/db/taskman/tasks.go
@@ -51,6 +51,7 @@ var TaskManager *STaskManager
 
 func init() {
 	TaskManager = &STaskManager{SResourceBaseManager: db.NewResourceBaseManager(STask{}, "tasks_tbl", "task", "tasks")}
+	TaskManager.TableSpec().AddIndex(true, "deleted", "obj_name", "obj_id", "created_at", "stage")
 }
 
 type STask struct {

--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -1173,7 +1173,7 @@ func (account *SCloudaccount) SubmitSyncAccountTask(ctx context.Context, userCre
 				syncRange := SSyncRange{FullSync: true}
 				providers := account.GetEnabledCloudproviders()
 				for i := range providers {
-					providers[i].syncCloudproviderRegions(ctx, userCred, &syncRange, nil, autoSync)
+					providers[i].syncCloudproviderRegions(ctx, userCred, syncRange, nil, autoSync)
 					syncCnt += 1
 				}
 			}

--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math/rand"
 	"net/url"
 	"strconv"
 	"strings"
@@ -1067,7 +1068,7 @@ func (manager *SCloudaccountManager) AutoSyncCloudaccountTask(ctx context.Contex
 	}
 
 	for i := range accounts {
-		if accounts[i].shouldProbeStatus() && accounts[i].needSync() && accounts[i].CanSync() {
+		if accounts[i].shouldProbeStatus() && accounts[i].needSync() && accounts[i].CanSync() && rand.Float32() < 0.6 {
 			accounts[i].SubmitSyncAccountTask(ctx, userCred, nil, true)
 		}
 	}

--- a/pkg/compute/models/cloudproviderregions.go
+++ b/pkg/compute/models/cloudproviderregions.go
@@ -335,22 +335,14 @@ func (cpr *SCloudproviderregion) needAutoSync() bool {
 }
 
 func (cpr *SCloudproviderregion) isEmptyOnPremise() bool {
-	if cpr.SyncResults == nil {
-		return false
-	}
-	syncResults := SSyncResultSet{}
-	err := cpr.SyncResults.Unmarshal(&syncResults)
-	if err != nil {
-		return false
-	}
-	result := syncResults[HostManager.KeywordPlural()]
-	if result != nil && (result.UpdateCnt > 0 || result.AddCnt > 0) {
-		return false
-	}
-	return true
+	return cpr.isEmpty(HostManager.KeywordPlural())
 }
 
 func (cpr *SCloudproviderregion) isEmptyPublicCloud() bool {
+	return cpr.isEmpty(NetworkManager.KeywordPlural())
+}
+
+func (cpr *SCloudproviderregion) isEmpty(resKey string) bool {
 	if cpr.SyncResults == nil {
 		return false
 	}
@@ -359,7 +351,7 @@ func (cpr *SCloudproviderregion) isEmptyPublicCloud() bool {
 	if err != nil {
 		return false
 	}
-	result := syncResults[NetworkManager.KeywordPlural()]
+	result := syncResults[resKey]
 	if result != nil && (result.UpdateCnt > 0 || result.AddCnt > 0) {
 		return false
 	}

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -900,7 +900,7 @@ func (provider *SCloudprovider) GetCloudproviderRegions() []SCloudproviderregion
 	return CloudproviderRegionManager.fetchRecordsByQuery(q)
 }
 
-func (provider *SCloudprovider) syncCloudproviderRegions(ctx context.Context, userCred mcclient.TokenCredential, syncRange *SSyncRange, wg *sync.WaitGroup, autoSync bool) {
+func (provider *SCloudprovider) syncCloudproviderRegions(ctx context.Context, userCred mcclient.TokenCredential, syncRange SSyncRange, wg *sync.WaitGroup, autoSync bool) {
 	provider.markSyncing(userCred)
 	cprs := provider.GetCloudproviderRegions()
 	syncCnt := 0
@@ -924,7 +924,7 @@ func (provider *SCloudprovider) syncCloudproviderRegions(ctx context.Context, us
 	}
 }
 
-func (provider *SCloudprovider) SyncCallSyncCloudproviderRegions(ctx context.Context, userCred mcclient.TokenCredential, syncRange *SSyncRange) {
+func (provider *SCloudprovider) SyncCallSyncCloudproviderRegions(ctx context.Context, userCred mcclient.TokenCredential, syncRange SSyncRange) {
 	var wg sync.WaitGroup
 	provider.syncCloudproviderRegions(ctx, userCred, syncRange, &wg, false)
 	wg.Wait()

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -326,6 +326,7 @@ func (self *SCloudprovider) saveProject(userCred mcclient.TokenCredential, proje
 type SSyncRange struct {
 	Force    bool
 	FullSync bool
+	DeepSync bool
 	// ProjectSync bool
 
 	Region []string
@@ -513,7 +514,7 @@ func (self *SCloudprovider) PerformChangeProject(ctx context.Context, userCred m
 		return nil, nil
 	}
 
-	return nil, self.StartSyncCloudProviderInfoTask(ctx, userCred, &SSyncRange{FullSync: true}, "")
+	return nil, self.StartSyncCloudProviderInfoTask(ctx, userCred, &SSyncRange{FullSync: true, DeepSync: true}, "")
 }
 
 func (self *SCloudprovider) markStartSync(userCred mcclient.TokenCredential) error {

--- a/pkg/compute/models/cloudsync.go
+++ b/pkg/compute/models/cloudsync.go
@@ -44,7 +44,7 @@ func (pair *sStoragecacheSyncPair) syncCloudImages(ctx context.Context, userCred
 }
 
 func isInCache(pairs []sStoragecacheSyncPair, localCacheId string) bool {
-	log.Debugf("isInCache %d %s", len(pairs), localCacheId)
+	// log.Debugf("isInCache %d %s", len(pairs), localCacheId)
 	for i := range pairs {
 		if pairs[i].local.Id == localCacheId {
 			return true

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -197,7 +197,7 @@ type SGuest struct {
 
 	KeypairId string `width:"36" charset:"ascii" nullable:"true" list:"user" create:"optional"` // Column(VARCHAR(36, charset='ascii'), nullable=True)
 
-	HostId       string `width:"36" charset:"ascii" nullable:"true" list:"admin" get:"admin"` // Column(VARCHAR(36, charset='ascii'), nullable=True)
+	HostId       string `width:"36" charset:"ascii" nullable:"true" list:"admin" get:"admin" index:"true"` // Column(VARCHAR(36, charset='ascii'), nullable=True)
 	BackupHostId string `width:"36" charset:"ascii" nullable:"true" list:"admin" get:"admin"`
 
 	Vga     string `width:"36" charset:"ascii" nullable:"true" list:"user" update:"user" create:"optional"` // Column(VARCHAR(36, charset='ascii'), nullable=True)

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -24,8 +24,9 @@ type ComputeOptions struct {
 
 	pending_delete.SPendingDeleteOptions
 
-	PrepaidExpireCheckSeconds       int `default:"600" help:"How long to wait to scan expired prepaid VM or disks, default is 10 minutes"`
-	ExpiredPrepaidMaxCleanBatchSize int `default:"50" help:"How many expired prepaid servers can be deleted in a batch"`
+	PrepaidExpireCheck              bool `default:"false" help:"clean expired servers or disks"`
+	PrepaidExpireCheckSeconds       int  `default:"600" help:"How long to wait to scan expired prepaid VM or disks, default is 10 minutes"`
+	ExpiredPrepaidMaxCleanBatchSize int  `default:"50" help:"How many expired prepaid servers can be deleted in a batch"`
 
 	LoadbalancerPendingDeleteCheckInterval int `default:"3600" help:"Interval between checks of pending deleted loadbalancer objects, defaults to 1h"`
 

--- a/pkg/compute/service/service.go
+++ b/pkg/compute/service/service.go
@@ -73,7 +73,9 @@ func StartService() {
 	cron.AddJob1("CleanPendingDeleteServers", time.Duration(opts.PendingDeleteCheckSeconds)*time.Second, models.GuestManager.CleanPendingDeleteServers)
 	cron.AddJob1("CleanPendingDeleteDisks", time.Duration(opts.PendingDeleteCheckSeconds)*time.Second, models.DiskManager.CleanPendingDeleteDisks)
 	cron.AddJob1("CleanPendingDeleteLoadbalancers", time.Duration(opts.LoadbalancerPendingDeleteCheckInterval)*time.Second, models.LoadbalancerAgentManager.CleanPendingDeleteLoadbalancers)
-	cron.AddJob1("CleanExpiredPrepaidServers", time.Duration(opts.PrepaidExpireCheckSeconds)*time.Second, models.GuestManager.DeleteExpiredPrepaidServers)
+	if opts.PrepaidExpireCheck {
+		cron.AddJob1("CleanExpiredPrepaidServers", time.Duration(opts.PrepaidExpireCheckSeconds)*time.Second, models.GuestManager.DeleteExpiredPrepaidServers)
+	}
 	cron.AddJob1("StartHostPingDetectionTask", time.Duration(opts.HostOfflineDetectionInterval)*time.Second, models.HostManager.PingDetectionTask)
 
 	cron.AddJob1WithStartRun("AutoSyncCloudaccountTask", time.Duration(opts.CloudAutoSyncIntervalSeconds)*time.Second, models.CloudaccountManager.AutoSyncCloudaccountTask, true)

--- a/pkg/compute/tasks/cloud_account_sync_task.go
+++ b/pkg/compute/tasks/cloud_account_sync_task.go
@@ -42,6 +42,7 @@ func (self *CloudAccountSyncInfoTask) OnInit(ctx context.Context, obj db.IStanda
 		syncRangeJson.Unmarshal(&syncRange)
 	} else {
 		syncRange.FullSync = true
+		syncRange.DeepSync = true
 	}
 
 	if !syncRange.NeedSyncInfo() {

--- a/pkg/compute/tasks/cloud_provider_sync_info_task.go
+++ b/pkg/compute/tasks/cloud_provider_sync_info_task.go
@@ -60,7 +60,7 @@ func (self *CloudProviderSyncInfoTask) OnInit(ctx context.Context, obj db.IStand
 	self.SetStage("OnSyncCloudProviderInfoComplete", nil)
 
 	taskman.LocalTaskRun(self, func() (jsonutils.JSONObject, error) {
-		provider.SyncCallSyncCloudproviderRegions(ctx, self.UserCred, &syncRange)
+		provider.SyncCallSyncCloudproviderRegions(ctx, self.UserCred, syncRange)
 		return nil, nil
 	})
 }

--- a/pkg/mcclient/modules/mod_cloudproviderregions.go
+++ b/pkg/mcclient/modules/mod_cloudproviderregions.go
@@ -12,6 +12,7 @@ func init() {
 			"Cloudregion_ID", "CloudRegion",
 			"Enabled", "Sync_Status",
 			"Last_Sync", "Last_Sync_End_At", "Auto_Sync",
+			"last_deep_sync_at",
 			"Sync_Results"},
 		[]string{},
 		&Cloudproviders,

--- a/pkg/scheduler/data_manager/sku/doc.go
+++ b/pkg/scheduler/data_manager/sku/doc.go
@@ -1,0 +1,1 @@
+package sku // import "yunion.io/x/onecloud/pkg/scheduler/data_manager/sku"


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 减少同步信息：对于已有的VM和storagecache，在非DeepSync的情况下，不同步其属性
2. 同步时间随机化，降低同时几个账号一起同步的概率
3. 根据slowlog对数据库优化，增加tasks和guets的索引
4. 其他一些修正

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
