### PR TITLE
Automated cherry pick of #888: - set disk storage_id not required - can't do syncstatus on guest has active tasks in last one hour - fix guestdisk index set wrong number on guest attach disk

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -75,7 +75,7 @@ type SDisk struct {
 
 	AutoDelete bool `nullable:"false" default:"false" get:"user" update:"user"` // Column(Boolean, nullable=False, default=False)
 
-	StorageId       string `width:"128" charset:"ascii" nullable:"true" list:"admin" create:"required"` // Column(VARCHAR(ID_LENGTH, charset='ascii'), nullable=False)
+	StorageId       string `width:"128" charset:"ascii" nullable:"true" list:"admin"` // Column(VARCHAR(ID_LENGTH, charset='ascii'), nullable=False)
 	BackupStorageId string `width:"128" charset:"ascii" nullable:"true" list:"admin"`
 
 	// # backing template id and type

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -2159,9 +2159,17 @@ func (self *SGuest) AllowPerformSyncstatus(ctx context.Context, userCred mcclien
 }
 
 func (self *SGuest) PerformSyncstatus(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+	var openTask = true
+	count, err := taskman.TaskManager.QueryTasksOfObject(self, time.Now().Add(-1*time.Hour), &openTask).CountWithError()
+	if err != nil {
+		return nil, err
+	}
+	if count > 0 {
+		return nil, httperrors.NewBadRequestError("Guest has %d task active, can't sync status", count)
+	}
+
 	self.SetStatus(userCred, api.VM_SYNCING_STATUS, "perform_syncstatus")
-	err := self.StartSyncstatus(ctx, userCred, "")
-	return nil, err
+	return nil, self.StartSyncstatus(ctx, userCred, "")
 }
 
 func (self *SGuest) isNotRunningStatus(status string) bool {

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -2323,9 +2323,28 @@ func (self *SGuest) isAttach2Disk(disk *SDisk) (bool, error) {
 	return cnt > 0, nil
 }
 
-func (self *SGuest) getMaxDiskIndex() int8 {
+func (self *SGuest) getDiskIndex() int8 {
 	guestdisks := self.GetDisks()
-	return int8(len(guestdisks))
+	var max uint
+	for i := 0; i < len(guestdisks); i++ {
+		if uint(guestdisks[i].Index) > max {
+			max = uint(guestdisks[i].Index)
+		}
+	}
+
+	idxs := make([]int, max+1)
+	for i := 0; i < len(guestdisks); i++ {
+		idxs[guestdisks[i].Index] = 1
+	}
+
+	// find first idx not set
+	for i := 0; i < len(idxs); i++ {
+		if idxs[i] != 1 {
+			return int8(i)
+		}
+	}
+
+	return int8(max + 1)
 }
 
 func (self *SGuest) AttachDisk(ctx context.Context, disk *SDisk, userCred mcclient.TokenCredential, driver string, cache string, mountpoint string) error {
@@ -2340,17 +2359,20 @@ func (self *SGuest) attach2Disk(ctx context.Context, disk *SDisk, userCred mccli
 	if attached {
 		return fmt.Errorf("Guest has been attached to disk")
 	}
-	index := self.getMaxDiskIndex()
+
 	if len(driver) == 0 {
 		osProf := self.getOSProfile()
 		driver = osProf.DiskDriver
 	}
 	guestdisk := SGuestdisk{}
 	guestdisk.SetModelManager(GuestdiskManager)
-
 	guestdisk.DiskId = disk.Id
 	guestdisk.GuestId = self.Id
-	guestdisk.Index = index
+
+	defer lockman.ReleaseObject(ctx, self)
+	lockman.LockObject(ctx, self)
+
+	guestdisk.Index = self.getDiskIndex()
 	err = guestdisk.DoSave(driver, cache, mountpoint)
 	if err == nil {
 		db.OpsLog.LogAttachEvent(ctx, self, disk, userCred, nil)


### PR DESCRIPTION
Cherry pick of #888 on release/2.9.0.

#888: - set disk storage_id not required - can't do syncstatus on guest has active tasks in last one hour - fix guestdisk index set wrong number on guest attach disk