### PR TITLE
Automated cherry pick of #294: fix: scheduler disk schedtag filter host type not convert to

### DIFF
--- a/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
@@ -109,7 +109,7 @@ func (p *DiskSchedtagPredicate) PreExecute(u *core.Unit, cs []core.Candidater) (
 		return false, nil
 	}
 
-	p.Hypervisor = u.SchedData().Hypervisor
+	p.Hypervisor = computeapi.HOSTTYPE_HYPERVISOR[u.SchedData().Hypervisor]
 
 	// always select each storages to disks
 	u.AppendSelectPlugin(p)


### PR DESCRIPTION
Cherry pick of #294 on release/2.8.0.

#294: fix: scheduler disk schedtag filter host type not convert to