### PR TITLE
Automated cherry pick of #716: fix baremetal disk config auto extend not work and ipmi_info not record

### DIFF
--- a/cmd/climc/shell/hosts.go
+++ b/cmd/climc/shell/hosts.go
@@ -451,6 +451,7 @@ func init() {
 		MAC        string `help:"Default MAC address of baremetal"`
 		Rack       string `help:"Rack number of baremetal"`
 		Slots      string `help:"Slots number of baremetal"`
+		IpmiUser   string `help:"IPMI user name"`
 		IpmiPasswd string `help:"IPMI user password"`
 		IpmiAddr   string `help:"IPMI IP address"`
 	}
@@ -464,6 +465,9 @@ func init() {
 		}
 		if len(args.Slots) > 0 {
 			params.Add(jsonutils.NewString(args.Slots), "slots")
+		}
+		if len(args.IpmiUser) > 0 {
+			params.Add(jsonutils.NewString(args.IpmiUser), "ipmi_username")
 		}
 		if len(args.IpmiPasswd) > 0 {
 			params.Add(jsonutils.NewString(args.IpmiPasswd), "ipmi_password")

--- a/pkg/apis/compute/disk_const.go
+++ b/pkg/apis/compute/disk_const.go
@@ -37,4 +37,6 @@ const (
 	DISK_TYPE_VOLUME = "volume"
 
 	DISK_BACKING_IMAGE = "image"
+
+	DISK_SIZE_AUTOEXTEND = -1
 )

--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -1216,7 +1216,7 @@ func fillDiskConfigByImage(ctx context.Context, userCred mcclient.TokenCredentia
 		// }
 		// diskConfig.ImageDiskFormat = image.DiskFormat
 		CachedimageManager.ImageAddRefCount(image.Id)
-		if diskConfig.SizeMb < image.MinDiskMB {
+		if diskConfig.SizeMb != api.DISK_SIZE_AUTOEXTEND && diskConfig.SizeMb < image.MinDiskMB {
 			diskConfig.SizeMb = image.MinDiskMB // MB
 		}
 	}

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -945,7 +945,7 @@ func (manager *SGuestManager) ValidateCreateData(ctx context.Context, userCred m
 			}
 		}
 		sysMinDiskMB := GetDriver(hypervisor).GetMinimalSysDiskSizeGb() * 1024
-		if rootDiskConfig.SizeMb < sysMinDiskMB {
+		if rootDiskConfig.SizeMb != api.DISK_SIZE_AUTOEXTEND && rootDiskConfig.SizeMb < sysMinDiskMB {
 			rootDiskConfig.SizeMb = sysMinDiskMB
 		}
 		log.Debugf("ROOT DISK: %#v", rootDiskConfig)

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -2505,7 +2505,6 @@ func fetchIpmiInfo(data *jsonutils.JSONDict, hostId string) (*jsonutils.JSONDict
 		if strings.HasPrefix(key, IPMI_KEY_PERFIX) {
 			value, _ := data.GetString(key)
 			subkey := key[len(IPMI_KEY_PERFIX):]
-			data.Remove(key)
 			if subkey == "password" && len(hostId) > 0 {
 				value, err = utils.EncryptAESBase64(hostId, value)
 				if err != nil {

--- a/pkg/mcclient/modules/mod_hosts.go
+++ b/pkg/mcclient/modules/mod_hosts.go
@@ -86,7 +86,7 @@ func parseHosts(data string) ([]jsonutils.JSONObject, string) {
 		}
 
 		fields := strings.Split(host, ",")
-		if len(fields) != 4 {
+		if len(fields) != 5 {
 			msg += fmt.Sprintf("第%d行： %s (格式不正确)\n", i, host)
 			continue
 		}
@@ -113,6 +113,10 @@ func parseHosts(data string) ([]jsonutils.JSONObject, string) {
 
 		if len(fields[3]) > 0 {
 			params.Add(jsonutils.NewString(fields[3]), "ipmi_password")
+		}
+
+		if len(fields[4]) > 0 {
+			params.Add(jsonutils.NewString(fields[4]), "ipmi_username")
 		}
 
 		ret = append(ret, params)


### PR DESCRIPTION
Cherry pick of #716 on release/2.8.0.

#716: fix baremetal disk config auto extend not work and ipmi_info not record