### PR TITLE
scheduler: host filter by cloudprovider domain id

### DIFF
--- a/pkg/mcclient/modules/mod_scheduler.go
+++ b/pkg/mcclient/modules/mod_scheduler.go
@@ -88,8 +88,25 @@ func (this *SchedulerManager) Test(s *mcclient.ClientSession, params *api.Schedu
 }
 
 func (this *SchedulerManager) DoForecast(s *mcclient.ClientSession, params jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+	projectId := s.GetProjectId()
+	domainId := s.GetDomainId()
+	cliProjectId, _ := params.GetString("project_id")
+	if cliProjectId != "" {
+		projectId = cliProjectId
+		domainId = ""
+	}
+	if domainId == "" {
+		ret, err := Projects.Get(s, projectId, nil)
+		if err != nil {
+			return nil, err
+		}
+		domainId, _ = ret.GetString("domain_id")
+	}
+	data := params.(*jsonutils.JSONDict)
+	data.Set("domain_id", jsonutils.NewString(domainId))
+	data.Set("project_id", jsonutils.NewString(projectId))
 	url := newSchedURL("forecast")
-	_, obj, err := this.jsonRequest(s, "POST", url, nil, params)
+	_, obj, err := this.jsonRequest(s, "POST", url, nil, data)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mcclient/session.go
+++ b/pkg/mcclient/session.go
@@ -260,6 +260,22 @@ func (this *ClientSession) GetTenantName() string {
 	return this.token.GetTenantName()
 }
 
+func (this *ClientSession) GetProjectId() string {
+	return this.GetTenantId()
+}
+
+func (this *ClientSession) GetProjectName() string {
+	return this.GetTenantName()
+}
+
+func (this *ClientSession) GetDomainId() string {
+	return this.token.GetDomainId()
+}
+
+func (this *ClientSession) GetDomainName() string {
+	return this.token.GetDomainName()
+}
+
 func (this *ClientSession) SetTaskNotifyUrl(url string) {
 	this.Header.Add(TASK_NOTIFY_URL, url)
 }

--- a/pkg/scheduler/algorithm/predicates/guest/status_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/guest/status_predicate.go
@@ -75,6 +75,10 @@ func (p *StatusPredicate) Execute(u *core.Unit, c core.Candidater) (bool, []core
 		if cloudprovider.HealthStatus != api.CLOUD_PROVIDER_HEALTH_NORMAL {
 			h.Exclude2("cloud_provider_health_status", cloudprovider.HealthStatus, api.CLOUD_PROVIDER_HEALTH_NORMAL)
 		}
+		domainId := getter.DomainId()
+		if domainId != u.SchedInfo.Domain {
+			h.Exclude2("domain_belong", domainId, u.SchedInfo.Domain)
+		}
 	}
 
 	return h.GetResult()

--- a/pkg/scheduler/cache/candidate/base.go
+++ b/pkg/scheduler/cache/candidate/base.go
@@ -67,6 +67,14 @@ func (b baseHostGetter) Cloudprovider() *computemodels.SCloudprovider {
 	return b.h.Cloudprovider
 }
 
+func (b baseHostGetter) DomainId() string {
+	provider := b.Cloudprovider()
+	if provider == nil {
+		return ""
+	}
+	return provider.DomainId
+}
+
 func (b baseHostGetter) Region() *computemodels.SCloudregion {
 	return b.h.Region
 }

--- a/pkg/scheduler/core/types.go
+++ b/pkg/scheduler/core/types.go
@@ -57,6 +57,7 @@ type CandidatePropertyGetter interface {
 	Name() string
 	Zone() *computemodels.SZone
 	Cloudprovider() *computemodels.SCloudprovider
+	DomainId() string
 	Region() *computemodels.SCloudregion
 	HostType() string
 	HostSchedtags() []computemodels.SSchedtag


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

调度器: 拥有 cloudprovider 的 host 会根据用户输入的 domain_id 进行过滤

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.10.0
/cc @swordqiu 
/area scheduler