### PR TITLE
scheduler forecast select_candidate not add count

### DIFF
--- a/pkg/scheduler/handler/forecast_helper.go
+++ b/pkg/scheduler/handler/forecast_helper.go
@@ -86,7 +86,6 @@ func transToSchedForecastResult(result *core.SchedResultItemList) interface{} {
 	for _, candi := range output.Candidates {
 		if len(candi.Error) != 0 {
 			info, exist := getOrNewFilter("select_candidate")
-			info.Count++
 			msg := candi.Error
 			info.Messages = append(info.Messages, msg)
 			if !exist {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

去掉 scheduler forecast 接口不需要的 select_candidate filter info

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.9.0
- release/2.8.0

/cc @swordqiu 