### PR TITLE
优化scheduler缓存的sku数据

### DIFF
--- a/pkg/scheduler/data_manager/sku/sku.go
+++ b/pkg/scheduler/data_manager/sku/sku.go
@@ -39,7 +39,7 @@ func Start(refreshInterval time.Duration) {
 	skuManager.sync()
 }
 
-func GetByZone(instanceType, zoneId string) *models.SServerSku {
+func GetByZone(instanceType, zoneId string) *ServerSku {
 	return skuManager.GetByZone(instanceType, zoneId)
 }
 
@@ -47,9 +47,15 @@ type skuMap struct {
 	*sync.Map
 }
 
-type skuList []*models.SServerSku
+type ServerSku struct {
+	Id     string `json:"id"`
+	Name   string `json:"name"`
+	ZoneId string `json:"zone_id"`
+}
 
-func (l skuList) Has(newSku *models.SServerSku) (int, bool) {
+type skuList []*ServerSku
+
+func (l skuList) Has(newSku *ServerSku) (int, bool) {
 	for i, oldSku := range l {
 		if oldSku.Id == newSku.Id {
 			return i, true
@@ -62,7 +68,7 @@ func (l skuList) DebugString() string {
 	return fmt.Sprintf("%s", jsonutils.Marshal(l).String())
 }
 
-func (l skuList) GetByZone(zoneId string) *models.SServerSku {
+func (l skuList) GetByZone(zoneId string) *ServerSku {
 	for _, s := range l {
 		if s.ZoneId == zoneId {
 			return s
@@ -85,10 +91,10 @@ func (cache *skuMap) Get(instanceType string) skuList {
 	return nil
 }
 
-func (cache *skuMap) Add(instanceType string, sku *models.SServerSku) {
+func (cache *skuMap) Add(instanceType string, sku *ServerSku) {
 	skus := cache.Get(instanceType)
 	if skus == nil {
-		skus = make([]*models.SServerSku, 0)
+		skus = make([]*ServerSku, 0)
 	}
 	skus = append(skus, sku)
 	cache.Store(instanceType, skus)
@@ -104,8 +110,8 @@ func (m *SSkuManager) syncOnce() {
 	log.Infof("SkuManager start sync")
 	startTime := time.Now()
 
-	skus := make([]models.SServerSku, 0)
-	q := models.ServerSkuManager.Query()
+	skus := make([]ServerSku, 0)
+	q := models.ServerSkuManager.Query("id", "name", "zone_id")
 	q = q.Filter(
 		sqlchemy.OR(
 			sqlchemy.Equals(q.Field("prepaid_status"), models.SkuStatusAvailable),
@@ -126,7 +132,7 @@ func (m *SSkuManager) sync() {
 	wait.Forever(m.syncOnce, m.refreshInterval)
 }
 
-func (m *SSkuManager) GetByZone(instanceType, zoneId string) *models.SServerSku {
+func (m *SSkuManager) GetByZone(instanceType, zoneId string) *ServerSku {
 	l := m.skuMap.Get(instanceType)
 	if l == nil {
 		return nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
减少调度器查询 sku 表的时间和缓存数据的内存大小

**是否需要 backport 到之前的 release 分支**:
NONE
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
