### PR TITLE
fix: cloud-account sync ignore db failure

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -520,6 +520,9 @@ func (self *SCloudaccount) importSubAccount(ctx context.Context, userCred mcclie
 	isNew := false
 	q := CloudproviderManager.Query().Equals("cloudaccount_id", self.Id).Equals("account", subAccount.Account)
 	providerCount := q.Count()
+	if providerCount < 0 {
+		return nil, false, fmt.Errorf("fail to query subaccount")
+	}
 	if providerCount > 1 {
 		log.Errorf("cloudaccount %s has duplicate subaccount with name %s", self.Name, subAccount.Account)
 		return nil, isNew, cloudprovider.ErrDuplicateId


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：cloudaccount同步时忽略了数据库错误，导致import重复的子账号
 
**是否需要 backport 到之前的 release 分支**:
- release/2.8.0