### PR TITLE
fix: baremetal raid logical volume and block device map

### DIFF
--- a/pkg/apis/compute/baremetal.go
+++ b/pkg/apis/compute/baremetal.go
@@ -1,0 +1,11 @@
+package compute
+
+type SGMapItem struct {
+	SGDeviceName    string
+	HostNumber      int
+	Bus             int
+	SCSIId          int
+	Lun             int
+	Type            int
+	LinuxDeviceName string
+}

--- a/pkg/baremetal/tasks/baseprepare.go
+++ b/pkg/baremetal/tasks/baseprepare.go
@@ -205,7 +205,7 @@ func (task *sBaremetalPrepareTask) DoPrepare(cli *ssh.Client) error {
 				if lanConf.IPAddr == nic.IpAddr {
 					break
 				}
-				log.Infof("waiting IPMI DHCP address %s %s", lanConf.IPAddr, nic.IpAddr)
+				log.Infof("waiting IPMI DHCP address old:%s expect:%s", lanConf.IPAddr, nic.IpAddr)
 				tried += 2
 			}
 			if tried >= maxTries {

--- a/pkg/baremetal/utils/detect_storages/detect_storages.go
+++ b/pkg/baremetal/utils/detect_storages/detect_storages.go
@@ -36,8 +36,8 @@ func GetRaidDevices(drv raid.IRaidDriver) []*baremetal.BaremetalStorage {
 	return devs
 }
 
-func GetRaidLogicVolumes(drv raid.IRaidDriver) ([]int, error) {
-	lvs := []int{}
+func GetRaidLogicVolumes(drv raid.IRaidDriver) ([]*raid.RaidLogicalVolume, error) {
+	lvs := []*raid.RaidLogicalVolume{}
 	for _, adapter := range drv.GetAdapters() {
 		lv, err := adapter.GetLogicVolumes()
 		if err != nil {
@@ -50,7 +50,7 @@ func GetRaidLogicVolumes(drv raid.IRaidDriver) ([]int, error) {
 
 func DetectStorageInfo(term *ssh.Client, wait bool) ([]*baremetal.BaremetalStorage, []*baremetal.BaremetalStorage, []*baremetal.BaremetalStorage, error) {
 	raidDiskInfo := make([]*baremetal.BaremetalStorage, 0)
-	lvDiskInfo := make([]int, 0)
+	lvDiskInfo := make([]*raid.RaidLogicalVolume, 0)
 
 	raidDrivers := []string{}
 	for _, drv := range drivers.GetDrivers(term) {

--- a/pkg/baremetal/utils/raid/interface.go
+++ b/pkg/baremetal/utils/raid/interface.go
@@ -31,7 +31,7 @@ type IRaidDriver interface {
 type IRaidAdapter interface {
 	GetIndex() int
 	PreBuildRaid(confs []*api.BaremetalDiskConfig) error
-	GetLogicVolumes() ([]int, error)
+	GetLogicVolumes() ([]*RaidLogicalVolume, error)
 	RemoveLogicVolumes() error
 	GetDevices() []*baremetal.BaremetalStorage
 

--- a/pkg/baremetal/utils/raid/megactl/megactl.go
+++ b/pkg/baremetal/utils/raid/megactl/megactl.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/pkg/util/stringutils"
@@ -60,8 +61,8 @@ func NewMegaRaidPhyDev() *MegaRaidPhyDev {
 	}
 }
 
-func (dev *MegaRaidPhyDev) ToBaremetalStorage() *baremetal.BaremetalStorage {
-	s := dev.RaidBasePhyDev.ToBaremetalStorage()
+func (dev *MegaRaidPhyDev) ToBaremetalStorage(index int) *baremetal.BaremetalStorage {
+	s := dev.RaidBasePhyDev.ToBaremetalStorage(index)
 	s.Enclosure = dev.enclosure
 	s.Slot = dev.slot
 	s.Size = dev.GetSize()
@@ -182,16 +183,130 @@ func GetSpecString(dev *baremetal.BaremetalStorage) string {
 }
 
 type MegaRaidAdaptor struct {
-	index int
-	raid  *MegaRaid
-	devs  []*MegaRaidPhyDev
+	index        int
+	storcliIndex int
+	raid         *MegaRaid
+	devs         []*MegaRaidPhyDev
+	sn           string
+	busNumber    string
+	deviceNumber string
+	funcNumber   string
+	// used by sg_map
+	hostNum int
+	//channelNum int
 }
 
-func NewMegaRaidAdaptor(index int, raid *MegaRaid) *MegaRaidAdaptor {
-	return &MegaRaidAdaptor{
-		index: index,
-		raid:  raid,
+func NewMegaRaidAdaptor(index int, raid *MegaRaid) (*MegaRaidAdaptor, error) {
+	adapter := &MegaRaidAdaptor{
+		index:        index,
+		storcliIndex: -1,
+		raid:         raid,
 	}
+	if err := adapter.fillInfo(); err != nil {
+		return adapter, errors.Wrapf(err, "%d fill info", adapter.index)
+	}
+	return adapter, nil
+}
+
+func (adapter *MegaRaidAdaptor) fillInfo() error {
+	cmd := GetCommand("-AdpAllInfo", fmt.Sprintf("-a%d", adapter.index))
+	ret, err := adapter.remoteRun(cmd)
+	if err != nil {
+		return errors.Wrap(err, "remote get SN")
+	}
+	for _, l := range ret {
+		key, val := stringutils.SplitKeyValue(l)
+		if len(key) == 0 {
+			continue
+		}
+		switch key {
+		case "Serial No":
+			adapter.sn = val
+		}
+	}
+	if len(adapter.sn) == 0 {
+		return errors.New("Not found Serial No")
+	}
+	return adapter.fillPCIInfo()
+}
+
+func (adapter *MegaRaidAdaptor) fillPCIInfo() error {
+	cmd := GetCommand("-adpgetpciinfo", fmt.Sprintf("-a%d", adapter.index))
+	ret, err := adapter.remoteRun(cmd)
+	if err != nil {
+		return errors.Wrapf(err, "%d remote run get pci info", adapter.index)
+	}
+	for _, l := range ret {
+		key, val := stringutils.SplitKeyValue(l)
+		if len(key) == 0 {
+			continue
+		}
+		switch key {
+		case "Bus Number":
+			if len(val) == 1 {
+				val = fmt.Sprintf("0%s", val)
+			}
+			if len(val) != 2 {
+				return errors.Errorf("Invalid bus number: %s", val)
+			}
+			adapter.busNumber = val
+		case "Device Number":
+			if len(val) == 1 {
+				val = fmt.Sprintf("0%s", val)
+			}
+			if len(val) != 2 {
+				return errors.Errorf("Invalid device number: %s", val)
+			}
+			adapter.deviceNumber = val
+		case "Function Number":
+			if len(val) != 1 {
+				return errors.Errorf("Invalid function number: %s", val)
+			}
+			adapter.funcNumber = val
+		}
+	}
+	if len(adapter.busNumber) == 0 || len(adapter.deviceNumber) == 0 || len(adapter.funcNumber) == 0 {
+		return errors.New("Not found bus number")
+	}
+	pciDir := fmt.Sprintf("/sys/bus/pci/devices/0000:%s:%s.%s/", adapter.busNumber, adapter.deviceNumber, adapter.funcNumber)
+	cmd = raiddrivers.GetCommand("ls", pciDir, "|", "grep", "host")
+	ret, err = adapter.remoteRun(cmd)
+	if err != nil {
+		return errors.Wrapf(err, "find pci host number")
+	}
+	if len(ret) == 0 {
+		return errors.Errorf("Not find pci host dir")
+	}
+	hostNumStr := ret[0]
+	hostNum, err := strconv.Atoi(strings.TrimLeft(hostNumStr, "host"))
+	if err != nil {
+		return errors.Errorf("Invalid hostNum %s", hostNumStr)
+	}
+	adapter.hostNum = hostNum
+	pciHostDir := fmt.Sprintf("%s%s/", pciDir, hostNumStr)
+	// $ ls /sys/bus/pci/devices/0000:03:00.0/host0/ | grep target | head -n 1
+	// target0:2:0
+	targetCmd := raiddrivers.GetCommand("ls", pciHostDir, "|", "grep", "target", "|", "head", "-n", "1")
+	ret, err = adapter.remoteRun(targetCmd)
+	if err != nil {
+		return errors.Wrapf(err, "find target %q", targetCmd)
+	}
+	if len(ret) == 0 {
+		return errors.Errorf("Not find target dir")
+	}
+	//targetStr := ret[0]
+	//parts := strings.Split(targetStr, ":")
+	//if len(parts) != 3 {
+	//// not build raid logical volume yet
+	//log.Warningf("Cmd %q invalid target string %q, skip fill logical volume info", targetCmd, targetStr)
+	//return nil
+	//}
+	//channelNum, err := strconv.Atoi(parts[1])
+	//if err != nil {
+	//return errors.Errorf("Invalid channel number %s", parts[1])
+	//}
+	//adapter.channelNum = channelNum
+	return nil
 }
 
 func (adapter *MegaRaidAdaptor) GetIndex() int {
@@ -213,31 +328,61 @@ func (adapter *MegaRaidAdaptor) AddPhyDev(dev *MegaRaidPhyDev) {
 
 func (adapter *MegaRaidAdaptor) GetDevices() []*baremetal.BaremetalStorage {
 	ret := []*baremetal.BaremetalStorage{}
-	for _, dev := range adapter.devs {
-		ret = append(ret, dev.ToBaremetalStorage())
+	for idx, dev := range adapter.devs {
+		ret = append(ret, dev.ToBaremetalStorage(idx))
 	}
 	return ret
 }
 
-func (adapter *MegaRaidAdaptor) GetLogicVolumes() ([]int, error) {
+func (adapter *MegaRaidAdaptor) GetLogicVolumes() ([]*raiddrivers.RaidLogicalVolume, error) {
 	cmd := GetCommand("-LDInfo", "-Lall", fmt.Sprintf("-a%d", adapter.index))
 	ret, err := adapter.remoteRun(cmd)
 	if err != nil {
 		return nil, fmt.Errorf("GetLogicVolumes error: %v", err)
 	}
-	return adapter.parseLogicVolumes(ret), nil
+	return adapter.parseLogicVolumes(ret)
 }
 
-func (adapter *MegaRaidAdaptor) parseLogicVolumes(lines []string) []int {
-	lvIdx := []int{}
+var logicalVolumeIdRegexp = regexp.MustCompile(`.*(Target Id: (?P<idx>[0-9]+))`)
+
+func (adapter *MegaRaidAdaptor) parseLogicVolumes(lines []string) ([]*raiddrivers.RaidLogicalVolume, error) {
+	lvs := make([]*raiddrivers.RaidLogicalVolume, 0)
 	for _, line := range lines {
 		key, val := stringutils.SplitKeyValue(line)
 		if key != "" && key == "Virtual Drive" {
-			idx, _ := strconv.Atoi(strings.Split(val, " ")[0])
-			lvIdx = append(lvIdx, idx)
+			idxStr := regutils2.GetParams(logicalVolumeIdRegexp, val)["idx"]
+			idx, err := strconv.Atoi(idxStr)
+			if err != nil {
+				return nil, errors.Errorf("index %q to int: %v", idxStr, err)
+			}
+			blockDev, err := getLogicVolumeDeviceById(adapter.hostNum, idx, adapter.getTerm())
+			if err != nil {
+				return nil, err
+			}
+			lvs = append(lvs, &raiddrivers.RaidLogicalVolume{
+				Index:    idx,
+				Adapter:  adapter.index,
+				BlockDev: blockDev,
+			})
 		}
 	}
-	return lvIdx
+	return lvs, nil
+}
+
+func getLogicVolumeDeviceById(hostNum, scsiId int, term *ssh.Client) (string, error) {
+	items, err := raiddrivers.SGMap(term)
+	if err != nil {
+		return "", err
+	}
+	isMatch := func(item api.SGMapItem) bool {
+		return item.HostNumber == hostNum && item.SCSIId == scsiId
+	}
+	for _, item := range items {
+		if isMatch(item) {
+			return item.LinuxDeviceName, nil
+		}
+	}
+	return "", errors.Errorf("Not found SG item by id: %d:%d", hostNum, scsiId)
 }
 
 func (adapter *MegaRaidAdaptor) PreBuildRaid(confs []*api.BaremetalDiskConfig) error {
@@ -384,7 +529,6 @@ func (adapter *MegaRaidAdaptor) megacliBuildRaid10(devs []*baremetal.BaremetalSt
 
 func (adapter *MegaRaidAdaptor) storcliBuildRaid(devs []*baremetal.BaremetalStorage, conf *api.BaremetalDiskConfig, level uint) error {
 	args := []string{}
-	args = append(args, fmt.Sprintf("/c%d", adapter.index))
 	args = append(args, "add", "vd", fmt.Sprintf("type=r%d", level))
 	args = append(args, adapter.conf2ParamsStorcliSize(conf)...)
 	labels := []string{}
@@ -396,9 +540,12 @@ func (adapter *MegaRaidAdaptor) storcliBuildRaid(devs []*baremetal.BaremetalStor
 		args = append(args, "PDperArray=2")
 	}
 	args = append(args, adapter.conf2ParamsStorcli(conf)...)
-	cmd := GetCommand2(args...)
+	cmd, err := adapter.GetStorcliCommand(args...)
+	if err != nil {
+		return errors.Wrapf(err, "build raid %d", level)
+	}
 	log.Infof("_storcliBuildRaid command: %s", cmd)
-	_, err := adapter.remoteRun(cmd)
+	_, err = adapter.remoteRun(cmd)
 	return err
 }
 
@@ -451,8 +598,86 @@ func (adapter *MegaRaidAdaptor) BuildNoneRaid(devs []*baremetal.BaremetalStorage
 	return cliBuildRaid(devs, nil, adapter.megacliBuildNoRaid, adapter.storcliBuildNoRaid)
 }
 
+type StorcliAdaptor struct {
+	Controller int
+	SN         string
+}
+
+func newStorcliAdaptor() *StorcliAdaptor {
+	return &StorcliAdaptor{
+		Controller: -1,
+		SN:         "",
+	}
+}
+
+func (a *StorcliAdaptor) isComplete() bool {
+	return a.Controller >= 0 && a.SN != ""
+}
+
+func (a *StorcliAdaptor) parseLine(l string) {
+	parts := strings.Split(l, " = ")
+	if len(parts) != 2 {
+		return
+	}
+	key := parts[0]
+	val := parts[1]
+	switch key {
+	case "Controller":
+		a.Controller, _ = strconv.Atoi(val)
+	case "Serial Number":
+		a.SN = val
+	}
+}
+
+func (raid *MegaRaid) GetStorcliAdaptor() (map[string]*StorcliAdaptor, error) {
+	ret := make(map[string]*StorcliAdaptor)
+	cmd := GetCommand2("/call", "show", "|", "grep", "-iE", `'^(Controller|Serial Number)\s='`)
+	lines, err := raid.term.Run(cmd)
+	if err != nil {
+		return nil, errors.Wrap(err, "Get storcli adapter")
+	}
+	adapter := newStorcliAdaptor()
+	for _, l := range lines {
+		adapter.parseLine(l)
+		if adapter.isComplete() {
+			ret[adapter.SN] = adapter
+			adapter = newStorcliAdaptor()
+		}
+	}
+	return ret, nil
+}
+
+func (adapter *MegaRaidAdaptor) storcliCtrlIndex() (int, error) {
+	if adapter.storcliIndex >= 0 {
+		return adapter.storcliIndex, nil
+	}
+	storcliAdaps, err := adapter.raid.GetStorcliAdaptor()
+	if err != nil {
+		return -1, errors.Wrap(err, "Get all Storcli adaptor")
+	}
+	storAdap, ok := storcliAdaps[adapter.sn]
+	if !ok {
+		return -1, errors.Errorf("Not found storcli adaptor by SN %q", adapter.sn)
+	}
+	return storAdap.Controller, nil
+}
+
+func (adapter *MegaRaidAdaptor) GetStorcliCommand(args ...string) (string, error) {
+	controllerIdx, err := adapter.storcliCtrlIndex()
+	if err != nil {
+		return "", errors.Errorf("Adapter %d get storcli controller index: %v", adapter.index, err)
+	}
+	nargs := []string{fmt.Sprintf("/c%d", controllerIdx)}
+	nargs = append(nargs, args...)
+	return GetCommand2(nargs...), nil
+}
+
 func (adapter *MegaRaidAdaptor) storcliIsJBODEnabled() bool {
-	cmd := GetCommand2(fmt.Sprintf("/c%d", adapter.index), "show", "jbod")
+	cmd, err := adapter.GetStorcliCommand("show", "jbod")
+	if err != nil {
+		log.Errorf("get storcli controller cmd: %v", err)
+		return false
+	}
 	lines, err := adapter.remoteRun(cmd)
 	if err != nil {
 		log.Errorf("storcliIsJBODEnabled error: %s", err)
@@ -476,8 +701,12 @@ func (adapter *MegaRaidAdaptor) storcliEnableJBOD(enable bool) bool {
 	if enable {
 		val = "on"
 	}
-	cmd := GetCommand2(fmt.Sprintf("/c%d", adapter.index), "set", fmt.Sprintf("jbod=%s", val))
-	_, err := adapter.remoteRun(cmd)
+	cmd, err := adapter.GetStorcliCommand("set", fmt.Sprintf("jbod=%s", val))
+	if err != nil {
+		log.Errorf("get storcli controller cmd: %v", err)
+		return false
+	}
+	_, err = adapter.remoteRun(cmd)
 	if err != nil {
 		log.Errorf("EnableJBOD %v fail: %v", enable, err)
 		return false
@@ -496,7 +725,7 @@ func (adapter *MegaRaidAdaptor) storcliBuildJBOD(devs []*baremetal.BaremetalStor
 	}
 	cmds := []string{}
 	for _, d := range devs {
-		cmd := GetCommand2(fmt.Sprintf("/c%d/e%d/s%d", adapter.index, d.Enclosure, d.Slot))
+		cmd := GetCommand2(fmt.Sprintf("/c%d/e%d/s%d", adapter.storcliIndex, d.Enclosure, d.Slot))
 		cmds = append(cmds, cmd)
 	}
 	log.Infof("storcliBuildJBOD cmds: %v", cmds)
@@ -518,12 +747,14 @@ func (adapter *MegaRaidAdaptor) storcliBuildNoRaid(devs []*baremetal.BaremetalSt
 		labels = append(labels, GetSpecString(dev))
 	}
 	args := []string{
-		fmt.Sprintf("/c%d", adapter.index),
 		"add", "vd", "each", "type=raid0",
 		fmt.Sprintf("drives=%s", strings.Join(labels, ",")),
 		"wt", "nora", "direct",
 	}
-	cmd := GetCommand2(args...)
+	cmd, err := adapter.GetStorcliCommand(args...)
+	if err != nil {
+		return errors.Wrapf(err, "build none raid")
+	}
 	_, err = adapter.remoteRun(cmd)
 	return err
 }
@@ -602,8 +833,8 @@ func (adapter *MegaRaidAdaptor) RemoveLogicVolumes() error {
 	if err != nil {
 		return err
 	}
-	for _, i := range raiddrivers.ReverseIntArray(lvIdx) {
-		cmd := GetCommand("-CfgLdDel", fmt.Sprintf("-L%d", i), "-Force", fmt.Sprintf("-a%d", adapter.index))
+	for _, i := range raiddrivers.ReverseLogicalArray(lvIdx) {
+		cmd := GetCommand("-CfgLdDel", fmt.Sprintf("-L%d", i.Index), "-Force", fmt.Sprintf("-a%d", adapter.index))
 		cmds = append(cmds, cmd)
 	}
 	if len(cmds) > 0 {
@@ -630,8 +861,8 @@ def _storcli_clear_jbod_disks(self):
 
 func (adapter *MegaRaidAdaptor) megacliClearJBODDisks() error {
 	devIds := []string{}
-	for _, dev := range adapter.devs {
-		devIds = append(devIds, GetSpecString(dev.ToBaremetalStorage()))
+	for idx, dev := range adapter.devs {
+		devIds = append(devIds, GetSpecString(dev.ToBaremetalStorage(idx)))
 	}
 	cmd := GetCommand("-PDMakeGood", fmt.Sprintf("-PhysDrv[%s]", strings.Join(devIds, ",")), "-Force", fmt.Sprintf("-a%d", adapter.index))
 	_, err := adapter.remoteRun(cmd)
@@ -674,7 +905,7 @@ func (raid *MegaRaid) GetName() string {
 }
 
 func (raid *MegaRaid) ParsePhyDevs() error {
-	if !utils.IsInStringArray("megaraid_sas", raiddrivers.GetModules(raid.term)) {
+	if !utils.IsInStringArray(raiddrivers.MODULE_MEGARAID, raiddrivers.GetModules(raid.term)) {
 		return fmt.Errorf("Not found megaraid_sas module")
 	}
 	cmd := GetCommand("-PDList", "-aALL")
@@ -692,6 +923,7 @@ func (raid *MegaRaid) ParsePhyDevs() error {
 func (raid *MegaRaid) parsePhyDevs(lines []string) error {
 	phyDev := NewMegaRaidPhyDev()
 	var adapter *MegaRaidAdaptor
+	var err error
 	for _, line := range lines {
 		matches := adapterPatter.FindStringSubmatch(line)
 		if len(matches) != 0 {
@@ -703,7 +935,10 @@ func (raid *MegaRaid) parsePhyDevs(lines []string) error {
 			}
 			adapterStr := paramsMap["idx"]
 			adapterInt, _ := strconv.Atoi(adapterStr)
-			adapter = NewMegaRaidAdaptor(adapterInt, raid)
+			adapter, err = NewMegaRaidAdaptor(adapterInt, raid)
+			if err != nil {
+				return errors.Wrapf(err, "New raid adapter %d", adapterInt)
+			}
 			raid.adapters = append(raid.adapters, adapter)
 		} else if phyDev.parseLine(line) && phyDev.isComplete() {
 			if adapter == nil {
@@ -734,24 +969,6 @@ func (raid *MegaRaid) addPhyDevStripSize(phyDev *MegaRaidPhyDev) error {
 	}
 	return phyDev.parseStripSize(ret)
 }
-
-/*func (raid *MegaRaid) GetPhyDevs() []*MegaRaidPhyDev {
-	devs := make([]*MegaRaidPhyDev, 0)
-	for _, ada := range raid.adapters {
-		devs = append(devs, ada.GetPhyDevs()...)
-	}
-	return devs
-}*/
-
-//func (raid *MegaRaid) ParseLogicVolumes() bool {
-//cmd := GetCommand("-LDInfo", "-Lall", "-aALL")
-//ret, err := raid.term.Run(cmd)
-//if err != nil {
-//return false
-//}
-//raid.parseLogicVolumes(ret)
-//return true
-//}
 
 func (raid *MegaRaid) CleanRaid() error {
 	for _, adapter := range raid.adapters {

--- a/pkg/baremetal/utils/raid/raid_test.go
+++ b/pkg/baremetal/utils/raid/raid_test.go
@@ -19,26 +19,32 @@ import (
 	"testing"
 )
 
-func TestReverseIntArray(t *testing.T) {
+func TestReverseLogicalArray(t *testing.T) {
 	tests := []struct {
 		name  string
-		input []int
-		want  []int
+		input []*RaidLogicalVolume
+		want  []*RaidLogicalVolume
 	}{
 		{
 			name:  "empty input",
-			input: []int{},
-			want:  []int{},
+			input: []*RaidLogicalVolume{},
+			want:  []*RaidLogicalVolume{},
 		},
 		{
-			name:  "reverse",
-			input: []int{1, 2, 3},
-			want:  []int{3, 2, 1},
+			name: "reverse",
+			input: []*RaidLogicalVolume{
+				{Index: 1},
+				{Index: 2},
+			},
+			want: []*RaidLogicalVolume{
+				{Index: 2},
+				{Index: 1},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ReverseIntArray(tt.input); !reflect.DeepEqual(got, tt.want) {
+			if got := ReverseLogicalArray(tt.input); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ReverseIntArray() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/compute/baremetal/diskconfig_test.go
+++ b/pkg/compute/baremetal/diskconfig_test.go
@@ -202,7 +202,7 @@ var (
 			Adapter: 2,
 		},
 
-		// 12-13 disk on adapter0
+		// 0-1 disk on adapter0
 		{
 			Driver:  DISK_DRIVER_MEGARAID,
 			Rotate:  true,
@@ -294,7 +294,7 @@ var (
 
 func TestCalculateLayout(t *testing.T) {
 	confs, err := NewBaremetalDiskConfigs(
-		"[12-13]:raid1:(100g,32g,):adapter0",
+		"[0-1]:raid1:(100g,32g,):adapter0",
 		"6:raid5:adapter2",
 		"6:raid5:adapter2",
 	)
@@ -310,13 +310,13 @@ func TestCalculateLayout(t *testing.T) {
         "rotate": true,
         "driver": "MegaRaid",
         "size": 953344,
-        "index": 12
+        "index": 0
       },
       {
         "rotate": true,
         "driver": "MegaRaid",
         "size": 953344,
-        "index": 13
+        "index": 1
       }
     ],
     "conf": {
@@ -324,8 +324,8 @@ func TestCalculateLayout(t *testing.T) {
       "conf": "raid1",
       "count": 0,
       "range": [
-        12,
-        13
+        0,
+        1
       ],
       "splits": "100g,32g,",
       "size": [
@@ -471,7 +471,7 @@ func TestCalculateLayout(t *testing.T) {
 
 func TestCheckDisksAllocable(t *testing.T) {
 	confs, err := NewBaremetalDiskConfigs(
-		"[12-13]:raid1:(100g,32g,):adapter0",
+		"[0-1]:raid1:(100g,32g,):adapter0",
 		"6:raid5:adapter2",
 		"6:raid5:adapter2",
 	)

--- a/pkg/hostman/guestfs/sshpart/sshpart.go
+++ b/pkg/hostman/guestfs/sshpart/sshpart.go
@@ -24,6 +24,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/pkg/errors"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/utils"
 
@@ -524,9 +525,13 @@ func MountSSHRootfs(term *ssh.Client, layouts []baremetal.Layout) (*SSHPartition
 		return nil, nil, err
 	}
 	tool.RetrievePartitionInfo()
-	parts := tool.GetPartitions()
+	rootDisk := tool.GetRootDisk()
+	if err := rootDisk.ReInitInfo(); err != nil {
+		return nil, nil, errors.Wrapf(err, "Reinit root disk")
+	}
+	parts := rootDisk.GetPartitions()
 	if len(parts) == 0 {
-		return nil, nil, fmt.Errorf("Not found partitions")
+		return nil, nil, fmt.Errorf("Not found root disk partitions")
 	}
 	for _, part := range parts {
 		dev := NewSSHPartition(term, part.GetDev())

--- a/pkg/util/sysutils/sysutils.go
+++ b/pkg/util/sysutils/sysutils.go
@@ -25,6 +25,7 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 
+	"yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/types"
 	"yunion.io/x/onecloud/pkg/compute/baremetal"
 )
@@ -259,6 +260,37 @@ func GetSerialPorts(lines []string) []string {
 			idx := l[0:pos]
 			ret = append(ret, fmt.Sprintf("ttyS%s", idx))
 		}
+	}
+	return ret
+}
+
+// ParseSGMap parse command 'sg_map -x' outputs:
+//
+//  /dev/sg1 0 2 0 0 0 /dev/sda
+//  /dev/sg2 0 2 1 0 0 /dev/sdb
+//  /dev/sg3 0 2 2 0 0 /dev/sdc
+//
+func ParseSGMap(lines []string) []compute.SGMapItem {
+	ret := make([]compute.SGMapItem, 0)
+	for _, l := range lines {
+		items := strings.Fields(l)
+		if len(items) != 7 {
+			continue
+		}
+		hostNum, _ := strconv.Atoi(items[1])
+		bus, _ := strconv.Atoi(items[2])
+		scsiId, _ := strconv.Atoi(items[3])
+		lun, _ := strconv.Atoi(items[4])
+		typ, _ := strconv.Atoi(items[5])
+		ret = append(ret, compute.SGMapItem{
+			SGDeviceName:    items[0],
+			HostNumber:      hostNum,
+			Bus:             bus,
+			SCSIId:          scsiId,
+			Lun:             lun,
+			Type:            typ,
+			LinuxDeviceName: items[6],
+		})
 	}
 	return ret
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

- 修复 baremetal MegaRaid 和 JBOD 同时存在分区错乱

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.9.0

/area baremetal
/cc @wanyaoqi @swordqiu 