### PR TITLE
fix: scheduler schedtag filters execute when candidates specified

### DIFF
--- a/pkg/scheduler/algorithm/predicates/aggregate_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/aggregate_predicate.go
@@ -51,7 +51,7 @@ func (p *AggregatePredicate) Clone() core.FitPredicate {
 func (p *AggregatePredicate) PreExecute(u *core.Unit, cs []core.Candidater) (bool, error) {
 	data := u.SchedData()
 
-	if len(data.Candidates) > 0 {
+	if !u.ShouldExecuteSchedtagFilter() {
 		return false, nil
 	}
 

--- a/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
@@ -157,30 +157,34 @@ func (w schedtagStorageW) ResourceType() string {
 	return models.StorageManager.KeywordPlural()
 }
 
-func (p *DiskSchedtagPredicate) check(d *computeapi.DiskConfig, s *api.CandidateStorage) (*PredicatedStorage, error) {
+func (p *DiskSchedtagPredicate) check(d *computeapi.DiskConfig, s *api.CandidateStorage, u *core.Unit) (*PredicatedStorage, error) {
 	allTags, err := GetAllSchedtags(models.StorageManager.KeywordPlural())
 	if err != nil {
 		return nil, err
 	}
 	tagPredicate := NewSchedtagPredicate(d.Schedtags, allTags)
-	if err := tagPredicate.Check(
-		schedtagStorageW{
-			candidater: s,
-			disk:       d,
-		},
-	); err != nil {
-		return nil, err
+	shouldExec := u.ShouldExecuteSchedtagFilter()
+	ps := newPredicatedStorage(s, nil, nil)
+	if shouldExec {
+		if err := tagPredicate.Check(
+			schedtagStorageW{
+				candidater: s,
+				disk:       d,
+			},
+		); err != nil {
+			return nil, err
+		}
+		ps.PreferTags = tagPredicate.GetPreferTags()
+		ps.AvoidTags = tagPredicate.GetAvoidTags()
 	}
-	avoidTags := tagPredicate.GetAvoidTags()
-	preferTags := tagPredicate.GetPreferTags()
-	return newPredicatedStorage(s, preferTags, avoidTags), nil
+	return ps, nil
 }
 
-func (p *DiskSchedtagPredicate) checkStorages(d *computeapi.DiskConfig, storages []*api.CandidateStorage) ([]*PredicatedStorage, error) {
+func (p *DiskSchedtagPredicate) checkStorages(d *computeapi.DiskConfig, storages []*api.CandidateStorage, u *core.Unit) ([]*PredicatedStorage, error) {
 	errs := make([]error, 0)
 	ret := make([]*PredicatedStorage, 0)
 	for _, s := range storages {
-		ps, err := p.check(d, s)
+		ps, err := p.check(d, s, u)
 		if err != nil {
 			// append err, storage not suit disk
 			errs = append(errs, err)
@@ -222,7 +226,7 @@ func (p *DiskSchedtagPredicate) Execute(u *core.Unit, c core.Candidater) (bool, 
 			break
 		}
 
-		matchedStorages, err := p.checkStorages(d, fitStorages)
+		matchedStorages, err := p.checkStorages(d, fitStorages, u)
 		if err != nil {
 			h.Exclude(err.Error())
 		}

--- a/pkg/scheduler/core/context.go
+++ b/pkg/scheduler/core/context.go
@@ -415,6 +415,10 @@ func (u *Unit) SchedData() *api.SchedInfo {
 	return u.SchedInfo
 }
 
+func (u *Unit) ShouldExecuteSchedtagFilter() bool {
+	return len(u.SchedData().Candidates) == 0
+}
+
 func (u *Unit) IsPublicCloudProvider() bool {
 	return u.SchedData().IsPublicCloudProvider()
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复调度时指定了宿主机，但还被调度标签过滤的问题

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @swordqiu