### PR TITLE
避免qcloud password和keypair冲突

### DIFF
--- a/pkg/util/qcloud/instance.go
+++ b/pkg/util/qcloud/instance.go
@@ -683,14 +683,16 @@ func (self *SRegion) ReplaceSystemDisk(instanceId string, imageId string, passwd
 	params["ImageId"] = imageId
 	params["EnhancedService.SecurityService.Enabled"] = "TRUE"
 	params["EnhancedService.MonitorService.Enabled"] = "TRUE"
-	if len(passwd) > 0 {
+
+	// 秘钥和密码及保留镜像设置只能选其一
+	if len(keypairName) > 0 {
+		params["LoginSettings.KeyIds.0"] = keypairName
+	} else if len(passwd) > 0 {
 		params["LoginSettings.Password"] = passwd
 	} else {
 		params["LoginSettings.KeepImageLogin"] = "TRUE"
 	}
-	if len(keypairName) > 0 {
-		params["LoginSettings.KeyIds.0"] = keypairName
-	}
+
 	if sysDiskSizeGB > 0 {
 		params["SystemDisk.DiskSize"] = fmt.Sprintf("%d", sysDiskSizeGB)
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免qcloud password和keypair冲突

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.7.0
- release/2.6.0

/cc @yousong 