### PR TITLE
lb: 改正预删listener时未预删listener rule

### DIFF
--- a/pkg/compute/models/loadbalancerlisteners.go
+++ b/pkg/compute/models/loadbalancerlisteners.go
@@ -158,7 +158,7 @@ func (man *SLoadbalancerListenerManager) pendingDeleteSubs(ctx context.Context, 
 	subs := []SLoadbalancerListener{}
 	db.FetchModelObjects(man, q, &subs)
 	for _, sub := range subs {
-		sub.DoPendingDelete(ctx, userCred)
+		sub.LBPendingDelete(ctx, userCred)
 	}
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

lb: 改正预删listener时未预删listener rule

**是否需要 backport 到之前的 release 分支**:

- release/2.8.0

与 #370 一起，之后手工往2.7, 2.6 backport