### PR TITLE
bugfix: fix query networks not set model manager

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1697,7 +1697,7 @@ func (self *SNetwork) PerformSplit(ctx context.Context, userCred mcclient.TokenC
 	})
 
 	guestnetworks := make([]SGuestnetwork, 0)
-	err = GuestnetworkManager.Query().Equals("network_id", self.Id).All(&guestnetworks)
+	err = db.FetchModelObjects(GuestnetworkManager, GuestnetworkManager.Query().Equals("network_id", self.Id), &guestnetworks)
 	if err != nil {
 		logclient.AddActionLogWithContext(ctx, self, logclient.ACT_SPLIT, err.Error(), userCred, false)
 		return nil, err
@@ -1716,7 +1716,7 @@ func (self *SNetwork) PerformSplit(ctx context.Context, userCred mcclient.TokenC
 	}
 
 	hostnetworks := make([]SHostnetwork, 0)
-	err = HostnetworkManager.Query().Equals("network_id", self.Id).All(&hostnetworks)
+	err = db.FetchModelObjects(HostnetworkManager, HostnetworkManager.Query().Equals("network_id", self.Id), &hostnetworks)
 	if err != nil {
 		logclient.AddActionLogWithContext(ctx, self, logclient.ACT_SPLIT, err.Error(), userCred, false)
 		return nil, err
@@ -1735,7 +1735,7 @@ func (self *SNetwork) PerformSplit(ctx context.Context, userCred mcclient.TokenC
 	}
 
 	reservedips := make([]SReservedip, 0)
-	err = ReservedipManager.Query().Equals("network_id", self.Id).All(&reservedips)
+	err = db.FetchModelObjects(ReservedipManager, ReservedipManager.Query().Equals("network_id", self.Id), &reservedips)
 	if err != nil {
 		logclient.AddActionLogWithContext(ctx, self, logclient.ACT_SPLIT, err.Error(), userCred, false)
 		return nil, err
@@ -1754,7 +1754,8 @@ func (self *SNetwork) PerformSplit(ctx context.Context, userCred mcclient.TokenC
 	}
 
 	groupnetworks := make([]SGroupnetwork, 0)
-	err = GroupnetworkManager.Query().Equals("network_id", self.Id).All(&groupnetworks)
+	err = db.FetchModelObjects(
+		GroupnetworkManager, GroupnetworkManager.Query().Equals("network_id", self.Id), &groupnetworks)
 	if err != nil {
 		logclient.AddActionLogWithContext(ctx, self, logclient.ACT_SPLIT, err.Error(), userCred, false)
 		return nil, err


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix query networks not set model manager on network split and merge
**是否需要 backport 到之前的 release 分支**:
release/2.8.0

/cc @yousong @swordqiu 
