### PR TITLE
Automated cherry pick of #241: fix: baremetal convert to host missing cpu and memory params

### DIFF
--- a/pkg/compute/hostdrivers/base.go
+++ b/pkg/compute/hostdrivers/base.go
@@ -61,6 +61,8 @@ func (self *SBaseHostDriver) PrepareConvert(host *models.SHost, image, raid stri
 	} else {
 		params.Set("name", jsonutils.NewString(host.Name))
 	}
+	params.Set("vcpu_count", jsonutils.NewInt(int64(host.CpuCount)))
+	params.Set("vmem_size", jsonutils.NewInt(int64(host.MemSize)))
 	params.Set("auto_start", jsonutils.NewBool(true))
 	params.Set("is_system", jsonutils.NewBool(true))
 	params.Set("prefer_baremetal", jsonutils.NewString(host.Id))


### PR DESCRIPTION
Cherry pick of #241 on release/2.8.0.

#241: fix: baremetal convert to host missing cpu and memory params