### PR TITLE
避免OpenStack不支持安全组部署失败

### DIFF
--- a/pkg/util/openstack/host.go
+++ b/pkg/util/openstack/host.go
@@ -157,7 +157,9 @@ func (host *SHost) CreateVM(desc *cloudprovider.SManagedVMCreateConfig) (cloudpr
 	secgroups := []map[string]string{}
 
 	for _, secgroupId := range desc.ExternalSecgroupIds {
-		secgroups = append(secgroups, map[string]string{"name": secgroupId})
+		if secgroupId != SECGROUP_NOT_SUPPORT {
+			secgroups = append(secgroups, map[string]string{"name": secgroupId})
+		}
 	}
 
 	image, err := host.zone.region.GetImage(desc.ExternalImageId)

--- a/pkg/util/openstack/instance.go
+++ b/pkg/util/openstack/instance.go
@@ -606,6 +606,9 @@ func (region *SRegion) AttachDisk(instanceId string, diskId string) error {
 }
 
 func (instance *SInstance) AssignSecurityGroup(secgroupId string) error {
+	if secgroupId == SECGROUP_NOT_SUPPORT {
+		return fmt.Errorf("Security groups are not supported. Security group components are not installed")
+	}
 	secgroup, err := instance.host.zone.region.GetSecurityGroup(secgroupId)
 	if err != nil {
 		return err
@@ -620,6 +623,10 @@ func (instance *SInstance) AssignSecurityGroup(secgroupId string) error {
 }
 
 func (instance *SInstance) RevokeSecurityGroup(secgroupId string) error {
+	// 若OpenStack不支持安全组，则忽略解绑安全组
+	if secgroupId == SECGROUP_NOT_SUPPORT {
+		return nil
+	}
 	secgroup, err := instance.host.zone.region.GetSecurityGroup(secgroupId)
 	if err != nil {
 		return err

--- a/pkg/util/openstack/securitygroup.go
+++ b/pkg/util/openstack/securitygroup.go
@@ -30,6 +30,10 @@ import (
 	"yunion.io/x/onecloud/pkg/util/httputils"
 )
 
+const (
+	SECGROUP_NOT_SUPPORT = "openstack_skip_security_group"
+)
+
 type SSecurityGroupRule struct {
 	Direction       string
 	Ethertype       string
@@ -218,6 +222,11 @@ func (region *SRegion) SyncSecurityGroup(secgroupId string, vpcId string, name s
 	if len(secgroupId) == 0 {
 		secgroups, err := region.GetSecurityGroups()
 		if err != nil {
+			// 若返回 cloudprovider.ErrNotFound, 表明不支持安全组或者未安装安全组相关组件
+			if err == cloudprovider.ErrNotFound {
+				return SECGROUP_NOT_SUPPORT, nil
+			}
+			log.Errorf("failed to get secgroups: %v", err)
 			return "", err
 		}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免OpenStack不支持安全组部署失败

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0

/cc @yousong @swordqiu 
