### PR TITLE
Automated cherry pick of #157: fix: image stream error should return immediately

### DIFF
--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -391,6 +391,10 @@ func (self *SImage) SaveImageFromStream(reader io.Reader) error {
 	localPath := self.GetPath("")
 
 	sp, err := self.saveImageFromStream(localPath, reader)
+	if err != nil {
+		log.Errorf("saveImageFromStream fail %s", err)
+		return err
+	}
 
 	virtualSizeBytes := int64(0)
 	format := ""


### PR DESCRIPTION
Cherry pick of #157 on release/2.7.0.

#157: fix: image stream error should return immediately