### PR TITLE
Automated cherry pick of #138: fix: skip syncing status if guest in failure status

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-	"yunion.io/x/onecloud/pkg/util/cloudinit"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
@@ -37,6 +36,7 @@ import (
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/util/billing"
+	"yunion.io/x/onecloud/pkg/util/cloudinit"
 	"yunion.io/x/onecloud/pkg/util/logclient"
 	"yunion.io/x/onecloud/pkg/util/netutils2"
 	"yunion.io/x/onecloud/pkg/util/seclib2"
@@ -1821,6 +1821,10 @@ func (self *SGuest) GetIsolatedDevices() []SIsolatedDevice {
 	return IsolatedDeviceManager.findAttachedDevicesOfGuest(self)
 }
 
+func (self *SGuest) IsFailureStatus() bool {
+	return strings.Index(self.Status, "fail") >= 0
+}
+
 func (self *SGuest) syncRemoveCloudVM(ctx context.Context, userCred mcclient.TokenCredential) error {
 	lockman.LockObject(ctx, self)
 	defer lockman.ReleaseObject(ctx, self)
@@ -1837,6 +1841,10 @@ func (self *SGuest) syncRemoveCloudVM(ctx context.Context, userCred mcclient.Tok
 		db.OpsLog.LogSyncUpdate(self, diff, userCred)
 	}
 
+	if self.IsFailureStatus() {
+		return nil
+	}
+
 	return self.SetStatus(userCred, VM_UNKNOWN, "Sync lost")
 }
 
@@ -1851,7 +1859,9 @@ func (self *SGuest) syncWithCloudVM(ctx context.Context, userCred mcclient.Token
 	diff, err := db.UpdateWithLock(ctx, self, func() error {
 		extVM.Refresh()
 		// self.Name = extVM.GetName()
-		self.Status = extVM.GetStatus()
+		if !self.IsFailureStatus() {
+			self.Status = extVM.GetStatus()
+		}
 		self.VcpuCount = extVM.GetVcpuCount()
 		self.BootOrder = extVM.GetBootOrder()
 		self.Vga = extVM.GetVga()

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -1748,7 +1748,7 @@ func (self *SHost) SyncHostVMs(ctx context.Context, userCred mcclient.TokenCrede
 
 	for i := range dbVMs {
 		if taskman.TaskManager.IsInTask(&dbVMs[i]) {
-			syncResult.Error(fmt.Errorf("object in task"))
+			syncResult.Error(fmt.Errorf("server %s(%s)in task", dbVMs[i].Name, dbVMs[i].Id))
 			return nil, syncResult
 		}
 	}


### PR DESCRIPTION
Cherry pick of #138 on release/2.8.0.

#138: fix: skip syncing status if guest in failure status