### PR TITLE
避免返回不是id not found,导致network一直删除失败

### DIFF
--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -506,7 +506,7 @@ func (self *SVpc) GetIVpc() (cloudprovider.ICloudVpc, error) {
 	ivpc, err := iregion.GetIVpcById(self.ExternalId)
 	if err != nil {
 		log.Errorf("fail to find ivpc by id %s %s", self.ExternalId, err)
-		return nil, fmt.Errorf("fail to find ivpc by id %s", err)
+		return nil, err
 	}
 	return ivpc, nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免返回不是id not found,导致network一直删除失败

**是否需要 backport 到之前的 release 分支**:
- release/2.9.0
- release/2.8.0

/cc @swordqiu @yousong 