### PR TITLE
fix: cloud account/provider missing event logs for delete/enable/disable/change_project

### DIFF
--- a/pkg/cloudcommon/db/enabledstatusstandalone.go
+++ b/pkg/cloudcommon/db/enabledstatusstandalone.go
@@ -21,6 +21,7 @@ import (
 	"yunion.io/x/log"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/util/logclient"
 )
 
 type SEnabledStatusStandaloneResourceBase struct {
@@ -52,6 +53,7 @@ func (self *SEnabledStatusStandaloneResourceBase) PerformEnable(ctx context.Cont
 			return nil, err
 		}
 		OpsLog.LogEvent(self, ACT_ENABLE, "", userCred)
+		logclient.AddSimpleActionLog(self, logclient.ACT_ENABLE, nil, userCred, true)
 	}
 	return nil, nil
 }
@@ -71,6 +73,7 @@ func (self *SEnabledStatusStandaloneResourceBase) PerformDisable(ctx context.Con
 			return nil, err
 		}
 		OpsLog.LogEvent(self, ACT_DISABLE, "", userCred)
+		logclient.AddSimpleActionLog(self, logclient.ACT_DISABLE, nil, userCred, true)
 	}
 	return nil, nil
 }

--- a/pkg/cloudcommon/db/virtualresource.go
+++ b/pkg/cloudcommon/db/virtualresource.go
@@ -269,6 +269,18 @@ func (model *SVirtualResourceBase) PerformChangeOwner(ctx context.Context, userC
 		return nil, err
 	}
 	OpsLog.SyncOwner(model, former, userCred)
+	notes := struct {
+		OldProjectId string
+		OldProject   string
+		NewProjectId string
+		NewProject   string
+	}{
+		OldProjectId: former.Id,
+		OldProject:   former.Name,
+		NewProjectId: tobj.GetId(),
+		NewProject:   tobj.GetName(),
+	}
+	logclient.AddActionLogWithContext(ctx, model, logclient.ACT_CHANGE_OWNER, notes, userCred, true)
 	return nil, nil
 }
 

--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -179,6 +179,10 @@ func (self *SCloudaccount) PerformEnable(ctx context.Context, userCred mcclient.
 }
 
 func (self *SCloudaccount) PerformDisable(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+	_, err := self.SEnabledStatusStandaloneResourceBase.PerformDisable(ctx, userCred, query, data)
+	if err != nil {
+		return nil, err
+	}
 	cloudproviders := self.GetCloudproviders()
 	for i := 0; i < len(cloudproviders); i++ {
 		if cloudproviders[i].Enabled {
@@ -193,10 +197,6 @@ func (self *SCloudaccount) PerformDisable(ctx context.Context, userCred mcclient
 		if err != nil {
 			return nil, err
 		}
-	}
-	_, err := self.SEnabledStatusStandaloneResourceBase.PerformDisable(ctx, userCred, query, data)
-	if err != nil {
-		return nil, err
 	}
 	return nil, nil
 }

--- a/pkg/compute/tasks/cloud_provider_delete_task.go
+++ b/pkg/compute/tasks/cloud_provider_delete_task.go
@@ -23,6 +23,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/compute/models"
+	"yunion.io/x/onecloud/pkg/util/logclient"
 )
 
 type CloudProviderDeleteTask struct {
@@ -42,10 +43,12 @@ func (self *CloudProviderDeleteTask) OnInit(ctx context.Context, obj db.IStandal
 	if err != nil {
 		provider.SetStatus(self.UserCred, api.CLOUD_PROVIDER_DELETE_FAILED, "StartDiskCloudproviderTask")
 		self.SetStageFailed(ctx, err.Error())
+		logclient.AddActionLogWithStartable(self, provider, logclient.ACT_DELETE, err.Error(), self.UserCred, false)
 		return
 	}
 
 	provider.SetStatus(self.UserCred, api.CLOUD_PROVIDER_DELETED, "StartDiskCloudproviderTask")
 
 	self.SetStageComplete(ctx, nil)
+	logclient.AddActionLogWithStartable(self, provider, logclient.ACT_DELETE, nil, self.UserCred, true)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：cloudaccount/provider缺少启用，禁用，删除，更改项目的操作日志

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0

/cc zexi