### PR TITLE
fix: esxi server skus return empty results

### DIFF
--- a/pkg/compute/models/cloudproviderregions.go
+++ b/pkg/compute/models/cloudproviderregions.go
@@ -160,7 +160,7 @@ func (self *SCloudproviderregion) Detach(ctx context.Context, userCred mcclient.
 func (manager *SCloudproviderregionManager) QueryRelatedRegionIds(cloudAccountId string, providerIds ...string) *sqlchemy.SSubQuery {
 	q := manager.Query("cloudregion_id")
 
-	if len(providerIds) > 0  {
+	if len(providerIds) > 0 {
 		q = q.Filter(sqlchemy.In(q.Field("cloudprovider_id"), providerIds))
 	}
 

--- a/pkg/compute/models/skus.go
+++ b/pkg/compute/models/skus.go
@@ -514,7 +514,7 @@ func providerFilter(q *sqlchemy.SQuery, provider string, public_cloud bool) *sql
 	if provider == "all" {
 		// provider 参数为all时。表示查询所有instance type.
 		return q
-	} else if len(provider) > 0 && !utils.IsInStringArray(provider, []string{api.CLOUD_PROVIDER_ONECLOUD, api.CLOUD_PROVIDER_VMWARE, "kvm"}) {
+	} else if len(provider) > 0 && !utils.IsInStringArray(provider, []string{api.CLOUD_PROVIDER_ONECLOUD, api.CLOUD_PROVIDER_VMWARE, "kvm", "esxi"}) {
 		q = q.Equals("provider", provider)
 	} else if public_cloud {
 		q = q.IsNotEmpty("provider")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：serverskus/instance-type当provider=esxi时返回空值

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0

/cc @tb365 @Zexi 