### PR TITLE
fix: image stream error should return immediately

### DIFF
--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -406,6 +406,7 @@ func (self *SImage) SaveImageFromStream(reader io.Reader) error {
 
 	sp, err := self.saveImageFromStream(localPath, reader)
 	if err != nil {
+		log.Errorf("saveImageFromStream fail %s", err)
 		return err
 	}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：saveImageFromStream的error应该立即return

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0