### PR TITLE
Automated cherry pick of #894: 避免keystone region中使用-导致region被截取

### DIFF
--- a/pkg/mcclient/token3.go
+++ b/pkg/mcclient/token3.go
@@ -223,9 +223,8 @@ func (catalog KeystoneServiceCatalogV3) getRegions() []string {
 	regions := make([]string, 0)
 	for i := 0; i < len(catalog); i++ {
 		for j := 0; j < len(catalog[i].Endpoints); j++ {
-			r, _ := Id2RegionZone(catalog[i].Endpoints[j].Region_id)
-			if !stringArrayContains(regions, r) {
-				regions = append(regions, r)
+			if len(catalog[i].Endpoints[j].Region_id) > 0 && !stringArrayContains(regions, catalog[i].Endpoints[j].Region_id) {
+				regions = append(regions, catalog[i].Endpoints[j].Region_id)
 			}
 		}
 	}

--- a/pkg/util/huawei/securitygroup.go
+++ b/pkg/util/huawei/securitygroup.go
@@ -107,13 +107,13 @@ func SecurityRuleSetToAllowSet(srs secrules.SecurityRuleSet) secrules.SecurityRu
 	if outRuleSet.Len() == 0 {
 		_, ipNet, _ := net.ParseCIDR("0.0.0.0/0")
 		outRuleSet = append(outRuleSet, secrules.SecurityRule{
-			Priority:    0,
-			Action:      secrules.SecurityRuleAllow,
-			IPNet:       ipNet,
-			Protocol:    secrules.PROTO_ANY,
-			Direction:   secrules.SecurityRuleEgress,
-			PortStart:   -1,
-			PortEnd:     -1,
+			Priority:  0,
+			Action:    secrules.SecurityRuleAllow,
+			IPNet:     ipNet,
+			Protocol:  secrules.PROTO_ANY,
+			Direction: secrules.SecurityRuleEgress,
+			PortStart: -1,
+			PortEnd:   -1,
 		})
 	}
 	outRuleSet = outRuleSet.AllowList()


### PR DESCRIPTION
Cherry pick of #894 on release/2.9.0.

#894: 避免keystone region中使用-导致region被截取