### PR TITLE
fix qcloud disk create name error

### DIFF
--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/pkg/errors"
 	"yunion.io/x/onecloud/pkg/util/cloudinit"
 
 	"yunion.io/x/jsonutils"
@@ -288,7 +289,10 @@ func (self *SManagedVirtualizedGuestDriver) GetLinuxDefaultAccount(desc cloudpro
 }
 
 func (self *SManagedVirtualizedGuestDriver) RemoteDeployGuestForCreate(ctx context.Context, userCred mcclient.TokenCredential, guest *models.SGuest, host *models.SHost, desc cloudprovider.SManagedVMCreateConfig) (jsonutils.JSONObject, error) {
-	ihost, _ := host.GetIHost()
+	ihost, err := host.GetIHost()
+	if err != nil {
+		return nil, errors.Wrapf(err, "RemoteDeployGuestForCreate.GetIHost")
+	}
 
 	iVM, err := func() (cloudprovider.ICloudVM, error) {
 		lockman.LockObject(ctx, host)

--- a/pkg/util/qcloud/disk.go
+++ b/pkg/util/qcloud/disk.go
@@ -375,6 +375,10 @@ func (self *SRegion) CreateDisk(zoneId string, category string, name string, siz
 	params["Region"] = self.Region
 	params["DiskType"] = category
 	params["DiskChargeType"] = "POSTPAID_BY_HOUR"
+	// [TencentCloudSDKError] Code=InvalidParameter, Message=DiskName: vdisk_stress-testvm-qcloud-1_1560117118026502729, length is 48, out of range [0,20] (e11d6c4007e4), RequestId=a8409994-0357-42e9-b028-e11d6c4007e4
+	if len(name) > 20 {
+		name = name[:20]
+	}
 	params["DiskName"] = name
 	params["Placement.Zone"] = zoneId
 	//params["Encrypted"] = "false"

--- a/pkg/util/qcloud/networkinterface.go
+++ b/pkg/util/qcloud/networkinterface.go
@@ -1,0 +1,75 @@
+package qcloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type SPrivateIpAddress struct {
+	Description      string
+	Primary          bool
+	PrivateIpAddress string
+	PublicIpAddress  string
+	IsWanIpBlocked   bool
+	State            string
+}
+
+type SNetworkInterface struct {
+	VpcId                       string
+	SubnetId                    string
+	NetworkInterfaceId          string
+	NetworkInterfaceName        string
+	NetworkInterfaceDescription string
+	GroupSet                    []string
+	Primary                     bool
+	MacAddress                  string
+	State                       string
+	CreatedTime                 time.Time
+	Attachment                  string
+	Zone                        string
+	PrivateIpAddressSet         []SPrivateIpAddress
+}
+
+func (region *SRegion) GetNetworkInterfaces(interfaceIds []string, subnetId string, offset int, limit int) ([]SNetworkInterface, int, error) {
+	if limit > 50 || limit <= 0 {
+		limit = 50
+	}
+	params := map[string]string{}
+	params["Limit"] = fmt.Sprintf("%d", limit)
+	params["Offset"] = fmt.Sprintf("%d", offset)
+
+	for idx, interfaceId := range interfaceIds {
+		params[fmt.Sprintf("NetworkInterfaceIds.%d", idx)] = interfaceId
+	}
+
+	if len(subnetId) > 0 {
+		params["Filters.0.Name"] = "subnet-id"
+		params["Filters.0.Values.0"] = subnetId
+	}
+	body, err := region.vpcRequest("DescribeNetworkInterfaces", params)
+	if err != nil {
+		return nil, 0, errors.Wrapf(err, "DescribeNetworkInterfaces")
+	}
+
+	interfaces := []SNetworkInterface{}
+	err = body.Unmarshal(&interfaces, "NetworkInterfaceSet")
+	if err != nil {
+		return nil, 0, errors.Wrapf(err, "Unmarshal.NetworkInterfaceSet")
+	}
+	total, _ := body.Float("TotalCount")
+	return interfaces, int(total), nil
+}
+
+func (region *SRegion) DeleteNetworkInterface(interfaceId string) error {
+	params := map[string]string{}
+	params["Region"] = region.Region
+	params["NetworkInterfaceId"] = interfaceId
+
+	_, err := region.vpcRequest("DeleteNetworkInterface", params)
+	if err != nil {
+		return errors.Wrapf(err, "vpcRequest.DeleteNetworkInterface")
+	}
+	return nil
+}

--- a/pkg/util/qcloud/qcloud.go
+++ b/pkg/util/qcloud/qcloud.go
@@ -276,7 +276,7 @@ func _baseJsonRequest(client *common.Client, req tchttp.Request, resp qcloudResp
 			break
 		}
 		needRetry := false
-		for _, msg := range []string{"EOF", "TLS handshake timeout", "Code=InternalError", "retry later", "Code=MutexOperation.TaskRunning", "Code=InvalidInstance.NotSupported"} {
+		for _, msg := range []string{"EOF", "TLS handshake timeout", "Code=InternalError", "retry later", "Code=MutexOperation.TaskRunning", "Code=InvalidInstance.NotSupported", "i/o timeout"} {
 			// Code=InvalidInstance.NotSupported, Message=The request does not support the instances `ins-bg54517v` which are in operation or in a special state., RequestId=79d02048-a8c9-4b59-b442-3c6f01fb728e
 			// 重装系统后立即关机有可能会引发 Code=InvalidInstance.NotSupported 错误, 重试可以避免任务失败
 			if strings.Contains(err.Error(), msg) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 修复qcloud disk名称长度不超过20问题
2. 修复删除子网时因关联弹性网卡而失败问题

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.9.0
- release/2.8.0

/cc @swordqiu @yousong 