### PR TITLE
fix: create disk input need storage_id in JSON object

### DIFF
--- a/pkg/apis/compute/api.go
+++ b/pkg/apis/compute/api.go
@@ -73,7 +73,7 @@ type DiskConfig struct {
 	Medium          string            `json:"medium"`
 	ImageProperties map[string]string `json:"image_properties"`
 
-	Storage string `json:"storage"`
+	Storage string `json:"storage_id"`
 	DiskId  string `json:"disk_id"`
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

DiskCreateInput Marshal 为 json 后 storage 需要变为 storage_id，因为 models.SDisk 需要

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @swordqiu 