### PR TITLE
fix: host undo convert not delete isolated_devices

### DIFF
--- a/pkg/compute/models/isolated_devices.go
+++ b/pkg/compute/models/isolated_devices.go
@@ -589,7 +589,8 @@ func (manager *SIsolatedDeviceManager) FindByHost(id string) []SIsolatedDevice {
 
 func (manager *SIsolatedDeviceManager) FindByHosts(ids []string) []SIsolatedDevice {
 	dest := make([]SIsolatedDevice, 0)
-	err := manager.Query().In("host_id", ids).All(&dest)
+	q := manager.Query().In("host_id", ids)
+	err := db.FetchModelObjects(manager, q, &dest)
 	if err != nil {
 		log.Errorln(err)
 		return nil

--- a/pkg/compute/tasks/baremetal_unconvert_hypervisor_task.go
+++ b/pkg/compute/tasks/baremetal_unconvert_hypervisor_task.go
@@ -49,6 +49,7 @@ func (self *BaremetalUnconvertHypervisorTask) OnInit(ctx context.Context, obj db
 	} else {
 		self.OnGuestDeleteComplete(ctx, baremetal, nil)
 	}
+	models.IsolatedDeviceManager.DeleteDevicesByHost(ctx, self.GetUserCred(), baremetal)
 }
 
 func (self *BaremetalUnconvertHypervisorTask) OnGuestDeleteComplete(ctx context.Context, baremetal *models.SHost, body jsonutils.JSONObject) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: host 回收为物理机时没有删除上面的 gpu 记录

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.9.0

/cc @swordqiu 
/area region baremetal