### PR TITLE
Automated cherry pick of #233: fix: move vm's metadata sync into deep sync cycle

### DIFF
--- a/pkg/compute/models/cloudsync.go
+++ b/pkg/compute/models/cloudsync.go
@@ -362,6 +362,7 @@ func syncZoneHosts(ctx context.Context, userCred mcclient.TokenCredential, syncR
 			lockman.LockObject(ctx, &localHosts[i])
 			defer lockman.ReleaseObject(ctx, &localHosts[i])
 
+			syncMetadata(ctx, userCred, &localHosts[i], remoteHosts[i])
 			newCachePairs = syncHostStorages(ctx, userCred, syncResults, provider, &localHosts[i], remoteHosts[i], storageCachePairs)
 			syncHostWires(ctx, userCred, syncResults, provider, &localHosts[i], remoteHosts[i])
 			syncHostVMs(ctx, userCred, syncResults, provider, driver, &localHosts[i], remoteHosts[i], syncRange)
@@ -392,6 +393,7 @@ func syncHostStorages(ctx context.Context, userCred mcclient.TokenCredential, sy
 
 	newCacheIds := make([]sStoragecacheSyncPair, 0)
 	for i := 0; i < len(localStorages); i += 1 {
+		syncMetadata(ctx, userCred, &localStorages[i], remoteStorages[i])
 		if !isInCache(storageCachePairs, localStorages[i].StoragecacheId) && !isInCache(newCacheIds, localStorages[i].StoragecacheId) {
 			cachePair := syncStorageCaches(ctx, userCred, provider, &localStorages[i], remoteStorages[i])
 			if cachePair.remote != nil && cachePair.local != nil {
@@ -453,6 +455,7 @@ func syncHostVMs(ctx context.Context, userCred mcclient.TokenCredential, syncRes
 			lockman.LockObject(ctx, syncVMPairs[i].Local)
 			defer lockman.ReleaseObject(ctx, syncVMPairs[i].Local)
 
+			syncMetadata(ctx, userCred, syncVMPairs[i].Local, syncVMPairs[i].Remote)
 			syncVMNics(ctx, userCred, provider, localHost, syncVMPairs[i].Local, syncVMPairs[i].Remote)
 			syncVMDisks(ctx, userCred, provider, driver, localHost, syncVMPairs[i].Local, syncVMPairs[i].Remote, syncRange)
 			syncVMEip(ctx, userCred, provider, syncVMPairs[i].Local, syncVMPairs[i].Remote)

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -1320,7 +1320,6 @@ func (manager *SHostManager) SyncHosts(ctx context.Context, userCred mcclient.To
 		if err != nil {
 			syncResult.UpdateError(err)
 		} else {
-			syncMetadata(ctx, userCred, &commondb[i], commonext[i])
 			localHosts = append(localHosts, commondb[i])
 			remoteHosts = append(remoteHosts, commonext[i])
 			syncResult.Update()
@@ -1331,7 +1330,6 @@ func (manager *SHostManager) SyncHosts(ctx context.Context, userCred mcclient.To
 		if err != nil {
 			syncResult.AddError(err)
 		} else {
-			syncMetadata(ctx, userCred, new, added[i])
 			localHosts = append(localHosts, *new)
 			remoteHosts = append(remoteHosts, added[i])
 			syncResult.Add()
@@ -1532,7 +1530,6 @@ func (self *SHost) SyncHostStorages(ctx context.Context, userCred mcclient.Token
 		if err != nil {
 			syncResult.UpdateError(err)
 		} else {
-			syncMetadata(ctx, userCred, &commondb[i], commonext[i])
 			localStorages = append(localStorages, commondb[i])
 			remoteStorages = append(remoteStorages, commonext[i])
 			syncResult.Update()
@@ -1545,7 +1542,6 @@ func (self *SHost) SyncHostStorages(ctx context.Context, userCred mcclient.Token
 		if err != nil {
 			syncResult.AddError(err)
 		} else {
-			syncMetadata(ctx, userCred, local, added[i])
 			localStorages = append(localStorages, *local)
 			remoteStorages = append(remoteStorages, added[i])
 			syncResult.Add()
@@ -1779,7 +1775,6 @@ func (self *SHost) SyncHostVMs(ctx context.Context, userCred mcclient.TokenCrede
 		if err != nil {
 			syncResult.UpdateError(err)
 		} else {
-			syncMetadata(ctx, userCred, &commondb[i], commonext[i])
 			syncVMPair := SGuestSyncResult{
 				Local:  &commondb[i],
 				Remote: commonext[i],
@@ -1806,7 +1801,6 @@ func (self *SHost) SyncHostVMs(ctx context.Context, userCred mcclient.TokenCrede
 		if err != nil {
 			syncResult.AddError(err)
 		} else {
-			syncMetadata(ctx, userCred, new, added[i])
 			syncVMPair := SGuestSyncResult{
 				Local:  new,
 				Remote: added[i],

--- a/pkg/util/aws/instance.go
+++ b/pkg/util/aws/instance.go
@@ -176,17 +176,21 @@ func (self *SInstance) GetMetadata() *jsonutils.JSONDict {
 	}
 
 	data.Add(jsonutils.NewString(self.host.zone.GetGlobalId()), "zone_ext_id")
-	if len(self.ImageId) > 0 {
-		image, err := self.host.zone.region.GetImage(self.ImageId)
-		if err != nil {
-			log.Errorf("Failed to find image %s for instance %s zone %s", self.ImageId, self.GetId(), self.ZoneId)
-		} else {
-			meta := image.GetMetadata()
-			if meta != nil {
-				data.Update(meta)
+
+	// no need to sync image metadata
+	/*
+		if len(self.ImageId) > 0 {
+			image, err := self.host.zone.region.GetImage(self.ImageId)
+			if err != nil {
+				log.Errorf("Failed to find image %s for instance %s zone %s", self.ImageId, self.GetId(), self.ZoneId)
+			} else {
+				meta := image.GetMetadata()
+				if meta != nil {
+					data.Update(meta)
+				}
 			}
 		}
-	}
+	*/
 	return data
 }
 


### PR DESCRIPTION
Cherry pick of #233 on release/2.8.0.

#233: fix: move vm's metadata sync into deep sync cycle