### PR TITLE
fix: cloud account sync status not accurate

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -715,7 +715,7 @@ func (self *SCloudaccount) getMoreDetails(extra *jsonutils.JSONDict) *jsonutils.
 	}
 	extra.Add(projects, "projects")
 	extra.Set("sync_interval_seconds", jsonutils.NewInt(int64(self.getSyncIntervalSeconds())))
-	extra.Set("sync_status", jsonutils.NewString(self.getSyncStatus()))
+	extra.Set("sync_status2", jsonutils.NewString(self.getSyncStatus()))
 	return extra
 }
 
@@ -1273,10 +1273,6 @@ func (self *SCloudaccount) StartCloudaccountDeleteTask(ctx context.Context, user
 }
 
 func (self *SCloudaccount) getSyncStatus() string {
-	if self.SyncStatus == api.CLOUD_PROVIDER_SYNC_STATUS_QUEUED {
-		return self.SyncStatus
-	}
-
 	cprs := CloudproviderRegionManager.Query().SubQuery()
 	providers := CloudproviderManager.Query().SubQuery()
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：cloud account通过计算getSyncStatus获得的状态不准确，设置为sync_status2字段，不再覆盖sync_status

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0