### PR TITLE
region: add one random config if user input net config is empty when …

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1009,6 +1009,10 @@ func (manager *SGuestManager) ValidateCreateData(ctx context.Context, userCred m
 		}
 	}
 
+	// HACK: if input networks is empty, add one random network config
+	if len(input.Networks) == 0 {
+		input.Networks = append(input.Networks, &api.NetworkConfig{Exit: false})
+	}
 	netArray := input.Networks
 	for idx := 0; idx < len(netArray); idx += 1 {
 		netConfig, err := parseNetworkInfo(userCred, netArray[idx])


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

如果用户创建虚拟机时没有指定网络，默认添加 random 的网络配置

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
NONE

/cc @swordqiu @yousong 