### PR TITLE
Automated cherry pick of #174: openstack不能有protocol

### DIFF
--- a/pkg/webconsole/session/remote_console.go
+++ b/pkg/webconsole/session/remote_console.go
@@ -108,7 +108,7 @@ func (info *RemoteConsoleInfo) GetPassword() string {
 }
 
 func (info *RemoteConsoleInfo) getOpenStackURL() (string, error) {
-	return info.getConnParamsURL(info.Url, nil), nil
+	return info.Url, nil
 }
 
 func (info *RemoteConsoleInfo) getConnParamsURL(baseURL string, params url.Values) string {


### PR DESCRIPTION
Cherry pick of #174 on release/2.8.0.

#174: openstack不能有protocol