### PR TITLE
region: storage support set schedtags

### DIFF
--- a/cmd/climc/shell/hosts.go
+++ b/cmd/climc/shell/hosts.go
@@ -518,21 +518,4 @@ func init() {
 		printObject(result)
 		return nil
 	})
-
-	type HostSetSchedtagOptions struct {
-		ID       string   `help:"ID or Name of host"`
-		Schedtag []string `help:"Ids of schedtag"`
-	}
-	R(&HostSetSchedtagOptions{}, "host-set-schedtag", "Set schedtags to a host", func(s *mcclient.ClientSession, args *HostSetSchedtagOptions) error {
-		params := jsonutils.NewDict()
-		for idx, tag := range args.Schedtag {
-			params.Add(jsonutils.NewString(tag), fmt.Sprintf("schedtag.%d", idx))
-		}
-		result, err := modules.Hosts.PerformAction(s, args.ID, "set-schedtag", params)
-		if err != nil {
-			return err
-		}
-		printObject(result)
-		return nil
-	})
 }

--- a/cmd/climc/shell/schedtaghosts.go
+++ b/cmd/climc/shell/schedtaghosts.go
@@ -35,6 +35,7 @@ func (h *schedtagModelHelper) register() {
 		h.list(man.Slave, man.Slave.GetKeyword())
 		h.add(man, man.Slave.GetKeyword())
 		h.remove(man, man.Slave.GetKeyword())
+		h.setTags(man, man.Slave.GetKeyword())
 	}
 }
 
@@ -93,6 +94,25 @@ func (h *schedtagModelHelper) remove(man modules.JointResourceManager, kw string
 				return err
 			}
 			printObject(schedtag)
+			return nil
+		})
+}
+
+func (h *schedtagModelHelper) setTags(man modules.JointResourceManager, kw string) {
+	R(
+		&options.SchedtagSetOptions{},
+		fmt.Sprintf("%s-set-schedtag", kw),
+		fmt.Sprintf("Set schedtags to %v", kw),
+		func(s *mcclient.ClientSession, args *options.SchedtagSetOptions) error {
+			params, err := args.Params()
+			if err != nil {
+				return err
+			}
+			ret, err := man.Slave.PerformAction(s, args.ID, "set-schedtag", params)
+			if err != nil {
+				return err
+			}
+			printObject(ret)
 			return nil
 		})
 }

--- a/cmd/climc/shell/storages.go
+++ b/cmd/climc/shell/storages.go
@@ -228,5 +228,4 @@ func init() {
 		printObject(storage)
 		return nil
 	})
-
 }

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -515,9 +515,7 @@ func (self *SHost) StartDeleteBaremetalTask(ctx context.Context, userCred mcclie
 }
 
 func (self *SHost) RealDelete(ctx context.Context, userCred mcclient.TokenCredential) error {
-	for _, hostschedtag := range self.GetHostschedtags() {
-		hostschedtag.Delete(ctx, userCred)
-	}
+	DeleteResourceJointSchedtags(self, ctx, userCred)
 
 	IsolatedDeviceManager.DeleteDevicesByHost(ctx, userCred, self)
 
@@ -553,17 +551,6 @@ func (self *SHost) RealDelete(ctx context.Context, userCred mcclient.TokenCreden
 		}
 	}
 	return self.SEnabledStatusStandaloneResourceBase.Delete(ctx, userCred)
-}
-
-func (self *SHost) GetHostschedtags() []SHostschedtag {
-	q := HostschedtagManager.Query().Equals("host_id", self.Id)
-	hostschedtags := make([]SHostschedtag, 0)
-	err := db.FetchModelObjects(HostschedtagManager, q, &hostschedtags)
-	if err != nil {
-		log.Errorf("GetHostschedtags error %s", err)
-		return nil
-	}
-	return hostschedtags
 }
 
 func (self *SHost) GetHoststoragesQuery() *sqlchemy.SQuery {
@@ -2199,14 +2186,7 @@ func (self *SHost) getMoreDetails(ctx context.Context, extra *jsonutils.JSONDict
 		extra.Add(jsonutils.NewInt(int64(len(nicInfos))), "nic_count")
 		extra.Add(jsonutils.NewArray(nicInfos...), "nic_info")
 	}
-	schedtags := self.GetSchedtags()
-	if schedtags != nil && len(schedtags) > 0 {
-		info := make([]jsonutils.JSONObject, len(schedtags))
-		for i := 0; i < len(schedtags); i += 1 {
-			info[i] = schedtags[i].GetShortDesc(ctx)
-		}
-		extra.Add(jsonutils.NewArray(info...), "schedtags")
-	}
+	extra = GetSchedtagsDetailsToResource(self, ctx, extra)
 	var usage *SHostGuestResourceUsage
 	if options.Options.IgnoreNonrunningGuests {
 		usage = self.getGuestsResource(VM_RUNNING)
@@ -3808,63 +3788,11 @@ func (self *SHost) IsPrepaidRecycleResource() bool {
 }
 
 func (host *SHost) AllowPerformSetSchedtag(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) bool {
-	return db.IsAdminAllowPerform(userCred, host, "set-schedtag")
-}
-
-func (host *SHost) getHostschedtags() []SHostschedtag {
-	tags := make([]SHostschedtag, 0)
-	hostschedtags := HostschedtagManager.Query().SubQuery()
-	q := hostschedtags.Query().Equals("host_id", host.Id)
-	err := db.FetchModelObjects(HostschedtagManager, q, &tags)
-	if err != nil {
-		log.Errorf("Get hostschedtags: %v", err)
-		return nil
-	}
-	return tags
+	return AllowPerformSetResourceSchedtag(host, ctx, userCred, query, data)
 }
 
 func (host *SHost) PerformSetSchedtag(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
-	schedtags := jsonutils.GetArrayOfPrefix(data, "schedtag")
-	setTagsId := []string{}
-	for idx := 0; idx < len(schedtags); idx++ {
-		schedtagIdent, _ := schedtags[idx].GetString()
-		tag, err := SchedtagManager.FetchByIdOrName(userCred, schedtagIdent)
-		if err != nil {
-			if err == sql.ErrNoRows {
-				return nil, httperrors.NewNotFoundError("Schedtag %s not found", schedtagIdent)
-			}
-			return nil, httperrors.NewGeneralError(err)
-		}
-		setTagsId = append(setTagsId, tag.GetId())
-	}
-	oldTags := host.getHostschedtags()
-	for _, oldTag := range oldTags {
-		if !utils.IsInStringArray(oldTag.SchedtagId, setTagsId) {
-			if err := oldTag.Detach(ctx, userCred); err != nil {
-				return nil, httperrors.NewGeneralError(err)
-			}
-		}
-	}
-	var oldTagIds []string
-	for _, tag := range oldTags {
-		oldTagIds = append(oldTagIds, tag.SchedtagId)
-	}
-	for _, setTagId := range setTagsId {
-		if !utils.IsInStringArray(setTagId, oldTagIds) {
-			if newTagObj, err := db.NewModelObject(HostschedtagManager); err != nil {
-				return nil, httperrors.NewGeneralError(err)
-			} else {
-				newTag := newTagObj.(*SHostschedtag)
-				newTag.HostId = host.Id
-				newTag.SchedtagId = setTagId
-				if err := newTag.GetModelManager().TableSpec().Insert(newTag); err != nil {
-					return nil, httperrors.NewGeneralError(err)
-				}
-			}
-		}
-	}
-	host.ClearSchedDescCache()
-	return nil, nil
+	return PerformSetResourceSchedtag(host, ctx, userCred, query, data)
 }
 
 func (host *SHost) GetDynamicConditionInput() *jsonutils.JSONDict {
@@ -3878,4 +3806,8 @@ func (host *SHost) PerformStatus(ctx context.Context, userCred mcclient.TokenCre
 	}
 	host.ClearSchedDescCache()
 	return ret, nil
+}
+
+func (host *SHost) GetSchedtagJointManager() ISchedtagJointManager {
+	return HostschedtagManager
 }

--- a/pkg/compute/models/schedtagjoint.go
+++ b/pkg/compute/models/schedtagjoint.go
@@ -115,6 +115,10 @@ func (self *SSchedtagJointsBase) AllowDeleteItem(ctx context.Context, userCred m
 	return db.IsAdminAllowDelete(userCred, self)
 }
 
+func (joint *SSchedtagJointsBase) GetSchedtagId() string {
+	return joint.SchedtagId
+}
+
 func (joint *SSchedtagJointsBase) master(obj db.IJointModel) db.IStandaloneModel {
 	return db.JointMaster(obj)
 }
@@ -145,7 +149,7 @@ func (joint *SSchedtagJointsBase) Delete(ctx context.Context, userCred mcclient.
 }
 
 func (joint *SSchedtagJointsBase) delete(obj db.IJointModel, ctx context.Context, userCred mcclient.TokenCredential) error {
-	return db.DeleteModel(ctx, userCred, joint)
+	return db.DeleteModel(ctx, userCred, obj)
 }
 
 func (joint *SSchedtagJointsBase) Detach(ctx context.Context, userCred mcclient.TokenCredential) error {
@@ -153,5 +157,5 @@ func (joint *SSchedtagJointsBase) Detach(ctx context.Context, userCred mcclient.
 }
 
 func (joint *SSchedtagJointsBase) detach(obj db.IJointModel, ctx context.Context, userCred mcclient.TokenCredential) error {
-	return db.DetachJoint(ctx, userCred, joint)
+	return db.DetachJoint(ctx, userCred, obj)
 }

--- a/pkg/mcclient/options/schedtags.go
+++ b/pkg/mcclient/options/schedtags.go
@@ -15,6 +15,8 @@
 package options
 
 import (
+	"fmt"
+
 	"yunion.io/x/jsonutils"
 )
 
@@ -34,4 +36,17 @@ func (o SchedtagModelListOptions) Params() (*jsonutils.JSONDict, error) {
 type SchedtagModelPairOptions struct {
 	SCHEDTAG string `help:"Scheduler tag"`
 	OBJECT   string `help:"Object id"`
+}
+
+type SchedtagSetOptions struct {
+	ID       string   `help:"Id or name of resource"`
+	Schedtag []string `help:"Ids of schedtag"`
+}
+
+func (o SchedtagSetOptions) Params() (*jsonutils.JSONDict, error) {
+	params := jsonutils.NewDict()
+	for idx, tag := range o.Schedtag {
+		params.Add(jsonutils.NewString(tag), fmt.Sprintf("schedtag.%d", idx))
+	}
+	return params, nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

抽象 host set-schedtags 方法，能够支持 storages 和 hosts 设置 schedtag

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @yousong @swordqiu 
