### PR TITLE
避免一些公有云重装系统后数据未刷新导致任务失败

### DIFF
--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -368,12 +368,15 @@ func (self *SManagedVirtualizedGuestDriver) RemoteDeployGuestForRebuildRoot(ctx 
 			time.Sleep(time.Second * 5)
 			waited += 5
 		} else {
-			if idisks[0].GetGlobalId() != diskId {
-				log.Errorf("system disk id inconsistent %s != %s", idisks[0].GetGlobalId(), diskId)
+			if idisks[0].GetGlobalId() == diskId {
+				break
+			}
+			if waited > maxWaitSecs {
 				return nil, fmt.Errorf("inconsistent sys disk id after rebuild root")
 			}
-
-			break
+			log.Debugf("current system disk id inconsistent %s != %s, try after 5 seconds", idisks[0].GetGlobalId(), diskId)
+			time.Sleep(time.Second * 5)
+			waited += 5
 		}
 	}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免一些公有云重装系统后数据未刷新导致任务失败

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0

/cc @yousong @swordqiu 