### PR TITLE
腾讯云重装系统后状态默认是running

### DIFF
--- a/pkg/compute/guestdrivers/qcloud.go
+++ b/pkg/compute/guestdrivers/qcloud.go
@@ -164,7 +164,7 @@ func (self *SQcloudGuestDriver) GetGuestInitialStateAfterCreate() string {
 }
 
 func (self *SQcloudGuestDriver) GetGuestInitialStateAfterRebuild() string {
-	return models.VM_READY
+	return models.VM_RUNNING
 }
 
 func (self *SQcloudGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManagedVMCreateConfig) string {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
腾讯云重装系统后状态默认是running

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0
