### PR TITLE
fix: mark synced removed server with @lost<date> suffix

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -1788,6 +1789,10 @@ func (self *SGuest) IsFailureStatus() bool {
 	return strings.Index(self.Status, "fail") >= 0
 }
 
+var (
+	lostNamePattern = regexp.MustCompile(`-lost@\d{8}$`)
+)
+
 func (self *SGuest) syncRemoveCloudVM(ctx context.Context, userCred mcclient.TokenCredential) error {
 	lockman.LockObject(ctx, self)
 	defer lockman.ReleaseObject(ctx, self)
@@ -1808,7 +1813,18 @@ func (self *SGuest) syncRemoveCloudVM(ctx context.Context, userCred mcclient.Tok
 		return nil
 	}
 
-	return self.SetStatus(userCred, VM_UNKNOWN, "Sync lost")
+	if !lostNamePattern.MatchString(self.Name) {
+		db.Update(self, func() error {
+			self.Name = fmt.Sprintf("%s-lost@%s", self.Name, timeutils.ShortDate(time.Now()))
+			return nil
+		})
+	}
+
+	if self.Status != VM_UNKNOWN {
+		self.SetStatus(userCred, VM_UNKNOWN, "Sync lost")
+	}
+
+	return nil
 }
 
 func (self *SGuest) syncWithCloudVM(ctx context.Context, userCred mcclient.TokenCredential, provider cloudprovider.ICloudProvider, host *SHost, extVM cloudprovider.ICloudVM, projectId string) error {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
为同步删除的主机添加-lost@<date>后缀，避免同名的正常主机名字不唯一

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0