### PR TITLE
fix: disk input erase storage_id by backend

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4143,7 +4143,7 @@ func (self *SGuest) FillDiskSchedDesc(desc *api.ServerConfigs) {
 	for i := 0; i < len(guestDisks); i++ {
 		diskConf := guestDisks[i].ToDiskConfig()
 		// HACK: storage used by self, so earse it
-		if diskConf.DiskType == api.STORAGE_LOCAL {
+		if diskConf.Backend == api.STORAGE_LOCAL {
 			diskConf.Storage = ""
 		}
 		desc.Disks = append(desc.Disks, diskConf)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: disk 转换成调度参数时根据 backend 去掉 storage_id

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.8.0

/area region
/cc @wanyaoqi 
