### PR TITLE
fix: create backup server panic

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -2569,10 +2569,10 @@ func (self *SGuest) CreateDisksOnHost(
 		}
 		var candidateDisk *schedapi.CandidateDisk
 		var backupCandidateDisk *schedapi.CandidateDisk
-		if candidate != nil && len(candidate.Disks) >= idx {
+		if candidate != nil && len(candidate.Disks) > idx {
 			candidateDisk = candidate.Disks[idx]
 		}
-		if backupCandidate != nil && len(backupCandidate.Disks) >= idx {
+		if backupCandidate != nil && len(backupCandidate.Disks) > idx {
 			backupCandidateDisk = backupCandidate.Disks[idx]
 		}
 		disk, err := self.createDiskOnHost(ctx, userCred, host, diskConfig, pendingUsage, inheritBilling, isWithServerCreate, candidateDisk, backupCandidateDisk)
@@ -2651,7 +2651,7 @@ func (self *SGuest) createDiskOnHost(
 	// TODO: use scheduler candidate storage
 	if len(self.BackupHostId) > 0 {
 		backupHost := HostManager.FetchHostById(self.BackupHostId)
-		backupStorage := self.GetDriver().ChooseHostStorage(backupHost, diskConfig.Backend, backupCandidate.StorageIds)
+		backupStorage := self.ChooseHostStorage(backupHost, diskConfig.Backend, backupCandidate)
 		diff, err := db.Update(disk, func() error {
 			disk.BackupStorageId = backupStorage.Id
 			return nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复 2.8 创建 backup server panic 的问题，master 没有这个问题

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/cc @swordqiu 