### PR TITLE
fix: capability 接口没有考虑 cloudaccount 的禁用情况

### DIFF
--- a/pkg/compute/models/capabilities.go
+++ b/pkg/compute/models/capabilities.go
@@ -72,7 +72,7 @@ func getRegionZoneSubq(region *SCloudregion) *sqlchemy.SSubQuery {
 }
 
 func getHypervisors(region *SCloudregion, zone *SZone) []string {
-	q := HostManager.Query("host_type")
+	q := HostManager.Query("host_type", "manager_id")
 	if region != nil {
 		subq := getRegionZoneSubq(region)
 		q = q.Filter(sqlchemy.In(q.Field("zone_id"), subq))
@@ -92,8 +92,9 @@ func getHypervisors(region *SCloudregion, zone *SZone) []string {
 	hypervisors := make([]string, 0)
 	for rows.Next() {
 		var hostType string
-		rows.Scan(&hostType)
-		if len(hostType) > 0 {
+		var managerId string
+		rows.Scan(&hostType, &managerId)
+		if len(hostType) > 0 && IsProviderAccountEnabled(managerId) {
 			hypervisors = append(hypervisors, HOSTTYPE_HYPERVISOR[hostType])
 		}
 	}
@@ -101,7 +102,7 @@ func getHypervisors(region *SCloudregion, zone *SZone) []string {
 }
 
 func getResourceTypes(region *SCloudregion, zone *SZone) []string {
-	q := HostManager.Query("resource_type")
+	q := HostManager.Query("resource_type", "manager_id")
 	if region != nil {
 		subq := getRegionZoneSubq(region)
 		q = q.Filter(sqlchemy.In(q.Field("zone_id"), subq))
@@ -120,8 +121,9 @@ func getResourceTypes(region *SCloudregion, zone *SZone) []string {
 	resourceTypes := make([]string, 0)
 	for rows.Next() {
 		var resType string
-		rows.Scan(&resType)
-		if len(resType) > 0 {
+		var managerId string
+		rows.Scan(&resType, &managerId)
+		if len(resType) > 0 && IsProviderAccountEnabled(managerId) {
 			resourceTypes = append(resourceTypes, resType)
 		}
 	}

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -600,6 +600,28 @@ func (manager *SCloudproviderManager) FetchCloudproviderById(providerId string) 
 	return providerObj.(*SCloudprovider)
 }
 
+func IsProviderAccountEnabled(providerId string) bool {
+	if len(providerId) == 0 {
+		return true
+	}
+	return CloudproviderManager.IsProviderAccountEnabled(providerId)
+}
+
+func (manager *SCloudproviderManager) IsProviderAccountEnabled(providerId string) bool {
+	providerObj := manager.FetchCloudproviderById(providerId)
+	if providerObj == nil {
+		return false
+	}
+	if !providerObj.Enabled {
+		return false
+	}
+	account := providerObj.GetCloudaccount()
+	if account == nil {
+		return false
+	}
+	return account.Enabled
+}
+
 func (manager *SCloudproviderManager) FetchCloudproviderByIdOrName(providerId string) *SCloudprovider {
 	providerObj, err := manager.FetchByIdOrName(nil, providerId)
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: capability 获取 hypervisor, resource_type 时没有考虑 cloudaccount 被禁用

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @swordqiu @yousong 
/area region