### PR TITLE
fix: baremetal support options for tftp timeout retry times and block size

### DIFF
--- a/pkg/baremetal/options/options.go
+++ b/pkg/baremetal/options/options.go
@@ -32,7 +32,8 @@ type BaremetalOptions struct {
 	DhcpRenewalTime        int    `default:"67108864" help:"DHCP renewal time in seconds"` // 0x4000000
 	EnableGeneralGuestDhcp bool   `default:"false" help:"Enable DHCP service for general guest, e.g. those on VMware ESXi or Xen"`
 	ForceDhcpProbeIpmi     bool   `default:"false" help:"Force DHCP probe IPMI interface network connection"`
-	TftpMaxTimeoutRetries  int    `default:"20" help:"Maximal tftp timeout retries, default is 20"`
+	TftpBlockSizeInBytes   int    `default:"1024" help:"tftp block size, default is 1024"`
+	TftpMaxTimeoutRetries  int    `default:"50" help:"Maximal tftp timeout retries, default is 50"`
 	LengthyWorkerCount     int    `default:"8" help:"Parallel worker count for lengthy tasks"`
 	ShortWorkerCount       int    `default:"8" help:"Parallel worker count for short-lived tasks"`
 

--- a/pkg/baremetal/pxe/tftp.go
+++ b/pkg/baremetal/pxe/tftp.go
@@ -26,6 +26,7 @@ import (
 
 	"yunion.io/x/log"
 
+	"yunion.io/x/onecloud/pkg/baremetal/options"
 	"yunion.io/x/onecloud/pkg/util/tftp"
 )
 
@@ -139,7 +140,8 @@ func (s *Server) serveTFTP(l net.PacketConn, handler *TFTPHandler) error {
 		TransferLog: handler.transferLog,
 		Dial:        bindDial,
 
-		MaxBlockSize: 512,
+		MaxBlockSize:  int64(options.Options.TftpBlockSizeInBytes),
+		WriteAttempts: options.Options.TftpMaxTimeoutRetries,
 	}
 	err := ts.Serve(l)
 	if err != nil {

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -145,7 +145,7 @@ type SHost struct {
 	AccessIp   string `width:"16" charset:"ascii" nullable:"true" list:"admin" update:"admin" create:"admin_optional"`               // Column(VARCHAR(16, charset='ascii'), nullable=True)
 	ManagerUri string `width:"256" charset:"ascii" nullable:"true" list:"admin" update:"admin" create:"admin_optional"`              // Column(VARCHAR(256, charset='ascii'), nullable=True)
 
-	SysInfo jsonutils.JSONObject `nullable:"true" search:"admin" get:"admin" update:"admin" create:"admin_optional"`               // Column(JSONEncodedDict, nullable=True)
+	SysInfo jsonutils.JSONObject `nullable:"true" search:"admin" list:"admin" update:"admin" create:"admin_optional"`              // Column(JSONEncodedDict, nullable=True)
 	SN      string               `width:"128" charset:"ascii" nullable:"true" list:"admin" update:"admin" create:"admin_optional"` // Column(VARCHAR(128, charset='ascii'), nullable=True)
 
 	CpuCount    int8    `nullable:"true" list:"admin" update:"admin" create:"admin_optional"`                           // Column(TINYINT, nullable=True) # cpu count


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:
修正：baremetal agent支持TftpMaxTimeoutRetries和TftpBlockSizeInBytes两个参数

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0