### PR TITLE
Azure: 修复因系统盘大小导致重装系统失败

### DIFF
--- a/pkg/util/azure/instance.go
+++ b/pkg/util/azure/instance.go
@@ -812,6 +812,13 @@ func (region *SRegion) ReplaceSystemDisk(instance *SInstance, cpu int8, memoryMb
 
 	networkId := nic.Properties.IPConfigurations[0].Properties.Subnet.ID
 	osType := instance.Properties.StorageProfile.OsDisk.OsType
+
+	// https://support.microsoft.com/zh-cn/help/4018933/the-default-size-of-windows-server-images-in-azure-is-changed-from-128
+	// windows默认系统盘是128G, 若重装系统时，系统盘小于128G，则会出现 {"error":{"code":"ResizeDiskError","message":"Disk size reduction is not supported. Current size is 137438953472 bytes, requested size is 33285996544 bytes.","target":"osDisk.diskSizeGB"}} 错误
+	if osType == osprofile.OS_TYPE_WINDOWS && sysSizeGB < 128 {
+		sysSizeGB = 128
+	}
+
 	newInstance, err := region.CreateInstanceSimple(instance.Name+"-1", imageId, osType, cpu, memoryMb, sysSizeGB, storageType, []int{}, networkId, passwd, publicKey)
 	if err != nil {
 		return "", err
@@ -824,6 +831,7 @@ func (region *SRegion) ReplaceSystemDisk(instance *SInstance, cpu int8, memoryMb
 
 	//交换系统盘
 	instance.Properties.StorageProfile.OsDisk.ManagedDisk.ID, newInstance.Properties.StorageProfile.OsDisk.ManagedDisk.ID = newInstance.Properties.StorageProfile.OsDisk.ManagedDisk.ID, instance.Properties.StorageProfile.OsDisk.ManagedDisk.ID
+	instance.Properties.StorageProfile.OsDisk.DiskSizeGB = newInstance.Properties.StorageProfile.OsDisk.DiskSizeGB
 	instance.Properties.StorageProfile.OsDisk.Name = ""
 	instance.Properties.ProvisioningState = ""
 	instance.Properties.InstanceView = nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
Azure: 修复因系统盘大小导致重装系统失败

**是否需要 backport 到之前的 release 分支**:
- release/2.9.0
- release/2.8.0
- release/2.7.0
- release/2.6.0

/cc @swordqiu @yousong 
