### PR TITLE
scheduler: fix nets result not select

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -262,6 +262,7 @@ func (item *SchedResultItem) ToCandidateResource() *schedapi.CandidateResource {
 		HostId: item.ID,
 		Name:   item.Name,
 		Disks:  item.Disks,
+		Nets:   item.Nets,
 	}
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

调度器忘记把选择的 network 结果作为输出

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/cc @wanyaoqi 
/area scheduler