### PR TITLE
fix: validate baremetal raid config

### DIFF
--- a/pkg/compute/baremetal/diskconfig_test.go
+++ b/pkg/compute/baremetal/diskconfig_test.go
@@ -1076,3 +1076,59 @@ func TestGetDiskSpecs(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateDiskConfigs(t *testing.T) {
+	tests := []struct {
+		name    string
+		confs   []*api.BaremetalDiskConfig
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			confs:   []*api.BaremetalDiskConfig{},
+			wantErr: false,
+		},
+		{
+			name: "none_raid",
+			confs: []*api.BaremetalDiskConfig{
+				{Conf: DISK_CONF_NONE},
+				{Conf: DISK_CONF_RAID0},
+			},
+			wantErr: true,
+		},
+		{
+			name: "raid_none_raid",
+			confs: []*api.BaremetalDiskConfig{
+				{Conf: DISK_CONF_RAID0},
+				{Conf: DISK_CONF_NONE},
+				{Conf: DISK_CONF_RAID5},
+			},
+			wantErr: true,
+		},
+		{
+			name: "nones",
+			confs: []*api.BaremetalDiskConfig{
+				{Conf: DISK_CONF_NONE},
+				{Conf: DISK_CONF_NONE},
+			},
+			wantErr: false,
+		},
+		{
+			name: "raids_nones",
+			confs: []*api.BaremetalDiskConfig{
+				{Conf: DISK_CONF_RAID0},
+				{Conf: DISK_CONF_RAID5},
+				{Conf: DISK_CONF_NONE},
+				{Conf: DISK_CONF_NONE},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateDiskConfigs(tt.confs); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateDiskConfigs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/compute/guestdrivers/baremetals.go
+++ b/pkg/compute/guestdrivers/baremetals.go
@@ -312,23 +312,11 @@ func (self *SBaremetalGuestDriver) StartGuestSyncstatusTask(guest *models.SGuest
 }
 
 func (self *SBaremetalGuestDriver) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential, input *api.ServerCreateInput) (*api.ServerCreateInput, error) {
-	/*var confs = make([]api.BaremetalDiskConfig, 0)*/
-	//jsonArray := jsonutils.GetArrayOfPrefix(data, "baremetal_disk_config")
-	//for i := 0; i < len(jsonArray); i += 1 {
-	//// for data.Contains(fmt.Sprintf("baremetal_disk_config.%d", len(confs))) {
-	//desc, _ := jsonArray[i].GetString() // data.GetString(fmt.Sprintf("baremetal_disk_config.%d", len(confs)))
-	//data.Remove(fmt.Sprintf("baremetal_disk_config.%d", i))
-	//bmConf, err := baremetal.ParseDiskConfig(desc)
-	//if err != nil {
-	//return nil, httperrors.NewInputParameterError("baremetal_disk_config.%d", i)
-	//}
-	//confs = append(confs, bmConf)
-	//}
-	//if len(confs) == 0 {
-	//bmConf, _ := baremetal.ParseDiskConfig("")
-	//confs = append(confs, bmConf)
-	//}
-	/*data.Set("baremetal_disk_config", jsonutils.Marshal(confs))*/
+	if len(input.BaremetalDiskConfigs) != 0 {
+		if err := baremetal.ValidateDiskConfigs(input.BaremetalDiskConfigs); err != nil {
+			return nil, httperrors.NewInputParameterError("Invalid raid config: %v", err)
+		}
+	}
 	if len(input.Disks) <= 0 {
 		return nil, httperrors.NewInputParameterError("Root disk must be present")
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

创建 baremetal server 时检验 baremetal_disks_configs 的合法性

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.9.0
- release/2.8.0

/cc @swordqiu 