### PR TITLE
Automated cherry pick of #130: fix: host update status should notify scheduler

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -3850,3 +3850,12 @@ func (host *SHost) PerformSetSchedtag(ctx context.Context, userCred mcclient.Tok
 func (host *SHost) GetDynamicConditionInput() *jsonutils.JSONDict {
 	return jsonutils.Marshal(host).(*jsonutils.JSONDict)
 }
+
+func (host *SHost) PerformStatus(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+	ret, err := host.SEnabledStatusStandaloneResourceBase.PerformStatus(ctx, userCred, query, data)
+	if err != nil {
+		return nil, err
+	}
+	host.ClearSchedDescCache()
+	return ret, nil
+}


### PR DESCRIPTION
Cherry pick of #130 on release/2.8.0.

#130: fix: host update status should notify scheduler