### PR TITLE
Automated cherry pick of #850: fix: SSHPartition test symbolic file exists fail

### DIFF
--- a/pkg/hostman/guestfs/sshpart/sshpart.go
+++ b/pkg/hostman/guestfs/sshpart/sshpart.go
@@ -106,7 +106,8 @@ func (p *SSHPartition) osRmDir(path string) error {
 }
 
 func (p *SSHPartition) osPathExists(path string) bool {
-	_, err := p.term.Run(fmt.Sprintf("test -e %s", path))
+	// test file or symbolic link exists
+	_, err := p.term.Run(fmt.Sprintf("test -e %s || test -L %s", path, path))
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
Cherry pick of #850 on release/2.9.0.

#850: fix: SSHPartition test symbolic file exists fail