### PR TITLE
fix: do not directly manage ESXi host that is managed by vcenter

### DIFF
--- a/cmd/esxicli/main.go
+++ b/cmd/esxicli/main.go
@@ -88,7 +88,7 @@ func newClient(options *BaseOptions) (*esxi.SESXiClient, error) {
 		return nil, fmt.Errorf("Missing password")
 	}
 
-	return esxi.NewESXiClient("", "", options.Host, options.Port, options.Account, options.Password)
+	return esxi.NewESXiClient2("", "", options.Host, options.Port, options.Account, options.Password, false)
 }
 
 func main() {

--- a/pkg/util/esxi/host.go
+++ b/pkg/util/esxi/host.go
@@ -605,3 +605,11 @@ func (host *SHost) newLocalStorageCache() (*SDatastoreImageCache, error) {
 		host:      host,
 	}, nil
 }
+
+func (host *SHost) GetManagementServerIp() string {
+	return host.getHostSystem().Summary.ManagementServerIp
+}
+
+func (host *SHost) IsManagedByVCenter() bool {
+	return len(host.getHostSystem().Summary.ManagementServerIp) > 0
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：不直接管理被vcener管理的ESXi宿主机

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.9.0

/area region
/cc @wanyaoqi @yousong 