### PR TITLE
fix: prepaid recycle host not check storage types

### DIFF
--- a/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
@@ -72,13 +72,16 @@ func (p *DiskSchedtagPredicate) GetResources(c core.Candidater) []ISchedtagCandi
 	return ret
 }
 
-func (p *DiskSchedtagPredicate) IsResourceFitInput(u *core.Unit, res ISchedtagCandidateResource, input ISchedtagCustomer) error {
+func (p *DiskSchedtagPredicate) IsResourceFitInput(u *core.Unit, c core.Candidater, res ISchedtagCandidateResource, input ISchedtagCustomer) error {
 	storage := res.(*api.CandidateStorage)
 	d := input.(*diskW)
 	if d.Storage != "" {
 		if storage.Id != d.Storage && storage.Name != d.Storage {
 			return fmt.Errorf("Storage name %s != (%s:%s)", d.Storage, storage.Name, storage.Id)
 		}
+	}
+	if c.Getter().ResourceType() == computeapi.HostResourceTypePrepaidRecycle {
+		return nil
 	}
 	if !(len(d.Backend) == 0 || d.Backend == computeapi.STORAGE_LOCAL) {
 		if storage.StorageType != d.Backend {

--- a/pkg/scheduler/algorithm/predicates/network_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/network_schedtag_predicate.go
@@ -59,7 +59,7 @@ func (p *NetworkSchedtagPredicate) GetResources(c core.Candidater) []ISchedtagCa
 	return ret
 }
 
-func (p *NetworkSchedtagPredicate) IsResourceFitInput(u *core.Unit, res ISchedtagCandidateResource, input ISchedtagCustomer) error {
+func (p *NetworkSchedtagPredicate) IsResourceFitInput(u *core.Unit, _ core.Candidater, res ISchedtagCandidateResource, input ISchedtagCustomer) error {
 	network := res.(*api.CandidateNetwork)
 	net := input.(*netW)
 	if net.Network != "" {

--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -237,7 +237,7 @@ type ISchedtagPredicateInstance interface {
 
 	GetInputs(u *core.Unit) []ISchedtagCustomer
 	GetResources(c core.Candidater) []ISchedtagCandidateResource
-	IsResourceFitInput(unit *core.Unit, res ISchedtagCandidateResource, input ISchedtagCustomer) error
+	IsResourceFitInput(unit *core.Unit, c core.Candidater, res ISchedtagCandidateResource, input ISchedtagCustomer) error
 
 	DoSelect(c core.Candidater, input ISchedtagCustomer, res []ISchedtagCandidateResource) []ISchedtagCandidateResource
 	AddSelectResult(index int, selectRes []ISchedtagCandidateResource, output *core.AllocatedResource)
@@ -392,7 +392,7 @@ func (p *BaseSchedtagPredicate) Execute(
 		fitResources := make([]ISchedtagCandidateResource, 0)
 		errs := make([]error, 0)
 		for _, res := range resources {
-			if err := sp.IsResourceFitInput(u, res, input); err == nil {
+			if err := sp.IsResourceFitInput(u, c, res, input); err == nil {
 				fitResources = append(fitResources, res)
 			} else {
 				errs = append(errs, err)
@@ -408,7 +408,6 @@ func (p *BaseSchedtagPredicate) Execute(
 
 		matchedResources, err := p.checkResources(input, fitResources, u, c)
 		if err != nil {
-			log.Errorf("=========err: %v, filterErrs: %v", err, filterErrs)
 			aggErr := errors.NewAggregate(filterErrs)
 			errMsg := fmt.Sprintf("schedtag: %v", err.Error())
 			if aggErr != nil {

--- a/pkg/scheduler/cache/candidate/base.go
+++ b/pkg/scheduler/cache/candidate/base.go
@@ -87,6 +87,10 @@ func (b baseHostGetter) Networks() []*api.CandidateNetwork {
 	return b.h.Networks
 }
 
+func (b baseHostGetter) ResourceType() string {
+	return reviseResourceType(b.h.ResourceType)
+}
+
 func reviseResourceType(resType string) string {
 	if resType == "" {
 		return computeapi.HostResourceTypeDefault

--- a/pkg/scheduler/core/types.go
+++ b/pkg/scheduler/core/types.go
@@ -60,6 +60,7 @@ type CandidatePropertyGetter interface {
 	HostSchedtags() []computemodels.SSchedtag
 	Storages() []*api.CandidateStorage
 	Networks() []*api.CandidateNetwork
+	ResourceType() string
 }
 
 // Candidater replace host Candidate resource info


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: prepaid recycle host 调度时不校验　storage_type

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.9.0
- release/2.8.0

/cc @swordqiu 
/area scheduler