### PR TITLE
openstack不能有protocol参数

### DIFF
--- a/pkg/webconsole/session/remote_console.go
+++ b/pkg/webconsole/session/remote_console.go
@@ -122,7 +122,7 @@ func (info *RemoteConsoleInfo) GetPassword() string {
 }
 
 func (info *RemoteConsoleInfo) getOpenStackURL() (string, error) {
-	return info.getConnParamsURL(info.Url, nil), nil
+	return info.Url, nil
 }
 
 func (info *RemoteConsoleInfo) getConnParamsURL(baseURL string, params url.Values) string {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免openstack vnc加入protocol参数
**是否需要 backport 到之前的 release 分支**:

- release/2.8.0
- release/2.7.0
- release/2.6.0

