### PR TITLE
修复:通过镜像创建的磁盘只能使用镜像ID参数

### DIFF
--- a/pkg/util/azure/disk.go
+++ b/pkg/util/azure/disk.go
@@ -100,10 +100,16 @@ func (self *SRegion) CreateDisk(storageType string, name string, sizeGb int32, d
 				SourceURI:    blobUrl,
 			}
 		} else {
-			imgRef := image.getImageReference()
+			// 通过镜像创建的磁盘只能传ID参数，不能通过sku,offer等参数创建.
+			_imageId, err := self.getOfferedImageId(&image)
+			if err != nil {
+				return nil, err
+			}
 			disk.Properties.CreationData = CreationData{
-				CreateOption:   "FromImage",
-				ImageReference: &imgRef,
+				CreateOption: "FromImage",
+				ImageReference: &ImageReference{
+					ID: _imageId,
+				},
 			}
 		}
 		disk.Properties.OsType = image.GetOsType()

--- a/pkg/util/azure/image.go
+++ b/pkg/util/azure/image.go
@@ -550,6 +550,18 @@ func (region *SRegion) getOfferedImage(offerId string) (SImage, error) {
 	return image, nil
 }
 
+func (region *SRegion) getOfferedImageId(image *SImage) (string, error) {
+	if isPrivateImageID(image.ID) {
+		return image.ID, nil
+	}
+	_image, err := region.getImageDetail(image.Publisher, image.Offer, image.Sku, image.Version)
+	if err != nil {
+		log.Errorf("failed to get offered image ID from %s error: %v", jsonutils.Marshal(image).PrettyString(), err)
+		return "", err
+	}
+	return _image.Id, nil
+}
+
 func (image *SImage) getImageReference() ImageReference {
 	if isPrivateImageID(image.ID) {
 		return ImageReference{


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
通过镜像创建的磁盘只能使用镜像ID参数

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0