### PR TITLE
mark removed server with @lost<date> suffix

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -1788,6 +1789,10 @@ func (self *SGuest) IsFailureStatus() bool {
 	return strings.Index(self.Status, "fail") >= 0
 }
 
+var (
+	lostNamePattern = regexp.MustCompile(`-lost@\d{8}$`)
+)
+
 func (self *SGuest) syncRemoveCloudVM(ctx context.Context, userCred mcclient.TokenCredential) error {
 	lockman.LockObject(ctx, self)
 	defer lockman.ReleaseObject(ctx, self)
@@ -1808,7 +1813,18 @@ func (self *SGuest) syncRemoveCloudVM(ctx context.Context, userCred mcclient.Tok
 		return nil
 	}
 
-	return self.SetStatus(userCred, VM_UNKNOWN, "Sync lost")
+	if !lostNamePattern.MatchString(self.Name) {
+		db.Update(self, func() error {
+			self.Name = fmt.Sprintf("%s-lost@%s", self.Name, timeutils.ShortDate(time.Now()))
+			return nil
+		})
+	}
+
+	if self.Status != VM_UNKNOWN {
+		self.SetStatus(userCred, VM_UNKNOWN, "Sync lost")
+	}
+
+	return nil
 }
 
 func (self *SGuest) syncWithCloudVM(ctx context.Context, userCred mcclient.TokenCredential, provider cloudprovider.ICloudProvider, host *SHost, extVM cloudprovider.ICloudVM, projectId string) error {

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1821,7 +1821,9 @@ func (self *SGuest) syncWithCloudVM(ctx context.Context, userCred mcclient.Token
 	// metaData := extVM.GetMetadata()
 	diff, err := db.UpdateWithLock(ctx, self, func() error {
 		extVM.Refresh()
-		// self.Name = extVM.GetName()
+		if options.NameSyncResources.Contains(self.Keyword()) {
+			self.Name = extVM.GetName()
+		}
 		if !self.IsFailureStatus() {
 			self.Status = extVM.GetStatus()
 		}
@@ -1891,7 +1893,11 @@ func (manager *SGuestManager) newCloudVM(ctx context.Context, userCred mcclient.
 
 	guest.Status = extVM.GetStatus()
 	guest.ExternalId = extVM.GetGlobalId()
-	guest.Name = db.GenerateName(manager, projectId, extVM.GetName())
+	if options.NameSyncResources.Contains(manager.Keyword()) {
+		guest.Name = extVM.GetName()
+	} else {
+		guest.Name = db.GenerateName(manager, projectId, extVM.GetName())
+	}
 	guest.VcpuCount = extVM.GetVcpuCount()
 	guest.BootOrder = extVM.GetBootOrder()
 	guest.Vga = extVM.GetVga()

--- a/pkg/compute/options/namesync.go
+++ b/pkg/compute/options/namesync.go
@@ -1,0 +1,16 @@
+package options
+
+import (
+	"yunion.io/x/log"
+
+	"yunion.io/x/onecloud/pkg/util/stringutils2"
+)
+
+var (
+	NameSyncResources stringutils2.SSortedStrings
+)
+
+func InitNameSyncResources() {
+	NameSyncResources = stringutils2.NewSortedStrings(Options.NameSyncResources)
+	log.Infof("NameSyncResources: %s", NameSyncResources)
+}

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -99,6 +99,8 @@ type ComputeOptions struct {
 	MinimalSyncIntervalSeconds   int `help:"minimal synchronization interval, default 1 minutes" default:"300"`
 	MaxCloudAccountErrorCount    int `help:"maximal consecutive error count allow for a cloud account" default:"5"`
 
+	NameSyncResources []string `help:"resources that need synchronization of name"`
+
 	DisconnectedCloudAccountRetryProbeIntervalHours int `help:"interval to wait to probe status of a disconnected cloud account" default:"24"`
 
 	SCapabilityOptions

--- a/pkg/compute/service/service.go
+++ b/pkg/compute/service/service.go
@@ -56,6 +56,8 @@ func StartService() {
 		commonOpts.Port = opts.PortV2
 	}
 
+	options.InitNameSyncResources()
+
 	app_common.InitAuth(commonOpts, func() {
 		log.Infof("Auth complete!!")
 	})


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
在删除机器名后增加-lost@<date>的后缀，避免无法通过名字找到同名主机的正常主机

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0