### PR TITLE
fix: 创建公有云虚拟机保留镜像原密码功能失效

### DIFF
--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -34,7 +34,6 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/billing"
-	"yunion.io/x/onecloud/pkg/util/seclib2"
 )
 
 type SManagedVirtualizedGuestDriver struct {
@@ -226,11 +225,6 @@ func (self *SManagedVirtualizedGuestDriver) GetLinuxDefaultAccount(desc cloudpro
 }
 
 func (self *SManagedVirtualizedGuestDriver) RemoteDeployGuestForCreate(ctx context.Context, userCred mcclient.TokenCredential, guest *models.SGuest, host *models.SHost, desc cloudprovider.SManagedVMCreateConfig) (jsonutils.JSONObject, error) {
-	if len(desc.Password) == 0 {
-		//Azure创建必须要设置密码
-		desc.Password = seclib2.RandomPassword2(12)
-	}
-
 	ihost, _ := host.GetIHost()
 
 	iVM, err := func() (cloudprovider.ICloudVM, error) {

--- a/pkg/util/azure/host.go
+++ b/pkg/util/azure/host.go
@@ -24,6 +24,7 @@ import (
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/util/ansible"
+	"yunion.io/x/onecloud/pkg/util/seclib2"
 )
 
 type SHost struct {
@@ -96,6 +97,12 @@ func (self *SHost) CreateVM(desc *cloudprovider.SManagedVMCreateConfig) (cloudpr
 			return nil, err
 		}
 	}
+
+	if len(desc.Password) == 0 {
+		//Azure创建必须要设置密码
+		desc.Password = seclib2.RandomPassword2(12)
+	}
+
 	vmId, err := self._createVM(desc.Name, desc.ExternalImageId, desc.SysDisk, desc.Cpu, desc.MemoryMB, desc.InstanceType, nic.ID, desc.IpAddr, desc.Description, desc.Password, desc.DataDisks, desc.PublicKey, desc.UserData)
 	if err != nil {
 		self.zone.region.DeleteNetworkInterface(nic.ID)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: 创建公有云虚拟机保留镜像原密码功能失效

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @ioito @swordqiu 