### PR TITLE
fix: use db.FetchModelObjects to batch Query objects

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -285,7 +285,7 @@ func (self *SDisk) isAttached() (bool, error) {
 func (self *SDisk) GetGuestdisks() []SGuestdisk {
 	guestdisks := make([]SGuestdisk, 0)
 	q := GuestdiskManager.Query().Equals("disk_id", self.Id)
-	err := q.All(&guestdisks)
+	err := db.FetchModelObjects(GuestdiskManager, q, &guestdisks)
 	if err != nil {
 		log.Errorf("%s", err)
 		return nil

--- a/pkg/compute/models/isolated_devices.go
+++ b/pkg/compute/models/isolated_devices.go
@@ -349,7 +349,7 @@ func (manager *SIsolatedDeviceManager) FindUnusedByModels(models []string) ([]SI
 	devs := make([]SIsolatedDevice, 0)
 	q := manager.findUnusedQuery()
 	q = q.In("model", models)
-	err := q.All(&devs)
+	err := db.FetchModelObjects(manager, q, &devs)
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +360,7 @@ func (manager *SIsolatedDeviceManager) FindUnusedGpusOnHost(hostId string) ([]SI
 	devs := make([]SIsolatedDevice, 0)
 	q := manager.UnusedGpuQuery()
 	q = q.Equals("host_id", hostId)
-	err := q.All(&devs)
+	err := db.FetchModelObjects(manager, q, &devs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/skus.go
+++ b/pkg/compute/models/skus.go
@@ -541,7 +541,7 @@ func providerFilter(q *sqlchemy.SQuery, provider string, public_cloud bool) *sql
 	return q
 }
 
-func (self *SServerSkuManager) GetPropertyInstanceSpecs(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+func (manager *SServerSkuManager) GetPropertyInstanceSpecs(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (jsonutils.JSONObject, error) {
 	params := NewInstanceSpecQueryParams(query)
 	if !params.IngoreCache {
 		v := Cache.Get(params.GetCacheKey())
@@ -552,7 +552,7 @@ func (self *SServerSkuManager) GetPropertyInstanceSpecs(ctx context.Context, use
 		}
 	}
 
-	q := self.Query()
+	q := manager.Query()
 	// 未明确指定provider或者public_cloud时，默认查询私有云
 	q = providerFilter(q, params.Provider, params.PublicCloud)
 	q = excludeSkus(q)
@@ -580,7 +580,7 @@ func (self *SServerSkuManager) GetPropertyInstanceSpecs(ctx context.Context, use
 	}
 	q = q.GroupBy(q.Field("cpu_core_count"), q.Field("memory_size_mb"))
 	q = q.Asc(q.Field("cpu_core_count"), q.Field("memory_size_mb"))
-	err := q.All(&skus)
+	err := db.FetchModelObjects(manager, q, &skus)
 	if err != nil {
 		log.Errorf("%s", err)
 		return nil, httperrors.NewBadRequestError("instance specs list query error")
@@ -1149,7 +1149,7 @@ func (manager *SServerSkuManager) FetchAllAvailableSkuIdByZoneId(zoneId string) 
 		sqlchemy.Equals(q.Field("prepaid_status"), api.SkuStatusAvailable),
 		sqlchemy.Equals(q.Field("postpaid_status"), api.SkuStatusAvailable)))
 
-	err := q.All(&skus)
+	err := db.FetchModelObjects(manager, q, &skus)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -933,7 +933,7 @@ func (self *SStorage) GetAllAttachingHosts() []SHost {
 	q = q.Filter(sqlchemy.Equals(hosts.Field("host_status"), api.HOST_ONLINE))
 
 	ret := make([]SHost, 0)
-	err := q.All(&ret)
+	err := db.FetchModelObjects(HostManager, q, &ret)
 	if err != nil {
 		log.Errorf("%s", err)
 		return nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：部分批量model查询未使用db.FetchModelObjects，导致访问modelManager空指针

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.9.0

/area region
/cc @yousong @Zexi 