### PR TITLE
backport fix: scheduler hypervisor panic

### DIFF
--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -370,6 +370,9 @@ func (p *BaseSchedtagPredicate) PreExecute(sp ISchedtagPredicateInstance, u *cor
 	}
 
 	p.Hypervisor = computeapi.HOSTTYPE_HYPERVISOR[u.SchedData().Hypervisor]
+	if len(p.Hypervisor) == 0 {
+		p.Hypervisor = u.SchedData().Hypervisor
+	}
 
 	// always do select step
 	u.AppendSelectPlugin(sp)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复 scheduler panic

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.9.0

/cc @wanyaoqi 
/area scheduler