### PR TITLE
Automated cherry pick of #1120: network创建或删除后刷新调度缓存

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1236,12 +1236,6 @@ func (self *SNetwork) CustomizeCreate(ctx context.Context, userCred mcclient.Tok
 
 func (self *SNetwork) PostCreate(ctx context.Context, userCred mcclient.TokenCredential, ownerProjId string, query jsonutils.JSONObject, data jsonutils.JSONObject) {
 	self.SSharableVirtualResourceBase.PostCreate(ctx, userCred, ownerProjId, query, data)
-	wire := self.GetWire()
-	if wire == nil {
-		log.Errorf("cannot find wire???")
-	} else {
-		wire.clearHostSchedDescCache()
-	}
 	vpc := self.GetVpc()
 	if vpc != nil && vpc.IsManaged() {
 		task, err := taskman.TaskManager.NewTask(ctx, "NetworkCreateTask", self, userCred, nil, "", "", nil)
@@ -1252,6 +1246,7 @@ func (self *SNetwork) PostCreate(ctx context.Context, userCred mcclient.TokenCre
 		}
 	} else {
 		self.SetStatus(userCred, api.NETWORK_STATUS_AVAILABLE, "")
+		self.ClearSchedDescCache()
 	}
 }
 
@@ -1281,6 +1276,7 @@ func (self *SNetwork) CustomizeDelete(ctx context.Context, userCred mcclient.Tok
 func (self *SNetwork) RealDelete(ctx context.Context, userCred mcclient.TokenCredential) error {
 	db.OpsLog.LogEvent(self, db.ACT_DELOCATE, self.GetShortDesc(ctx), userCred)
 	self.SetStatus(userCred, api.NETWORK_STATUS_DELETED, "real delete")
+	self.ClearSchedDescCache()
 	return self.SSharableVirtualResourceBase.Delete(ctx, userCred)
 }
 
@@ -1681,4 +1677,12 @@ func (manager *SNetworkManager) IsValidOnPremiseNetworkIP(ipStr string) bool {
 		return true
 	}
 	return false
+}
+
+func (network *SNetwork) ClearSchedDescCache() error {
+	wire := network.GetWire()
+	if wire == nil {
+		return nil
+	}
+	return wire.clearHostSchedDescCache()
 }

--- a/pkg/compute/tasks/network_create_task.go
+++ b/pkg/compute/tasks/network_create_task.go
@@ -73,5 +73,7 @@ func (self *NetworkCreateTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 		return
 	}
 
+	network.ClearSchedDescCache()
+
 	self.SetStageComplete(ctx, nil)
 }


### PR DESCRIPTION
Cherry pick of #1120 on release/2.8.0.

#1120: network创建或删除后刷新调度缓存