### PR TITLE
fix: automatically purge removed servers on public cloud

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1839,6 +1839,11 @@ func (self *SGuest) syncRemoveCloudVM(ctx context.Context, userCred mcclient.Tok
 		return nil
 	}
 
+	if options.SyncPurgeRemovedResources.Contains(self.Keyword()) {
+		log.Debugf("purge removed resource %s", self.Name)
+		return self.purge(ctx, userCred)
+	}
+
 	if !lostNamePattern.MatchString(self.Name) {
 		db.Update(self, func() error {
 			self.Name = fmt.Sprintf("%s-lost@%s", self.Name, timeutils.ShortDate(time.Now()))

--- a/pkg/compute/options/namesync.go
+++ b/pkg/compute/options/namesync.go
@@ -8,9 +8,14 @@ import (
 
 var (
 	NameSyncResources stringutils2.SSortedStrings
+
+	SyncPurgeRemovedResources stringutils2.SSortedStrings
 )
 
 func InitNameSyncResources() {
 	NameSyncResources = stringutils2.NewSortedStrings(Options.NameSyncResources)
 	log.Infof("NameSyncResources: %s", NameSyncResources)
+
+	SyncPurgeRemovedResources = stringutils2.NewSortedStrings(Options.SyncPurgeRemovedResources)
+	log.Infof("SyncPurgeRemovedResources: %s", SyncPurgeRemovedResources)
 }

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -101,6 +101,8 @@ type ComputeOptions struct {
 
 	NameSyncResources []string `help:"resources that need synchronization of name"`
 
+	SyncPurgeRemovedResources []string `help:"resources that shoud be purged immediately if found removed"`
+
 	DisconnectedCloudAccountRetryProbeIntervalHours int `help:"interval to wait to probe status of a disconnected cloud account" default:"24"`
 
 	SCapabilityOptions


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
增加选项SyncPurgeRemovedResources,当公有云上资源删除后，自动清理相关资源

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0