### PR TITLE
routetables: 修复add/del routes功能

### DIFF
--- a/cmd/climc/shell/routetables.go
+++ b/cmd/climc/shell/routetables.go
@@ -39,10 +39,10 @@ func init() {
 				typ, _ := routeObj.GetString("type")
 				cidr, _ := routeObj.GetString("cidr")
 				next_hop_type, _ := routeObj.GetString("next_hop_type")
-				next_hop, _ := routeObj.GetString("next_hop")
+				next_hop_id, _ := routeObj.GetString("next_hop_id")
 				route := fmt.Sprintf("%8s: %18s %s", typ, cidr, next_hop_type)
-				if len(next_hop) > 0 {
-					route += fmt.Sprintf(":%s", next_hop)
+				if next_hop_id != "" {
+					route += fmt.Sprintf(":%s", next_hop_id)
 				}
 				routes = append(routes, route)
 			}

--- a/pkg/compute/models/routetables.go
+++ b/pkg/compute/models/routetables.go
@@ -60,18 +60,23 @@ func (route *SRoute) Validate(data *jsonutils.JSONDict) error {
 
 type SRoutes []*SRoute
 
-func (routes *SRoutes) String() string {
+func (routes SRoutes) String() string {
 	return jsonutils.Marshal(routes).String()
 }
-func (routes *SRoutes) IsZero() bool {
-	if len([]*SRoute(*routes)) == 0 {
+func (routes SRoutes) IsZero() bool {
+	if len(routes) == 0 {
 		return true
 	}
 	return false
 }
 
 func (routes *SRoutes) Validate(data *jsonutils.JSONDict) error {
-	found := map[string]bool{}
+	if routes == nil {
+		*routes = SRoutes{}
+		return nil
+	}
+
+	found := map[string]struct{}{}
 	for _, route := range *routes {
 		if err := route.Validate(data); err != nil {
 			return err
@@ -81,7 +86,7 @@ func (routes *SRoutes) Validate(data *jsonutils.JSONDict) error {
 			return httperrors.NewInputParameterError("duplicate route cidr %s", route.Cidr)
 		}
 		// TODO aliyun: check overlap with System type route
-		found[route.Cidr] = true
+		found[route.Cidr] = struct{}{}
 	}
 	return nil
 }
@@ -258,7 +263,11 @@ func (rt *SRouteTable) AllowPerformDelRoutes(ctx context.Context, userCred mccli
 // PerformAddRoutes patches acl entries by adding then deleting the specified acls.
 // This is intended mainly for command line operations.
 func (rt *SRouteTable) PerformAddRoutes(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
-	routes := gotypes.DeepCopy(rt.Routes).(SRoutes)
+	var routes SRoutes
+	if rt.Routes != nil {
+		routes_ := gotypes.DeepCopy(rt.Routes).(*SRoutes)
+		routes = *routes_
+	}
 	{
 		adds := SRoutes{}
 		addsV := validators.NewStructValidator("routes", &adds)
@@ -291,7 +300,11 @@ func (rt *SRouteTable) PerformAddRoutes(ctx context.Context, userCred mcclient.T
 }
 
 func (rt *SRouteTable) PerformDelRoutes(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
-	routes := gotypes.DeepCopy(rt.Routes).(SRoutes)
+	var routes SRoutes
+	if rt.Routes != nil {
+		routes_ := gotypes.DeepCopy(rt.Routes).(*SRoutes)
+		routes = *routes_
+	}
 	{
 		cidrs := []string{}
 		err := data.Unmarshal(&cidrs, "cidrs")
@@ -412,7 +425,7 @@ func (man *SRouteTableManager) SyncRouteTables(ctx context.Context, userCred mcc
 }
 
 func (man *SRouteTableManager) newRouteTableFromCloud(userCred mcclient.TokenCredential, vpc *SVpc, cloudRouteTable cloudprovider.ICloudRouteTable) (*SRouteTable, error) {
-	routes := []*SRoute{}
+	routes := SRoutes{}
 	{
 		cloudRoutes, err := cloudRouteTable.GetIRoutes()
 		if err != nil {
@@ -432,7 +445,7 @@ func (man *SRouteTableManager) newRouteTableFromCloud(userCred mcclient.TokenCre
 		CloudregionId: vpc.CloudregionId,
 		VpcId:         vpc.Id,
 		Type:          cloudRouteTable.GetType(),
-		Routes:        (*SRoutes)(&routes),
+		Routes:        &routes,
 	}
 	newName, err := db.GenerateName(man, userCred.GetProjectId(), cloudRouteTable.GetName())
 	if err != nil {

--- a/pkg/mcclient/options/routetables.go
+++ b/pkg/mcclient/options/routetables.go
@@ -57,7 +57,7 @@ func (opts *RoutesOptions) Params() (jsonutils.JSONObject, error) {
 
 type RouteTableCreateOptions struct {
 	NAME string
-	Vpc  string
+	Vpc  string `required:"true"`
 
 	RoutesOptions
 }

--- a/pkg/mcclient/options/routetables.go
+++ b/pkg/mcclient/options/routetables.go
@@ -30,25 +30,25 @@ type Route struct {
 type Routes []*Route
 
 type RoutesOptions struct {
-	RouteType        []string
-	RouteCidr        []string
-	RouteNextHopType []string
-	RouteNextHopId   []string
+	Type        []string
+	Cidr        []string
+	NextHopType []string
+	NextHopId   []string
 }
 
 func (opts *RoutesOptions) Params() (jsonutils.JSONObject, error) {
-	len0 := len(opts.RouteType)
-	len1 := len(opts.RouteCidr)
-	if len0 != len1 || len0 != len(opts.RouteNextHopType) || len1 != len(opts.RouteNextHopId) {
-		return nil, fmt.Errorf("there must be equal number of options of --route-xxx")
+	len0 := len(opts.Type)
+	len1 := len(opts.Cidr)
+	if len0 != len1 || len0 != len(opts.NextHopType) || len1 != len(opts.NextHopId) {
+		return nil, fmt.Errorf("there must be equal number of options for each route")
 	}
 	routes := []*Route{}
 	for i := 0; i < len0; i++ {
 		routes = append(routes, &Route{
-			Type:        opts.RouteType[i],
-			Cidr:        opts.RouteCidr[i],
-			NextHopType: opts.RouteNextHopType[i],
-			NextHopId:   opts.RouteNextHopId[i],
+			Type:        opts.Type[i],
+			Cidr:        opts.Cidr[i],
+			NextHopType: opts.NextHopType[i],
+			NextHopId:   opts.NextHopId[i],
 		})
 	}
 	routesJson := jsonutils.Marshal(routes)
@@ -91,7 +91,7 @@ func (opts *RouteTableUpdateOptions) Params() (*jsonutils.JSONDict, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(opts.RouteCidr) != 0 {
+	if len(opts.Cidr) != 0 {
 		routesJson, err := opts.RoutesOptions.Params()
 		if err != nil {
 			return nil, err
@@ -108,7 +108,7 @@ type RouteTableAddRoutesOptions struct {
 }
 
 func (opts *RouteTableAddRoutesOptions) Params() (*jsonutils.JSONDict, error) {
-	if len(opts.RouteCidr) == 0 {
+	if len(opts.Cidr) == 0 {
 		return nil, fmt.Errorf("nothing to add")
 	}
 	routesJson, err := opts.RoutesOptions.Params()
@@ -123,15 +123,15 @@ func (opts *RouteTableAddRoutesOptions) Params() (*jsonutils.JSONDict, error) {
 type RouteTableDelRoutesOptions struct {
 	ID string `json:"-"`
 
-	RouteCidr []string
+	Cidr []string
 }
 
 func (opts *RouteTableDelRoutesOptions) Params() (*jsonutils.JSONDict, error) {
-	if len(opts.RouteCidr) == 0 {
+	if len(opts.Cidr) == 0 {
 		return nil, fmt.Errorf("nothing to del")
 	}
 	params := jsonutils.NewDict()
-	params.Set("cidrs", jsonutils.Marshal(opts.RouteCidr))
+	params.Set("cidrs", jsonutils.Marshal(opts.Cidr))
 	return params, nil
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

routetables: 修复add/del routes功能

**是否需要 backport 到之前的 release 分支**:

- release/2.9.0
- release/2.8.0

/cc @ioito 
/cc @swordqiu 