### PR TITLE
避免net_desc为空未进行错误处理,避免network没有IP地址

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -1484,6 +1484,9 @@ func (self *SGuest) PerformChangeIpaddr(ctx context.Context, userCred mcclient.T
 		return nil, httperrors.NewMissingParameterError("net_desc")
 	}
 	conf, err := cmdline.ParseNetworkConfigByJSON(netDesc, -1)
+	if err != nil {
+		return nil, err
+	}
 	conf, err = parseNetworkInfo(userCred, conf)
 	if err != nil {
 		log.Errorf("parseNetworkInfo fail %s", err)

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -781,6 +781,9 @@ func isValidNetworkInfo(userCred mcclient.TokenCredential, netConfig *api.Networ
 		if netConfig.BwLimit > MAX_BANDWIDTH {
 			return httperrors.NewInputParameterError("Bandwidth limit cannot exceed %dMbps", MAX_BANDWIDTH)
 		}
+		if net.getFreeAddressCount() < 1 {
+			return httperrors.NewInputParameterError("network %s(%s) has no free addresses", net.Name, net.Id)
+		}
 	}
 	/* scheduler to the check
 	else if ! netConfig.Vip {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免net_desc为空未进行错误处理,避免network没有IP地址未报错

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0
