### PR TITLE
fix: region statusstandalone resource get status api missing

### DIFF
--- a/pkg/cloudcommon/db/statusstandalone.go
+++ b/pkg/cloudcommon/db/statusstandalone.go
@@ -77,3 +77,13 @@ func (model *SStatusStandaloneResourceBase) PerformStatus(ctx context.Context, u
 func (model *SStatusStandaloneResourceBase) IsInStatus(status ...string) bool {
 	return utils.IsInStringArray(model.Status, status)
 }
+
+func (model *SStatusStandaloneResourceBase) AllowGetDetailsStatus(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {
+	return IsAdminAllowGetSpec(userCred, model, "status")
+}
+
+func (model *SStatusStandaloneResourceBase) GetDetailsStatus(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+	ret := jsonutils.NewDict()
+	ret.Add(jsonutils.NewString(model.Status), "status")
+	return ret, nil
+}

--- a/pkg/cloudcommon/db/virtualresource.go
+++ b/pkg/cloudcommon/db/virtualresource.go
@@ -183,6 +183,10 @@ func (model *SVirtualResourceBase) AllowPerformMetadata(ctx context.Context, use
 	return model.IsOwner(userCred) || IsAdminAllowPerform(userCred, model, "metadata")
 }
 
+func (model *SVirtualResourceBase) AllowGetDetailsStatus(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {
+	return model.IsOwner(userCred) || IsAdminAllowGetSpec(userCred, model, "status")
+}
+
 func (model *SVirtualResourceBase) GetTenantCache(ctx context.Context) (*STenant, error) {
 	// log.Debugf("Get tenant by Id %s", model.ProjectId)
 	return TenantCacheManager.FetchTenantById(ctx, model.ProjectId)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: region status 相关资源缺少 get status  api

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @yousong @swordqiu @zhasm 