### PR TITLE
修复AWS资源名称为空的问题&增加注入用户登录信息

### DIFF
--- a/pkg/compute/guestdrivers/aws.go
+++ b/pkg/compute/guestdrivers/aws.go
@@ -68,7 +68,8 @@ func fetchAwsUserName(desc cloudprovider.SManagedVMCreateConfig) string {
 }
 
 func (self *SAwsGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManagedVMCreateConfig) string {
-	return fetchAwsUserName(desc)
+	// return fetchAwsUserName(desc)
+	return models.VM_AWS_DEFAULT_LOGIN_USER
 }
 
 func (self *SAwsGuestDriver) GetHypervisor() string {

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"yunion.io/x/onecloud/pkg/util/cloudinit"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
@@ -164,6 +165,8 @@ const (
 	//	HYPERVISOR_DEFAULT = HYPERVISOR_KVM
 	HYPERVISOR_DEFAULT = HYPERVISOR_KVM
 )
+
+const VM_AWS_DEFAULT_LOGIN_USER = "ec2user"
 
 var VM_RUNNING_STATUS = api.VM_RUNNING_STATUS
 var VM_CREATING_STATUS = api.VM_CREATING_STATUS
@@ -2942,8 +2945,34 @@ func (self *SGuest) GetDeployConfigOnHost(ctx context.Context, userCred mcclient
 		registerVpcId := vpc.ExternalId
 		externalVpcId := vpc.ExternalId
 		switch self.Hypervisor {
-		case HYPERVISOR_ALIYUN, HYPERVISOR_AWS, HYPERVISOR_HUAWEI:
+		case HYPERVISOR_ALIYUN, HYPERVISOR_HUAWEI:
 			break
+		case HYPERVISOR_AWS:
+			loginUser := cloudinit.NewUser(VM_AWS_DEFAULT_LOGIN_USER)
+			loginUser.SudoPolicy(cloudinit.USER_SUDO_NOPASSWD)
+			if pub, _ := config.GetString("public_key"); len(pub) > 0 {
+				loginUser.SshKey(pub)
+			} else if pwd, _ := config.GetString("password"); len(pwd) > 0 {
+				loginUser.Password(pwd)
+			} else {
+				pwd = seclib2.RandomPassword2(12)
+				config.Set("password", jsonutils.NewString(pwd))
+				loginUser.Password(pwd)
+			}
+
+			cloudconfig := cloudinit.SCloudConfig{Users: []cloudinit.SUser{loginUser}}
+
+			if d, _ := config.GetString("user_data"); len(d) > 0 {
+				_d, err := cloudinit.ParseUserDataBase64(d)
+				if err != nil {
+					return nil, fmt.Errorf("invalid user data %s", d)
+				}
+
+				cloudconfig.Merge(_d)
+			}
+
+			userdata := cloudconfig.UserDataBase64()
+			config.Add(jsonutils.NewString(userdata), "user_data")
 		case HYPERVISOR_QCLOUD, HYPERVISOR_OPENSTACK:
 			registerVpcId = "normal"
 		case HYPERVISOR_AZURE:

--- a/pkg/util/aws/image.go
+++ b/pkg/util/aws/image.go
@@ -104,7 +104,11 @@ func (self *SImage) GetId() string {
 }
 
 func (self *SImage) GetName() string {
-	return self.ImageName
+	if len(self.ImageName) > 0 {
+		return self.ImageName
+	}
+
+	return self.GetId()
 }
 
 func (self *SImage) GetGlobalId() string {

--- a/pkg/util/aws/instance.go
+++ b/pkg/util/aws/instance.go
@@ -128,7 +128,11 @@ func (self *SInstance) GetId() string {
 }
 
 func (self *SInstance) GetName() string {
-	return self.InstanceName
+	if len(self.InstanceName) > 0 {
+		return self.InstanceName
+	}
+
+	return self.GetId()
 }
 
 func (self *SInstance) GetGlobalId() string {

--- a/pkg/util/aws/securitygroup.go
+++ b/pkg/util/aws/securitygroup.go
@@ -20,8 +20,6 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/golang-plus/uuid"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/secrules"
@@ -45,7 +43,7 @@ type SSecurityGroup struct {
 	VpcId             string
 	SecurityGroupId   string
 	Description       string
-	SecurityGroupName string //对应tag中的name标签
+	SecurityGroupName string
 	Permissions       []secrules.SecurityRule
 	Tags              Tags
 
@@ -221,12 +219,7 @@ func (self *SRegion) createSecurityGroup(vpcId string, name string, secgroupIdTa
 	params.SetVpcId(vpcId)
 	// 这里的描述aws 上层代码拼接的描述。并非用户提交的描述，用户描述放置在Yunion本地数据库中。）
 	params.SetDescription(desc)
-	// aws name 要求唯一，且不含中文等字符。所以随机生成一个uuid作为name。实际用户传入的name使用tag标记
-	secid, err := uuid.NewV4()
-	if err != nil {
-		return "", err
-	}
-	params.SetGroupName(secid.String())
+	params.SetGroupName(name)
 
 	group, err := self.ec2Client.CreateSecurityGroup(params)
 	if err != nil {
@@ -295,14 +288,11 @@ func (self *SRegion) GetSecurityGroupDetails(secGroupId string) (*SSecurityGroup
 
 		permissions := self.getSecRules(s.IpPermissions, s.IpPermissionsEgress)
 
-		tagspec := TagSpec{ResourceType: "scuritygroup"}
-		tagspec.LoadingEc2Tags(s.Tags)
-
 		return &SSecurityGroup{
 			vpc:               vpc,
 			Description:       *s.Description,
 			SecurityGroupId:   *s.GroupId,
-			SecurityGroupName: tagspec.GetNameTag(),
+			SecurityGroupName: *s.GroupName,
 			VpcId:             *s.VpcId,
 			Permissions:       permissions,
 			RegionId:          self.RegionId,
@@ -471,15 +461,12 @@ func (self *SRegion) GetSecurityGroups(vpcId string, secgroupId string, offset i
 			continue
 		}
 
-		tagspec := TagSpec{ResourceType: "scuritygroup"}
-		tagspec.LoadingEc2Tags(item.Tags)
-
 		permissions := self.getSecRules(item.IpPermissions, item.IpPermissionsEgress)
 		group := SSecurityGroup{
 			vpc:               vpc,
 			Description:       *item.Description,
 			SecurityGroupId:   *item.GroupId,
-			SecurityGroupName: tagspec.GetNameTag(),
+			SecurityGroupName: *item.GroupName,
 			VpcId:             *item.VpcId,
 			Permissions:       permissions,
 			RegionId:          self.RegionId,


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1.修复aws资源名称可能为空的问题
2.使用Userdata注入密钥。PS：目前不支持设置密码

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
