### PR TITLE
baremetal-agent: fix host undo convert duplicate access_mac error

### DIFF
--- a/pkg/baremetal/pxe/dhcp.go
+++ b/pkg/baremetal/pxe/dhcp.go
@@ -235,12 +235,11 @@ func (req *dhcpRequest) findNetworkConf(session *mcclient.ClientSession, filterU
 
 func (req *dhcpRequest) findBaremetalsOfAnyMac(session *mcclient.ClientSession, isBaremetal bool) (*modules.ListResult, error) {
 	params := jsonutils.NewDict()
-	params.Add(jsonutils.NewString(api.HOST_TYPE_BAREMETAL), "host_type")
 	params.Add(jsonutils.NewString(req.ClientMac.String()), "any_mac")
 	if isBaremetal {
 		params.Add(jsonutils.JSONTrue, "is_baremetal")
 	} else {
-		params.Add(jsonutils.NewString("baremetal"), "host_type")
+		params.Add(jsonutils.NewString(api.HOST_TYPE_BAREMETAL), "host_type")
 	}
 	return modules.Hosts.List(session, params)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复宿主机重新变为物理机发生 'Duplicate access_mac' 的问题，原因是 findBaremetalsOfAnyMac 函数调用 host-list 接口参数传错，找不到 host，baremetal-agent 就去新建 baremetal，最后导致 Duplicate error

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @swordqiu @wanyaoqi 