### PR TITLE
fix: allow automatically choosing disk storage type if host is given

### DIFF
--- a/pkg/compute/guestdrivers/baremetals.go
+++ b/pkg/compute/guestdrivers/baremetals.go
@@ -326,7 +326,7 @@ func (self *SBaremetalGuestDriver) ValidateCreateData(ctx context.Context, userC
 	return data, nil
 }
 
-func (self *SBaremetalGuestDriver) ValidateCreateHostData(ctx context.Context, userCred mcclient.TokenCredential, bmName string, host *models.SHost, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
+func (self *SBaremetalGuestDriver) ValidateCreateDataOnHost(ctx context.Context, userCred mcclient.TokenCredential, bmName string, host *models.SHost, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
 	if host.HostType != models.HOST_TYPE_BAREMETAL || !host.IsBaremetal {
 		return nil, httperrors.NewInputParameterError("Host %s is not a baremetal", bmName)
 	}

--- a/pkg/compute/guestdrivers/virtualization.go
+++ b/pkg/compute/guestdrivers/virtualization.go
@@ -187,7 +187,7 @@ func (self *SVirtualizedGuestDriver) ValidateCreateData(ctx context.Context, use
 	return data, nil
 }
 
-func (self *SVirtualizedGuestDriver) ValidateCreateHostData(ctx context.Context, userCred mcclient.TokenCredential, bmName string, host *models.SHost, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
+func (self *SVirtualizedGuestDriver) ValidateCreateDataOnHost(ctx context.Context, userCred mcclient.TokenCredential, bmName string, host *models.SHost, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
 	if host.HostStatus != models.HOST_ONLINE {
 		return nil, httperrors.NewInvalidStatusError("Host %s is not online", bmName)
 	}

--- a/pkg/compute/models/guestdrivers.go
+++ b/pkg/compute/models/guestdrivers.go
@@ -33,7 +33,7 @@ type IGuestDriver interface {
 
 	ValidateUpdateData(ctx context.Context, userCred mcclient.TokenCredential, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error)
 
-	ValidateCreateHostData(ctx context.Context, userCred mcclient.TokenCredential, bmName string, host *SHost, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error)
+	ValidateCreateDataOnHost(ctx context.Context, userCred mcclient.TokenCredential, bmName string, host *SHost, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error)
 
 	PrepareDiskRaidConfig(host *SHost, params *jsonutils.JSONDict) error
 

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -889,7 +889,12 @@ func (manager *SGuestManager) ValidateCreateData(ctx context.Context, userCred m
 			return nil, httperrors.NewGeneralError(err) // should no error
 		}
 		if len(rootDiskConfig.Backend) == 0 {
-			rootDiskConfig.Backend = GetDriver(hypervisor).GetDefaultSysDiskBackend()
+			defaultStorageType, _ := data.GetString("default_storage_type")
+			if len(defaultStorageType) > 0 {
+				rootDiskConfig.Backend = defaultStorageType
+			} else {
+				rootDiskConfig.Backend = GetDriver(hypervisor).GetDefaultSysDiskBackend()
+			}
 		}
 		if rootDiskConfig.SizeMb == 0 {
 			rootDiskConfig.SizeMb = GetDriver(hypervisor).GetMinimalSysDiskSizeGb() * 1024

--- a/pkg/compute/models/helper.go
+++ b/pkg/compute/models/helper.go
@@ -80,10 +80,17 @@ func ValidateScheduleCreateData(ctx context.Context, userCred mcclient.TokenCred
 			hypervisor = HYPERVISOR_DEFAULT
 		}
 
-		_, err = GetDriver(hypervisor).ValidateCreateHostData(ctx, userCred, bmName, baremetal, data)
+		_, err = GetDriver(hypervisor).ValidateCreateDataOnHost(ctx, userCred, bmName, baremetal, data)
 		if err != nil {
 			return nil, err
 		}
+
+		defaultStorage := GetDriver(hypervisor).ChooseHostStorage(baremetal, "")
+		if defaultStorage == nil {
+			return nil, httperrors.NewInsufficientResourceError("no valid storage on host")
+		}
+
+		data.Set("default_storage_type", jsonutils.NewString(defaultStorage.StorageType))
 
 		data.Set("prefer_baremetal_id", jsonutils.NewString(baremetal.Id))
 		data.Set("prefer_host_id", jsonutils.NewString(baremetal.Id))


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
当选择宿主机时，自动选择后端存储时，将从该宿主机可用存储中选择

**是否需要 backport 到之前的 release 分支**:
NONE