### PR TITLE
避免keystone region中使用"-"导致region被截取

### DIFF
--- a/pkg/mcclient/token3.go
+++ b/pkg/mcclient/token3.go
@@ -231,9 +231,8 @@ func (catalog KeystoneServiceCatalogV3) getRegions() []string {
 	regions := make([]string, 0)
 	for i := 0; i < len(catalog); i++ {
 		for j := 0; j < len(catalog[i].Endpoints); j++ {
-			r, _ := Id2RegionZone(catalog[i].Endpoints[j].RegionId)
-			if !stringArrayContains(regions, r) {
-				regions = append(regions, r)
+			if len(catalog[i].Endpoints[j].RegionId) > 0 && !stringArrayContains(regions, catalog[i].Endpoints[j].RegionId) {
+				regions = append(regions, catalog[i].Endpoints[j].RegionId)
 			}
 		}
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免keystone region中使用"-"导致region被截取

**是否需要 backport 到之前的 release 分支**:
- release/2.9.0
- release/2.8.0
- release/2.7.0
- release/2.6.0

/cc @swordqiu @yousong 