### PR TITLE
baremetal: support http download kernel and initramfs for pxe boot

### DIFF
--- a/pkg/baremetal/nic.go
+++ b/pkg/baremetal/nic.go
@@ -76,7 +76,11 @@ func GetNicDHCPConfig(
 		case 6:
 			conf.BootFile = "bootia32.efi"
 		default:
-			conf.BootFile = "pxelinux.0"
+			bootFile := "pxelinux.0"
+			if o.Options.EnableTftpHttpDownload {
+				bootFile = "lpxelinux.0"
+			}
+			conf.BootFile = bootFile
 		}
 		pxePath := filepath.Join(o.Options.TftpRoot, conf.BootFile)
 		if f, err := os.Open(pxePath); err != nil {

--- a/pkg/baremetal/options/options.go
+++ b/pkg/baremetal/options/options.go
@@ -22,7 +22,7 @@ type BaremetalOptions struct {
 	ListenInterface        string `help:"Master net interface of baremetal server" default:"br0"`
 	AccessAddress          string `help:"Management IP address of baremetal server, only need to use when multiple address bind to ListenInterface"`
 	ListenAddress          string `help:"PXE serve IP address to select when multiple address bind to ListenInterface" default:"0.0.0.0"`
-	TftpRoot               string `help:"tftp root directory"`
+	TftpRoot               string `default:"/opt/cloud/yunion/baremetal" help:"tftp root directory"`
 	AutoRegisterBaremetal  bool   `default:"true" help:"Automatically create a baremetal instance"`
 	BaremetalsPath         string `default:"/opt/cloud/workspace/baremetals" help:"Path for baremetals configuration files"`
 	LinuxDefaultRootUser   bool   `default:"false" help:"Default account for linux system is root"`
@@ -41,6 +41,7 @@ type BaremetalOptions struct {
 	DefaultStrongIpmiPassword string `help:"Default strong IPMI passowrd"`
 
 	WindowsDefaultAdminUser bool `default:"true" help:"Default account for Windows system is Administrator"`
+	EnableTftpHttpDownload  bool `default:"true" help:"Pxelinux download file through http"`
 }
 
 var (


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

物理机 pxe boot 时支持使用 http 下载 kernel 和 initramfs (#438)

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.9.0

/area baremetal
/cc @swordqiu @wanyaoqi 