### PR TITLE
fix: host 内存规格信息直接为 MB

### DIFF
--- a/cmd/climc/shell/specs.go
+++ b/cmd/climc/shell/specs.go
@@ -67,7 +67,7 @@ func init() {
 		options.BaseListOptions
 		HostType string   `help:"Host type filter" choices:"baremetal|hypervisor|esxi|kubelet|hyperv"`
 		Ncpu     int64    `help:"#CPU count of host" metavar:"<CPU_COUNT>"`
-		MemSize  string   `help:"Memory GB size"`
+		MemSize  int64    `help:"Memory MB size"`
 		DiskSpec []string `help:"Disk spec string, like 'Linux_adapter0_HDD_111Gx4'"`
 		Nic      int64    `help:"#Nics count of host" metavar:"<NIC_COUNT>"`
 		GpuModel []string `help:"GPU model, like 'GeForce GTX 1050 Ti'"`
@@ -78,8 +78,8 @@ func init() {
 			if args.Ncpu > 0 {
 				keys = append(keys, fmt.Sprintf("cpu:%d", args.Ncpu))
 			}
-			if len(args.MemSize) != 0 {
-				keys = append(keys, fmt.Sprintf("mem:%s", args.MemSize))
+			if args.MemSize > 0 {
+				keys = append(keys, fmt.Sprintf("mem:%dM", args.MemSize))
 			}
 			for _, gm := range args.GpuModel {
 				keys = append(keys, fmt.Sprintf("gpu_model:%s", gm))

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -891,15 +891,7 @@ func (manager *SHostManager) GetSpecIdent(spec *jsonutils.JSONDict) []string {
 	nCpu, _ := spec.Int("cpu")
 	memSize, _ := spec.Int("mem")
 	var memSizeStr string
-	if memSize < 1024 {
-		memSizeStr = fmt.Sprintf("mem:%dM", memSize)
-	} else {
-		memGB, err := utils.GetSizeGB(fmt.Sprintf("%d", memSize), "M")
-		if err != nil {
-			log.Errorf("Get mem size %d GB error: %v", memSize, err)
-		}
-		memSizeStr = fmt.Sprintf("mem:%dG", memGB)
-	}
+	memSizeStr = fmt.Sprintf("mem:%dM", memSize)
 	nicCount, _ := spec.Int("nic_count")
 	manufacture, _ := spec.GetString("manufacture")
 	model, _ := spec.GetString("model")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

获取 host spec memory 信息时，直接返回 MB，不再转换为 GB，因为这样不准确，会被向下取整

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @swordqiu @wanyaoqi 
