### PR TITLE
fix: scheduler not init app db

### DIFF
--- a/pkg/scheduler/service/service.go
+++ b/pkg/scheduler/service/service.go
@@ -81,7 +81,8 @@ func StartService() error {
 		startSched()
 	})
 
-	//app := cloudcommon.InitApp(commonOpts, true)
+	app := app_common.InitApp(commonOpts, true)
+	cloudcommon.AppDBInit(app)
 
 	//InitHandlers(app)
 	return startHTTP(opts)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: 调度器启动时没有调用 app init db

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.9.0
- release/2.8.0

/cc @wanyaoqi 

/area scheduler