### PR TITLE
feature: mcclient spec modules add rpc method

### DIFF
--- a/pkg/hostman/guestman/libvirt.go
+++ b/pkg/hostman/guestman/libvirt.go
@@ -89,7 +89,7 @@ func setAttributeFromLibvirtConfig(
 ) (int, error) {
 	var Matched = true
 	for i, server := range libvirtConfig.Servers {
-		for mac, _ := range server.MacIp {
+		for mac := range server.MacIp {
 			if !IsMacInGuestConfig(guestConfig, mac) {
 				Matched = false
 				break

--- a/pkg/mcclient/modules/mod_specs.go
+++ b/pkg/mcclient/modules/mod_specs.go
@@ -22,6 +22,7 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/utils"
 
+	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 
@@ -62,6 +63,22 @@ func (this *SpecsManager) GetAllSpecs(s *mcclient.ClientSession, params jsonutil
 
 func (this *SpecsManager) GetModelSpecs(s *mcclient.ClientSession, model string, params jsonutils.JSONObject) (jsonutils.JSONObject, error) {
 	url := newSpecURL(model, params)
+	return this._get(s, url, this.Keyword)
+}
+
+func (this *SpecsManager) GetObjects(s *mcclient.ClientSession, params jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+	dict := params.(*jsonutils.JSONDict)
+	model, err := dict.GetString("kind")
+	if err != nil {
+		return nil, httperrors.NewInputParameterError("Not found kind in query: %v", err)
+	}
+	dict.Remove("kind")
+	specKey, err := params.GetString("key")
+	if err != nil {
+		return nil, httperrors.NewInputParameterError("Not found key in query: %v", err)
+	}
+	dict.Remove("key")
+	url := newSpecActionURL(model, specKey, "resource", dict)
 	return this._get(s, url, this.Keyword)
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

specs module 添加 GetObjects 方法，主要是可以作为 rpc 方式调用

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/cc @wanyaoqi 