### PR TITLE
避免级联镜像分类不一致

### DIFF
--- a/pkg/util/openstack/image.go
+++ b/pkg/util/openstack/image.go
@@ -24,6 +24,7 @@ import (
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/util/imagetools"
 )
 
 const (
@@ -167,6 +168,10 @@ func (image *SImage) GetOsType() string {
 }
 
 func (image *SImage) GetOsDist() string {
+	osDist := imagetools.NormalizeImageInfo(image.Name, "", "", "", "").OsDistro
+	if len(osDist) > 0 {
+		return osDist
+	}
 	return "Linux"
 }
 

--- a/pkg/util/zstack/image.go
+++ b/pkg/util/zstack/image.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"time"
 
+	"yunion.io/x/onecloud/pkg/util/imagetools"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
@@ -137,7 +139,11 @@ func (image *SImage) GetOsType() string {
 }
 
 func (image *SImage) GetOsDist() string {
-	return ""
+	osDist := imagetools.NormalizeImageInfo(image.URL, "", "", "", "").OsDistro
+	if len(osDist) > 0 {
+		return osDist
+	}
+	return image.Platform
 }
 
 func (image *SImage) GetOsVersion() string {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免级联镜像分类不一致

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/cc @swordqiu @yousong 