### PR TITLE
bugfix: host register add version record, fix getBmAgentUrl

### DIFF
--- a/pkg/compute/misc/handler.go
+++ b/pkg/compute/misc/handler.go
@@ -42,12 +42,13 @@ func addHandler(method, prefix string, f appsrv.FilterHandler, app *appsrv.Appli
 }
 
 func getBmAgentUrl(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	body, _ := appsrv.FetchJSON(r)
-	if body == nil || !body.Contains("ip") {
-		httperrors.InputParameterError(w, "Missing ip ?")
+	_, query, _ := appsrv.FetchEnv(ctx, w, r)
+	ipAddr, err := query.GetString("ip")
+	if err != nil {
+		httperrors.MissingParameterError(w, "ip")
 		return
 	}
-	ipAddr, _ := body.GetString("ip")
+
 	n, _ := models.NetworkManager.GetOnPremiseNetworkOfIP(ipAddr, "baremetal", tristate.None)
 	if n == nil {
 		httperrors.NotFoundError(w, "Network not found")

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -27,6 +27,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/util/version"
 	"yunion.io/x/pkg/utils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
@@ -750,7 +751,7 @@ func (h *SHostInfo) updateHostRecord(hostId string) {
 		content.Set("slots", jsonutils.NewString(options.HostOptions.Slots))
 	}
 	content.Set("__meta__", jsonutils.Marshal(h.getSysInfo()))
-	// content.Set("version", GetVersion())
+	content.Set("version", jsonutils.NewString(version.GetShortString()))
 	body := jsonutils.NewDict()
 	body.Set("host", content)
 	session := h.GetSession()


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
bugfix: host register add version record, fix getBmAgentUrl
**是否需要 backport 到之前的 release 分支**:
release/2.8.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
