### PR TITLE
fix: region usage guest 统计数量包括 host disabled

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -2373,7 +2373,7 @@ func filterGuestByRange(q *sqlchemy.SQuery, rangeObj db.IStandaloneModel, hostTy
 	hosts := HostManager.Query().SubQuery()
 
 	q = q.Join(hosts, sqlchemy.Equals(hosts.Field("id"), q.Field("host_id")))
-	q = q.Filter(sqlchemy.IsTrue(hosts.Field("enabled")))
+	//q = q.Filter(sqlchemy.IsTrue(hosts.Field("enabled")))
 	// q = q.Filter(sqlchemy.Equals(hosts.Field("host_status"), HOST_ONLINE))
 
 	q = AttachUsageQuery(q, hosts, hostTypes, resourceTypes, providers, rangeObj)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

usage 接口统计 guest count 时不忽略 host disable

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @swordqiu 