### PR TITLE
fix: host update status should notify scheduler

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -3864,3 +3864,12 @@ func (host *SHost) PerformSetSchedtag(ctx context.Context, userCred mcclient.Tok
 func (host *SHost) GetDynamicConditionInput() *jsonutils.JSONDict {
 	return jsonutils.Marshal(host).(*jsonutils.JSONDict)
 }
+
+func (host *SHost) PerformStatus(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+	ret, err := host.SEnabledStatusStandaloneResourceBase.PerformStatus(ctx, userCred, query, data)
+	if err != nil {
+		return nil, err
+	}
+	host.ClearSchedDescCache()
+	return ret, nil
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正host状态变为running后没有通知scheduler，导致新建主机调度失败

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0
