### PR TITLE
fix: scheduler input incompatibility

### DIFF
--- a/pkg/cloudcommon/cmdline/helper.go
+++ b/pkg/cloudcommon/cmdline/helper.go
@@ -324,10 +324,11 @@ func FetchScheduleInputByJSON(obj jsonutils.JSONObject) (*scheduler.ScheduleInpu
 	if err != nil {
 		return nil, err
 	}
+	conf := &input.ServerConfig
 	if obj.Contains("scheduler") {
 		obj, _ = obj.Get("scheduler")
+		obj.Unmarshal(conf)
 	}
-	conf := &input.ServerConfig
 	conf.ServerConfigs, err = FetchServerConfigsByJSON(obj)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复 scheduler input 不兼容旧的请求

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @wanyaoqi 