### PR TITLE
fix: deploy_configs was removed when invoke SetCreateParams

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1275,8 +1275,8 @@ func (guest *SGuest) setApptags(ctx context.Context, appTags []string, userCred 
 
 func (guest *SGuest) SetCreateParams(ctx context.Context, userCred mcclient.TokenCredential, data jsonutils.JSONObject) {
 	// delete deploy files info
-	data.(*jsonutils.JSONDict).Remove("deploy_configs")
-	err := guest.SetMetadata(ctx, api.VM_METADATA_CREATE_PARAMS, data.String(), userCred)
+	createParams := data.(*jsonutils.JSONDict).CopyExcludes("deploy_configs")
+	err := guest.SetMetadata(ctx, api.VM_METADATA_CREATE_PARAMS, createParams.String(), userCred)
 	if err != nil {
 		log.Errorf("Server %s SetCreateParams: %v", guest.Name, err)
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: 创建 server 时 deploy_configs 被 SetCreateParams 删掉了，导致部署文件都失效

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0
- release/2.9.0

/area region
/cc @swordqiu @wanyaoqi 