### PR TITLE
fix: scheduler disk schedtag filter host type not convert to guest hy…

### DIFF
--- a/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
@@ -123,7 +123,7 @@ func (p *DiskSchedtagPredicate) PreExecute(u *core.Unit, cs []core.Candidater) (
 		return false, nil
 	}
 
-	p.Hypervisor = u.SchedData().Hypervisor
+	p.Hypervisor = computeapi.HOSTTYPE_HYPERVISOR[u.SchedData().Hypervisor]
 
 	// always select each storages to disks
 	u.AppendSelectPlugin(p)


### PR DESCRIPTION
…pervisor

**这个 PR 实现什么功能/修复什么问题**:

修复调度器调用 GetGuestDriver 时 Hypervisor 不正确

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @wanyaoqi 