### PR TITLE
host add property server_ips that carries the ip list of baremetal server

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -2180,6 +2180,9 @@ func (self *SHost) getMoreDetails(ctx context.Context, extra *jsonutils.JSONDict
 	if server != nil {
 		extra.Add(jsonutils.NewString(server.Id), "server_id")
 		extra.Add(jsonutils.NewString(server.Name), "server")
+		if self.HostType == HOST_TYPE_BAREMETAL {
+			extra.Add(jsonutils.NewString(strings.Join(server.getRealIPs(), ",")), "server_ips")
+		}
 	}
 	netifs := self.GetNetInterfaces()
 	if netifs != nil && len(netifs) > 0 {


### PR DESCRIPTION
feature: host add property server_ips that carries the ip list of baremetal server

**这个 PR 实现什么功能/修复什么问题**:
物理机增加server_ips的属性，携带裸金属服务的ip地址，用于作为装机后裸金属服务器web ssh的目标IP

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0