### PR TITLE
fix: webconsole vmrc protocol not support

### DIFF
--- a/pkg/webconsole/handlers.go
+++ b/pkg/webconsole/handlers.go
@@ -203,7 +203,7 @@ func handleServerRemoteConsole(ctx context.Context, w http.ResponseWriter, r *ht
 		return
 	}
 	switch info.Protocol {
-	case session.ALIYUN, session.QCLOUD, session.OPENSTACK:
+	case session.ALIYUN, session.QCLOUD, session.OPENSTACK, session.VMRC:
 		responsePublicCloudConsole(info, w)
 	case session.VNC, session.SPICE, session.WMKS:
 		handleDataSession(info, w, url.Values{"password": {info.GetPassword()}})

--- a/pkg/webconsole/session/remote_console.go
+++ b/pkg/webconsole/session/remote_console.go
@@ -30,6 +30,7 @@ const (
 	OPENSTACK = "openstack"
 	SPICE     = "spice"
 	WMKS      = "wmks"
+	VMRC      = "vmrc"
 )
 
 type RemoteConsoleInfo struct {
@@ -107,8 +108,8 @@ func (info *RemoteConsoleInfo) GetConnectParams() (string, error) {
 		return info.getAliyunURL()
 	case QCLOUD:
 		return info.getQcloudURL()
-	case OPENSTACK:
-		return info.getOpenStackURL()
+	case OPENSTACK, VMRC:
+		return info.Url, nil
 	default:
 		return "", fmt.Errorf("Can't convert protocol %s to connect params", info.Protocol)
 	}
@@ -119,10 +120,6 @@ func (info *RemoteConsoleInfo) GetPassword() string {
 		return info.Password
 	}
 	return info.VncPassword
-}
-
-func (info *RemoteConsoleInfo) getOpenStackURL() (string, error) {
-	return info.Url, nil
 }
 
 func (info *RemoteConsoleInfo) getConnParamsURL(baseURL string, params url.Values) string {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

webconsole 不支持 vmrc 协议

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @swordqiu 