### PR TITLE
Automated cherry pick of #1104: fix: disk input erase storage_id by backend

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4034,7 +4034,7 @@ func (self *SGuest) FillDiskSchedDesc(desc *api.ServerConfigs) {
 	for i := 0; i < len(guestDisks); i++ {
 		diskConf := guestDisks[i].ToDiskConfig()
 		// HACK: storage used by self, so earse it
-		if diskConf.DiskType == api.STORAGE_LOCAL {
+		if diskConf.Backend == api.STORAGE_LOCAL {
 			diskConf.Storage = ""
 		}
 		desc.Disks = append(desc.Disks, diskConf)


### PR DESCRIPTION
Cherry pick of #1104 on release/2.8.0.

#1104: fix: disk input erase storage_id by backend