### PR TITLE
fix: allow automatically choosing available disk storage type if host given

### DIFF
--- a/pkg/apis/compute/api.go
+++ b/pkg/apis/compute/api.go
@@ -179,6 +179,8 @@ type ServerCreateInput struct {
 
 	// Used to store BaremetalConvertHypervisorTaskId
 	ParentTaskId string `json:"__parent_task_id,omitempty"`
+	// default stroage type if host is given
+	DefaultStorageType string `json:"default_storage_type,omitempty"`
 }
 
 type ServerCloneInput struct {

--- a/pkg/compute/guestdrivers/baremetals.go
+++ b/pkg/compute/guestdrivers/baremetals.go
@@ -338,7 +338,7 @@ func (self *SBaremetalGuestDriver) ValidateCreateData(ctx context.Context, userC
 	return input, nil
 }
 
-func (self *SBaremetalGuestDriver) ValidateCreateHostData(ctx context.Context, userCred mcclient.TokenCredential, bmName string, host *models.SHost, input *api.ServerCreateInput) (*api.ServerCreateInput, error) {
+func (self *SBaremetalGuestDriver) ValidateCreateDataOnHost(ctx context.Context, userCred mcclient.TokenCredential, bmName string, host *models.SHost, input *api.ServerCreateInput) (*api.ServerCreateInput, error) {
 	if host.HostType != models.HOST_TYPE_BAREMETAL || !host.IsBaremetal {
 		return nil, httperrors.NewInputParameterError("Host %s is not a baremetal", bmName)
 	}

--- a/pkg/compute/guestdrivers/virtualization.go
+++ b/pkg/compute/guestdrivers/virtualization.go
@@ -206,7 +206,7 @@ func (self *SVirtualizedGuestDriver) ValidateCreateData(ctx context.Context, use
 	return input, nil
 }
 
-func (self *SVirtualizedGuestDriver) ValidateCreateHostData(ctx context.Context, userCred mcclient.TokenCredential, bmName string, host *models.SHost, input *api.ServerCreateInput) (*api.ServerCreateInput, error) {
+func (self *SVirtualizedGuestDriver) ValidateCreateDataOnHost(ctx context.Context, userCred mcclient.TokenCredential, bmName string, host *models.SHost, input *api.ServerCreateInput) (*api.ServerCreateInput, error) {
 	if host.HostStatus != models.HOST_ONLINE {
 		return nil, httperrors.NewInvalidStatusError("Host %s is not online", bmName)
 	}

--- a/pkg/compute/models/guestdrivers.go
+++ b/pkg/compute/models/guestdrivers.go
@@ -49,7 +49,7 @@ type IGuestDriver interface {
 
 	ValidateUpdateData(ctx context.Context, userCred mcclient.TokenCredential, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error)
 
-	ValidateCreateHostData(ctx context.Context, userCred mcclient.TokenCredential, bmName string, host *SHost, input *api.ServerCreateInput) (*api.ServerCreateInput, error)
+	ValidateCreateDataOnHost(ctx context.Context, userCred mcclient.TokenCredential, bmName string, host *SHost, input *api.ServerCreateInput) (*api.ServerCreateInput, error)
 
 	PrepareDiskRaidConfig(userCred mcclient.TokenCredential, host *SHost, params []*api.BaremetalDiskConfig) error
 

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -937,7 +937,12 @@ func (manager *SGuestManager) ValidateCreateData(ctx context.Context, userCred m
 			return nil, httperrors.NewGeneralError(err) // should no error
 		}
 		if len(rootDiskConfig.Backend) == 0 {
-			rootDiskConfig.Backend = GetDriver(hypervisor).GetDefaultSysDiskBackend()
+			defaultStorageType, _ := data.GetString("default_storage_type")
+			if len(defaultStorageType) > 0 {
+				rootDiskConfig.Backend = defaultStorageType
+			} else {
+				rootDiskConfig.Backend = GetDriver(hypervisor).GetDefaultSysDiskBackend()
+			}
 		}
 		if rootDiskConfig.SizeMb == 0 {
 			rootDiskConfig.SizeMb = GetDriver(hypervisor).GetMinimalSysDiskSizeGb() * 1024

--- a/pkg/compute/models/helper.go
+++ b/pkg/compute/models/helper.go
@@ -92,12 +92,18 @@ func ValidateScheduleCreateData(ctx context.Context, userCred mcclient.TokenCred
 			hypervisor = HYPERVISOR_DEFAULT
 		}
 
-		_, err = GetDriver(hypervisor).ValidateCreateHostData(ctx, userCred, bmName, baremetal, input)
+		_, err = GetDriver(hypervisor).ValidateCreateDataOnHost(ctx, userCred, bmName, baremetal, input)
 		if err != nil {
 			return nil, err
 		}
 
+		defaultStorage := GetDriver(hypervisor).ChooseHostStorage(baremetal, "")
+		if defaultStorage == nil {
+			return nil, httperrors.NewInsufficientResourceError("no valid storage on host")
+		}
 		input.PreferHost = baremetal.Id
+		input.DefaultStorageType = defaultStorage.StorageType
+
 		zone := baremetal.GetZone()
 		input.PreferZone = zone.Id
 		region := zone.GetRegion()


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
当用户指定宿主机时，如果不指定存储类型，则自动从宿主机可用的存储类型中选择（cherry pick from 2.6.0)

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0