### PR TITLE
fix: baremetal convert to host missing cpu and memory params

### DIFF
--- a/pkg/compute/hostdrivers/base.go
+++ b/pkg/compute/hostdrivers/base.go
@@ -75,6 +75,8 @@ func (self *SBaseHostDriver) PrepareConvert(host *models.SHost, image, raid stri
 	} else {
 		params.Set("name", jsonutils.NewString(host.Name))
 	}
+	params.Set("vcpu_count", jsonutils.NewInt(int64(host.CpuCount)))
+	params.Set("vmem_size", jsonutils.NewInt(int64(host.MemSize)))
 	params.Set("auto_start", jsonutils.NewBool(true))
 	params.Set("is_system", jsonutils.NewBool(true))
 	params.Set("prefer_baremetal", jsonutils.NewString(host.Id))


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复 host convert 缺失 cpu 和 memory 参数的 bug

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @swordqiu @wanyaoqi 