### PR TITLE
避免eip未找到时,未设置server状态为fail

### DIFF
--- a/pkg/compute/tasks/eip_associate_task.go
+++ b/pkg/compute/tasks/eip_associate_task.go
@@ -44,23 +44,23 @@ func (self *EipAssociateTask) TaskFail(ctx context.Context, eip *models.SElastic
 func (self *EipAssociateTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
 	eip := obj.(*models.SElasticip)
 
-	extEip, err := eip.GetIEip()
-	if err != nil {
-		msg := fmt.Sprintf("fail to find iEIP for eip %s", err)
+	instanceId, _ := self.Params.GetString("instance_id")
+	server := models.GuestManager.FetchGuestById(instanceId)
+
+	if server == nil {
+		msg := fmt.Sprintf("fail to find server for instanceId %s", instanceId)
 		self.TaskFail(ctx, eip, msg, nil)
 		return
 	}
-
-	instanceId, _ := self.Params.GetString("instance_id")
-	server := models.GuestManager.FetchGuestById(instanceId)
 
 	if server.Status != models.VM_ASSOCIATE_EIP {
 		server.SetStatus(self.UserCred, models.VM_ASSOCIATE_EIP, "associate eip")
 	}
 
-	if server == nil {
-		msg := fmt.Sprintf("fail to find server for instanceId %s", instanceId)
-		self.TaskFail(ctx, eip, msg, nil)
+	extEip, err := eip.GetIEip()
+	if err != nil {
+		msg := fmt.Sprintf("fail to find iEIP for eip %s", err)
+		self.TaskFail(ctx, eip, msg, server)
 		return
 	}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免eip未找到时,未设置server状态为fail

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0

