### PR TITLE
fix: baremetal scheduler forecast fail

### DIFF
--- a/pkg/scheduler/cache/candidate/baremetals.go
+++ b/pkg/scheduler/cache/candidate/baremetals.go
@@ -59,6 +59,7 @@ func (bd *BaremetalDesc) Type() int {
 	return 1
 }
 
+// TODO: remove this ugly code
 func (bd *BaremetalDesc) Get(key string) interface{} {
 	switch key {
 	case "ID":

--- a/pkg/scheduler/cache/candidate/hosts.go
+++ b/pkg/scheduler/cache/candidate/hosts.go
@@ -244,6 +244,7 @@ func (h *HostDesc) GetGuestCount() int64 {
 	return h.GuestCount
 }
 
+// TODO: remove this ugly code
 func (h *HostDesc) Get(key string) interface{} {
 	switch key {
 	case "ID":

--- a/pkg/scheduler/handler/forecast_helper.go
+++ b/pkg/scheduler/handler/forecast_helper.go
@@ -64,7 +64,7 @@ func transToSchedForecastResult(result *core.SchedResultItemList) interface{} {
 
 	items := make([]*core.SchedResultItem, 0)
 	for _, item := range result.Data {
-		hostType := item.Candidater.Get("HostType")
+		hostType := item.Candidater.Getter().HostType()
 		if result.Unit.SchedData().Hypervisor == hostType {
 			items = append(items, item)
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复裸金属服务器 forecast 接口失效

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0