### PR TITLE
Automated cherry pick of #1076: 避免OpenStack为设置默认值,导致认证失败

### DIFF
--- a/cmd/openstackcli/main.go
+++ b/cmd/openstackcli/main.go
@@ -34,8 +34,8 @@ type BaseOptions struct {
 	Password      string `help:"Password" default:"$OPENSTACK_PASSWORD"`
 	Project       string `help:"Project" default:"$OPENSTACK_PROJECT"`
 	EndpointType  string `help:"Project" default:"$OPENSTACK_ENDPOINT_TYPE|internal"`
-	DomainName    string `help:"Domain of user" default:"$OPENSTACK_DOMAIN_NAME"`
-	ProjectDomain string `help:"Domain of project" default:"$OPENSTACK_PROJECT_DOMAIN"`
+	DomainName    string `help:"Domain of user" default:"$OPENSTACK_DOMAIN_NAME|Default"`
+	ProjectDomain string `help:"Domain of project" default:"$OPENSTACK_PROJECT_DOMAIN|Default"`
 	RegionID      string `help:"RegionId" default:"$OPENSTACK_REGION_ID"`
 	SUBCOMMAND    string `help:"openstackcli subcommand" subcommand:"true"`
 }

--- a/pkg/util/openstack/provider/provider.go
+++ b/pkg/util/openstack/provider/provider.go
@@ -112,9 +112,9 @@ func (self *SOpenStackProviderFactory) GetProvider(providerId, providerName, url
 	if len(accountInfo) < 2 {
 		return nil, fmt.Errorf("Missing username or project name %s", account)
 	}
-	project, username, endpointType, domainName, projectDomainName := accountInfo[0], accountInfo[1], "internal", "", ""
+	project, username, endpointType, domainName, projectDomainName := accountInfo[0], accountInfo[1], "internal", "Default", "Default"
 	if len(accountInfo) == 3 {
-		domainName = accountInfo[2]
+		domainName, projectDomainName = accountInfo[2], accountInfo[2]
 	}
 	client, err := openstack.NewOpenStackClient(providerId, providerName, url, username, password, project, endpointType, domainName, projectDomainName, false)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #1076 on release/2.10.0.

#1076: 避免OpenStack为设置默认值,导致认证失败