### PR TITLE
fix: fail to fetch private image as admin role

### DIFF
--- a/pkg/cloudcommon/db/fetch.go
+++ b/pkg/cloudcommon/db/fetch.go
@@ -124,6 +124,9 @@ func fetchItemById(manager IModelManager, ctx context.Context, userCred mcclient
 	q := manager.Query()
 	var err error
 	if query != nil && !query.IsZero() {
+		if isListRbacAllowed(manager, userCred, true) {
+			query.(*jsonutils.JSONDict).Set("admin", jsonutils.JSONTrue)
+		}
 		q, err = listItemQueryFilters(manager, ctx, q, userCred, query)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：host无法下载私有镜像文件，根本原因是fetchItem会应用list的ListItemFilter。

为了允许管理源能够查看私有镜像的details，却要默认加上admin=true的filter

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0