### PR TITLE
Automated cherry pick of #277: fix: scheduler schedtag filters execute when candidates

### DIFF
--- a/pkg/scheduler/algorithm/predicates/aggregate_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/aggregate_predicate.go
@@ -37,7 +37,7 @@ func (p *AggregatePredicate) Clone() core.FitPredicate {
 func (p *AggregatePredicate) PreExecute(u *core.Unit, cs []core.Candidater) (bool, error) {
 	data := u.SchedData()
 
-	if len(data.Candidates) > 0 {
+	if !u.ShouldExecuteSchedtagFilter() {
 		return false, nil
 	}
 

--- a/pkg/scheduler/core/context.go
+++ b/pkg/scheduler/core/context.go
@@ -401,6 +401,10 @@ func (u *Unit) SchedData() *api.SchedInfo {
 	return u.SchedInfo
 }
 
+func (u *Unit) ShouldExecuteSchedtagFilter() bool {
+	return len(u.SchedData().Candidates) == 0
+}
+
 func (u *Unit) IsPublicCloudProvider() bool {
 	return u.SchedData().IsPublicCloudProvider()
 }


### PR DESCRIPTION
Cherry pick of #277 on release/2.8.0.

#277: fix: scheduler schedtag filters execute when candidates