### PR TITLE
fix: resource set schedtags

### DIFF
--- a/pkg/compute/models/schedtags.go
+++ b/pkg/compute/models/schedtags.go
@@ -402,7 +402,7 @@ func PerformSetResourceSchedtag(obj IModelWithSchedtag, ctx context.Context, use
 		return nil, httperrors.NewGeneralError(fmt.Errorf("Get old joint schedtags: %v", err))
 	}
 	for _, oldTag := range oldTags {
-		if !utils.IsInStringArray(oldTag.GetId(), setTagsId) {
+		if !utils.IsInStringArray(oldTag.GetSchedtagId(), setTagsId) {
 			if err := oldTag.Detach(ctx, userCred); err != nil {
 				return nil, httperrors.NewGeneralError(err)
 			}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: set schedtags 函数逻辑错误

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/area region
/cc @wanyaoqi 
/cherrypick release/2.9.0