### PR TITLE
Automated cherry pick of #888: - set disk storage_id not required - can't do syncstatus on guest has active tasks in last one hour - fix guestdisk index set wrong number on guest attach disk

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -61,7 +61,7 @@ type SDisk struct {
 
 	AutoDelete bool `nullable:"false" default:"false" get:"user" update:"user"` // Column(Boolean, nullable=False, default=False)
 
-	StorageId       string `width:"128" charset:"ascii" nullable:"true" list:"admin" create:"required"` // Column(VARCHAR(ID_LENGTH, charset='ascii'), nullable=False)
+	StorageId       string `width:"128" charset:"ascii" nullable:"true" list:"admin"` // Column(VARCHAR(ID_LENGTH, charset='ascii'), nullable=False)
 	BackupStorageId string `width:"128" charset:"ascii" nullable:"true" list:"admin"`
 
 	// # backing template id and type


### PR DESCRIPTION
Cherry pick of #888 on release/2.8.0.

#888: - set disk storage_id not required - can't do syncstatus on guest has active tasks in last one hour - fix guestdisk index set wrong number on guest attach disk