### PR TITLE
Automated cherry pick of #157: fix: image stream error should return immediately

### DIFF
--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -392,6 +392,7 @@ func (self *SImage) SaveImageFromStream(reader io.Reader) error {
 
 	sp, err := self.saveImageFromStream(localPath, reader)
 	if err != nil {
+		log.Errorf("saveImageFromStream fail %s", err)
 		return err
 	}
 


### PR DESCRIPTION
Cherry pick of #157 on release/2.8.0.

#157: fix: image stream error should return immediately