### PR TITLE
Automated cherry pick of #613: Azure: 修复虚拟机时未设置keypair路径

### DIFF
--- a/pkg/util/azure/host.go
+++ b/pkg/util/azure/host.go
@@ -175,7 +175,7 @@ func (self *SHost) _createVM(desc *cloudprovider.SManagedVMCreateConfig, nicId s
 				PublicKeys: []SSHPublicKey{
 					{
 						KeyData: desc.PublicKey,
-						Path:    fmt.Sprintf("/home/%s/.ssh/authorized_keys", api.VM_AZURE_DEFAULT_LOGIN_USER),
+						Path:    fmt.Sprintf("/home/%s/.ssh/authorized_keys", cloudprovider.VM_AZURE_DEFAULT_LOGIN_USER),
 					},
 				},
 			},

--- a/pkg/util/azure/host.go
+++ b/pkg/util/azure/host.go
@@ -168,12 +168,15 @@ func (self *SHost) _createVM(desc *cloudprovider.SManagedVMCreateConfig, nicId s
 		},
 		Type: "Microsoft.Compute/virtualMachines",
 	}
-	if len(desc.PublicKey) > 0 {
+	if len(desc.PublicKey) > 0 && desc.OsType == osprofile.OS_TYPE_LINUX {
 		instance.Properties.OsProfile.LinuxConfiguration = &LinuxConfiguration{
 			DisablePasswordAuthentication: false,
 			SSH: &SSHConfiguration{
 				PublicKeys: []SSHPublicKey{
-					{KeyData: desc.PublicKey},
+					{
+						KeyData: desc.PublicKey,
+						Path:    fmt.Sprintf("/home/%s/.ssh/authorized_keys", api.VM_AZURE_DEFAULT_LOGIN_USER),
+					},
 				},
 			},
 		}


### PR DESCRIPTION
Cherry pick of #613 on release/2.6.0.

#613: Azure: 修复虚拟机时未设置keypair路径