### PR TITLE
region: enhance server clone releated apis

### DIFF
--- a/cmd/climc/shell/hosts.go
+++ b/cmd/climc/shell/hosts.go
@@ -518,4 +518,16 @@ func init() {
 		printObject(result)
 		return nil
 	})
+
+	type HostSpecOptions struct {
+		ID string `help:"ID or name of host"`
+	}
+	R(&HostSpecOptions{}, "host-spec", "Get host spec info", func(s *mcclient.ClientSession, args *HostSpecOptions) error {
+		spec, err := modules.Hosts.GetSpecific(s, args.ID, "spec", nil)
+		if err != nil {
+			return err
+		}
+		printObject(spec)
+		return nil
+	})
 }

--- a/cmd/climc/shell/servers.go
+++ b/cmd/climc/shell/servers.go
@@ -837,4 +837,13 @@ func init() {
 		printBatchResults(results, modules.Servers.GetColumns(s))
 		return nil
 	})
+
+	R(&options.ServerIdOptions{}, "server-create-params", "Show server create params", func(s *mcclient.ClientSession, opts *options.ServerIdOptions) error {
+		ret, e := modules.Servers.GetSpecific(s, opts.ID, "create-params", nil)
+		if e != nil {
+			return e
+		}
+		printObject(ret)
+		return nil
+	})
 }

--- a/pkg/appsrv/appsrv.go
+++ b/pkg/appsrv/appsrv.go
@@ -233,7 +233,7 @@ func (app *Application) handleCORS(w http.ResponseWriter, r *http.Request) bool 
 }
 
 func (app *Application) defaultHandle(w http.ResponseWriter, r *http.Request, rid string) (*SHandlerInfo, *SAppParams) {
-	segs := SplitPath(r.URL.Path)
+	segs := SplitPath(r.URL.EscapedPath())
 	params := make(map[string]string)
 	w.Header().Set("Server", "Yunion AppServer/Go/2018.4")
 	w.Header().Set("X-Frame-Options", "SAMEORIGIN")

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -382,6 +382,15 @@ func (self *SGuest) PerformClone(ctx context.Context, userCred mcclient.TokenCre
 	return nil, nil
 }
 
+func (self *SGuest) AllowGetDetailsCreateParams(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {
+	return self.IsOwner(userCred) || db.IsAdminAllowGetSpec(userCred, self, "create-params")
+}
+
+func (self *SGuest) GetDetailsCreateParams(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+	input := self.ToCreateInput(userCred)
+	return input.JSON(input), nil
+}
+
 func (self *SGuest) AllowPerformDeploy(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) bool {
 	return self.IsOwner(userCred) || db.IsAdminAllowPerform(userCred, self, "deploy")
 }

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -3300,6 +3300,10 @@ func (manager *SGuestManager) FetchGuestById(guestId string) *SGuest {
 	return guest.(*SGuest)
 }
 
+func (manager *SGuestManager) GetSpecShouldCheckStatus(query *jsonutils.JSONDict) (bool, error) {
+	return true, nil
+}
+
 func (self *SGuest) GetSpec(checkStatus bool) *jsonutils.JSONDict {
 	if checkStatus {
 		if utils.IsInStringArray(self.Status, []string{VM_SCHEDULE_FAILED}) {

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -832,6 +832,28 @@ func (self *SHost) ClearSchedDescCache() error {
 	return HostManager.ClearSchedDescCache(self.Id)
 }
 
+func (self *SHost) AllowGetDetailsSpec(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {
+	return db.IsAdminAllowGetSpec(userCred, self, "spec")
+}
+
+func (self *SHost) GetDetailsSpec(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+	return GetModelSpec(HostManager, self)
+}
+
+func (man *SHostManager) GetSpecShouldCheckStatus(query *jsonutils.JSONDict) (bool, error) {
+	statusCheck := true
+	if query.Contains("is_empty") {
+		isEmpty, err := query.Bool("is_empty")
+		if err != nil {
+			return statusCheck, err
+		}
+		if !isEmpty {
+			statusCheck = false
+		}
+	}
+	return statusCheck, nil
+}
+
 func (self *SHost) GetSpec(statusCheck bool) *jsonutils.JSONDict {
 	if statusCheck {
 		if !self.Enabled {

--- a/pkg/compute/models/isolated_devices.go
+++ b/pkg/compute/models/isolated_devices.go
@@ -439,6 +439,10 @@ func (self *SIsolatedDevice) getDesc() *jsonutils.JSONDict {
 	return desc
 }
 
+func (man *SIsolatedDeviceManager) GetSpecShouldCheckStatus(query *jsonutils.JSONDict) (bool, error) {
+	return true, nil
+}
+
 func (self *SIsolatedDevice) GetSpec(statusCheck bool) *jsonutils.JSONDict {
 	if statusCheck {
 		if len(self.GuestId) > 0 {

--- a/pkg/compute/models/specs.go
+++ b/pkg/compute/models/specs.go
@@ -28,6 +28,7 @@ import (
 
 type ISpecModelManager interface {
 	db.IStandaloneModelManager
+	GetSpecShouldCheckStatus(query *jsonutils.JSONDict) (bool, error)
 	GetSpecIdent(spec *jsonutils.JSONDict) []string
 }
 
@@ -65,21 +66,36 @@ func GetServerSpecs(ctx context.Context, userCred mcclient.TokenCredential, quer
 	return getModelSpecs(GuestManager, ctx, userCred, query)
 }
 
+func GetSpecIdentKey(keys []string) string {
+	sort.Strings(keys)
+	return strings.Join(keys, "/")
+}
+
+func GetModelSpec(manager ISpecModelManager, model ISpecModel) (jsonutils.JSONObject, error) {
+	spec := model.GetSpec(false)
+	specKey := GetSpecIdentKey(manager.GetSpecIdent(spec))
+	spec.Add(jsonutils.NewString(specKey), "spec_key")
+	return spec, nil
+}
+
 func getModelSpecs(manager ISpecModelManager, ctx context.Context, userCred mcclient.TokenCredential, query *jsonutils.JSONDict) (jsonutils.JSONObject, error) {
 	items, err := ListItems(manager, ctx, userCred, query)
 	if err != nil {
 		return nil, err
 	}
 	retDict := jsonutils.NewDict()
+	statusCheck, err := manager.GetSpecShouldCheckStatus(query)
+	if err != nil {
+		return nil, err
+	}
 	for _, obj := range items {
 		specObj := obj.(ISpecModel)
-		spec := specObj.GetSpec(true)
+		spec := specObj.GetSpec(statusCheck)
 		if spec == nil {
 			continue
 		}
 		specKeys := manager.GetSpecIdent(spec)
-		sort.Strings(specKeys)
-		specKey := strings.Join(specKeys, "/")
+		specKey := GetSpecIdentKey(specKeys)
 		if oldSpec, _ := retDict.Get(specKey); oldSpec == nil {
 			spec.Add(jsonutils.NewInt(1), "count")
 			retDict.Add(spec, specKey)

--- a/pkg/compute/specs/handler.go
+++ b/pkg/compute/specs/handler.go
@@ -194,14 +194,24 @@ func handleQueryModel(
 		ret := jsonutils.NewArray()
 		return ret, nil
 	}
-	objs := QueryObjects(manager, objects, specKeys, isOkF)
+	statusCheck, err := manager.GetSpecShouldCheckStatus(query)
+	if err != nil {
+		return nil, err
+	}
+	objs := QueryObjects(manager, objects, specKeys, isOkF, statusCheck)
 	return QueryObjectsToJson(objs, ctx, userCred, query)
 }
 
-func QueryObjects(manager models.ISpecModelManager, objs []models.ISpecModel, specKeys []string, isOkF func(models.ISpecModel) bool) []models.ISpecModel {
+func QueryObjects(
+	manager models.ISpecModelManager,
+	objs []models.ISpecModel,
+	specKeys []string,
+	isOkF func(models.ISpecModel) bool,
+	statusCheck bool,
+) []models.ISpecModel {
 	selectedObjs := make([]models.ISpecModel, 0)
 	for _, obj := range objs {
-		specs := obj.GetSpec(true)
+		specs := obj.GetSpec(statusCheck)
 		if specs == nil {
 			continue
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

- 添加 get create params 接口返回 server 的创建参数
- 完善 spec 相关的接口，用于 server-clone 时过滤物理机

clone 流程如下:

### clone 虚拟机
调用 server create-params 接口获取创建参数，调用 server-create 接口创建机器

### clone 裸金属服务器
1. 根据当前 server 的 host_id 调用 host-spec 获取 spec_key
2. 根据 spec_key 过滤出其他空闲可用的物理机，如果没有同规格的空闲物理机，则无法 clone
3. 调用 server create-params 接口获取创建参数，调用 server-create 接口创建机器

### 物理机安装操作系统
1. 调用 host-spec 获取该物理机的 spec_key
2. 根据 spec_key 过滤出和该物理机同规格的其他已装机的物理机
3. 选择一台过滤出的物理机，根据物理机里面的 server_id 调用 server create-params 获取创建参数，调用 server-create 接口创建机器

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0
/cc @swordqiu @wanyaoqi 