### PR TITLE
fix: esxi ignore check file failure in host.getIStoragecache

### DIFF
--- a/pkg/util/esxi/host.go
+++ b/pkg/util/esxi/host.go
@@ -565,6 +565,7 @@ func (host *SHost) newLocalStorageCache() (*SDatastoreImageCache, error) {
 	if err != nil {
 		return nil, err
 	}
+	var errmsg string
 	var cacheDs *SDatastore
 	var maxDs *SDatastore
 	var maxCapacity int
@@ -576,9 +577,12 @@ func (host *SHost) newLocalStorageCache() (*SDatastoreImageCache, error) {
 		_, err := ds.CheckFile(ctx, IMAGE_CACHE_DIR_NAME)
 		if err != nil {
 			if err != cloudprovider.ErrNotFound {
-				return nil, err
-			}
-			if maxCapacity < ds.GetCapacityMB() {
+				// return nil, err
+				if len(errmsg) > 0 {
+					errmsg += ","
+				}
+				errmsg += err.Error()
+			} else if maxCapacity < ds.GetCapacityMB() {
 				maxCapacity = ds.GetCapacityMB()
 				maxDs = ds
 			}
@@ -590,6 +594,10 @@ func (host *SHost) newLocalStorageCache() (*SDatastoreImageCache, error) {
 	if cacheDs == nil {
 		// if no existing image cache dir found, use the one with maximal capacilty
 		cacheDs = maxDs
+	}
+
+	if cacheDs == nil {
+		return nil, fmt.Errorf(errmsg)
 	}
 
 	return &SDatastoreImageCache{


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：esix host.getIStoragecache中因为checkfile的错误导致同步esxi失败

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0