### PR TITLE
fix: SSHPartition test symbolic file exists fail

### DIFF
--- a/pkg/hostman/guestfs/sshpart/sshpart.go
+++ b/pkg/hostman/guestfs/sshpart/sshpart.go
@@ -106,7 +106,8 @@ func (p *SSHPartition) osRmDir(path string) error {
 }
 
 func (p *SSHPartition) osPathExists(path string) bool {
-	_, err := p.term.Run(fmt.Sprintf("test -e %s", path))
+	// test file or symbolic link exists
+	_, err := p.term.Run(fmt.Sprintf("test -e %s || test -L %s", path, path))
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复 baremetal 在多次 deploy 后开启串口失败的问题，根本原因是当软连接文件存在时, SSHPartition.osPathExists 函数判断出错， `test -e` 命令检测的是软连接的目标文件是否存在，如果要看软连接文件是否存在需要用 `test -L`

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.9.0

/cc @swordqiu @wanyaoqi 
