### PR TITLE
Automated cherry pick of #896: 未设置正确的region prefix

### DIFF
--- a/pkg/compute/tasks/cloud_provider_sync_info_task.go
+++ b/pkg/compute/tasks/cloud_provider_sync_info_task.go
@@ -137,6 +137,8 @@ func syncPublicCloudProviderInfo(ctx context.Context, provider *models.SCloudpro
 	externalIdPrefix := provider.Provider
 	if externalIdPrefix == models.CLOUD_PROVIDER_HUAWEI {
 		externalIdPrefix = externalIdPrefix + "/" + strings.Split(provider.Name, "_")[0]
+	} else if externalIdPrefix == models.CLOUD_PROVIDER_OPENSTACK {
+		externalIdPrefix = fmt.Sprintf("%s/%s/", externalIdPrefix, provider.Id)
 	}
 
 	localRegions, remoteRegions, result := models.CloudregionManager.SyncRegions(ctx, task.UserCred, externalIdPrefix, regions)

--- a/pkg/util/openstack/region.go
+++ b/pkg/util/openstack/region.go
@@ -41,7 +41,7 @@ func (region *SRegion) GetName() string {
 }
 
 func (region *SRegion) GetGlobalId() string {
-	return fmt.Sprintf("%s/%s/%s", CLOUD_PROVIDER_OPENSTACK, region.Name, region.client.providerID)
+	return fmt.Sprintf("%s/%s/%s", CLOUD_PROVIDER_OPENSTACK, region.client.providerID, region.Name)
 }
 
 func (region *SRegion) IsEmulated() bool {


### PR DESCRIPTION
Cherry pick of #896 on release/2.6.0.

#896: 未设置正确的region prefix