### PR TITLE
fix: skip quota check in server validateupdatedata if cpu and mem not updated

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -798,9 +798,11 @@ func (self *SGuest) ValidateUpdateData(ctx context.Context, userCred mcclient.To
 		return nil, err
 	}
 
-	err = self.checkUpdateQuota(ctx, userCred, vcpuCount, vmemSize)
-	if err != nil {
-		return nil, httperrors.NewOutOfQuotaError(err.Error())
+	if vcpuCount > 0 || vmemSize > 0 {
+		err = self.checkUpdateQuota(ctx, userCred, vcpuCount, vmemSize)
+		if err != nil {
+			return nil, httperrors.NewOutOfQuotaError(err.Error())
+		}
 	}
 
 	if data.Contains("name") {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：如果没有更新cpu和内存，guest.ValidateUpdateData不需要check quota

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0