### PR TITLE
避免未setstorageinfo之前连接ceph集群

### DIFF
--- a/pkg/hostman/storageman/storagehandler.go
+++ b/pkg/hostman/storageman/storagehandler.go
@@ -83,8 +83,6 @@ func storageAttach(ctx context.Context, body jsonutils.JSONObject) (interface{},
 
 	storagecacheId, _ := body.GetString("storagecache_id")
 	imagecachePath, _ := body.GetString("imagecache_path")
-	storageManager.InitSharedStorageImageCache(storageType, storagecacheId, imagecachePath, storage)
-
 	storageId, _ := body.GetString("storage_id")
 	storageName, _ := body.GetString("name")
 	storageConf, _ := body.Get("storage_conf")
@@ -94,6 +92,7 @@ func storageAttach(ctx context.Context, body jsonutils.JSONObject) (interface{},
 	if err != nil {
 		return nil, err
 	}
+	storageManager.InitSharedStorageImageCache(storageType, storagecacheId, imagecachePath, storage)
 	storageManager.Storages = append(storageManager.Storages, storage)
 	return resp, nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免未setstorageinfo之前连接ceph集群

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0

