### PR TITLE
Automated cherry pick of #120: feature: host add property server_ips that carries the ip

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -2104,6 +2104,9 @@ func (self *SHost) getMoreDetails(ctx context.Context, extra *jsonutils.JSONDict
 	if server != nil {
 		extra.Add(jsonutils.NewString(server.Id), "server_id")
 		extra.Add(jsonutils.NewString(server.Name), "server")
+		if self.HostType == HOST_TYPE_BAREMETAL {
+			extra.Add(jsonutils.NewString(strings.Join(server.getRealIPs(), ",")), "server_ips")
+		}
 	}
 	netifs := self.GetNetInterfaces()
 	if netifs != nil && len(netifs) > 0 {


### PR DESCRIPTION
Cherry pick of #120 on release/2.6.0.

#120: feature: host add property server_ips that carries the ip