### PR TITLE
Azure: 修复虚拟机时未设置keypair路径

### DIFF
--- a/pkg/util/azure/host.go
+++ b/pkg/util/azure/host.go
@@ -182,12 +182,15 @@ func (self *SHost) _createVM(desc *cloudprovider.SManagedVMCreateConfig, nicId s
 		},
 		Type: "Microsoft.Compute/virtualMachines",
 	}
-	if len(desc.PublicKey) > 0 {
+	if len(desc.PublicKey) > 0 && desc.OsType == osprofile.OS_TYPE_LINUX {
 		instance.Properties.OsProfile.LinuxConfiguration = &LinuxConfiguration{
 			DisablePasswordAuthentication: false,
 			SSH: &SSHConfiguration{
 				PublicKeys: []SSHPublicKey{
-					{KeyData: desc.PublicKey},
+					{
+						KeyData: desc.PublicKey,
+						Path:    fmt.Sprintf("/home/%s/.ssh/authorized_keys", api.VM_AZURE_DEFAULT_LOGIN_USER),
+					},
 				},
 			},
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
Azure: 修复虚拟机时未设置keypair路径

**是否需要 backport 到之前的 release 分支**:
- release/2.9.0
- release/2.8.0
- release/2.7.0
- release/2.6.0

/cc @swordqiu @yousong 