### PR TITLE
fix: limit baremetal tftp MaxBlockSize to 512

### DIFF
--- a/pkg/baremetal/pxe/tftp.go
+++ b/pkg/baremetal/pxe/tftp.go
@@ -138,6 +138,8 @@ func (s *Server) serveTFTP(l net.PacketConn, handler *TFTPHandler) error {
 		InfoLog:     func(msg string) { log.Debugf("TFTP msg: %s", msg) },
 		TransferLog: handler.transferLog,
 		Dial:        bindDial,
+
+		MaxBlockSize: 512,
 	}
 	err := ts.Serve(l)
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：baremetal tftp的最大block设置为512字节

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0