### PR TITLE
避免同步时删除vpc失败,导致不同步vpc底下资源

### DIFF
--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -317,7 +317,7 @@ func (self *SVpc) syncRemoveCloudVpc(ctx context.Context, userCred mcclient.Toke
 	err := self.ValidateDeleteCondition(ctx)
 	if err != nil { // cannot delete
 		self.markAllNetworksUnknown(userCred)
-		_, err := self.PerformDisable(ctx, userCred, nil, nil)
+		_, err = self.PerformDisable(ctx, userCred, nil, nil)
 		if err == nil {
 			err = self.SetStatus(userCred, api.VPC_STATUS_UNKNOWN, "sync to delete")
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免同步时删除vpc失败,导致不同步vpc底下资源

**是否需要 backport 到之前的 release 分支**:
- release/2.9.0
- release/2.8.0
- release/2.7.0

/cc @swordqiu 