### PR TITLE
fix: skip syncing status if guest in failure status

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -1762,7 +1762,7 @@ func (self *SHost) SyncHostVMs(ctx context.Context, userCred mcclient.TokenCrede
 
 	for i := range dbVMs {
 		if taskman.TaskManager.IsInTask(&dbVMs[i]) {
-			syncResult.Error(fmt.Errorf("object in task"))
+			syncResult.Error(fmt.Errorf("server %s(%s)in task", dbVMs[i].Name, dbVMs[i].Id))
 			return nil, syncResult
 		}
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
当主机处于错误状态时，不能通过同步把错误状态同步丢失

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0