### PR TITLE
统一使用const,避免city命名不一致

### DIFF
--- a/pkg/apis/compute/cloudregions_const.go
+++ b/pkg/apis/compute/cloudregions_const.go
@@ -5,4 +5,138 @@ const (
 	CLOUD_REGION_STATUS_OUTOFSERVICE = "outofservice"
 
 	DEFAULT_REGION_ID = "default"
+
+	// 中国
+	CITY_QING_DAO      = "Qingdao"     //青岛
+	CITY_BEI_JING      = "Beijing"     //北京
+	CITY_ZHANG_JIA_KOU = "Zhangjiakou" //张家口
+	CITY_HU_HE_HAO_TE  = "Huhehaote"   //呼和浩特
+	CITY_HANG_ZHOU     = "Hangzhou"    //杭州
+	CITY_SHANG_HAI     = "Shanghai"    //上海
+	CITY_SHEN_ZHEN     = "Shenzhen"    //深圳
+	CITY_HONG_KONG     = "Hongkong"    //香港
+	CITY_NING_XIA      = "Ningxia"     //宁夏
+	CITY_GUANG_ZHOU    = "Guangzhou"   //广州
+	CITY_GUI_YANG      = "Guiyang"     //贵阳
+	CITY_TAIPEI        = "Taipei"      //台北市
+	CITY_KAOHSIUNG     = "Kaohsiung"   //高雄市
+	CITY_CHENG_DU      = "Chengdu"     //成都
+	CITY_CHONG_QING    = "Chongqing"   //重庆
+
+	// 日本
+	CITY_TOKYO = "Tokyo" //东京
+	CITY_OSAKA = "Osaka" //大阪市
+
+	// 新加坡
+	CITY_SINGAPORE = "Singapore" //新加坡
+
+	// 澳大利亚
+	CITY_SYDNEY     = "Sydney"     //悉尼
+	CITY_YARRALUMLA = "Yarralumla" //亚拉伦拉
+	CITY_MELBOURNE  = "Melbourne"  //墨尔本
+
+	// 马来西亚
+	CITY_KUALA_LUMPUR = "Kuala Lumpur" //吉隆坡
+
+	// 印度尼西亚
+	CITY_JAKARTA = "Jakarta" //雅加达
+
+	// 印度
+	CITY_MUMBAI      = "Mumbai"      //孟买
+	CITY_KANCHIPURAM = "Kanchipuram" //甘吉布勒姆
+	CITY_MAHARASHTRA = "Maharashtra" //马哈拉施特拉邦
+
+	// 美国
+	CITY_VIRGINIA      = "Virginia"      //弗吉尼亚
+	CITY_SILICONVALLEY = "Siliconvalley" //硅谷
+	CITY_OHIO          = "Ohio"          //俄亥俄州
+	CITY_N_VIRGINIA    = "N. Virginia"   //北弗吉尼亚
+	CITY_N_CALIFORNIA  = "N. California" //北加州
+	CITY_OREGON        = "Oregon"        //俄勒冈州
+	CITY_LOS_ANGELES   = "Los Angeles"   //洛杉矶
+	CITY_SAN_FRANCISCO = "San Francisco" //旧金山
+	CITY_UTAH          = "Utah"          //犹他州
+	CITY_WASHINGTON    = "Washington"    //华盛顿
+	CITY_TEXAS         = "Texas"         //德克萨斯
+	CITY_CHICAGO       = "Chicago"       //芝加哥
+	CITY_IOWA          = "Iowa"          //爱荷华
+	CITY_US_GOV_WEST   = "us-gov-west"   //???
+
+	// 英国
+	CITY_LONDON      = "London"      //伦敦
+	CITY_HALTON      = "Halton"      //哈尔顿
+	CITY_WEST_SUSSEX = "West Sussex" //西苏塞克斯
+
+	// 阿拉伯联合酋长国
+	CITY_DUBAI = "Dubai" //迪拜
+
+	// 德国
+	CITY_FRANKFURT = "Frankfurt" //法兰克福
+
+	// 韩国
+	CITY_SEOUL = "Seoul" //首尔
+	CITY_BUSAN = "Busan" //釜山
+
+	// 加拿大
+	CITY_CANADA_CENTRAL = "Canada Central" //加拿大中部
+	CITY_QUEBEC         = "Quebec"         //魁北克市
+	CITY_TORONTO        = "Toronto"        //多伦多
+
+	// 爱尔兰
+	CITY_IRELAND = "Ireland" //爱尔兰
+	CITY_DUBLIN  = "Dublin"  //都柏林
+
+	// 法国
+	CITY_PARIS  = "Paris"  //巴黎
+	CITY_ALLIER = "Allier" //阿利埃河
+	CITY_TARN   = "Tarn"   //塔恩
+
+	// 瑞典
+	CITY_STOCKHOLM = "Stockholm" //斯德哥尔摩
+
+	// 巴西
+	CITY_SAO_PAULO = "Sao Paulo" //圣保罗
+
+	// 荷兰
+	CITY_HOLLAND = "Holland" //荷兰
+
+	// 南非
+	CITY_PRETORIA  = "Pretoria"  //比勒陀利亚
+	CITY_CAPE_TOWN = "Cape Town" //开普敦
+
+	// 泰国
+	CITY_BANGKOK = "Bangkok" //曼谷
+
+	// 俄罗斯
+	CITY_MOSCOW = "Moscow" //莫斯科
+
+	// 尼日利亚
+	CITY_LAGOS = "Lagos" //拉哥斯
+
+	// 越南
+	CITY_HO_CHI_MINH = "Ho Chi Minh" //???
+
+	COUNTRY_CODE_CN = "CN" //中国
+	COUNTRY_CODE_JP = "JP" //日本
+	COUNTRY_CODE_SG = "SG" //新加坡
+	COUNTRY_CODE_AU = "AU" //澳大利亚
+	COUNTRY_CODE_MY = "MY" //马来西亚
+	COUNTRY_CODE_ID = "ID" //印度尼西亚
+	COUNTRY_CODE_IN = "IN" //印度
+	COUNTRY_CODE_US = "US" //美国
+	COUNTRY_CODE_GB = "GB" //英国
+	COUNTRY_CODE_AE = "AE" //阿拉伯联合酋长国
+	COUNTRY_CODE_DE = "DE" //德国
+	COUNTRY_CODE_KR = "KR" //韩国
+	COUNTRY_CODE_CA = "CA" //加拿大
+	COUNTRY_CODE_IE = "IE" //爱尔兰
+	COUNTRY_CODE_FR = "FR" //法国
+	COUNTRY_CODE_SE = "SE" //瑞典
+	COUNTRY_CODE_BR = "BR" //巴西
+	COUNTRY_CODE_NL = "NL" //荷兰
+	COUNTRY_CODE_ZA = "ZA" //南非
+	COUNTRY_CODE_TH = "TH" //泰国
+	COUNTRY_CODE_RU = "RU" //俄罗斯
+	COUNTRY_CODE_NG = "NG" //尼日利亚
+	COUNTRY_CODE_VN = "VN" //越南
 )

--- a/pkg/util/aliyun/latitud_and_longitude.go
+++ b/pkg/util/aliyun/latitud_and_longitude.go
@@ -14,26 +14,29 @@
 
 package aliyun
 
-import "yunion.io/x/onecloud/pkg/cloudprovider"
+import (
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+)
 
 var LatitudeAndLongitude = map[string]cloudprovider.SGeographicInfo{
-	"cn-qingdao":     {Latitude: 36.067108, Longitude: 120.382607, City: "Qingdao", CountryCode: "CN"},
-	"cn-beijing":     {Latitude: 39.904202, Longitude: 116.407394, City: "Beijing", CountryCode: "CN"},
-	"cn-zhangjiakou": {Latitude: 40.767544, Longitude: 114.886337, City: "Zhangjiakou", CountryCode: "CN"},
-	"cn-huhehaote":   {Latitude: 40.842358, Longitude: 111.749992, City: "Huhehaote", CountryCode: "CN"},
-	"cn-hangzhou":    {Latitude: 30.274084, Longitude: 120.155067, City: "Hangzhou", CountryCode: "CN"},
-	"cn-shanghai":    {Latitude: 31.230391, Longitude: 121.473701, City: "Shanghai", CountryCode: "CN"},
-	"cn-shenzhen":    {Latitude: 22.543097, Longitude: 114.057861, City: "Shenzhen", CountryCode: "CN"},
-	"cn-hongkong":    {Latitude: 22.396427, Longitude: 114.109497, City: "Hongkong", CountryCode: "CN"},
-	"ap-northeast-1": {Latitude: 35.709026, Longitude: 139.731995, City: "Tokyo", CountryCode: "JP"},
-	"ap-southeast-1": {Latitude: 1.352083, Longitude: 103.819839, City: "Singapore", CountryCode: "SG"},
-	"ap-southeast-2": {Latitude: -33.868820, Longitude: 151.209290, City: "Sydney", CountryCode: "AU"},
-	"ap-southeast-3": {Latitude: 3.139003, Longitude: 101.686852, City: "Kuala Lumpur", CountryCode: "MY"},
-	"ap-southeast-5": {Latitude: -6.175110, Longitude: 106.865036, City: "Jakarta", CountryCode: "ID"},
-	"ap-south-1":     {Latitude: 19.075983, Longitude: 72.877655, City: "Mumbai", CountryCode: "IN"},
-	"us-east-1":      {Latitude: 37.431572, Longitude: -78.656891, City: "Virgina", CountryCode: "US"},
-	"us-west-1":      {Latitude: 37.387474, Longitude: -122.057541, City: "Siliconvalley", CountryCode: "US"},
-	"eu-west-1":      {Latitude: 51.507351, Longitude: -0.127758, City: "London", CountryCode: "GB"},
-	"me-east-1":      {Latitude: 25.204849, Longitude: 55.270782, City: "Dubai", CountryCode: "AE"},
-	"eu-central-1":   {Latitude: 50.110924, Longitude: 8.682127, City: "Frankfurt", CountryCode: "DE"},
+	"cn-qingdao":     {Latitude: 36.067108, Longitude: 120.382607, City: api.CITY_QING_DAO, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-beijing":     {Latitude: 39.904202, Longitude: 116.407394, City: api.CITY_BEI_JING, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-zhangjiakou": {Latitude: 40.767544, Longitude: 114.886337, City: api.CITY_ZHANG_JIA_KOU, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-huhehaote":   {Latitude: 40.842358, Longitude: 111.749992, City: api.CITY_HU_HE_HAO_TE, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-hangzhou":    {Latitude: 30.274084, Longitude: 120.155067, City: api.CITY_HANG_ZHOU, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-shanghai":    {Latitude: 31.230391, Longitude: 121.473701, City: api.CITY_SHANG_HAI, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-shenzhen":    {Latitude: 22.543097, Longitude: 114.057861, City: api.CITY_SHEN_ZHEN, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-hongkong":    {Latitude: 22.396427, Longitude: 114.109497, City: api.CITY_HONG_KONG, CountryCode: api.COUNTRY_CODE_CN},
+	"ap-northeast-1": {Latitude: 35.709026, Longitude: 139.731995, City: api.CITY_TOKYO, CountryCode: api.COUNTRY_CODE_JP},
+	"ap-southeast-1": {Latitude: 1.352083, Longitude: 103.819839, City: api.CITY_SINGAPORE, CountryCode: api.COUNTRY_CODE_SG},
+	"ap-southeast-2": {Latitude: -33.868820, Longitude: 151.209290, City: api.CITY_SYDNEY, CountryCode: api.COUNTRY_CODE_AU},
+	"ap-southeast-3": {Latitude: 3.139003, Longitude: 101.686852, City: api.CITY_KUALA_LUMPUR, CountryCode: api.COUNTRY_CODE_MY},
+	"ap-southeast-5": {Latitude: -6.175110, Longitude: 106.865036, City: api.CITY_JAKARTA, CountryCode: api.COUNTRY_CODE_ID},
+	"ap-south-1":     {Latitude: 19.075983, Longitude: 72.877655, City: api.CITY_MUMBAI, CountryCode: api.COUNTRY_CODE_IN},
+	"us-east-1":      {Latitude: 37.431572, Longitude: -78.656891, City: api.CITY_VIRGINIA, CountryCode: api.COUNTRY_CODE_US},
+	"us-west-1":      {Latitude: 37.387474, Longitude: -122.057541, City: api.CITY_SILICONVALLEY, CountryCode: api.COUNTRY_CODE_US},
+	"eu-west-1":      {Latitude: 51.507351, Longitude: -0.127758, City: api.CITY_LONDON, CountryCode: api.COUNTRY_CODE_GB},
+	"me-east-1":      {Latitude: 25.204849, Longitude: 55.270782, City: api.CITY_DUBAI, CountryCode: api.COUNTRY_CODE_AE},
+	"eu-central-1":   {Latitude: 50.110924, Longitude: 8.682127, City: api.CITY_FRANKFURT, CountryCode: api.COUNTRY_CODE_DE},
 }

--- a/pkg/util/aws/latitude_and_longitude.go
+++ b/pkg/util/aws/latitude_and_longitude.go
@@ -14,29 +14,33 @@
 
 package aws
 
-import "yunion.io/x/onecloud/pkg/cloudprovider"
+import (
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+)
 
 // https://docs.aws.amazon.com/general/latest/gr/rande.html
 
 var LatitudeAndLongitude = map[string]cloudprovider.SGeographicInfo{
-	"us-east-2":      {Latitude: 40.4172871, Longitude: -82.90712300000001, City: "Ohio", CountryCode: "US"},
-	"us-east-1":      {Latitude: 37.4315734, Longitude: -78.6568942, City: "N. Virginia", CountryCode: "US"},
-	"us-west-1":      {Latitude: 38.8375215, Longitude: -120.8958242, City: "N. California", CountryCode: "US"},
-	"us-west-2":      {Latitude: 43.8041334, Longitude: -120.5542012, City: "Oregon", CountryCode: "US"},
-	"ap-south-1":     {Latitude: 19.0759837, Longitude: 72.8776559, City: "Mumbai", CountryCode: "IN"},
-	"ap-northeast-3": {Latitude: 34.6937378, Longitude: 135.5021651, City: "Osaka-Local", CountryCode: "JP"},
-	"ap-northeast-2": {Latitude: 37.566535, Longitude: 126.9779692, City: "Seoul", CountryCode: "KR"},
-	"ap-southeast-1": {Latitude: 1.352083, Longitude: 103.819836, City: "Singapore", CountryCode: "SG"},
-	"ap-southeast-2": {Latitude: -33.8688197, Longitude: 151.2092955, City: "Sydney", CountryCode: "AU"},
-	"ap-northeast-1": {Latitude: 35.7090259, Longitude: 139.7319925, City: "Tokyo", CountryCode: "JP"},
-	"ca-central-1":   {Latitude: 56.130366, Longitude: -106.346771, City: "Central", CountryCode: "CA"},
-	"cn-north-1":     {Latitude: 39.90419989999999, Longitude: 116.4073963, City: "Beijing", CountryCode: "CN"},
-	"cn-northwest-1": {Latitude: 37.198731, Longitude: 106.1580937, City: "Ningxia", CountryCode: "CN"},
-	"eu-central-1":   {Latitude: 50.1109221, Longitude: 8.6821267, City: "Frankfurt", CountryCode: "DE"},
-	"eu-west-1":      {Latitude: 53.41291, Longitude: -8.24389, City: "Ireland", CountryCode: "IE"},
-	"eu-west-2":      {Latitude: 51.5073509, Longitude: -0.1277583, City: "London", CountryCode: "GB"},
-	"eu-west-3":      {Latitude: 48.856614, Longitude: 2.3522219, City: "Paris", CountryCode: "FR"},
-	"eu-north-1":     {Latitude: 59.1946, Longitude: 18.47, City: "Stockholm", CountryCode: "SE"},
-	"sa-east-1":      {Latitude: -23.5505199, Longitude: -46.63330939999999, City: "San Paulo", CountryCode: "BR"},
-	"us-gov-west-1":  {Latitude: 37.09024, Longitude: -95.712891, City: "us-gov-west", CountryCode: "US"},
+	"us-east-2":      {Latitude: 40.4172871, Longitude: -82.90712300000001, City: api.CITY_OHIO, CountryCode: api.COUNTRY_CODE_US},
+	"us-east-1":      {Latitude: 37.4315734, Longitude: -78.6568942, City: api.CITY_N_VIRGINIA, CountryCode: api.COUNTRY_CODE_US},
+	"us-west-1":      {Latitude: 38.8375215, Longitude: -120.8958242, City: api.CITY_N_CALIFORNIA, CountryCode: api.COUNTRY_CODE_US},
+	"us-west-2":      {Latitude: 43.8041334, Longitude: -120.5542012, City: api.CITY_OREGON, CountryCode: api.COUNTRY_CODE_US},
+	"ap-south-1":     {Latitude: 19.0759837, Longitude: 72.8776559, City: api.CITY_MUMBAI, CountryCode: api.COUNTRY_CODE_IN},
+	"ap-northeast-3": {Latitude: 34.6937378, Longitude: 135.5021651, City: api.CITY_OSAKA, CountryCode: api.COUNTRY_CODE_JP},
+	"ap-northeast-2": {Latitude: 37.566535, Longitude: 126.9779692, City: api.CITY_SEOUL, CountryCode: api.COUNTRY_CODE_KR},
+	"ap-southeast-1": {Latitude: 1.352083, Longitude: 103.819836, City: api.CITY_SINGAPORE, CountryCode: api.COUNTRY_CODE_SG},
+	"ap-southeast-2": {Latitude: -33.8688197, Longitude: 151.2092955, City: api.CITY_SYDNEY, CountryCode: api.COUNTRY_CODE_AU},
+	"ap-northeast-1": {Latitude: 35.7090259, Longitude: 139.7319925, City: api.CITY_TOKYO, CountryCode: api.COUNTRY_CODE_JP},
+	"ca-central-1":   {Latitude: 56.130366, Longitude: -106.346771, City: api.CITY_CANADA_CENTRAL, CountryCode: api.COUNTRY_CODE_CA},
+	"cn-north-1":     {Latitude: 39.90419989999999, Longitude: 116.4073963, City: api.CITY_BEI_JING, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-northwest-1": {Latitude: 37.198731, Longitude: 106.1580937, City: api.CITY_NING_XIA, CountryCode: api.COUNTRY_CODE_CN},
+	"eu-central-1":   {Latitude: 50.1109221, Longitude: 8.6821267, City: api.CITY_FRANKFURT, CountryCode: api.COUNTRY_CODE_DE},
+	"eu-west-1":      {Latitude: 53.41291, Longitude: -8.24389, City: api.CITY_IRELAND, CountryCode: api.COUNTRY_CODE_IE},
+	"eu-west-2":      {Latitude: 51.5073509, Longitude: -0.1277583, City: api.CITY_LONDON, CountryCode: api.COUNTRY_CODE_GB},
+	"eu-west-3":      {Latitude: 48.856614, Longitude: 2.3522219, City: api.CITY_PARIS, CountryCode: api.COUNTRY_CODE_FR},
+	"eu-north-1":     {Latitude: 59.1946, Longitude: 18.47, City: api.CITY_STOCKHOLM, CountryCode: api.COUNTRY_CODE_SE},
+	"sa-east-1":      {Latitude: -23.5505199, Longitude: -46.63330939999999, City: api.CITY_SAO_PAULO, CountryCode: api.COUNTRY_CODE_BR},
+	"us-gov-west-1":  {Latitude: 37.09024, Longitude: -95.712891, City: api.CITY_US_GOV_WEST, CountryCode: api.COUNTRY_CODE_US},
 }

--- a/pkg/util/azure/geographicinfo.go
+++ b/pkg/util/azure/geographicinfo.go
@@ -14,44 +14,47 @@
 
 package azure
 
-import "yunion.io/x/onecloud/pkg/cloudprovider"
+import (
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+)
 
 var AzureGeographicInfo = map[string]cloudprovider.SGeographicInfo{
-	"southafricanorth":   {City: "Pretoria", CountryCode: "ZA"},      //比勒陀利亚, 南非
-	"southafricawest":    {City: "Cape Town", CountryCode: "ZA"},     //开普敦 南非
-	"australiacentral2":  {City: "Yarralumla", CountryCode: "AU"},    //亚拉伦拉 澳大利亚
-	"koreasouth":         {City: "Busan", CountryCode: "KR"},         //釜山 韩国
-	"canadacentral":      {City: "Toronto", CountryCode: "CA"},       //加拿大 多伦多
-	"northeurope":        {City: "Dublin", CountryCode: "IE"},        //都柏林 爱尔兰
-	"australiacentral":   {City: "Yarralumla", CountryCode: "AU"},    //亚拉伦拉 澳大利亚
-	"francecentral":      {City: "Allier", CountryCode: "FR"},        //阿利埃河 法国
-	"westus":             {City: "San Francisco", CountryCode: "US"}, //旧金山 美国
-	"japanwest":          {City: "Osaka", CountryCode: "JP"},         //大阪市 日本
-	"francesouth":        {City: "Tarn", CountryCode: "FR"},          //塔恩 法国
-	"eastus":             {City: "Virginia", CountryCode: "US"},      // 美国 弗吉尼亚
-	"westindia":          {City: "Mumbai", CountryCode: "IN"},        //印度 孟买
-	"westcentralus":      {City: "Utah", CountryCode: "US"},          //美国 犹他州
-	"southeastasia":      {City: "Singapore", CountryCode: "SG"},     //新加坡
-	"eastasia":           {City: "HongKong", CountryCode: "CN"},
-	"eastus2":            {City: "Virginia", CountryCode: "US"},    // 美国 弗吉尼亚
-	"japaneast":          {City: "Tokyo", CountryCode: "JP"},       // 日本 东京
-	"ukwest":             {City: "Halton", CountryCode: "GB"},      //英国 哈尔顿
-	"australiasoutheast": {City: "Melbourne", CountryCode: "AU"},   // 澳大利亚 墨尔本
-	"uksouth":            {City: "West Sussex", CountryCode: "GB"}, //英国 西苏塞克斯
-	"westus2":            {City: "Washington", CountryCode: "US"},  //美国 华盛顿
-	"southcentralus":     {City: "Texas", CountryCode: "US"},       //美国 德克萨斯
-	"brazilsouth":        {City: "Sao Paulo", CountryCode: ""},     //巴西 圣保罗
-	"koreacentral":       {City: "Seoul", CountryCode: "KR"},       //韩国 汉城
-	"centralindia":       {City: "Maharashtra", CountryCode: "IN"}, //印度 马哈拉施特拉邦
-	"northcentralus":     {City: "Chicago", CountryCode: "US"},     //美国 芝加哥
-	"centralus":          {City: "Iowa", CountryCode: "US"},        //美国 爱荷华
-	"australiaeast":      {City: "Sydney", CountryCode: "AU"},      //澳大利亚 悉尼
-	"westeurope":         {City: "Holland", CountryCode: "NL"},     //荷兰
-	"canadaeast":         {City: "Quebec", CountryCode: "CA"},      //加拿大 魁北克市
-	"southindia":         {City: "Kanchipuram", CountryCode: "IN"}, //印度 甘吉布勒姆
+	"southafricanorth":   {City: api.CITY_PRETORIA, CountryCode: api.COUNTRY_CODE_ZA},      //比勒陀利亚, 南非
+	"southafricawest":    {City: api.CITY_CAPE_TOWN, CountryCode: api.COUNTRY_CODE_ZA},     //开普敦 南非
+	"australiacentral2":  {City: api.CITY_YARRALUMLA, CountryCode: api.COUNTRY_CODE_AU},    //亚拉伦拉 澳大利亚
+	"koreasouth":         {City: api.CITY_BUSAN, CountryCode: api.COUNTRY_CODE_KR},         //釜山 韩国
+	"canadacentral":      {City: api.CITY_TORONTO, CountryCode: api.COUNTRY_CODE_CA},       //加拿大 多伦多
+	"northeurope":        {City: api.CITY_DUBLIN, CountryCode: api.COUNTRY_CODE_IE},        //都柏林 爱尔兰
+	"australiacentral":   {City: api.CITY_YARRALUMLA, CountryCode: api.COUNTRY_CODE_AU},    //亚拉伦拉 澳大利亚
+	"francecentral":      {City: api.CITY_ALLIER, CountryCode: api.COUNTRY_CODE_FR},        //阿利埃河 法国
+	"westus":             {City: api.CITY_SAN_FRANCISCO, CountryCode: api.COUNTRY_CODE_US}, //旧金山 美国
+	"japanwest":          {City: api.CITY_OSAKA, CountryCode: api.COUNTRY_CODE_JP},         //大阪市 日本
+	"francesouth":        {City: api.CITY_TARN, CountryCode: api.COUNTRY_CODE_FR},          //塔恩 法国
+	"eastus":             {City: api.CITY_VIRGINIA, CountryCode: api.COUNTRY_CODE_US},      // 美国 弗吉尼亚
+	"westindia":          {City: api.CITY_MUMBAI, CountryCode: api.COUNTRY_CODE_IN},        //印度 孟买
+	"westcentralus":      {City: api.CITY_UTAH, CountryCode: api.COUNTRY_CODE_US},          //美国 犹他州
+	"southeastasia":      {City: api.CITY_SINGAPORE, CountryCode: api.COUNTRY_CODE_SG},     //新加坡
+	"eastasia":           {City: api.CITY_HONG_KONG, CountryCode: api.COUNTRY_CODE_CN},
+	"eastus2":            {City: api.CITY_VIRGINIA, CountryCode: api.COUNTRY_CODE_US},    // 美国 弗吉尼亚
+	"japaneast":          {City: api.CITY_TOKYO, CountryCode: api.COUNTRY_CODE_JP},       // 日本 东京
+	"ukwest":             {City: api.CITY_HALTON, CountryCode: api.COUNTRY_CODE_GB},      //英国 哈尔顿
+	"australiasoutheast": {City: api.CITY_MELBOURNE, CountryCode: api.COUNTRY_CODE_AU},   // 澳大利亚 墨尔本
+	"uksouth":            {City: api.CITY_WEST_SUSSEX, CountryCode: api.COUNTRY_CODE_GB}, //英国 西苏塞克斯
+	"westus2":            {City: api.CITY_WASHINGTON, CountryCode: api.COUNTRY_CODE_US},  //美国 华盛顿
+	"southcentralus":     {City: api.CITY_TEXAS, CountryCode: api.COUNTRY_CODE_US},       //美国 德克萨斯
+	"brazilsouth":        {City: api.CITY_SAO_PAULO, CountryCode: api.COUNTRY_CODE_BR},   //巴西 圣保罗
+	"koreacentral":       {City: api.CITY_SEOUL, CountryCode: api.COUNTRY_CODE_KR},       //韩国 汉城 -> 首尔
+	"centralindia":       {City: api.CITY_MAHARASHTRA, CountryCode: api.COUNTRY_CODE_IN}, //印度 马哈拉施特拉邦
+	"northcentralus":     {City: api.CITY_CHICAGO, CountryCode: api.COUNTRY_CODE_US},     //美国 芝加哥
+	"centralus":          {City: api.CITY_IOWA, CountryCode: api.COUNTRY_CODE_US},        //美国 爱荷华
+	"australiaeast":      {City: api.CITY_SYDNEY, CountryCode: api.COUNTRY_CODE_AU},      //澳大利亚 悉尼
+	"westeurope":         {City: api.CITY_HOLLAND, CountryCode: api.COUNTRY_CODE_NL},     //荷兰
+	"canadaeast":         {City: api.CITY_QUEBEC, CountryCode: api.COUNTRY_CODE_CA},      //加拿大 魁北克市
+	"southindia":         {City: api.CITY_KANCHIPURAM, CountryCode: api.COUNTRY_CODE_IN}, //印度 甘吉布勒姆
 
-	"chinaeast":   {City: "Shanghai", CountryCode: "CN"},
-	"chinaeast2":  {City: "Shanghai", CountryCode: "CN"},
-	"chinanorth":  {City: "Beijing", CountryCode: "CN"},
-	"chinanorth2": {City: "Beijing", CountryCode: "CN"},
+	"chinaeast":   {City: api.CITY_SHANG_HAI, CountryCode: api.COUNTRY_CODE_CN},
+	"chinaeast2":  {City: api.CITY_SHANG_HAI, CountryCode: api.COUNTRY_CODE_CN},
+	"chinanorth":  {City: api.CITY_BEI_JING, CountryCode: api.COUNTRY_CODE_CN},
+	"chinanorth2": {City: api.CITY_BEI_JING, CountryCode: api.COUNTRY_CODE_CN},
 }

--- a/pkg/util/huawei/latitud_and_longitude.go
+++ b/pkg/util/huawei/latitud_and_longitude.go
@@ -14,21 +14,24 @@
 
 package huawei
 
-import "yunion.io/x/onecloud/pkg/cloudprovider"
+import (
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+)
 
 // China: https://developer.huaweicloud.com/endpoint
 // International: https://developer-intl.huaweicloud.com/endpoint
 // ref: https://countrycode.org
 var LatitudeAndLongitude = map[string]cloudprovider.SGeographicInfo{
-	"cn-east-2":      {Latitude: 31.210344, Longitude: 121.455364, City: "Shanghai", CountryCode: "CN"},
-	"cn-north-1":     {Latitude: 39.997743, Longitude: 116.304542, City: "Beijing", CountryCode: "CN"},
-	"cn-north-4":     {Latitude: 39.997743, Longitude: 116.304542, City: "Beijing", CountryCode: "CN"},
-	"cn-south-1":     {Latitude: 23.12911, Longitude: 113.264385, City: "Guangzhou", CountryCode: "CN"},
-	"cn-south-2":     {Latitude: 23.12911, Longitude: 113.264385, City: "Guangzhou", CountryCode: "CN"},
-	"ap-southeast-1": {Latitude: 22.396428, Longitude: 114.109497, City: "Hongkong", CountryCode: "CN"},
-	"ap-southeast-2": {Latitude: 13.7563309, Longitude: 100.5017651, City: "Bangkok", CountryCode: "TH"},
-	"ap-southeast-3": {Latitude: 1.360386, Longitude: 103.821195, City: "Singapore", CountryCode: "SG"},
-	"eu-west-0":      {Latitude: 48.856614, Longitude: 2.3522219, City: "Paris", CountryCode: "FR"},
-	"cn-northeast-1": {Latitude: 38.91400300000001, Longitude: 121.614682, City: "Shanghai", CountryCode: "CN"},
-	"cn-southwest-2": {Latitude: 26.6470035286, Longitude: 106.6302113880, City: "Guiyang", CountryCode: "CN"},
+	"cn-east-2":      {Latitude: 31.210344, Longitude: 121.455364, City: api.CITY_SHANG_HAI, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-north-1":     {Latitude: 39.997743, Longitude: 116.304542, City: api.CITY_BEI_JING, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-north-4":     {Latitude: 39.997743, Longitude: 116.304542, City: api.CITY_BEI_JING, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-south-1":     {Latitude: 23.12911, Longitude: 113.264385, City: api.CITY_GUANG_ZHOU, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-south-2":     {Latitude: 23.12911, Longitude: 113.264385, City: api.CITY_GUANG_ZHOU, CountryCode: api.COUNTRY_CODE_CN},
+	"ap-southeast-1": {Latitude: 22.396428, Longitude: 114.109497, City: api.CITY_HONG_KONG, CountryCode: api.COUNTRY_CODE_CN},
+	"ap-southeast-2": {Latitude: 13.7563309, Longitude: 100.5017651, City: api.CITY_BANGKOK, CountryCode: api.COUNTRY_CODE_TH},
+	"ap-southeast-3": {Latitude: 1.360386, Longitude: 103.821195, City: api.CITY_SINGAPORE, CountryCode: api.COUNTRY_CODE_SG},
+	"eu-west-0":      {Latitude: 48.856614, Longitude: 2.3522219, City: api.CITY_PARIS, CountryCode: api.COUNTRY_CODE_FR},
+	"cn-northeast-1": {Latitude: 38.91400300000001, Longitude: 121.614682, City: api.CITY_SHANG_HAI, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-southwest-2": {Latitude: 26.6470035286, Longitude: 106.6302113880, City: api.CITY_GUI_YANG, CountryCode: api.COUNTRY_CODE_CN},
 }

--- a/pkg/util/qcloud/latitud_and_longitude.go
+++ b/pkg/util/qcloud/latitud_and_longitude.go
@@ -14,26 +14,29 @@
 
 package qcloud
 
-import "yunion.io/x/onecloud/pkg/cloudprovider"
+import (
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+)
 
 var LatitudeAndLongitude = map[string]cloudprovider.SGeographicInfo{
-	"ap-bangkok":        {Latitude: 13.756330, Longitude: 100.501762, City: "Bangkok", CountryCode: "TH"},        // 腾讯云 亚太地区(曼谷)
-	"ap-beijing":        {Latitude: 39.904202, Longitude: 116.407394, City: "Beijing", CountryCode: "CN"},        // 腾讯云 华北地区(北京)
-	"ap-chengdu":        {Latitude: 30.572815, Longitude: 104.066803, City: "Chengdu", CountryCode: "CN"},        // 腾讯云 西南地区(成都)
-	"ap-chongqing":      {Latitude: 29.431585, Longitude: 106.912254, City: "Chongqing", CountryCode: "CN"},      // 腾讯云 西南地区(重庆)
-	"ap-guangzhou":      {Latitude: 23.129110, Longitude: 113.264381, City: "Guangzhou", CountryCode: "CN"},      // 腾讯云 华南地区(广州)
-	"ap-guangzhou-open": {Latitude: 23.126593, Longitude: 113.273415, City: "Guangzhou", CountryCode: "CN"},      // 腾讯云 华南地区(广州Open)
-	"ap-hongkong":       {Latitude: 22.396427, Longitude: 114.109497, City: "Hongkong", CountryCode: "HK"},       // 腾讯云 东南亚地区(香港)
-	"ap-mumbai":         {Latitude: 19.075983, Longitude: 72.877655, City: "Mumbai", CountryCode: "IN"},          // 腾讯云 亚太地区(孟买)
-	"ap-seoul":          {Latitude: 37.566536, Longitude: 126.977966, City: "Seoul", CountryCode: "KR"},          // 腾讯云 东南亚地区(首尔)
-	"ap-shanghai":       {Latitude: 31.230391, Longitude: 121.473701, City: "Shanghai", CountryCode: "CN"},       // 腾讯云 华东地区(上海)
-	"ap-shanghai-fsi":   {Latitude: 31.311033, Longitude: 121.536217, City: "Shanghai", CountryCode: "CN"},       // 腾讯云 华东地区(上海金融)
-	"ap-shenzhen-fsi":   {Latitude: 22.531544, Longitude: 114.025467, City: "Shenzhen", CountryCode: "CN"},       // 腾讯云 华南地区(深圳金融)
-	"ap-singapore":      {Latitude: 1.352083, Longitude: 103.819839, City: "Singapore", CountryCode: "SG"},       // 腾讯云 东南亚地区(新加坡)
-	"ap-tokyo":          {Latitude: 35.709026, Longitude: 139.731995, City: "Tokyo", CountryCode: "JP"},          // 腾讯云 亚太地区(东京)
-	"eu-frankfurt":      {Latitude: 51.165691, Longitude: 10.451526, City: "Frankfurt", CountryCode: "DE"},       // 腾讯云 欧洲地区(德国)
-	"eu-moscow":         {Latitude: 55.755825, Longitude: 37.617298, City: "Moscow", CountryCode: "RU"},          // 腾讯云 欧洲地区(莫斯科)
-	"na-ashburn":        {Latitude: 37.431572, Longitude: -78.656891, City: "Virgina", CountryCode: "US"},        // 腾讯云 美国东部(弗吉尼亚)
-	"na-siliconvalley":  {Latitude: 37.387474, Longitude: -122.057541, City: "Siliconvalley", CountryCode: "US"}, // 腾讯云 美国西部(硅谷)
-	"na-toronto":        {Latitude: 43.653225, Longitude: -79.383186, City: "Toronto", CountryCode: "CA"},        // 腾讯云 北美地区(多伦多)
+	"ap-bangkok":        {Latitude: 13.756330, Longitude: 100.501762, City: api.CITY_BANGKOK, CountryCode: api.COUNTRY_CODE_TH},        // 腾讯云 亚太地区(曼谷)
+	"ap-beijing":        {Latitude: 39.904202, Longitude: 116.407394, City: api.CITY_BEI_JING, CountryCode: api.COUNTRY_CODE_CN},       // 腾讯云 华北地区(北京)
+	"ap-chengdu":        {Latitude: 30.572815, Longitude: 104.066803, City: api.CITY_CHENG_DU, CountryCode: api.COUNTRY_CODE_CN},       // 腾讯云 西南地区(成都)
+	"ap-chongqing":      {Latitude: 29.431585, Longitude: 106.912254, City: api.CITY_CHONG_QING, CountryCode: api.COUNTRY_CODE_CN},     // 腾讯云 西南地区(重庆)
+	"ap-guangzhou":      {Latitude: 23.129110, Longitude: 113.264381, City: api.CITY_GUANG_ZHOU, CountryCode: api.COUNTRY_CODE_CN},     // 腾讯云 华南地区(广州)
+	"ap-guangzhou-open": {Latitude: 23.126593, Longitude: 113.273415, City: api.CITY_GUANG_ZHOU, CountryCode: api.COUNTRY_CODE_CN},     // 腾讯云 华南地区(广州Open)
+	"ap-hongkong":       {Latitude: 22.396427, Longitude: 114.109497, City: api.CITY_HONG_KONG, CountryCode: api.COUNTRY_CODE_CN},      // 腾讯云 东南亚地区(香港)
+	"ap-mumbai":         {Latitude: 19.075983, Longitude: 72.877655, City: api.CITY_MUMBAI, CountryCode: api.COUNTRY_CODE_IN},          // 腾讯云 亚太地区(孟买)
+	"ap-seoul":          {Latitude: 37.566536, Longitude: 126.977966, City: api.CITY_SEOUL, CountryCode: api.COUNTRY_CODE_KR},          // 腾讯云 东南亚地区(首尔)
+	"ap-shanghai":       {Latitude: 31.230391, Longitude: 121.473701, City: api.CITY_SHANG_HAI, CountryCode: api.COUNTRY_CODE_CN},      // 腾讯云 华东地区(上海)
+	"ap-shanghai-fsi":   {Latitude: 31.311033, Longitude: 121.536217, City: api.CITY_SHANG_HAI, CountryCode: api.COUNTRY_CODE_CN},      // 腾讯云 华东地区(上海金融)
+	"ap-shenzhen-fsi":   {Latitude: 22.531544, Longitude: 114.025467, City: api.CITY_SHEN_ZHEN, CountryCode: api.COUNTRY_CODE_CN},      // 腾讯云 华南地区(深圳金融)
+	"ap-singapore":      {Latitude: 1.352083, Longitude: 103.819839, City: api.CITY_SINGAPORE, CountryCode: api.COUNTRY_CODE_SG},       // 腾讯云 东南亚地区(新加坡)
+	"ap-tokyo":          {Latitude: 35.709026, Longitude: 139.731995, City: api.CITY_TOKYO, CountryCode: api.COUNTRY_CODE_JP},          // 腾讯云 亚太地区(东京)
+	"eu-frankfurt":      {Latitude: 51.165691, Longitude: 10.451526, City: api.CITY_FRANKFURT, CountryCode: api.COUNTRY_CODE_DE},       // 腾讯云 欧洲地区(德国)
+	"eu-moscow":         {Latitude: 55.755825, Longitude: 37.617298, City: api.CITY_MOSCOW, CountryCode: api.COUNTRY_CODE_RU},          // 腾讯云 欧洲地区(莫斯科)
+	"na-ashburn":        {Latitude: 37.431572, Longitude: -78.656891, City: api.CITY_VIRGINIA, CountryCode: api.COUNTRY_CODE_US},       // 腾讯云 美国东部(弗吉尼亚)
+	"na-siliconvalley":  {Latitude: 37.387474, Longitude: -122.057541, City: api.CITY_SILICONVALLEY, CountryCode: api.COUNTRY_CODE_US}, // 腾讯云 美国西部(硅谷)
+	"na-toronto":        {Latitude: 43.653225, Longitude: -79.383186, City: api.CITY_TORONTO, CountryCode: api.COUNTRY_CODE_CA},        // 腾讯云 北美地区(多伦多)
 }

--- a/pkg/util/ucloud/latitud_and_longitude.go
+++ b/pkg/util/ucloud/latitud_and_longitude.go
@@ -14,31 +14,34 @@
 
 package ucloud
 
-import "yunion.io/x/onecloud/pkg/cloudprovider"
+import (
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+)
 
 // https://docs.ucloud.cn/api/summary/regionlist
 var LatitudeAndLongitude = map[string]cloudprovider.SGeographicInfo{
-	"cn-bj1":       {Latitude: 39.9041999, Longitude: 116.4073963, City: "Beijing", CountryCode: "CN"},
-	"cn-bj2":       {Latitude: 39.9041999, Longitude: 116.4073963, City: "Beijing", CountryCode: "CN"},
-	"cn-sh":        {Latitude: 31.2303904, Longitude: 121.4737021, City: "Shanghai", CountryCode: "CN"},
-	"cn-sh2":       {Latitude: 31.2303904, Longitude: 121.4737021, City: "Shanghai", CountryCode: "CN"},
-	"cn-gd":        {Latitude: 23.12911, Longitude: 113.264385, City: "Guangzhou", CountryCode: "CN"},
-	"hk":           {Latitude: 22.396428, Longitude: 114.109497, City: "Hong Kong", CountryCode: "CN"},
-	"us-ca":        {Latitude: 34.0522342, Longitude: -118.2436849, City: "Los Angeles", CountryCode: "US"},
-	"us-ws":        {Latitude: 38.9071923, Longitude: -77.0368707, City: "Washington", CountryCode: "US"},
-	"ge-fra":       {Latitude: 50.1109221, Longitude: 8.6821267, City: "Frankfurt", CountryCode: "GE"},
-	"th-bkk":       {Latitude: 13.7563309, Longitude: 100.5017651, City: "Bangkok", CountryCode: "TH"},
-	"kr-seoul":     {Latitude: 37.566535, Longitude: 126.9779692, City: "Seoul", CountryCode: "KR"},
-	"sg":           {Latitude: 1.352083, Longitude: 103.819836, City: "Singapore", CountryCode: "SG"},
-	"tw-tp":        {Latitude: 25.0329694, Longitude: 121.5654177, City: "Taipei", CountryCode: "CN"},
-	"tw-kh":        {Latitude: 22.6272784, Longitude: 120.3014353, City: "Kaohsiung", CountryCode: "CN"},
-	"jpn-tky":      {Latitude: 35.7090259, Longitude: 139.7319925, City: "Tokyo", CountryCode: "JP"},
-	"rus-mosc":     {Latitude: 55.755826, Longitude: 37.6172999, City: "Moscow", CountryCode: "RU"},
-	"uae-dubai":    {Latitude: 25.2048493, Longitude: 55.2707828, City: "Dubai", CountryCode: "UA"},
-	"idn-jakarta":  {Latitude: -6.2087634, Longitude: 106.845599, City: "Jakarta", CountryCode: "ID"},
-	"ind-mumbai":   {Latitude: 19.0759837, Longitude: 72.8776559, City: "Mumbai", CountryCode: "IN"},
-	"bra-saopaulo": {Latitude: -23.5505199, Longitude: -46.6333094, City: "São Paulo", CountryCode: "BR"},
-	"uk-london":    {Latitude: 51.5073509, Longitude: -0.1277583, City: "London", CountryCode: "UK"},
-	"afr-nigeria":  {Latitude: 6.5243793, Longitude: 3.3792057, City: "Lagos", CountryCode: "AF"},
-	"vn-sng":       {Latitude: 10.8230989, Longitude: 106.6296638, City: "Ho Chi Minh", CountryCode: "VN"},
+	"cn-bj1":       {Latitude: 39.9041999, Longitude: 116.4073963, City: api.CITY_BEI_JING, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-bj2":       {Latitude: 39.9041999, Longitude: 116.4073963, City: api.CITY_BEI_JING, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-sh":        {Latitude: 31.2303904, Longitude: 121.4737021, City: api.CITY_SHANG_HAI, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-sh2":       {Latitude: 31.2303904, Longitude: 121.4737021, City: api.CITY_SHANG_HAI, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-gd":        {Latitude: 23.12911, Longitude: 113.264385, City: api.CITY_GUANG_ZHOU, CountryCode: api.COUNTRY_CODE_CN},
+	"hk":           {Latitude: 22.396428, Longitude: 114.109497, City: api.CITY_HONG_KONG, CountryCode: api.COUNTRY_CODE_CN},
+	"us-ca":        {Latitude: 34.0522342, Longitude: -118.2436849, City: api.CITY_LOS_ANGELES, CountryCode: api.COUNTRY_CODE_US},
+	"us-ws":        {Latitude: 38.9071923, Longitude: -77.0368707, City: api.CITY_WASHINGTON, CountryCode: api.COUNTRY_CODE_US},
+	"ge-fra":       {Latitude: 50.1109221, Longitude: 8.6821267, City: api.CITY_FRANKFURT, CountryCode: api.COUNTRY_CODE_DE},
+	"th-bkk":       {Latitude: 13.7563309, Longitude: 100.5017651, City: api.CITY_BANGKOK, CountryCode: api.COUNTRY_CODE_TH},
+	"kr-seoul":     {Latitude: 37.566535, Longitude: 126.9779692, City: api.CITY_SEOUL, CountryCode: api.COUNTRY_CODE_KR},
+	"sg":           {Latitude: 1.352083, Longitude: 103.819836, City: api.CITY_SINGAPORE, CountryCode: api.COUNTRY_CODE_SG},
+	"tw-tp":        {Latitude: 25.0329694, Longitude: 121.5654177, City: api.CITY_TAIPEI, CountryCode: api.COUNTRY_CODE_CN},
+	"tw-kh":        {Latitude: 22.6272784, Longitude: 120.3014353, City: api.CITY_KAOHSIUNG, CountryCode: api.COUNTRY_CODE_CN},
+	"jpn-tky":      {Latitude: 35.7090259, Longitude: 139.7319925, City: api.CITY_TOKYO, CountryCode: api.COUNTRY_CODE_JP},
+	"rus-mosc":     {Latitude: 55.755826, Longitude: 37.6172999, City: api.CITY_MOSCOW, CountryCode: api.COUNTRY_CODE_RU},
+	"uae-dubai":    {Latitude: 25.2048493, Longitude: 55.2707828, City: api.CITY_DUBAI, CountryCode: api.COUNTRY_CODE_AE},
+	"idn-jakarta":  {Latitude: -6.2087634, Longitude: 106.845599, City: api.CITY_JAKARTA, CountryCode: api.COUNTRY_CODE_ID},
+	"ind-mumbai":   {Latitude: 19.0759837, Longitude: 72.8776559, City: api.CITY_MUMBAI, CountryCode: api.COUNTRY_CODE_IN},
+	"bra-saopaulo": {Latitude: -23.5505199, Longitude: -46.6333094, City: api.CITY_SAO_PAULO, CountryCode: api.COUNTRY_CODE_BR},
+	"uk-london":    {Latitude: 51.5073509, Longitude: -0.1277583, City: api.CITY_LONDON, CountryCode: api.COUNTRY_CODE_GB},
+	"afr-nigeria":  {Latitude: 6.5243793, Longitude: 3.3792057, City: api.CITY_LAGOS, CountryCode: api.COUNTRY_CODE_NG},
+	"vn-sng":       {Latitude: 10.8230989, Longitude: 106.6296638, City: api.CITY_HO_CHI_MINH, CountryCode: api.COUNTRY_CODE_VN},
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
统一使用const,避免city命名不一致

**是否需要 backport 到之前的 release 分支**:
- release/2.9.0
- release/2.8.0

/cc @swordqiu @yousong 