### PR TITLE
fix: scheduler network predicate not set capability when host filtered

### DIFF
--- a/pkg/scheduler/algorithm/predicates/baremetal/network_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/baremetal/network_predicate.go
@@ -109,7 +109,7 @@ func (p *NetworkPredicate) Execute(u *core.Unit, c core.Candidater) (bool, []cor
 
 	filterByRandomNetwork := func() {
 		if err_msg := isRandomNetworkAvailable(false, false, ""); err_msg != "" {
-			h.AppendPredicateFailMsg(err_msg)
+			h.Exclude(err_msg)
 		}
 		h.SetCapacityCounter(counters)
 	}
@@ -138,7 +138,7 @@ func (p *NetworkPredicate) Execute(u *core.Unit, c core.Candidater) (bool, []cor
 		}
 
 		if len(errMsgs) > 0 {
-			h.AppendPredicateFailMsg(strings.Join(errMsgs, ", "))
+			h.Exclude(strings.Join(errMsgs, ", "))
 		}
 	}
 

--- a/pkg/scheduler/algorithm/predicates/guest/network_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/guest/network_predicate.go
@@ -140,7 +140,7 @@ func (p *NetworkPredicate) Execute(u *core.Unit, c core.Candidater) (bool, []cor
 	filterByRandomNetwork := func() {
 		counters := core.NewCounters()
 		if err_msg := isRandomNetworkAvailable(false, false, "", counters); err_msg != "" {
-			h.AppendPredicateFailMsg(err_msg)
+			h.Exclude(err_msg)
 		}
 		h.SetCapacityCounter(counters)
 	}
@@ -202,7 +202,7 @@ func (p *NetworkPredicate) Execute(u *core.Unit, c core.Candidater) (bool, []cor
 		}
 
 		if len(errMsgs) > 0 {
-			h.AppendPredicateFailMsg(strings.Join(errMsgs, ", "))
+			h.Exclude(strings.Join(errMsgs, ", "))
 		} else {
 			h.SetCapacityCounter(counters)
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: 调度器 network filter 过滤宿主机时没有设置 capability

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @wanyaoqi 
