### PR TITLE
Hotfix/qx inject password by cloud init

### DIFF
--- a/pkg/cloudprovider/instance.go
+++ b/pkg/cloudprovider/instance.go
@@ -15,6 +15,8 @@
 package cloudprovider
 
 import (
+	"fmt"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/util/osprofile"
 
@@ -53,6 +55,7 @@ type SManagedVMCreateConfig struct {
 	PublicKey           string
 	ExternalSecgroupId  string
 	ExternalSecgroupIds []string
+	Account             string
 	Password            string
 	UserData            string
 	UserDataType        string
@@ -116,4 +119,35 @@ func generateUserData(adminPublicKey, projectPublicKey, oUserData string, userDa
 	}
 
 	return cloudConfig.UserDataBase64()
+}
+
+func (vmConfig *SManagedVMCreateConfig) InjectPasswordByCloudInit() error {
+	if vmConfig.OsType != osprofile.OS_TYPE_LINUX {
+		return fmt.Errorf("Only support inject Linux password, current osType is %s", vmConfig.OsType)
+	}
+	loginUser := cloudinit.NewUser(vmConfig.Account)
+	loginUser.SudoPolicy(cloudinit.USER_SUDO_NOPASSWD)
+	if len(vmConfig.PublicKey) > 0 {
+		loginUser.SshKey(vmConfig.PublicKey)
+	}
+	if len(vmConfig.Password) > 0 {
+		loginUser.Password(vmConfig.Password)
+	}
+
+	cloudconfig := cloudinit.SCloudConfig{Users: []cloudinit.SUser{loginUser}}
+
+	if len(vmConfig.UserData) > 0 {
+		oCloudConfig, err := cloudinit.ParseUserDataBase64(vmConfig.UserData)
+		if err != nil {
+			return err
+		}
+		cloudconfig.Merge(oCloudConfig)
+	}
+	switch vmConfig.UserDataType {
+	case CLOUD_SHELL:
+		vmConfig.UserData = cloudconfig.UserDataScriptBase64()
+	default:
+		vmConfig.UserData = cloudconfig.UserDataBase64()
+	}
+	return nil
 }

--- a/pkg/cloudprovider/instance.go
+++ b/pkg/cloudprovider/instance.go
@@ -134,7 +134,13 @@ func (vmConfig *SManagedVMCreateConfig) InjectPasswordByCloudInit() error {
 		loginUser.Password(vmConfig.Password)
 	}
 
-	cloudconfig := cloudinit.SCloudConfig{Users: []cloudinit.SUser{loginUser}}
+	cloudconfig := cloudinit.SCloudConfig{
+		DisableRoot: 0,
+		SshPwauth:   1,
+		Users: []cloudinit.SUser{
+			loginUser,
+		},
+	}
 
 	if len(vmConfig.UserData) > 0 {
 		oCloudConfig, err := cloudinit.ParseUserDataBase64(vmConfig.UserData)

--- a/pkg/compute/guestdrivers/aws.go
+++ b/pkg/compute/guestdrivers/aws.go
@@ -67,6 +67,10 @@ func fetchAwsUserName(desc cloudprovider.SManagedVMCreateConfig) string {
 	}
 }
 
+func (self *SAwsGuestDriver) IsNeedInjectPasswordByCloudInit() bool {
+	return true
+}
+
 func (self *SAwsGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManagedVMCreateConfig) string {
 	// return fetchAwsUserName(desc)
 	return api.VM_AWS_DEFAULT_LOGIN_USER

--- a/pkg/compute/guestdrivers/base.go
+++ b/pkg/compute/guestdrivers/base.go
@@ -247,6 +247,10 @@ func (self *SBaseGuestDriver) GetGuestInitialStateAfterRebuild() string {
 	return api.VM_READY
 }
 
+func (self *SBaseGuestDriver) IsNeedInjectPasswordByCloudInit() bool {
+	return false
+}
+
 func (self *SBaseGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManagedVMCreateConfig) string {
 	userName := "root"
 	if desc.ImageType == "system" && desc.OsType == "Windows" {

--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -206,6 +206,15 @@ func (self *SManagedVirtualizedGuestDriver) RequestDeployGuestOnHost(ctx context
 		return err
 	}
 
+	desc.Account = guest.GetDriver().GetLinuxDefaultAccount(desc)
+
+	if guest.GetDriver().IsNeedInjectPasswordByCloudInit() {
+		err = desc.InjectPasswordByCloudInit()
+		if err != nil {
+			log.Warningf("failed to inject password by cloud-init error: %v", err)
+		}
+	}
+
 	action, err := config.GetString("action")
 	if err != nil {
 		return err
@@ -246,6 +255,10 @@ func (self *SManagedVirtualizedGuestDriver) GetGuestInitialStateAfterRebuild() s
 
 func (self *SManagedVirtualizedGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManagedVMCreateConfig) string {
 	return "root"
+}
+
+func (self *SManagedVirtualizedGuestDriver) IsNeedInjectPasswordByCloudInit() bool {
+	return false
 }
 
 func (self *SManagedVirtualizedGuestDriver) RemoteDeployGuestForCreate(ctx context.Context, userCred mcclient.TokenCredential, guest *models.SGuest, host *models.SHost, desc cloudprovider.SManagedVMCreateConfig) (jsonutils.JSONObject, error) {
@@ -300,9 +313,7 @@ func (self *SManagedVirtualizedGuestDriver) RemoteDeployGuestForCreate(ctx conte
 		return nil, err
 	}
 
-	account := guest.GetDriver().GetLinuxDefaultAccount(desc)
-
-	data := fetchIVMinfo(desc, iVM, guest.Id, account, desc.Password, "create")
+	data := fetchIVMinfo(desc, iVM, guest.Id, desc.Account, desc.Password, "create")
 	return data, nil
 }
 
@@ -335,8 +346,7 @@ func (self *SManagedVirtualizedGuestDriver) RemoteDeployGuestForDeploy(ctx conte
 		return nil, err
 	}
 
-	account := guest.GetDriver().GetLinuxDefaultAccount(desc)
-	data := fetchIVMinfo(desc, iVM, guest.Id, account, desc.Password, "deploy")
+	data := fetchIVMinfo(desc, iVM, guest.Id, desc.Account, desc.Password, "deploy")
 
 	return data, nil
 }
@@ -404,8 +414,7 @@ func (self *SManagedVirtualizedGuestDriver) RemoteDeployGuestForRebuildRoot(ctx 
 		}
 	}
 
-	account := guest.GetDriver().GetLinuxDefaultAccount(desc)
-	data := fetchIVMinfo(desc, iVM, guest.Id, account, desc.Password, "rebuild")
+	data := fetchIVMinfo(desc, iVM, guest.Id, desc.Account, desc.Password, "rebuild")
 
 	return data, nil
 }

--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -151,6 +151,15 @@ func (self *SManagedVirtualizedGuestDriver) ValidateCreateData(ctx context.Conte
 		if provider != cloudprovider.Provider {
 			return nil, httperrors.NewInputParameterError("image %s(%s) not support provider %s only support %s", image.Name, image.Id, provider, cloudprovider.Provider)
 		}
+		if len(input.PreferRegion) == 0 && len(input.PreferZone) == 0 && len(input.PreferHost) == 0 {
+			regions, err := image.GetRegions()
+			if err != nil {
+				log.Warningf("failed to get regions for image %s(%s) error: %v", image.Name, image.Id, err)
+			}
+			if len(regions) > 0 {
+				input.PreferRegion = regions[0].Id
+			}
+		}
 	}
 
 	return input, nil

--- a/pkg/compute/models/cachedimages.go
+++ b/pkg/compute/models/cachedimages.go
@@ -507,6 +507,19 @@ func (image *SCachedimage) getValidStoragecache() []SStoragecache {
 	return caches
 }
 
+func (image *SCachedimage) GetRegions() ([]SCloudregion, error) {
+	regions := []SCloudregion{}
+	caches := image.getValidStoragecache()
+	for _, cache := range caches {
+		region, err := cache.GetRegion()
+		if err != nil {
+			return nil, err
+		}
+		regions = append(regions, *region)
+	}
+	return regions, nil
+}
+
 func (image *SCachedimage) GetCloudprovider() (*SCloudprovider, error) {
 	caches := image.getValidStoragecache()
 	if len(caches) == 0 {

--- a/pkg/compute/models/guestdrivers.go
+++ b/pkg/compute/models/guestdrivers.go
@@ -156,6 +156,8 @@ type IGuestDriver interface {
 
 	OnGuestChangeCpuMemFailed(ctx context.Context, guest *SGuest, data *jsonutils.JSONDict, task taskman.ITask) error
 	IsSupportGuestClone() bool
+
+	IsNeedInjectPasswordByCloudInit() bool
 }
 
 var guestDrivers map[string]IGuestDriver

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -54,7 +54,6 @@ import (
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/util/billing"
-	"yunion.io/x/onecloud/pkg/util/cloudinit"
 	"yunion.io/x/onecloud/pkg/util/logclient"
 	"yunion.io/x/onecloud/pkg/util/netutils2"
 	"yunion.io/x/onecloud/pkg/util/seclib2"
@@ -3049,27 +3048,7 @@ func (self *SGuest) GetDeployConfigOnHost(ctx context.Context, userCred mcclient
 		case api.HYPERVISOR_ALIYUN, api.HYPERVISOR_HUAWEI, api.HYPERVISOR_UCLOUD:
 			break
 		case api.HYPERVISOR_AWS:
-			loginUser := cloudinit.NewUser(api.VM_AWS_DEFAULT_LOGIN_USER)
-			loginUser.SudoPolicy(cloudinit.USER_SUDO_NOPASSWD)
-			if pub, _ := config.GetString("public_key"); len(pub) > 0 {
-				loginUser.SshKey(pub)
-			} else if pwd, _ := config.GetString("password"); len(pwd) > 0 {
-				loginUser.Password(pwd)
-			}
-
-			cloudconfig := cloudinit.SCloudConfig{Users: []cloudinit.SUser{loginUser}}
-
-			if d, _ := config.GetString("user_data"); len(d) > 0 {
-				_d, err := cloudinit.ParseUserDataBase64(d)
-				if err != nil {
-					return nil, fmt.Errorf("invalid user data %s", d)
-				}
-
-				cloudconfig.Merge(_d)
-			}
-
-			userdata := cloudconfig.UserDataBase64()
-			config.Add(jsonutils.NewString(userdata), "user_data")
+			break
 		case api.HYPERVISOR_QCLOUD, api.HYPERVISOR_OPENSTACK:
 			registerVpcId = "normal"
 		case api.HYPERVISOR_AZURE:

--- a/pkg/compute/models/storagecaches.go
+++ b/pkg/compute/models/storagecaches.go
@@ -121,6 +121,18 @@ func (self *SStoragecache) GetHost() (*SHost, error) {
 	return h, nil
 }
 
+func (self *SStoragecache) GetRegion() (*SCloudregion, error) {
+	host, err := self.GetHost()
+	if err != nil {
+		return nil, err
+	}
+	region := host.GetRegion()
+	if region == nil {
+		return nil, fmt.Errorf("failed to get region for host %s(%s)", host.Name, host.Id)
+	}
+	return region, nil
+}
+
 func (self *SStoragecache) getHostId() (string, error) {
 	hoststorages := HoststorageManager.Query().SubQuery()
 	storages := StorageManager.Query().SubQuery()

--- a/pkg/util/cloudinit/cloudconfig.go
+++ b/pkg/util/cloudinit/cloudconfig.go
@@ -56,7 +56,7 @@ type SWriteFile struct {
 type SUser struct {
 	Name              string
 	Passwd            string
-	LockPassword      string
+	LockPasswd        string
 	SshAuthorizedKeys []string
 	Sudo              string
 }
@@ -162,7 +162,7 @@ func (u *SUser) Password(passwd string) *SUser {
 		} else {
 			u.Passwd = hash
 		}
-		u.LockPassword = "false"
+		u.LockPasswd = "false"
 	}
 	return u
 }
@@ -281,7 +281,7 @@ func (conf *SCloudConfig) MergeUser(u SUser) {
 			// replace conf user password with input
 			if len(u.Passwd) > 0 {
 				conf.Users[i].Passwd = u.Passwd
-				conf.Users[i].LockPassword = u.LockPassword
+				conf.Users[i].LockPasswd = u.LockPasswd
 			}
 
 			// find user, merge keys


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 使用正确的lock_passwd参数，避免账号被锁定，登录不了
2. 避免climc指定公有云镜像后调度到非镜像所在的region，导致创建机器失败
3. 通用化inject passwd by cloud-init

**是否需要 backport 到之前的 release 分支**:
- release/2.9.0
- release/2.8.0

/cc @swordqiu @yousong 