### PR TITLE
fix: create backup server panic when schedule

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -2731,10 +2731,9 @@ func (self *SGuest) createDiskOnHost(
 	if err != nil {
 		return nil, err
 	}
-	// TODO: use scheduler candidate storage
 	if len(self.BackupHostId) > 0 {
 		backupHost := HostManager.FetchHostById(self.BackupHostId)
-		backupStorage := self.GetDriver().ChooseHostStorage(backupHost, diskConfig.Backend, backupCandidate.StorageIds)
+		backupStorage := self.ChooseHostStorage(backupHost, diskConfig.Backend, backupCandidate)
 		diff, err := db.Update(disk, func() error {
 			disk.BackupStorageId = backupStorage.Id
 			return nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复：创建主备机得到调度结果 panic

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.9.0

/cc @wanyaoqi 
/area region