### PR TITLE
避免创建时使用不同公有云的镜像

### DIFF
--- a/pkg/compute/guestdrivers/aliyun.go
+++ b/pkg/compute/guestdrivers/aliyun.go
@@ -42,6 +42,10 @@ func (self *SAliyunGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_ALIYUN
 }
 
+func (self *SAliyunGuestDriver) GetProvider() string {
+	return api.CLOUD_PROVIDER_ALIYUN
+}
+
 func (self *SAliyunGuestDriver) GetDefaultSysDiskBackend() string {
 	return api.STORAGE_CLOUD_EFFICIENCY
 }

--- a/pkg/compute/guestdrivers/aws.go
+++ b/pkg/compute/guestdrivers/aws.go
@@ -76,6 +76,10 @@ func (self *SAwsGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_AWS
 }
 
+func (self *SAwsGuestDriver) GetProvider() string {
+	return api.CLOUD_PROVIDER_AWS
+}
+
 func (self *SAwsGuestDriver) GetDefaultSysDiskBackend() string {
 	return api.STORAGE_GP2_SSD
 }

--- a/pkg/compute/guestdrivers/azure.go
+++ b/pkg/compute/guestdrivers/azure.go
@@ -45,6 +45,10 @@ func (self *SAzureGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_AZURE
 }
 
+func (self *SAzureGuestDriver) GetProvider() string {
+	return api.CLOUD_PROVIDER_AZURE
+}
+
 func (self *SAzureGuestDriver) GetDefaultSysDiskBackend() string {
 	return api.STORAGE_STANDARD_LRS
 }

--- a/pkg/compute/guestdrivers/baremetals.go
+++ b/pkg/compute/guestdrivers/baremetals.go
@@ -49,6 +49,10 @@ func (self *SBaremetalGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_BAREMETAL
 }
 
+func (self *SBaremetalGuestDriver) GetProvider() string {
+	return api.CLOUD_PROVIDER_ONECLOUD
+}
+
 func (self *SBaremetalGuestDriver) GetDefaultSysDiskBackend() string {
 	return api.STORAGE_LOCAL
 }

--- a/pkg/compute/guestdrivers/container.go
+++ b/pkg/compute/guestdrivers/container.go
@@ -51,6 +51,10 @@ func (self *SContainerDriver) GetHypervisor() string {
 	return api.HYPERVISOR_CONTAINER
 }
 
+func (self *SContainerDriver) GetProvider() string {
+	return api.CLOUD_PROVIDER_ONECLOUD
+}
+
 func (self *SContainerDriver) GetDefaultSysDiskBackend() string {
 	return api.STORAGE_LOCAL
 }

--- a/pkg/compute/guestdrivers/esxi.go
+++ b/pkg/compute/guestdrivers/esxi.go
@@ -45,6 +45,10 @@ func (self *SESXiGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_ESXI
 }
 
+func (self *SESXiGuestDriver) GetProvider() string {
+	return api.CLOUD_PROVIDER_VMWARE
+}
+
 func (self *SESXiGuestDriver) GetDefaultSysDiskBackend() string {
 	return api.STORAGE_LOCAL
 }

--- a/pkg/compute/guestdrivers/huawei.go
+++ b/pkg/compute/guestdrivers/huawei.go
@@ -40,6 +40,10 @@ func (self *SHuaweiGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_HUAWEI
 }
 
+func (self *SHuaweiGuestDriver) GetProvider() string {
+	return api.CLOUD_PROVIDER_HUAWEI
+}
+
 func (self *SHuaweiGuestDriver) GetDefaultSysDiskBackend() string {
 	return api.STORAGE_HUAWEI_SATA
 }

--- a/pkg/compute/guestdrivers/kvm.go
+++ b/pkg/compute/guestdrivers/kvm.go
@@ -48,6 +48,10 @@ func (self *SKVMGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_KVM
 }
 
+func (self *SKVMGuestDriver) GetProvider() string {
+	return api.CLOUD_PROVIDER_ONECLOUD
+}
+
 func (self *SKVMGuestDriver) GetDefaultSysDiskBackend() string {
 	return api.STORAGE_LOCAL
 }

--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -16,6 +16,7 @@ package guestdrivers
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"math"
 	"time"
@@ -129,6 +130,29 @@ func (self *SManagedVirtualizedGuestDriver) ValidateCreateData(ctx context.Conte
 	if input.Cdrom != "" {
 		return nil, httperrors.NewInputParameterError("%s not support cdrom params", input.Hypervisor)
 	}
+
+	_image, err := models.CachedimageManager.FetchById(input.Disks[0].ImageId)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, httperrors.NewResourceNotFoundError2("image", input.Disks[0].ImageId)
+		}
+		return nil, httperrors.NewGeneralError(err)
+	}
+	image := _image.(*models.SCachedimage)
+	if image.ImageType == cloudprovider.CachedImageTypeSystem {
+		cloudprovider, err := image.GetCloudprovider()
+		if err != nil {
+			if err == sql.ErrNoRows {
+				return nil, httperrors.NewResourceNotFoundError("failed to found image %s(%s) provider", image.Name, image.Id)
+			}
+			return nil, httperrors.NewGeneralError(err)
+		}
+		provider := models.GetDriver(input.Hypervisor).GetProvider()
+		if provider != cloudprovider.Provider {
+			return nil, httperrors.NewInputParameterError("image %s(%s) not support provider %s only support %s", image.Name, image.Id, provider, cloudprovider.Provider)
+		}
+	}
+
 	return input, nil
 }
 

--- a/pkg/compute/guestdrivers/openstack.go
+++ b/pkg/compute/guestdrivers/openstack.go
@@ -38,6 +38,10 @@ func (self *SOpenStackGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_OPENSTACK
 }
 
+func (self *SOpenStackGuestDriver) GetProvider() string {
+	return api.CLOUD_PROVIDER_OPENSTACK
+}
+
 func (self *SOpenStackGuestDriver) IsSupportEip() bool {
 	return false
 }

--- a/pkg/compute/guestdrivers/qcloud.go
+++ b/pkg/compute/guestdrivers/qcloud.go
@@ -42,6 +42,10 @@ func (self *SQcloudGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_QCLOUD
 }
 
+func (self *SQcloudGuestDriver) GetProvider() string {
+	return api.CLOUD_PROVIDER_QCLOUD
+}
+
 func (self *SQcloudGuestDriver) GetDefaultSysDiskBackend() string {
 	return api.STORAGE_CLOUD_PREMIUM
 }

--- a/pkg/compute/guestdrivers/ucloud.go
+++ b/pkg/compute/guestdrivers/ucloud.go
@@ -27,6 +27,10 @@ func (self *SUCloudGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_UCLOUD
 }
 
+func (self *SUCloudGuestDriver) GetProvider() string {
+	return api.CLOUD_PROVIDER_UCLOUD
+}
+
 func (self *SUCloudGuestDriver) GetDefaultSysDiskBackend() string {
 	return api.STORAGE_UCLOUD_CLOUD_SSD
 }

--- a/pkg/compute/models/cachedimages.go
+++ b/pkg/compute/models/cachedimages.go
@@ -496,6 +496,7 @@ func (image *SCachedimage) getValidStoragecache() []SStoragecache {
 	q = q.Filter(sqlchemy.In(providers.Field("status"), api.CLOUD_PROVIDER_VALID_STATUS))
 	q = q.Filter(sqlchemy.Equals(providers.Field("health_status"), api.CLOUD_PROVIDER_HEALTH_NORMAL))
 	q = q.Filter(sqlchemy.Equals(storagecacheimages.Field("cachedimage_id"), image.Id))
+	q = q.Filter(sqlchemy.Equals(storagecacheimages.Field("status"), api.CACHED_IMAGE_STATUS_READY))
 
 	caches := make([]SStoragecache, 0)
 	err := db.FetchModelObjects(StoragecacheManager, q, &caches)
@@ -504,6 +505,18 @@ func (image *SCachedimage) getValidStoragecache() []SStoragecache {
 		return nil
 	}
 	return caches
+}
+
+func (image *SCachedimage) GetCloudprovider() (*SCloudprovider, error) {
+	caches := image.getValidStoragecache()
+	if len(caches) == 0 {
+		return nil, fmt.Errorf("no valid storagecache for image %s(%s)", image.Name, image.Id)
+	}
+	cloudprovider := caches[0].GetCloudprovider()
+	if cloudprovider == nil {
+		return nil, fmt.Errorf("failed to found cloudprovider for storagecache %s(%s)", caches[0].Name, caches[0].Id)
+	}
+	return cloudprovider, nil
 }
 
 func (manager *SCachedimageManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQuery, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (*sqlchemy.SQuery, error) {

--- a/pkg/compute/models/guestdrivers.go
+++ b/pkg/compute/models/guestdrivers.go
@@ -31,6 +31,7 @@ import (
 
 type IGuestDriver interface {
 	GetHypervisor() string
+	GetProvider() string
 
 	GetMaxVCpuCount() int
 	GetMaxVMemSizeGB() int


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免创建时使用不同公有云的镜像

**是否需要 backport 到之前的 release 分支**:
- release/2.9.0
- release/2.8.0

/cc @yousong @swordqiu 

