### PR TITLE
cloudcommon: db: 名字唯一性检查时忽略pending_deleted资源

### DIFF
--- a/pkg/cloudcommon/db/namevalidator.go
+++ b/pkg/cloudcommon/db/namevalidator.go
@@ -25,6 +25,9 @@ import (
 
 func isNameUnique(manager IModelManager, ownerId mcclient.IIdentityProvider, name string) (bool, error) {
 	q := manager.Query()
+	if f := q.Field("pending_deleted"); f != nil {
+		q = q.IsFalse("pending_deleted")
+	}
 	q = manager.FilterByName(q, name)
 	q = manager.FilterByOwner(q, ownerId, manager.NamespaceScope())
 	q = manager.FilterBySystemAttributes(q, nil, nil, manager.ResourceScope())
@@ -53,6 +56,9 @@ func NewNameValidator(manager IModelManager, ownerId mcclient.IIdentityProvider,
 func isAlterNameUnique(model IModel, name string) (bool, error) {
 	manager := model.GetModelManager()
 	q := manager.Query()
+	if f := q.Field("pending_deleted"); f != nil {
+		q = q.IsFalse("pending_deleted")
+	}
 	q = manager.FilterByName(q, name)
 	q = manager.FilterByOwner(q, model.GetOwnerId(), manager.NamespaceScope())
 	q = manager.FilterBySystemAttributes(q, nil, nil, manager.ResourceScope())


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

cloudcommon: db: 名字唯一性检查时忽略pending_deleted资源

**是否需要 backport 到之前的 release 分支**:

- release/2.8.0
- release/2.6.0

/cc @yunionio/maintainer 
/hold