### PR TITLE
fix: 1. ignore yunioncloud temp VMs when syncing 2. start esxi VM on same host with lock

### DIFF
--- a/pkg/apis/compute/esxi_const.go
+++ b/pkg/apis/compute/esxi_const.go
@@ -1,0 +1,5 @@
+package compute
+
+const (
+	ESXI_IMAGE_CACHE_TMP_PREFIX = "yunioncloud.imagecache"
+)

--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -870,9 +870,12 @@ func (self *SDisk) AllowDeleteItem(ctx context.Context, userCred mcclient.TokenC
 }
 
 func (self *SDisk) GetTemplateId() string {
+	if len(self.TemplateId) == 0 {
+		return ""
+	}
 	imageObj, err := CachedimageManager.FetchById(self.TemplateId)
 	if err != nil || imageObj == nil {
-		log.Errorf("failed to found disk %s(%s) templateId", self.Name, self.Id)
+		log.Errorf("failed to found disk %s(%s) templateId %s: %s", self.Name, self.Id, self.TemplateId, err)
 		return ""
 	}
 	return self.TemplateId

--- a/pkg/util/esxi/host.go
+++ b/pkg/util/esxi/host.go
@@ -159,7 +159,7 @@ func (self *SHost) IsEmulated() bool {
 	return false
 }
 
-func (self *SHost) fetchVMs() error {
+func (self *SHost) fetchVMs(all bool) error {
 	if self.vms != nil {
 		return nil
 	}
@@ -175,7 +175,7 @@ func (self *SHost) fetchVMs() error {
 		return nil
 	}
 
-	vms, err := dc.fetchVms(hostVms)
+	vms, err := dc.fetchVms(hostVms, all)
 	if err != nil {
 		return err
 	}
@@ -183,8 +183,16 @@ func (self *SHost) fetchVMs() error {
 	return nil
 }
 
+func (self *SHost) GetIVMs2() ([]cloudprovider.ICloudVM, error) {
+	err := self.fetchVMs(true)
+	if err != nil {
+		return nil, err
+	}
+	return self.vms, nil
+}
+
 func (self *SHost) GetIVMs() ([]cloudprovider.ICloudVM, error) {
-	err := self.fetchVMs()
+	err := self.fetchVMs(false)
 	if err != nil {
 		return nil, err
 	}
@@ -212,9 +220,13 @@ func (self *SHost) GetIWires() ([]cloudprovider.ICloudWire, error) {
 
 func (self *SHost) GetIStorages() ([]cloudprovider.ICloudStorage, error) {
 	moHost := self.getHostSystem()
+	dc, err := self.GetDatacenter()
+	if err != nil {
+		return nil, err
+	}
 	istorages := make([]cloudprovider.ICloudStorage, len(moHost.Datastore))
 	for i := 0; i < len(moHost.Datastore); i += 1 {
-		storage, err := self.datacenter.GetIStorageByMoId(moRefId(moHost.Datastore[i]))
+		storage, err := dc.GetIStorageByMoId(moRefId(moHost.Datastore[i]))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/esxi/shell/host.go
+++ b/pkg/util/esxi/shell/host.go
@@ -60,4 +60,17 @@ func init() {
 		printList(storages, nil)
 		return nil
 	})
+
+	shellutils.R(&HostShowOptions{}, "host-nics", "Show all nics of a given host", func(cli *esxi.SESXiClient, args *HostShowOptions) error {
+		host, err := cli.FindHostByIp(args.IP)
+		if err != nil {
+			return err
+		}
+		nics, err := host.GetIHostNics()
+		if err != nil {
+			return err
+		}
+		printList(nics, nil)
+		return nil
+	})
 }

--- a/pkg/util/esxi/shell/virtualmachine.go
+++ b/pkg/util/esxi/shell/virtualmachine.go
@@ -32,7 +32,7 @@ func init() {
 		if err != nil {
 			return err
 		}
-		vms, err := host.GetIVMs()
+		vms, err := host.GetIVMs2()
 		if err != nil {
 			return err
 		}

--- a/pkg/util/esxi/storage.go
+++ b/pkg/util/esxi/storage.go
@@ -246,7 +246,7 @@ func (self *SDatastore) getVMs() ([]cloudprovider.ICloudVM, error) {
 	if len(vms) == 0 {
 		return nil, nil
 	}
-	return dc.fetchVms(vms)
+	return dc.fetchVms(vms, false)
 }
 
 func (self *SDatastore) GetIDiskById(idStr string) (cloudprovider.ICloudDisk, error) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：1. 同步esxi VM时忽略yunioncloud.imagecache...的临时VM 2. 启动同一宿主机的ESXi VM时加锁避免并发启动

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.9.0

/area region
/cc @yousong @wanyaoqi 