### PR TITLE
fix: scheduler sku cache stale when region sync sku finished

### DIFF
--- a/cmd/climc/shell/schedulers.go
+++ b/cmd/climc/shell/schedulers.go
@@ -168,4 +168,17 @@ func init() {
 			}
 			return nil
 		})
+
+	type SyncOpt struct {
+		Wait bool `help:"wait sync finish"`
+	}
+	R(&SyncOpt{}, "scheduler-sync-sku", "Sync scheduler SKU cache",
+		func(s *mcclient.ClientSession, args *SyncOpt) error {
+			result, err := modules.SchedManager.SyncSku(s, args.Wait)
+			if err != nil {
+				return err
+			}
+			fmt.Println(result.YAMLString())
+			return nil
+		})
 }

--- a/pkg/compute/models/cloudsync.go
+++ b/pkg/compute/models/cloudsync.go
@@ -29,6 +29,8 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/mcclient/modules"
 )
 
 type SSyncableBaseResource struct {
@@ -563,6 +565,10 @@ func syncZoneSkusFromCloud(ctx context.Context, userCred mcclient.TokenCredentia
 	log.Infof("SyncCloudSkusByRegion for zone %s result: %s", localZone.Name, msg)
 	if result.IsError() {
 		return
+	}
+	s := auth.GetSession(ctx, userCred, "", "")
+	if _, err := modules.SchedManager.SyncSku(s, true); err != nil {
+		log.Errorf("Sync scheduler sku cache error: %v", err)
 	}
 }
 

--- a/pkg/mcclient/modules/mod_scheduler.go
+++ b/pkg/mcclient/modules/mod_scheduler.go
@@ -101,6 +101,13 @@ func (this *SchedulerManager) Cleanup(s *mcclient.ClientSession, params jsonutil
 	return this._post(s, url, params, "")
 }
 
+func (this *SchedulerManager) SyncSku(s *mcclient.ClientSession, wait bool) (jsonutils.JSONObject, error) {
+	params := jsonutils.NewDict()
+	params.Add(jsonutils.NewBool(wait), "wait")
+	url := newSchedURL("sync-sku")
+	return this._post(s, url, params, "")
+}
+
 func (this *SchedulerManager) Kill(s *mcclient.ClientSession, params jsonutils.JSONObject) (jsonutils.JSONObject, error) {
 	return nil, fmt.Errorf("Not impl")
 }

--- a/pkg/scheduler/data_manager/sku/sku.go
+++ b/pkg/scheduler/data_manager/sku/sku.go
@@ -39,6 +39,18 @@ func Start(refreshInterval time.Duration) {
 	skuManager.sync()
 }
 
+func SyncOnce(wait bool) error {
+	if skuManager == nil {
+		return fmt.Errorf("sku manager not init")
+	}
+	if wait {
+		skuManager.syncOnce()
+	} else {
+		go skuManager.syncOnce()
+	}
+	return nil
+}
+
 func GetByZone(instanceType, zoneId string) *ServerSku {
 	return skuManager.GetByZone(instanceType, zoneId)
 }

--- a/pkg/scheduler/handler/handler.go
+++ b/pkg/scheduler/handler/handler.go
@@ -29,6 +29,7 @@ import (
 	computemodels "yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/scheduler/api"
 	"yunion.io/x/onecloud/pkg/scheduler/core"
+	skuman "yunion.io/x/onecloud/pkg/scheduler/data_manager/sku"
 	"yunion.io/x/onecloud/pkg/scheduler/db/models"
 	schedman "yunion.io/x/onecloud/pkg/scheduler/manager"
 )
@@ -77,6 +78,8 @@ func schedulerActionHandler(c *gin.Context) {
 		doHistoryList(c)
 	case "clean-cache":
 		doCleanAllHostCache(c)
+	case "sync-sku":
+		doSyncSku(c)
 	//case "reserved-resources":
 	//doReservedResources(c)
 	default:
@@ -367,6 +370,23 @@ func doCleanAllHostCache(c *gin.Context) {
 	}
 
 	doCleanHostCacheByArgs(c, args)
+}
+
+type SyncSkuArgs struct {
+	Wait bool `json:"wait"`
+}
+
+func doSyncSku(c *gin.Context) {
+	args := new(SyncSkuArgs)
+	if err := c.BindJSON(args); err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+	if err := skuman.SyncOnce(args.Wait); err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+	c.JSON(http.StatusOK, nil)
 }
 
 func doCleanHostCache(c *gin.Context, hostID string) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: region 和 scheduler 两边的 sku 不一致

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @ioito 请帮忙验证下是否解决 openstack 同步后调度失败的问题