### PR TITLE
bugfix: fix set migrate capability, fix resize fs catch error

### DIFF
--- a/pkg/hostman/monitor/qmp.go
+++ b/pkg/hostman/monitor/qmp.go
@@ -558,7 +558,7 @@ func (m *QmpMonitor) MigrateSetCapability(capability, state string, callback Str
 	}
 
 	cmd := &Command{
-		Execute: "query-migrate-capabilities",
+		Execute: "migrate-set-capabilities",
 		Args: map[string]interface{}{
 			"capabilities": []interface{}{
 				map[string]interface{}{

--- a/pkg/hostman/storageman/disk_base.go
+++ b/pkg/hostman/storageman/disk_base.go
@@ -118,6 +118,17 @@ func (d *SBaseDisk) DeployGuestFs(diskPath string, guestDesc *jsonutils.JSONDict
 	return guestfs.DeployGuestFs(root, guestDesc, deployInfo)
 }
 
+func (d *SBaseDisk) ResizeFs(diskPath string) error {
+	disk := NewKVMGuestDisk(diskPath)
+	if disk.Connect() {
+		defer disk.Disconnect()
+		if err := disk.ResizePartition(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (d *SBaseDisk) GetDiskSetupScripts(diskIndex int) string {
 	return ""
 }

--- a/pkg/hostman/storageman/disk_local.go
+++ b/pkg/hostman/storageman/disk_local.go
@@ -132,22 +132,9 @@ func (d *SLocalDisk) Resize(ctx context.Context, params interface{}) (jsonutils.
 		// d.Fallocate()
 	}
 
-	if err = d.ResizeFs(); err != nil {
-		return nil, err
-	}
+	d.ResizeFs(d.GetPath())
 
 	return d.GetDiskDesc(), nil
-}
-
-func (d *SLocalDisk) ResizeFs() error {
-	disk := NewKVMGuestDisk(d.GetPath())
-	if disk.Connect() {
-		defer disk.Disconnect()
-		if err := disk.ResizePartition(); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (d *SLocalDisk) CreateFromImageFuse(ctx context.Context, url string) error {

--- a/pkg/hostman/storageman/disk_rbd.go
+++ b/pkg/hostman/storageman/disk_rbd.go
@@ -111,22 +111,8 @@ func (d *SRBDDisk) Resize(ctx context.Context, params interface{}) (jsonutils.JS
 		return nil, err
 	}
 
-	if err := d.ResizeFs(); err != nil {
-		return nil, err
-	}
-
+	d.ResizeFs(d.GetPath())
 	return d.GetDiskDesc(), nil
-}
-
-func (d *SRBDDisk) ResizeFs() error {
-	disk := NewKVMGuestDisk(d.GetPath())
-	if disk.Connect() {
-		defer disk.Disconnect()
-		if err := disk.ResizePartition(); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (d *SRBDDisk) PrepareSaveToGlance(ctx context.Context, params interface{}) (jsonutils.JSONObject, error) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
bugfix: fix set migrate capability, fix resize fs catch error
**是否需要 backport 到之前的 release 分支**:
release/2.9.0

/cc @swordqiu @Zexi 
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
