### PR TITLE
fix: cloud account queued sync_status is override as idle

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -1273,6 +1273,10 @@ func (self *SCloudaccount) StartCloudaccountDeleteTask(ctx context.Context, user
 }
 
 func (self *SCloudaccount) getSyncStatus() string {
+	if self.SyncStatus == api.CLOUD_PROVIDER_SYNC_STATUS_QUEUED {
+		return self.SyncStatus
+	}
+
 	cprs := CloudproviderRegionManager.Query().SubQuery()
 	providers := CloudproviderManager.Query().SubQuery()
 

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -3192,7 +3192,7 @@ func (self *SHost) Attach2Network(ctx context.Context, userCred mcclient.TokenCr
 		return err
 	}
 	if len(ipAddr) > 0 && ipAddr != freeIp && requireDesignatedIp {
-		return fmt.Errorf("IP address %s is occupied", ipAddr)
+		return fmt.Errorf("IP address %s is occupied, get %s instead", ipAddr, freeIp)
 	}
 	bn := &SHostnetwork{}
 	bn.BaremetalId = self.Id


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：queued状态的cloudaccount的同步状态会被覆盖为idle状态

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0