### PR TITLE
baremetal schedule net bonding check

### DIFF
--- a/pkg/scheduler/algorithm/predicates/baremetal/net_bonding_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/baremetal/net_bonding_predicate.go
@@ -1,0 +1,90 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package baremetal
+
+import (
+	"fmt"
+
+	"yunion.io/x/onecloud/pkg/scheduler/algorithm/predicates"
+	"yunion.io/x/onecloud/pkg/scheduler/core"
+)
+
+type NetBondingPredicate struct {
+	BasePredicate
+}
+
+func (p *NetBondingPredicate) Name() string {
+	return "net_bonding"
+}
+
+func (p *NetBondingPredicate) Clone() core.FitPredicate {
+	return &NetBondingPredicate{}
+}
+
+func (p *NetBondingPredicate) PreExecute(u *core.Unit, _ []core.Candidater) (bool, error) {
+	netConfs := u.SchedData().Networks
+	requireTeaming := false
+	for _, conf := range netConfs {
+		if conf.RequireTeaming {
+			requireTeaming = true
+			break
+		}
+	}
+	if requireTeaming {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (p *NetBondingPredicate) Execute(u *core.Unit, c core.Candidater) (bool, []core.PredicateFailureReason, error) {
+	h := predicates.NewPredicateHelper(p, u, c)
+	wireNetIfs := c.Getter().NetInterfaces()
+	netConfs := u.SchedData().Networks
+
+	bondingCount := make(map[string]int)
+
+	for _, netConf := range netConfs {
+		if !netConf.RequireTeaming {
+			continue
+		}
+		count := 0
+		if _, ok := bondingCount[netConf.Wire]; ok {
+			count = bondingCount[netConf.Wire]
+		}
+		bondingCount[netConf.Wire] = count + 2
+	}
+	for wireId, count := range bondingCount {
+		if len(wireId) > 0 {
+			ifCount := len(wireNetIfs[wireId])
+			if ifCount < count {
+				h.Exclude(fmt.Sprintf("Wire %s has %d netifs, require %d, can't do bonding", wireId, ifCount, count))
+				return h.GetResult()
+			}
+		} else {
+			maxIfCount := 0
+			for _, netIfs := range wireNetIfs {
+				ifCount := len(netIfs)
+				if ifCount > maxIfCount {
+					maxIfCount = ifCount
+				}
+				if ifCount >= count {
+					return h.GetResult()
+				}
+			}
+			h.Exclude(fmt.Sprintf("Not enough netifs for bonding, require %d netifs, max count %d", count, maxIfCount))
+		}
+	}
+	return h.GetResult()
+}

--- a/pkg/scheduler/algorithmprovider/baremetal.go
+++ b/pkg/scheduler/algorithmprovider/baremetal.go
@@ -38,5 +38,6 @@ func baremetalPredicates() sets.String {
 		factory.RegisterFitPredicate("g-BaremetalResourceTypeFilter", &predicates.ResourceTypePredicate{}),
 		factory.RegisterFitPredicate("h-DiskschedtagFilter", &predicates.DiskSchedtagPredicate{}),
 		factory.RegisterFitPredicate("i-NetschedtagFilter", &predicates.NetworkSchedtagPredicate{}),
+		factory.RegisterFitPredicate("k-NetBondingFilter", &predicatebm.NetBondingPredicate{}),
 	)
 }

--- a/pkg/scheduler/cache/candidate/baremetals.go
+++ b/pkg/scheduler/cache/candidate/baremetals.go
@@ -285,10 +285,6 @@ func (bb *BaremetalBuilder) fillServerID(desc *BaremetalDesc, b *models.Host) er
 	return nil
 }
 
-func (bb *BaremetalBuilder) fillNetworks(desc *BaremetalDesc, b *models.Host) error {
-	return desc.fillNetworks(b.ID)
-}
-
 func (b *BaremetalBuilder) getZoneID(bm *models.Host) string {
 	return bm.ZoneID
 }

--- a/pkg/scheduler/core/types.go
+++ b/pkg/scheduler/core/types.go
@@ -61,6 +61,7 @@ type CandidatePropertyGetter interface {
 	Storages() []*api.CandidateStorage
 	Networks() []*api.CandidateNetwork
 	ResourceType() string
+	NetInterfaces() map[string][]computemodels.SNetInterface
 }
 
 // Candidater replace host Candidate resource info


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

调度 baremetal server 时添加对 bonding 的检查

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.9.0
- release/2.8.0

/area scheduler
/cc @swordqiu 