### PR TITLE
添加缺失的climc参数选项

### DIFF
--- a/pkg/mcclient/options/servers.go
+++ b/pkg/mcclient/options/servers.go
@@ -126,7 +126,7 @@ type ServerConfigs struct {
 	Host       string `help:"Preferred host where virtual server should be created" json:"prefer_host"`
 	BackupHost string `help:"Perfered host where virtual backup server should be created"`
 
-	Hypervisor   string `help:"Hypervisor type" choices:"kvm|esxi|baremetal|container|aliyun|azure|qcloud|aws|huawei"`
+	Hypervisor   string `help:"Hypervisor type" choices:"kvm|esxi|baremetal|container|aliyun|azure|qcloud|aws|huawei|openstack"`
 	ResourceType string `help:"Resource type" choices:"shared|prepaid|dedicated"`
 	Backup       bool   `help:"Create server with backup server"`
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
添加缺失的climc参数选项

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0
