### PR TITLE
fix: baremetal server create params not override disks

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4170,13 +4170,15 @@ func (self *SGuest) ToCreateInput(userCred mcclient.TokenCredential) *api.Server
 	if err != nil {
 		return genInput
 	}
-	// fill missing create params like schedtags
-	for idx, disk := range genInput.Disks {
-		if idx < len(userInput.Disks) {
-			disk.Schedtags = userInput.Disks[idx].Schedtags
-			userInput.Disks[idx] = disk
-		} else {
-			userInput.Disks = append(userInput.Disks, disk)
+	if self.GetHypervisor() != api.HYPERVISOR_BAREMETAL {
+		// fill missing create params like schedtags
+		for idx, disk := range genInput.Disks {
+			if idx < len(userInput.Disks) {
+				disk.Schedtags = userInput.Disks[idx].Schedtags
+				userInput.Disks[idx] = disk
+			} else {
+				userInput.Disks = append(userInput.Disks, disk)
+			}
 		}
 	}
 	for idx, net := range genInput.Networks {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

baremetal server create-params 不覆盖 disk

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.9.0
- release/2.8.0

/cc @wanyaoqi 