### PR TITLE
 为 climc 增加 update-perform --cmp-only 选项，只升级计算节点

### DIFF
--- a/cmd/climc/shell/updates.go
+++ b/cmd/climc/shell/updates.go
@@ -15,6 +15,7 @@
 package shell
 
 import (
+	"fmt"
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -41,13 +42,21 @@ func init() {
 	})
 
 	type SUpdatePerformOptions struct {
-		Cmp bool `help:"update all the compute nodes automatically"`
+		Cmp     bool `help:"update Controller And all the Compute nodes automatically"`
+		CmpOnly bool `help:"Updates only computes nodes, excluding controller nodes"`
 	}
 
 	R(&SUpdatePerformOptions{}, "update-perform", "Update the Controler", func(s *mcclient.ClientSession, args *SUpdatePerformOptions) error {
 		params := jsonutils.NewDict()
+
+		if args.Cmp && args.CmpOnly {
+			return fmt.Errorf("--cmp and --cmp-only can't go together")
+		}
+
 		if args.Cmp {
 			params.Add(jsonutils.JSONTrue, "cmp")
+		} else if args.CmpOnly {
+			params.Add(jsonutils.JSONTrue, "cmp_only")
 		}
 
 		result, err := modules.Updates.List(s, nil)

--- a/cmd/climc/shell/updates.go
+++ b/cmd/climc/shell/updates.go
@@ -16,6 +16,7 @@ package shell
 
 import (
 	"fmt"
+
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -59,12 +60,12 @@ func init() {
 			params.Add(jsonutils.JSONTrue, "cmp_only")
 		}
 
-		result, err := modules.Updates.List(s, nil)
+		modules.Updates.PerformAction(s, "", "", params)
 
+		result, err := modules.Updates.List(s, nil)
 		if err != nil {
 			return err
 		}
-		modules.Updates.DoUpdate(s, params)
 		printList(result, modules.Updates.GetColumns(s))
 		return nil
 	})


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
为 climc 增加 update-perform --cmd-only 选项，只升级计算节点
**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0