### PR TITLE
使用控制台名称作为同步名称

### DIFF
--- a/pkg/util/aliyun/instance.go
+++ b/pkg/util/aliyun/instance.go
@@ -263,6 +263,9 @@ func (self *SInstance) GetId() string {
 }
 
 func (self *SInstance) GetName() string {
+	if len(self.InstanceName) > 0 {
+		return self.InstanceName
+	}
 	return self.HostName
 }
 
@@ -793,6 +796,7 @@ func (self *SRegion) UpdateVM(instanceId string, hostname string) error {
 	*/
 	params := make(map[string]string)
 	params["HostName"] = hostname
+	params["InstanceName"] = hostname
 	return self.modifyInstanceAttribute(instanceId, params)
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复aliyun同步名称不一致

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0
