### PR TITLE
fix: domain-config-update rpc method panic

### DIFF
--- a/pkg/mcclient/modules/mod_domains.go
+++ b/pkg/mcclient/modules/mod_domains.go
@@ -168,6 +168,9 @@ func (this *DomainManager) DoDomainConfigUpdate(s *mcclient.ClientSession, domai
 
 	config := jsonutils.NewDict()
 	_config, _ := params.Get("config")
+	if _config == nil {
+		_config = jsonutils.NewDict()
+	}
 	_driver, _ := _config.GetString("identity", "driver")
 
 	if _driver == "ldap" {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: 调用 DoDomainConfigUpdate 会 panic

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.9.0
- release/2.8.0

/cc @yousong @swordqiu 