### PR TITLE
fix: add server create-params region and zone info

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1266,7 +1266,11 @@ func (guest *SGuest) SetCreateParams(ctx context.Context, userCred mcclient.Toke
 
 func (guest *SGuest) GetCreateParams(userCred mcclient.TokenCredential) (*api.ServerCreateInput, error) {
 	input := new(api.ServerCreateInput)
-	err := guest.GetMetadataJson(VM_METADATA_CREATE_PARAMS, userCred).Unmarshal(input)
+	data := guest.GetMetadataJson(VM_METADATA_CREATE_PARAMS, userCred)
+	if data == nil {
+		return nil, fmt.Errorf("Not found %s %s in metadata", guest.Name, VM_METADATA_CREATE_PARAMS)
+	}
+	err := data.Unmarshal(input)
 	return input, err
 }
 
@@ -4112,6 +4116,15 @@ func (self *SGuest) ToCreateInput(userCred mcclient.TokenCredential) *api.Server
 	userInput.SecgroupId = genInput.SecgroupId
 	userInput.KeypairId = genInput.KeypairId
 	userInput.Project = genInput.Project
+	if genInput.ResourceType != "" {
+		userInput.ResourceType = genInput.ResourceType
+	}
+	if genInput.PreferRegion != "" {
+		userInput.PreferRegion = genInput.PreferRegion
+	}
+	if genInput.PreferZone != "" {
+		userInput.PreferZone = genInput.PreferZone
+	}
 	return userInput
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

获取 server create params 补充 region, zone 信息

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @wanyaoqi 