### PR TITLE
bugfix: guest desc and guest create backup

### DIFF
--- a/cmd/climc/shell/hostwires.go
+++ b/cmd/climc/shell/hostwires.go
@@ -102,11 +102,16 @@ func init() {
 	})
 
 	type HostWireDetachOptions struct {
-		HOST string `help:"ID or Name of Host"`
-		WIRE string `help:"ID or Name of Wire"`
+		HOST    string `help:"ID or Name of Host"`
+		WIRE    string `help:"ID or Name of Wire"`
+		MacAddr string `help:"Host wire mac addr"`
 	}
 	R(&HostWireDetachOptions{}, "host-wire-detach", "Detach host from wire", func(s *mcclient.ClientSession, args *HostWireDetachOptions) error {
-		result, err := modules.Hostwires.Detach(s, args.HOST, args.WIRE, nil)
+		params := jsonutils.NewDict()
+		if len(args.MacAddr) > 0 {
+			params.Set("mac_addr", jsonutils.NewString(args.MacAddr))
+		}
+		result, err := modules.Hostwires.Detach(s, args.HOST, args.WIRE, params)
 		if err != nil {
 			return err
 		}

--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -281,7 +281,7 @@ func (self *SGuestnetwork) getJsonDescAtHost(host *SHost) jsonutils.JSONObject {
 		}
 	}
 	if hostWire == nil {
-		log.Errorf("Host %s network has can't find nic type %s", host.Name, NIC_TYPE_ADMIN)
+		log.Errorf("Host %s has no net interface on wire %s as guest network %s", host.Name, network.WireId, NIC_TYPE_ADMIN)
 		return nil
 	}
 	return self.getGeneralJsonDesc(host, network, hostWire)

--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -271,10 +271,20 @@ func (self *SGuestnetwork) getJsonDescAtBaremetal(host *SHost) jsonutils.JSONObj
 func (self *SGuestnetwork) getJsonDescAtHost(host *SHost) jsonutils.JSONObject {
 	network := self.GetNetwork()
 	hostwires := host.getHostwiresOfId(network.WireId)
-	if len(hostwires) > 1 {
-		log.Warningf("host attach to wire multiple times: %d", len(hostwires))
+	var hostWire *SHostwire
+	for i := 0; i < len(hostwires); i++ {
+		if netInter, _ := NetInterfaceManager.FetchByMac(hostwires[i].MacAddr); netInter != nil {
+			if netInter.NicType == NIC_TYPE_ADMIN {
+				hostWire = &hostwires[i]
+				break
+			}
+		}
 	}
-	return self.getGeneralJsonDesc(host, network, &hostwires[0])
+	if hostWire == nil {
+		log.Errorf("Host %s network has can't find nic type %s", host.Name, NIC_TYPE_ADMIN)
+		return nil
+	}
+	return self.getGeneralJsonDesc(host, network, hostWire)
 }
 
 func (self *SGuestnetwork) getGeneralJsonDesc(host *SHost, network *SNetwork, hostwire *SHostwire) jsonutils.JSONObject {

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1596,6 +1596,10 @@ func (self *SGuest) getDiskSize() int {
 	return size
 }
 
+func (self *SGuest) GetCdrom() *SGuestcdrom {
+	return self.getCdrom()
+}
+
 func (self *SGuest) getCdrom() *SGuestcdrom {
 	cdrom := SGuestcdrom{}
 	cdrom.SetModelManager(GuestcdromManager)

--- a/pkg/compute/tasks/guest_backup_tasks.go
+++ b/pkg/compute/tasks/guest_backup_tasks.go
@@ -255,9 +255,27 @@ func (self *GuestCreateBackupTask) StartCreateBackupDisks(ctx context.Context, g
 	}
 }
 
-func (self *GuestCreateBackupTask) OnCreateBackupDisks(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {
+func (self *GuestCreateBackupTask) StartInsertIso(ctx context.Context, guest *models.SGuest, imageId string) {
+	self.SetStage("OnInsertIso", nil)
+	guest.StartInsertIsoTask(ctx, imageId, guest.BackupHostId, self.UserCred, self.GetTaskId())
+}
+
+func (self *GuestCreateBackupTask) OnInsertIso(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {
 	self.SetStage("OnCreateBackup", nil)
 	guest.StartCreateBackup(ctx, self.UserCred, self.GetTaskId(), nil)
+}
+
+func (self *GuestCreateBackupTask) OnInsertIsoFailed(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {
+	self.TaskFailed(ctx, guest, fmt.Sprintf("Backup guest insert ISO failed %s", data.String()))
+}
+
+func (self *GuestCreateBackupTask) OnCreateBackupDisks(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {
+	if cdrom := guest.GetCdrom(); cdrom != nil && len(cdrom.ImageId) > 0 {
+		self.StartInsertIso(ctx, guest, cdrom.ImageId)
+	} else {
+		self.SetStage("OnCreateBackup", nil)
+		guest.StartCreateBackup(ctx, self.UserCred, self.GetTaskId(), nil)
+	}
 }
 
 func (self *GuestCreateBackupTask) OnCreateBackupDisksFailed(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
    1. fix get network desc choose wrong host wire
    2. fix guest create backup doesn't cache iso image
**是否需要 backport 到之前的 release 分支**:
    release/2.6.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
