### PR TITLE
Websockets 不再拉取 ActionLog 的消息

### DIFF
--- a/pkg/logger/models/actionlog.go
+++ b/pkg/logger/models/actionlog.go
@@ -69,17 +69,19 @@ func (action *SActionlog) CustomizeCreate(ctx context.Context, userCred mcclient
 	return nil
 }
 
-func (manager *SActionlogManager) OnCreateComplete(ctx context.Context, items []db.IModel, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) {
-	actionLog := items[0].(*SActionlog)
-	if IsInActionWhiteList(actionLog.Action) {
-		select {
-		case logQueue <- actionLog:
-			return
-		default:
-			log.Warningf("Log queue full, insert failed, log ignored: %s", actionLog.Action)
-		}
-	}
-}
+// Websockets 不再拉取 ActionLog 的消息，因此注释掉如下代码
+// 可以保留，以便有需求时，再次打开
+// func (manager *SActionlogManager) OnCreateComplete(ctx context.Context, items []db.IModel, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) {
+//	actionLog := items[0].(*SActionlog)
+//	if IsInActionWhiteList(actionLog.Action) {
+//		select {
+//		case logQueue <- actionLog:
+//			return
+//		default:
+//			log.Warningf("Log queue full, insert failed, log ignored: %s", actionLog.Action)
+//		}
+//	}
+// }
 
 func StartNotifyToWebsocketWorker() {
 	go func() {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
Websockets 不再拉取 ActionLog 的消息(ws 仅接收 notification 消息推送)
**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0