### PR TITLE
fix: keep order of network interface for baremetal

### DIFF
--- a/pkg/baremetal/tasks/baseprepare.go
+++ b/pkg/baremetal/tasks/baseprepare.go
@@ -262,14 +262,15 @@ func (task *sBaremetalPrepareTask) DoPrepare(cli *ssh.Client) error {
 	if err := task.sendStorageInfo(size); err != nil {
 		log.Errorf("sendStorageInfo error: %v", err)
 	}
-	for i := range nicsInfo {
-		if nicsInfo[i].Mac.String() == adminNic.GetMac().String() {
-			if i != 0 {
-				nicsInfo = append(nicsInfo[i:], nicsInfo[0:i]...)
-			}
-			break
-		}
-	}
+	// XXX do not change nic order anymore
+	// for i := range nicsInfo {
+	// 	if nicsInfo[i].Mac.String() == adminNic.GetMac().String() {
+	// 		if i != 0 {
+	// 			nicsInfo = append(nicsInfo[i:], nicsInfo[0:i]...)
+	// 		}
+	// 		break
+	// 	}
+	// }
 	err = task.removeAllNics()
 	if err != nil {
 		return err

--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -251,7 +251,7 @@ func (l *sLinuxRootFs) DeployNetworkingScripts(rootFs IDiskPartition, nics []jso
 		}
 		var nicRules string
 		for _, nic := range nics {
-			nicRules += `KERNEL=="eth*", SUBSYSTEM=="net", ACTION=="add", `
+			nicRules += `KERNEL=="*", SUBSYSTEM=="net", ACTION=="add", `
 			nicRules += `DRIVERS=="?*", `
 			mac, _ := nic.GetString("mac")
 			nicRules += fmt.Sprintf(`ATTR{address}=="%s", ATTR{type}=="1", `, strings.ToLower(mac))
@@ -279,7 +279,7 @@ func (l *sLinuxRootFs) DeployStandbyNetworkingScripts(rootFs IDiskPartition, nic
 	for _, nic := range nicsStandby {
 		nicType, _ := nic.GetString("nic_type")
 		if !nic.Contains("nic_type") || nicType != "impi" {
-			nicRules += `KERNEL=="eth*", SUBSYSTEM=="net", ACTION=="add", `
+			nicRules += `KERNEL=="*", SUBSYSTEM=="net", ACTION=="add", `
 			nicRules += `DRIVERS=="?*", `
 			mac, _ := nic.GetString("mac")
 			nicRules += fmt.Sprintf(`ATTR{address}=="%s", ATTR{type}=="1", `, strings.ToLower(mac))
@@ -745,18 +745,6 @@ func (r *sRedhatLikeRootFs) DeployHostname(rootFs IDiskPartition, hn, domain str
 	return nil
 }
 
-/*
-   udev_path = '/etc/udev/rules.d/'
-   if self.root_fs.exists(udev_path):
-       nic_rules = ''
-       for nic in nics:
-           nic_rules += 'KERNEL=="eth*", '
-           nic_rules += 'SYSFS{address}=="%s", ' % (nic['mac'].lower())
-           nic_rules += 'NAME="eth%d"\n' % (nic['index'])
-       print nic_rules
-       self.root_fs.file_put_contents(os.path.join(udev_path, '60-net.rules'), nic_rules)
-*/
-
 func (r *sRedhatLikeRootFs) Centos5DeployNetworkingScripts(rootFs IDiskPartition, nics []jsonutils.JSONObject) error {
 	var udevPath = "/etc/udev/rules.d/"
 	if rootFs.Exists(udevPath, false) {
@@ -766,7 +754,7 @@ func (r *sRedhatLikeRootFs) Centos5DeployNetworkingScripts(rootFs IDiskPartition
 			if err := nic.Unmarshal(nicdesc); err != nil {
 				return err
 			}
-			nicRules += `KERNEL=="eth*", `
+			nicRules += `KERNEL=="*", `
 			nicRules += fmt.Sprintf(`SYSFS{address}=="%s", `, strings.ToLower(nicdesc.Mac))
 			nicRules += fmt.Sprintf("NAME=\"eth%d\"\n", nicdesc.Index)
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：baremetal parepare不再调整网卡的顺序，在创建裸金属时，网卡index使用baremetal netinterface的index

**是否需要 backport 到之前的 release 分支**:
- release/2.9.0
- release/2.8.0
- release/2.7.0
- release/2.6.0

/area baremetal
/area region
/cc @Zexi @yousong @wanyaoqi 