### PR TITLE
fix: region list empty or occupied hosts not work

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -384,6 +384,16 @@ func (manager *SHostManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQu
 		))
 	}
 
+	if query.Contains("is_empty") {
+		isEmpty := jsonutils.QueryBoolean(query, "is_empty", false)
+		sq := GuestManager.Query("host_id").IsNotEmpty("host_id").GroupBy("host_id").SubQuery()
+		if isEmpty {
+			q = q.NotIn("id", sq)
+		} else {
+			q = q.In("id", sq)
+		}
+	}
+
 	if query.Contains("baremetal") {
 		isBaremetal := jsonutils.QueryBoolean(query, "baremetal", false)
 		if isBaremetal {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复 region host-list --empty/occupied api 不生效

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0
/cc @swordqiu @wanyaoqi 