### PR TITLE
fix: server-deploy fail to set password if reset_password not set

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -438,7 +438,16 @@ func (self *SGuest) PerformDeploy(ctx context.Context, userCred mcclient.TokenCr
 		}
 	}
 
-	resetPasswd := jsonutils.QueryBoolean(kwargs, "reset_password", false)
+	var resetPasswd bool
+	passwdStr, _ := kwargs.GetString("password")
+	if len(passwdStr) > 0 {
+		if !seclib2.MeetComplxity(passwdStr) {
+			return nil, httperrors.NewWeakPasswordError()
+		}
+		resetPasswd = true
+	} else {
+		resetPasswd = jsonutils.QueryBoolean(kwargs, "reset_password", false)
+	}
 	if resetPasswd {
 		kwargs.Set("reset_password", jsonutils.JSONTrue)
 	} else {

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -819,10 +819,12 @@ func (manager *SGuestManager) ValidateCreateData(ctx context.Context, userCred m
 	}
 
 	passwd := input.Password
-	if resetPassword && len(passwd) > 0 {
+	if len(passwd) > 0 {
 		if !seclib2.MeetComplxity(passwd) {
 			return nil, httperrors.NewWeakPasswordError()
 		}
+		resetPassword = true
+		input.ResetPassword = &resetPassword
 	}
 
 	var hypervisor string


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：server-deploy时候，指定password但是如果没有指定reset_password，会导致未设置密码

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0