### PR TITLE
bugfix: fix host setup network

### DIFF
--- a/pkg/hostman/hostinfo/hostbridge/linux_bridge.go
+++ b/pkg/hostman/hostinfo/hostbridge/linux_bridge.go
@@ -18,7 +18,9 @@ func NewLinuxBridgeDeriver(bridge, inter, ip string) (*SLinuxBridgeDriver, error
 	if err != nil {
 		return nil, err
 	}
-	return &SLinuxBridgeDriver{*base}, nil
+	linuxBridgeDrv := &SLinuxBridgeDriver{*base}
+	linuxBridgeDrv.drv = linuxBridgeDrv
+	return linuxBridgeDrv, nil
 }
 
 func LinuxBridgePrepare() error {
@@ -105,6 +107,14 @@ func (l *SLinuxBridgeDriver) SetupBridgeDev() error {
 		if err != nil {
 			return fmt.Errorf("Failed to create bridge %s", l.bridge)
 		}
+	}
+	return nil
+}
+
+func (d *SLinuxBridgeDriver) PersistentMac() error {
+	output, err := procutils.NewCommand("ifconfig", d.bridge.String(), "hw", "ether", d.inter.Mac).Run()
+	if err != nil {
+		return fmt.Errorf("Linux bridge set mac address failed %s %s", output, err)
 	}
 	return nil
 }

--- a/pkg/hostman/hostinfo/hostbridge/ovs.go
+++ b/pkg/hostman/hostinfo/hostbridge/ovs.go
@@ -315,5 +315,7 @@ func NewOVSBridgeDriver(bridge, inter, ip string) (*SOVSBridgeDriver, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SOVSBridgeDriver{*base}, nil
+	ovsDrv := &SOVSBridgeDriver{*base}
+	ovsDrv.drv = ovsDrv
+	return ovsDrv, nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
- golang host网络配置
- linux网桥设置mac地址

**是否需要 backport 到之前的 release 分支**:
release/2.8.0

/area host
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
