### PR TITLE
Automated cherry pick of #225: b'fix: GetJointModule2 \xe6\x97\xa0\xe6\xb3\x95'

### DIFF
--- a/pkg/mcclient/modules/modules.go
+++ b/pkg/mcclient/modules/modules.go
@@ -11,6 +11,7 @@ import (
 
 type BaseManagerInterface interface {
 	Version() string
+	GetApiVersion() string
 	GetKeyword() string
 	KeyString() string
 	ServiceType() string
@@ -279,7 +280,7 @@ func GetJointModule2(session *mcclient.ClientSession, mod1 Manager, mod2 Manager
 		return nil, fmt.Errorf("No such joint module: %s", key)
 	}
 	for _, mod := range mods {
-		url, e := session.GetServiceURL(mod.ServiceType(), mod.EndpointType())
+		url, e := session.GetServiceVersionURL(mod.ServiceType(), mod.EndpointType(), mod.GetApiVersion())
 		if e != nil {
 			return nil, e
 		}


### PR DESCRIPTION
Cherry pick of #225 on release/2.8.0.

#225: b'fix: GetJointModule2 \xe6\x97\xa0\xe6\xb3\x95'