### PR TITLE
fix: server clone 参数处理扩容情况

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4097,6 +4097,19 @@ func (self *SGuest) ToCreateInput(userCred mcclient.TokenCredential) *api.Server
 			userInput.IsolatedDevices = append(userInput.IsolatedDevices, dev)
 		}
 	}
+	userInput.Count = 1
+	// override some old userInput properties via genInput because of change config behavior
+	userInput.VmemSize = genInput.VmemSize
+	userInput.VcpuCount = genInput.VcpuCount
+	userInput.Vga = genInput.Vga
+	userInput.Vdi = genInput.Vdi
+	userInput.Bios = genInput.Bios
+	userInput.Description = genInput.Description
+	userInput.BootOrder = genInput.BootOrder
+	userInput.DisableDelete = genInput.DisableDelete
+	userInput.ShutdownBehavior = genInput.ShutdownBehavior
+	userInput.IsSystem = genInput.IsSystem
+	userInput.SecgroupId = genInput.SecgroupId
 	userInput.KeypairId = genInput.KeypairId
 	userInput.Project = genInput.Project
 	return userInput
@@ -4117,10 +4130,8 @@ func (self *SGuest) toCreateInput() *api.ServerCreateInput {
 	r.DisableDelete = new(bool)
 	*r.DisableDelete = self.DisableDelete.Bool()
 	r.ShutdownBehavior = self.ShutdownBehavior
-	// r.DeployConfigs
+	// ignore r.DeployConfigs
 	r.IsSystem = self.IsSystem
-	// r.Duration
-	// r.AutoPrepaidRecycle
 	r.SecgroupId = self.SecgrpId
 
 	r.ServerConfigs = new(api.ServerConfigs)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: 获取 server create params 时没有考虑扩容的情况 #289 

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/cc @wanyaoqi 
/cherrypick release/2.8.0