### PR TITLE
fix: 1. force use qcow2 format when creating kvm VM 2. add template lock

### DIFF
--- a/pkg/cloudcommon/notifyclient/notify.go
+++ b/pkg/cloudcommon/notifyclient/notify.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"yunion.io/x/jsonutils"
@@ -36,6 +37,7 @@ import (
 
 var (
 	templatesTable        map[string]*template.Template
+	templatesTableLock    *sync.Mutex
 	notifyClientWorkerMan *appsrv.SWorkerManager
 
 	notifyAdminUsers  []string
@@ -44,6 +46,7 @@ var (
 
 func init() {
 	notifyClientWorkerMan = appsrv.NewWorkerManager("NotifyClientWorkerManager", 1, 50, false)
+	templatesTableLock = &sync.Mutex{}
 	templatesTable = make(map[string]*template.Template)
 }
 
@@ -61,6 +64,9 @@ func getTemplateString(topic string, contType string, channel notify.TNotifyChan
 
 func getTemplate(topic string, contType string, channel notify.TNotifyChannel) (*template.Template, error) {
 	key := fmt.Sprintf("%s.%s.%s", topic, contType, channel)
+	templatesTableLock.Lock()
+	defer templatesTableLock.Unlock()
+
 	if _, ok := templatesTable[key]; !ok {
 		cont, err := getTemplateString(topic, contType, channel)
 		if err != nil {

--- a/pkg/compute/hostdrivers/kvm.go
+++ b/pkg/compute/hostdrivers/kvm.go
@@ -120,7 +120,7 @@ func (self *SKVMHostDriver) CheckAndSetCacheImage(ctx context.Context, host *mod
 	if err != nil {
 		return err
 	}
-	format, _ := params.GetString("format")
+	// format, _ := params.GetString("format")
 	isForce := jsonutils.QueryBoolean(params, "is_force", false)
 	obj, err := models.CachedimageManager.FetchById(imageId)
 	if err != nil {
@@ -142,7 +142,8 @@ func (self *SKVMHostDriver) CheckAndSetCacheImage(ctx context.Context, host *mod
 
 	content := contentStruct{}
 	content.ImageId = imageId
-	content.Format = format
+	// content.Format = format
+	content.Format = "qcow2"
 
 	if srcHostCacheImage != nil {
 		err = srcHostCacheImage.AddDownloadRefcount()

--- a/pkg/hostman/storageman/imagecachemanager_local.go
+++ b/pkg/hostman/storageman/imagecachemanager_local.go
@@ -127,9 +127,7 @@ func (c *SLocalImageCacheManager) PrefetchImageCache(ctx context.Context, data i
 	if err != nil {
 		return nil, err
 	}
-	// format, _ := body.GetString("format")
-	// force qcow2 for KVM
-	format := "qcow2"
+	format, _ := body.GetString("format")
 	srcUrl, _ := body.GetString("src_url")
 
 	if imgCache := c.AcquireImage(ctx, imageId, storageManager.GetZone(),


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：创建kvm虚拟机时强制使用qcow2格式的镜像

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0

/cc zexi
/cc yousong