### PR TITLE
fix: ni usercred cause rbac check panic

### DIFF
--- a/pkg/cloudcommon/db/rbac.go
+++ b/pkg/cloudcommon/db/rbac.go
@@ -138,33 +138,57 @@ func isJointObjectRbacAllowed(manager IJointModelManager, item IJointModel, user
 }
 
 func IsAdminAllowList(userCred mcclient.TokenCredential, manager IModelManager) bool {
+	if userCred == nil {
+		return false
+	}
 	return userCred.IsAdminAllow(consts.GetServiceType(), manager.KeywordPlural(), policy.PolicyActionList)
 }
 
 func IsAdminAllowCreate(userCred mcclient.TokenCredential, manager IModelManager) bool {
+	if userCred == nil {
+		return false
+	}
 	return userCred.IsAdminAllow(consts.GetServiceType(), manager.KeywordPlural(), policy.PolicyActionCreate)
 }
 
 func IsAdminAllowClassPerform(userCred mcclient.TokenCredential, manager IModelManager, action string) bool {
+	if userCred == nil {
+		return false
+	}
 	return userCred.IsAdminAllow(consts.GetServiceType(), manager.KeywordPlural(), policy.PolicyActionPerform, action)
 }
 
 func IsAdminAllowGet(userCred mcclient.TokenCredential, obj IModel) bool {
+	if userCred == nil {
+		return false
+	}
 	return userCred.IsAdminAllow(consts.GetServiceType(), obj.KeywordPlural(), policy.PolicyActionGet)
 }
 
 func IsAdminAllowGetSpec(userCred mcclient.TokenCredential, obj IModel, spec string) bool {
+	if userCred == nil {
+		return false
+	}
 	return userCred.IsAdminAllow(consts.GetServiceType(), obj.KeywordPlural(), policy.PolicyActionGet, spec)
 }
 
 func IsAdminAllowPerform(userCred mcclient.TokenCredential, obj IModel, action string) bool {
+	if userCred == nil {
+		return false
+	}
 	return userCred.IsAdminAllow(consts.GetServiceType(), obj.KeywordPlural(), policy.PolicyActionPerform, action)
 }
 
 func IsAdminAllowUpdate(userCred mcclient.TokenCredential, obj IModel) bool {
+	if userCred == nil {
+		return false
+	}
 	return userCred.IsAdminAllow(consts.GetServiceType(), obj.KeywordPlural(), policy.PolicyActionUpdate)
 }
 
 func IsAdminAllowDelete(userCred mcclient.TokenCredential, obj IModel) bool {
+	if userCred == nil {
+		return false
+	}
 	return userCred.IsAdminAllow(consts.GetServiceType(), obj.KeywordPlural(), policy.PolicyActionDelete)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正当认证失败后，rbac权限校验报nil pointer panic

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0