### PR TITLE
Automated cherry pick of #836: fix set migrate capability, fix resize fs catch error

### DIFF
--- a/pkg/hostman/monitor/qmp.go
+++ b/pkg/hostman/monitor/qmp.go
@@ -558,7 +558,7 @@ func (m *QmpMonitor) MigrateSetCapability(capability, state string, callback Str
 	}
 
 	cmd := &Command{
-		Execute: "query-migrate-capabilities",
+		Execute: "migrate-set-capabilities",
 		Args: map[string]interface{}{
 			"capabilities": []interface{}{
 				map[string]interface{}{

--- a/pkg/hostman/storageman/disk_base.go
+++ b/pkg/hostman/storageman/disk_base.go
@@ -118,6 +118,17 @@ func (d *SBaseDisk) DeployGuestFs(diskPath string, guestDesc *jsonutils.JSONDict
 	return guestfs.DeployGuestFs(root, guestDesc, deployInfo)
 }
 
+func (d *SBaseDisk) ResizeFs(diskPath string) error {
+	disk := NewKVMGuestDisk(diskPath)
+	if disk.Connect() {
+		defer disk.Disconnect()
+		if err := disk.ResizePartition(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (d *SBaseDisk) GetDiskSetupScripts(diskIndex int) string {
 	return ""
 }

--- a/pkg/hostman/storageman/disk_local.go
+++ b/pkg/hostman/storageman/disk_local.go
@@ -132,22 +132,9 @@ func (d *SLocalDisk) Resize(ctx context.Context, params interface{}) (jsonutils.
 		// d.Fallocate()
 	}
 
-	if err = d.ResizeFs(); err != nil {
-		return nil, err
-	}
+	d.ResizeFs(d.GetPath())
 
 	return d.GetDiskDesc(), nil
-}
-
-func (d *SLocalDisk) ResizeFs() error {
-	disk := NewKVMGuestDisk(d.GetPath())
-	if disk.Connect() {
-		defer disk.Disconnect()
-		if err := disk.ResizePartition(); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (d *SLocalDisk) CreateFromImageFuse(ctx context.Context, url string) error {

--- a/pkg/hostman/storageman/disk_rbd.go
+++ b/pkg/hostman/storageman/disk_rbd.go
@@ -111,22 +111,8 @@ func (d *SRBDDisk) Resize(ctx context.Context, params interface{}) (jsonutils.JS
 		return nil, err
 	}
 
-	if err := d.ResizeFs(); err != nil {
-		return nil, err
-	}
-
+	d.ResizeFs(d.GetPath())
 	return d.GetDiskDesc(), nil
-}
-
-func (d *SRBDDisk) ResizeFs() error {
-	disk := NewKVMGuestDisk(d.GetPath())
-	if disk.Connect() {
-		defer disk.Disconnect()
-		if err := disk.ResizePartition(); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (d *SRBDDisk) PrepareSaveToGlance(ctx context.Context, params interface{}) (jsonutils.JSONObject, error) {


### PR DESCRIPTION
Cherry pick of #836 on release/2.9.0.

#836: fix set migrate capability, fix resize fs catch error