### PR TITLE
fix: server create params isolated device config no vendor and device…

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4235,6 +4235,8 @@ func (self *SGuest) ToIsolatedDevicesConfig() []*api.IsolatedDeviceConfig {
 	for idx, guestIsolatedDevice := range guestIsolatedDevices {
 		devConf := new(api.IsolatedDeviceConfig)
 		devConf.Model = guestIsolatedDevice.Model
+		devConf.Vendor = guestIsolatedDevice.getVendor()
+		devConf.DevType = guestIsolatedDevice.DevType
 		ret[idx] = devConf
 	}
 	return ret


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复获取 server 创建参数时 gpu 没有 vendor 和 device type 信息

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0
/cc @yousong 