### PR TITLE
设置任务审批人功能优化

### DIFF
--- a/cmd/climc/shell/itsm_deployment.go
+++ b/cmd/climc/shell/itsm_deployment.go
@@ -27,7 +27,8 @@ func init() {
 	 * 使用文件创建部署
 	 */
 	type DeploymentCreateOptions struct {
-		FILE string `help:"The local bpmn filename to Upload"`
+		FILE     string `help:"The local bpmn filename to Upload"`
+		TenantID string `help:"ID of tenant"`
 	}
 	R(&DeploymentCreateOptions{}, "process-deployment-create", "Create deployment by upload BPMN file", func(s *mcclient.ClientSession, args *DeploymentCreateOptions) error {
 		// TODO

--- a/cmd/climc/shell/itsm_process_instance.go
+++ b/cmd/climc/shell/itsm_process_instance.go
@@ -29,15 +29,30 @@ func init() {
 	type ProcessInstanceCreateOptions struct {
 		PROCESS_DEFINITION_KEY string `help:"Key of the process definition"`
 		INITIATOR              string `help:"ID of user who launch the process instance"`
-		ASSIGNEE               string `help:"ID of assignee"`
 		SERVER_CREATE_PARAMTER string `help:"Onecloud server create spec json string"`
+		UserId                 string `help:"ID of user"`
+		RoleId                 string `help:"ID of role"`
+		ProjectId              string `help:"ID of project"`
+		Percent                string `help:"Great than Percent of nrOfCompletedInstances/nrOfInstances"`
 	}
 	R(&ProcessInstanceCreateOptions{}, "process-instance-create", "Create process instance", func(s *mcclient.ClientSession, args *ProcessInstanceCreateOptions) error {
 		variables_params := jsonutils.NewDict()
 		variables_params.Add(jsonutils.NewString(args.PROCESS_DEFINITION_KEY), "process_definition_key")
 		variables_params.Add(jsonutils.NewString(args.INITIATOR), "initiator")
-		variables_params.Add(jsonutils.NewString(args.ASSIGNEE), "assignee")
 		variables_params.Add(jsonutils.NewString(args.SERVER_CREATE_PARAMTER), "server-create-paramter")
+		if len(args.UserId) > 0 {
+			variables_params.Add(jsonutils.NewString(args.UserId), "user-id")
+		} else {
+			if len(args.RoleId) > 0 {
+				variables_params.Add(jsonutils.NewString(args.RoleId), "role-id")
+			}
+			if len(args.ProjectId) > 0 {
+				variables_params.Add(jsonutils.NewString(args.ProjectId), "project-id")
+			}
+		}
+		if len(args.Percent) > 0 {
+			variables_params.Add(jsonutils.NewString(args.Percent), "percent")
+		}
 		params := jsonutils.NewDict()
 		params.Add(variables_params, "variables")
 		result, err := modules.ProcessInstance.Create(s, params)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
发起流程时可以支持多种设置任务审批人
1. 直接设置用户ID
2. 设置角色ID（由这个角色下的用户进行审批）
3. 同时设置角色ID和项目Id（由特定项目下的某个角色的用户进行审批）

**是否需要 backport 到之前的 release 分支**:
NONE

/cc @Zexi @swordqiu @yousong
/area climc
