### PR TITLE
Bugfix/ningyu meteralert project support

### DIFF
--- a/cmd/climc/shell/meteralert.go
+++ b/cmd/climc/shell/meteralert.go
@@ -28,32 +28,23 @@ func init() {
 	 * 创建一条报警规则
 	 */
 	type MeterAlertCreateOptions struct {
-		TYPE       string  `help:"Alert rule type" choices:"balance|resFee|monthFee"`
-		THRESHOLD  float64 `help:"Threshold value of the metric"`
-		COMPARATOR string  `help:"Comparison operator for join expressions" choices:">|<|>=|<=|=|!="`
-		RECIPIENTS string  `help:"Comma separated recipient ID"`
-		LEVEL      string  `help:"Alert level" choices:"normal|important|fatal"`
-		CHANNEL    string  `help:"Ways to send an alarm" choices:"email|mobile"`
+		Type       string  `help:"Alert rule type" required:"true" choices:"balance|resFee|monthFee"`
+		Threshold  float64 `help:"Threshold value of the metric" required:"true"`
+		Comparator string  `help:"Comparison operator for join expressions" required:"true" choices:">|<|>=|<=|=|!="`
+		Recipients string  `help:"Comma separated recipient ID" required:"true"`
+		Level      string  `help:"Alert level" required:"true" choices:"normal|important|fatal"`
+		Channel    string  `help:"Ways to send an alarm" required:"true" choices:"email|mobile"`
 		Provider   string  `help:"Name of the cloud platform"`
 		AccountId  string  `help:"ID of the cloud platform"`
+		ProjectId  string  `help:"ID of the project" required:"true"`
 	}
 	R(&MeterAlertCreateOptions{}, "meteralert-create", "Create a meter alert rule", func(s *mcclient.ClientSession, args *MeterAlertCreateOptions) error {
-		params := jsonutils.NewDict()
-		params.Add(jsonutils.NewString(args.TYPE), "type")
-		params.Add(jsonutils.NewFloat(args.THRESHOLD), "threshold")
-		params.Add(jsonutils.NewString(args.COMPARATOR), "comparator")
-		params.Add(jsonutils.NewString(args.RECIPIENTS), "recipients")
-		params.Add(jsonutils.NewString(args.LEVEL), "level")
-		params.Add(jsonutils.NewString(args.CHANNEL), "channel")
-		if len(args.Provider) > 0 {
-			params.Add(jsonutils.NewString(args.Provider), "provider")
-		}
-		if len(args.AccountId) > 0 {
-			params.Add(jsonutils.NewString(args.AccountId), "account_id")
+		params, err := options.StructToParams(args)
+		if err != nil {
+			return err
 		}
 
 		rst, err := modules.MeterAlert.Create(s, params)
-
 		if err != nil {
 			return err
 		}
@@ -103,27 +94,15 @@ func init() {
 		Type          string `help:"Alarm rule type" choices:"balance|resFee|monthFee"`
 		CloudProvider string `help:"Name of cloud provider, case sensitive"`
 		AccountId     string `help:"Cloud account ID"`
+		ProjectId     string `help:"ID of the project" required:"true"`
 		options.BaseListOptions
 	}
 	R(&MeterAlertListOptions{}, "meteralert-list", "List meter alert", func(s *mcclient.ClientSession, args *MeterAlertListOptions) error {
-		var params *jsonutils.JSONDict
-		{
-			var err error
-			params, err = args.BaseListOptions.Params()
-			if err != nil {
-				return err
-
-			}
-			if len(args.Type) > 0 {
-				params.Add(jsonutils.NewString(args.Type), "type")
-			}
-			if len(args.CloudProvider) > 0 {
-				params.Add(jsonutils.NewString(args.CloudProvider), "provider")
-			}
-			if len(args.AccountId) > 0 {
-				params.Add(jsonutils.NewString(args.AccountId), "account_id")
-			}
+		params, err := options.ListStructToParams(args)
+		if err != nil {
+			return err
 		}
+
 		result, err := modules.MeterAlert.List(s, params)
 		if err != nil {
 			return err


### PR DESCRIPTION
**余额/消费报警引入了项目归属的概念，在创建、列出规则时都需要指定是哪个项目**:

/cherrypick release/2.8.0
/cherrypick release/2.9.0

/cc @yousong 
/cc @Zexi 
/cc @swordqiu 