### PR TITLE
fix: GetJointModule2 无法找到 compute_v2 的 endpoint

### DIFF
--- a/pkg/mcclient/modules/modules.go
+++ b/pkg/mcclient/modules/modules.go
@@ -25,6 +25,7 @@ import (
 
 type BaseManagerInterface interface {
 	Version() string
+	GetApiVersion() string
 	GetKeyword() string
 	KeyString() string
 	ServiceType() string
@@ -293,7 +294,7 @@ func GetJointModule2(session *mcclient.ClientSession, mod1 Manager, mod2 Manager
 		return nil, fmt.Errorf("No such joint module: %s", key)
 	}
 	for _, mod := range mods {
-		url, e := session.GetServiceURL(mod.ServiceType(), mod.EndpointType())
+		url, e := session.GetServiceVersionURL(mod.ServiceType(), mod.EndpointType(), mod.GetApiVersion())
 		if e != nil {
 			return nil, e
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复 joint module 无法找到 compute_v2 的 endpoint

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @wanyaoqi @yousong @swordqiu 
