### PR TITLE
feature: kvm support enable cloud init when deploy

### DIFF
--- a/pkg/apis/compute/api.go
+++ b/pkg/apis/compute/api.go
@@ -156,6 +156,7 @@ type ServerCreateInput struct {
 	Bios               string          `json:"bios"`
 	Description        string          `json:"description"`
 	BootOrder          string          `json:"boot_order"`
+	EnableCloudInit    bool            `json:"enable_cloud_init"`
 	ResetPassword      *bool           `json:"reset_password"`
 	DisableDelete      *bool           `json:"disable_delete"`
 	ShutdownBehavior   string          `json:"shutdown_behavior"`

--- a/pkg/baremetal/manager.go
+++ b/pkg/baremetal/manager.go
@@ -1459,7 +1459,7 @@ func (s *SBaremetalServer) DoDeploy(term *ssh.Client, data jsonutils.JSONObject,
 	if resetPassword && len(password) == 0 {
 		password = seclib.RandomPassword(12)
 	}
-	deployInfo := guestfs.NewDeployInfo(publicKey, deploys, password, isInit, true, o.Options.LinuxDefaultRootUser, o.Options.WindowsDefaultAdminUser)
+	deployInfo := guestfs.NewDeployInfo(publicKey, deploys, password, isInit, true, o.Options.LinuxDefaultRootUser, o.Options.WindowsDefaultAdminUser, false)
 	return s.deployFs(term, deployInfo)
 }
 

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -2965,6 +2965,7 @@ func (self *SGuest) GetDeployConfigOnHost(ctx context.Context, userCred mcclient
 	// if deployAction == "deploy" {
 	resetPasswd := jsonutils.QueryBoolean(params, "reset_password", true)
 	//}
+	config.Add(jsonutils.NewBool(jsonutils.QueryBoolean(params, "enable_cloud_init", false)), "enable_cloud_init")
 
 	if resetPasswd {
 		config.Add(jsonutils.JSONTrue, "reset_password")

--- a/pkg/hostman/guestfs/core.go
+++ b/pkg/hostman/guestfs/core.go
@@ -34,6 +34,7 @@ type SDeployInfo struct {
 	enableTty               bool
 	defaultRootUser         bool
 	windowsDefaultAdminUser bool
+	enableCloudInit         bool
 }
 
 func NewDeployInfo(
@@ -44,6 +45,7 @@ func NewDeployInfo(
 	enableTty bool,
 	defaultRootUser bool,
 	windowsDefaultAdminUser bool,
+	enableCloudInit bool,
 ) *SDeployInfo {
 	return &SDeployInfo{
 		publicKey:               publicKey,
@@ -53,12 +55,13 @@ func NewDeployInfo(
 		enableTty:               enableTty,
 		defaultRootUser:         defaultRootUser,
 		windowsDefaultAdminUser: windowsDefaultAdminUser,
+		enableCloudInit:         enableCloudInit,
 	}
 }
 
 func (d *SDeployInfo) String() string {
-	return fmt.Sprintf("deplys: %s, password %s, isInit: %v, enableTty: %v, defaultRootUser: %v",
-		d.deploys, d.password, d.isInit, d.enableTty, d.defaultRootUser)
+	return fmt.Sprintf("deplys: %s, password %s, isInit: %v, enableTty: %v, defaultRootUser: %v, enableCloudInit: %v",
+		d.deploys, d.password, d.isInit, d.enableTty, d.defaultRootUser, d.enableCloudInit)
 }
 
 func DetectRootFs(part fsdriver.IDiskPartition) fsdriver.IRootFsDriver {
@@ -179,7 +182,7 @@ func DeployGuestFs(
 		}
 	}
 
-	if err = rootfs.DeployYunionroot(partition, deployInfo.publicKey); err != nil {
+	if err = rootfs.DeployYunionroot(partition, deployInfo.publicKey, deployInfo.isInit, deployInfo.enableCloudInit); err != nil {
 		return nil, fmt.Errorf("DeployYunionroot: %v", err)
 	}
 	if partition.SupportSerialPorts() {

--- a/pkg/hostman/guestfs/fsdriver/base.go
+++ b/pkg/hostman/guestfs/fsdriver/base.go
@@ -81,7 +81,7 @@ func (d *sGuestRootFsDriver) IsFsCaseInsensitive() bool {
 	return false
 }
 
-func (d *sGuestRootFsDriver) DeployYunionroot(rootfs IDiskPartition, pubkeys *sshkeys.SSHKeys) error {
+func (d *sGuestRootFsDriver) DeployYunionroot(rootfs IDiskPartition, pubkeys *sshkeys.SSHKeys, isInit, enableCloudInit bool) error {
 	return nil
 }
 

--- a/pkg/hostman/guestfs/fsdriver/interface.go
+++ b/pkg/hostman/guestfs/fsdriver/interface.go
@@ -64,7 +64,7 @@ type IRootFsDriver interface {
 	GetLoginAccount(IDiskPartition, bool, bool) string
 	DeployPublicKey(IDiskPartition, string, *sshkeys.SSHKeys) error
 	ChangeUserPasswd(part IDiskPartition, account, gid, publicKey, password string) (string, error)
-	DeployYunionroot(IDiskPartition, *sshkeys.SSHKeys) error
+	DeployYunionroot(rootFs IDiskPartition, pubkeys *sshkeys.SSHKeys, isInit bool, enableCloudInit bool) error
 	EnableSerialConsole(IDiskPartition, *jsonutils.JSONDict) error
 	DisableSerialConsole(IDiskPartition) error
 	CommitChanges(IDiskPartition) error

--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -126,9 +126,11 @@ func (l *sLinuxRootFs) DeployPublicKey(rootFs IDiskPartition, selUsr string, pub
 	return DeployAuthorizedKeys(rootFs, usrDir, pubkeys, false)
 }
 
-func (l *sLinuxRootFs) DeployYunionroot(rootFs IDiskPartition, pubkeys *sshkeys.SSHKeys) error {
+func (l *sLinuxRootFs) DeployYunionroot(rootFs IDiskPartition, pubkeys *sshkeys.SSHKeys, isInit, enableCloudInit bool) error {
 	l.DisableSelinux(rootFs)
-	l.DisableCloudinit(rootFs)
+	if !enableCloudInit && isInit {
+		l.DisableCloudinit(rootFs)
+	}
 	var yunionroot = YUNIONROOT_USER
 	if err := rootFs.UserAdd(yunionroot, false); err != nil && !strings.Contains(err.Error(), "already exists") {
 		log.Errorf("UserAdd %s: %v", yunionroot, err)

--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -328,10 +328,11 @@ func (m *SGuestManager) GuestDeploy(ctx context.Context, params interface{}) (js
 		if resetPassword && len(password) == 0 {
 			password = seclib.RandomPassword(12)
 		}
+		enableCloudInit := jsonutils.QueryBoolean(deployParams.Body, "enable_cloud_init", false)
 
 		guestInfo, err := guest.DeployFs(guestfs.NewDeployInfo(
 			publicKey, deploys, password, deployParams.IsInit, false,
-			options.HostOptions.LinuxDefaultRootUser, options.HostOptions.WindowsDefaultAdminUser))
+			options.HostOptions.LinuxDefaultRootUser, options.HostOptions.WindowsDefaultAdminUser, enableCloudInit))
 		if err != nil {
 			log.Errorf("Deploy guest fs error: %s", err)
 			return nil, err

--- a/pkg/mcclient/options/servers.go
+++ b/pkg/mcclient/options/servers.go
@@ -245,6 +245,7 @@ type ServerCreateOptions struct {
 	Bios             string   `help:"BIOS" choices:"BIOS|UEFI"`
 	Desc             string   `help:"Description" metavar:"<DESCRIPTION>" json:"description"`
 	Boot             string   `help:"Boot device" metavar:"<BOOT_DEVICE>" choices:"disk|cdrom" json:"-"`
+	EnableCloudInit  bool     `help:"Enable cloud-init service"`
 	NoAccountInit    *bool    `help:"Not reset account password"`
 	AllowDelete      *bool    `help:"Unlock server to allow deleting" json:"-"`
 	ShutdownBehavior string   `help:"Behavior after VM server shutdown, stop or terminate server" metavar:"<SHUTDOWN_BEHAVIOR>" choices:"stop|terminate"`
@@ -337,6 +338,7 @@ func (opts *ServerCreateOptions) Params() (*computeapi.ServerCreateInput, error)
 		EipBw:              opts.EipBw,
 		EipChargeType:      opts.EipChargeType,
 		Eip:                opts.Eip,
+		EnableCloudInit:    opts.EnableCloudInit,
 	}
 
 	if opts.GenerateName {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

kvm 部署时如果设置 enable_cloud_init 参数，则不会 disable cloud-init 服务

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
NONE

/cc @wanyaoqi @swordqiu 