### PR TITLE
Automated cherry pick of #330: fix: server-deploy fail to set password if reset_password not

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -424,7 +424,16 @@ func (self *SGuest) PerformDeploy(ctx context.Context, userCred mcclient.TokenCr
 		}
 	}
 
-	resetPasswd := jsonutils.QueryBoolean(kwargs, "reset_password", false)
+	var resetPasswd bool
+	passwdStr, _ := kwargs.GetString("password")
+	if len(passwdStr) > 0 {
+		if !seclib2.MeetComplxity(passwdStr) {
+			return nil, httperrors.NewWeakPasswordError()
+		}
+		resetPasswd = true
+	} else {
+		resetPasswd = jsonutils.QueryBoolean(kwargs, "reset_password", false)
+	}
 	if resetPasswd {
 		kwargs.Set("reset_password", jsonutils.JSONTrue)
 	} else {

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -805,10 +805,12 @@ func (manager *SGuestManager) ValidateCreateData(ctx context.Context, userCred m
 	}
 
 	passwd := input.Password
-	if resetPassword && len(passwd) > 0 {
+	if len(passwd) > 0 {
 		if !seclib2.MeetComplxity(passwd) {
 			return nil, httperrors.NewWeakPasswordError()
 		}
+		resetPassword = true
+		input.ResetPassword = &resetPassword
 	}
 
 	var hypervisor string


### PR DESCRIPTION
Cherry pick of #330 on release/2.8.0.

#330: fix: server-deploy fail to set password if reset_password not