### PR TITLE
network创建或删除后刷新调度缓存

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1328,12 +1328,6 @@ func (self *SNetwork) CustomizeCreate(ctx context.Context, userCred mcclient.Tok
 
 func (self *SNetwork) PostCreate(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data jsonutils.JSONObject) {
 	self.SSharableVirtualResourceBase.PostCreate(ctx, userCred, ownerId, query, data)
-	wire := self.GetWire()
-	if wire == nil {
-		log.Errorf("cannot find wire???")
-	} else {
-		wire.clearHostSchedDescCache()
-	}
 	vpc := self.GetVpc()
 	if vpc != nil && vpc.IsManaged() {
 		task, err := taskman.TaskManager.NewTask(ctx, "NetworkCreateTask", self, userCred, nil, "", "", nil)
@@ -1344,6 +1338,7 @@ func (self *SNetwork) PostCreate(ctx context.Context, userCred mcclient.TokenCre
 		}
 	} else {
 		self.SetStatus(userCred, api.NETWORK_STATUS_AVAILABLE, "")
+		self.ClearSchedDescCache()
 	}
 }
 
@@ -1373,6 +1368,7 @@ func (self *SNetwork) CustomizeDelete(ctx context.Context, userCred mcclient.Tok
 func (self *SNetwork) RealDelete(ctx context.Context, userCred mcclient.TokenCredential) error {
 	db.OpsLog.LogEvent(self, db.ACT_DELOCATE, self.GetShortDesc(ctx), userCred)
 	self.SetStatus(userCred, api.NETWORK_STATUS_DELETED, "real delete")
+	self.ClearSchedDescCache()
 	return self.SSharableVirtualResourceBase.Delete(ctx, userCred)
 }
 

--- a/pkg/compute/tasks/network_create_task.go
+++ b/pkg/compute/tasks/network_create_task.go
@@ -87,5 +87,7 @@ func (self *NetworkCreateTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 		return
 	}
 
+	network.ClearSchedDescCache()
+
 	self.SetStageComplete(ctx, nil)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
network创建或删除后刷新调度缓存

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.9.0
- release/2.8.0

/cc @swordqiu @yousong 