### PR TITLE
Automated cherry pick of #173: climc: use default webconsole server url

### DIFF
--- a/cmd/climc/shell/webconsole.go
+++ b/cmd/climc/shell/webconsole.go
@@ -5,17 +5,23 @@ import (
 	"net/url"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/utils"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	o "yunion.io/x/onecloud/pkg/mcclient/options"
+	"yunion.io/x/onecloud/pkg/webconsole/command"
+	"yunion.io/x/onecloud/pkg/webconsole/session"
+)
+
+const (
+	DefaultWebconsoleServer = "https://console.yunion.cn/web-console"
 )
 
 func init() {
 	handleResult := func(opt o.WebConsoleOptions, obj jsonutils.JSONObject) error {
 		if opt.WebconsoleUrl == "" {
-			printObject(obj)
-			return nil
+			opt.WebconsoleUrl = DefaultWebconsoleServer
 		}
 		u, err := url.Parse(opt.WebconsoleUrl)
 		if err != nil {
@@ -25,6 +31,25 @@ func init() {
 		if err != nil {
 			return err
 		}
+		var query url.Values
+		connUrl, err := url.ParseRequestURI(connParams)
+		if err == nil {
+			query = connUrl.Query()
+		} else {
+			query, err = url.ParseQuery(connParams)
+			if err != nil {
+				return err
+			}
+		}
+		protocol := query.Get("protocol")
+		if !utils.IsInStringArray(protocol, []string{
+			command.PROTOCOL_TTY, session.VNC,
+			session.SPICE, session.WMKS,
+		}) {
+			fmt.Println(connParams)
+			return nil
+		}
+
 		u.RawQuery = connParams
 		fmt.Println(u.String())
 		return nil


### PR DESCRIPTION
Cherry pick of #173 on release/2.8.0.

#173: climc: use default webconsole server url