### PR TITLE
feature: add option to specify resources allowing name synchronization

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1821,7 +1821,9 @@ func (self *SGuest) syncWithCloudVM(ctx context.Context, userCred mcclient.Token
 	// metaData := extVM.GetMetadata()
 	diff, err := db.UpdateWithLock(ctx, self, func() error {
 		extVM.Refresh()
-		// self.Name = extVM.GetName()
+		if options.NameSyncResources.Contains(self.Keyword()) {
+			self.Name = extVM.GetName()
+		}
 		if !self.IsFailureStatus() {
 			self.Status = extVM.GetStatus()
 		}
@@ -1891,7 +1893,11 @@ func (manager *SGuestManager) newCloudVM(ctx context.Context, userCred mcclient.
 
 	guest.Status = extVM.GetStatus()
 	guest.ExternalId = extVM.GetGlobalId()
-	guest.Name = db.GenerateName(manager, projectId, extVM.GetName())
+	if options.NameSyncResources.Contains(manager.Keyword()) {
+		guest.Name = extVM.GetName()
+	} else {
+		guest.Name = db.GenerateName(manager, projectId, extVM.GetName())
+	}
 	guest.VcpuCount = extVM.GetVcpuCount()
 	guest.BootOrder = extVM.GetBootOrder()
 	guest.Vga = extVM.GetVga()

--- a/pkg/compute/options/namesync.go
+++ b/pkg/compute/options/namesync.go
@@ -1,0 +1,16 @@
+package options
+
+import (
+	"yunion.io/x/log"
+
+	"yunion.io/x/onecloud/pkg/util/stringutils2"
+)
+
+var (
+	NameSyncResources stringutils2.SSortedStrings
+)
+
+func InitNameSyncResources() {
+	NameSyncResources = stringutils2.NewSortedStrings(Options.NameSyncResources)
+	log.Infof("NameSyncResources: %s", NameSyncResources)
+}

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -99,6 +99,8 @@ type ComputeOptions struct {
 	MinimalSyncIntervalSeconds   int `help:"minimal synchronization interval, default 1 minutes" default:"300"`
 	MaxCloudAccountErrorCount    int `help:"maximal consecutive error count allow for a cloud account" default:"5"`
 
+	NameSyncResources []string `help:"resources that need synchronization of name"`
+
 	DisconnectedCloudAccountRetryProbeIntervalHours int `help:"interval to wait to probe status of a disconnected cloud account" default:"24"`
 
 	SCapabilityOptions

--- a/pkg/compute/service/service.go
+++ b/pkg/compute/service/service.go
@@ -56,6 +56,8 @@ func StartService() {
 		commonOpts.Port = opts.PortV2
 	}
 
+	options.InitNameSyncResources()
+
 	app_common.InitAuth(commonOpts, func() {
 		log.Infof("Auth complete!!")
 	})


### PR DESCRIPTION
add option NameSyncResources to specify resources allowing name synchronization

**这个 PR 实现什么功能/修复什么问题**:
增加NameSyncResources指定允许同步名称的资源，例如server

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0