### PR TITLE
fix: fail to create network in default vpc

### DIFF
--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -550,8 +550,8 @@ func (self *SVpc) StartDeleteVpcTask(ctx context.Context, userCred mcclient.Toke
 }
 
 func (self *SVpc) getPrefix() []netutils.IPV4Prefix {
-	ret := []netutils.IPV4Prefix{}
 	if len(self.CidrBlock) > 0 {
+		ret := []netutils.IPV4Prefix{}
 		blocks := strings.Split(self.CidrBlock, ",")
 		for _, block := range blocks {
 			prefix, _ := netutils.NewIPV4Prefix(block)
@@ -559,7 +559,7 @@ func (self *SVpc) getPrefix() []netutils.IPV4Prefix {
 		}
 		return ret
 	}
-	return ret
+	return []netutils.IPV4Prefix{{}}
 }
 
 func (self *SVpc) getIPRanges() []netutils.IPV4AddrRange {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：不能在default VPC中创建IP子网

**是否需要 backport 到之前的 release 分支**:
- release/2.9.0

/cc @Zexi @yousong 
/area region