### PR TITLE
上传到云上的镜像名称和本地保持一致

### DIFF
--- a/pkg/cloudprovider/images.go
+++ b/pkg/cloudprovider/images.go
@@ -71,3 +71,14 @@ func CloudImage2Image(image ICloudImage) SImage {
 		Status:    image.GetImageStatus(),
 	}
 }
+
+type SImageCreateOption struct {
+	ImageId        string
+	ExternalId     string
+	ImageName      string
+	OsType         string
+	OsArch         string
+	OsDistribution string
+	OsVersion      string
+	OsFullVersion  string
+}

--- a/pkg/cloudprovider/resources.go
+++ b/pkg/cloudprovider/resources.go
@@ -141,7 +141,7 @@ type ICloudStoragecache interface {
 
 	DownloadImage(userCred mcclient.TokenCredential, imageId string, extId string, path string) (jsonutils.JSONObject, error)
 
-	UploadImage(ctx context.Context, userCred mcclient.TokenCredential, imageId string, osArch, osType, osDist, osVersion string, extId string, isForce bool) (string, error)
+	UploadImage(ctx context.Context, userCred mcclient.TokenCredential, image *SImageCreateOption, isForce bool) (string, error)
 }
 
 type ICloudStorage interface {

--- a/pkg/compute/models/storagecaches.go
+++ b/pkg/compute/models/storagecaches.go
@@ -318,6 +318,7 @@ func (self *SStoragecache) StartImageCacheTask(ctx context.Context, userCred mcc
 		data.Add(jsonutils.NewString(imgInfo.OsDistro), "os_distribution")
 		data.Add(jsonutils.NewString(imgInfo.OsVersion), "os_version")
 		data.Add(jsonutils.NewString(imgInfo.OsFullVersion), "os_full_version")
+		data.Add(jsonutils.NewString(image.Name), "image_name")
 	}
 
 	if isForce {

--- a/pkg/util/esxi/storagecache.go
+++ b/pkg/util/esxi/storagecache.go
@@ -143,8 +143,6 @@ func (self *SDatastoreImageCache) DownloadImage(userCred mcclient.TokenCredentia
 	return nil, cloudprovider.ErrNotImplemented
 }
 
-func (self *SDatastoreImageCache) UploadImage(ctx context.Context, userCred mcclient.TokenCredential,
-	imageId string, osArch, osType, osDist, osVersion string, extId string, isForce bool,
-) (string, error) {
+func (self *SDatastoreImageCache) UploadImage(ctx context.Context, userCred mcclient.TokenCredential, image *cloudprovider.SImageCreateOption, isForce bool) (string, error) {
 	return "", cloudprovider.ErrNotImplemented
 }

--- a/pkg/util/ucloud/storagecache.go
+++ b/pkg/util/ucloud/storagecache.go
@@ -116,30 +116,30 @@ func (self *SStoragecache) DownloadImage(userCred mcclient.TokenCredential, imag
 }
 
 // https://docs.ucloud.cn/api/uhost-api/import_custom_image
-func (self *SStoragecache) UploadImage(ctx context.Context, userCred mcclient.TokenCredential, imageId string, osArch, osType, osDist, osVersion string, extId string, isForce bool) (string, error) {
-	if len(extId) > 0 {
-		log.Debugf("UploadImage: Image external ID exists %s", extId)
+func (self *SStoragecache) UploadImage(ctx context.Context, userCred mcclient.TokenCredential, image *cloudprovider.SImageCreateOption, isForce bool) (string, error) {
+	if len(image.ExternalId) > 0 {
+		log.Debugf("UploadImage: Image external ID exists %s", image.ExternalId)
 
-		image, err := self.region.GetImage(extId)
+		img, err := self.region.GetImage(image.ExternalId)
 		if err != nil {
 			log.Errorf("GetImageStatus error %s", err)
 		}
-		if image.GetStatus() == cloudprovider.IMAGE_STATUS_ACTIVE && !isForce {
-			return extId, nil
+		if img.GetStatus() == cloudprovider.IMAGE_STATUS_ACTIVE && !isForce {
+			return image.ExternalId, nil
 		}
 	} else {
 		log.Debugf("UploadImage: no external ID")
 	}
 
-	return self.uploadImage(ctx, userCred, imageId, osArch, osType, osDist, osVersion, isForce)
+	return self.uploadImage(ctx, userCred, image, isForce)
 }
 
-func (self *SStoragecache) uploadImage(ctx context.Context, userCred mcclient.TokenCredential, imageId string, osArch, osType, osDist string, osVersion string, isForce bool) (string, error) {
-	if len(osVersion) == 0 {
+func (self *SStoragecache) uploadImage(ctx context.Context, userCred mcclient.TokenCredential, image *cloudprovider.SImageCreateOption, isForce bool) (string, error) {
+	if len(image.OsVersion) == 0 {
 		return "", fmt.Errorf("uploadImage os version is empty")
 	}
 
-	bucketName := GetBucketName(self.region.GetId(), imageId)
+	bucketName := GetBucketName(self.region.GetId(), image.ImageId)
 
 	// create bucket
 	if _, err := self.region.GetBucketDomain(bucketName); err != nil {
@@ -157,7 +157,7 @@ func (self *SStoragecache) uploadImage(ctx context.Context, userCred mcclient.To
 
 	// upload to  ucloud
 	s := auth.GetAdminSession(ctx, options.Options.Region, "")
-	meta, reader, err := modules.Images.Download(s, imageId, string(qemuimg.VMDK), false)
+	meta, reader, err := modules.Images.Download(s, image.ImageId, string(qemuimg.VMDK), false)
 	if err != nil {
 		return "", err
 	}
@@ -179,7 +179,7 @@ func (self *SStoragecache) uploadImage(ctx context.Context, userCred mcclient.To
 		BucketName: bucketName,
 		File:       reader,
 		FileSize:   size,
-		FileName:   imageId,
+		FileName:   image.ImageId,
 		FileMD5:    md5,
 	}
 
@@ -195,9 +195,9 @@ func (self *SStoragecache) uploadImage(ctx context.Context, userCred mcclient.To
 	}() // remove object
 
 	// check image name, avoid name conflict
-	imageBaseName := imageId
+	imageBaseName := image.ImageId
 	if imageBaseName[0] >= '0' && imageBaseName[0] <= '9' {
-		imageBaseName = fmt.Sprintf("img%s", imageId)
+		imageBaseName = fmt.Sprintf("img%s", image.ImageId)
 	}
 	imageName := imageBaseName
 	nameIdx := 1
@@ -217,7 +217,7 @@ func (self *SStoragecache) uploadImage(ctx context.Context, userCred mcclient.To
 		log.Debugf("uploadImage Match remote name %s", imageName)
 	}
 
-	imgId, err := self.region.ImportImage(imageName, file.FetchFileUrl(), osDist, osVersion, diskFormat)
+	imgId, err := self.region.ImportImage(imageName, file.FetchFileUrl(), image.OsDistribution, image.OsVersion, diskFormat)
 
 	if err != nil {
 		log.Errorf("ImportImage error %s %s", file.FetchFileUrl(), err)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
上传到云上的镜像名称和本地保持一致(目前只有OpenStack已改,其余公有云依然使用image_id)

**是否需要 backport 到之前的 release 分支**:
- release/2.9.0
