### PR TITLE
设置镜像hw_qemu_guest_agent属性

### DIFF
--- a/pkg/hostman/hostmetrics/hostmetrics.go
+++ b/pkg/hostman/hostmetrics/hostmetrics.go
@@ -346,7 +346,7 @@ func (s *SGuestMonitorCollector) reportIo(curInfo, prevInfo jsonutils.JSONObject
 			prev, _ := prevInfo.GetString(field)
 			fcur, _ := strconv.ParseFloat(cur, 64)
 			fprev, _ := strconv.ParseFloat(prev, 64)
-			ioInfo.Set(s.GetIoFiledName(field), jsonutils.NewFloat((fcur - fprev)/float64(diffTime)))
+			ioInfo.Set(s.GetIoFiledName(field), jsonutils.NewFloat((fcur-fprev)/float64(diffTime)))
 		}
 	}
 	return ioInfo

--- a/pkg/util/openstack/image.go
+++ b/pkg/util/openstack/image.go
@@ -234,9 +234,10 @@ func (region *SRegion) GetImageByName(name string) (*SImage, error) {
 
 func (region *SRegion) CreateImage(imageName string) (*SImage, error) {
 	params := map[string]string{
-		"container_format": "bare",
-		"disk_format":      "vmdk",
-		"name":             imageName,
+		"container_format":    "bare",
+		"disk_format":         "vmdk",
+		"name":                imageName,
+		"hw_qemu_guest_agent": "yes",
 	}
 
 	_, resp, err := region.Post("image", "/v2/images", "", jsonutils.Marshal(params))


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免镜像未设置hw_qemu_guest_agent导致qemu-guest-agent启动失败
避免安全组规则与本地安全组规则语义不一致问题

**是否需要 backport 到之前的 release 分支**:
- release/2.9.0
- release/2.8.0

/cc @yousong @swordqiu 