### PR TITLE
region: fix pending_deleted virtual resource filter by name

### DIFF
--- a/pkg/cloudcommon/db/fetch.go
+++ b/pkg/cloudcommon/db/fetch.go
@@ -259,7 +259,7 @@ func FetchProjectInfo(ctx context.Context, data jsonutils.JSONObject) (mcclient.
 }
 
 func FetchDomainInfo(ctx context.Context, data jsonutils.JSONObject) (mcclient.IIdentityProvider, error) {
-	domainId := jsonutils.GetAnyString(data, []string{"domain", "domain_id", "project_domain", "project_domain_id"})
+	domainId := jsonutils.GetAnyString(data, []string{"domain_id", "project_domain", "project_domain_id"})
 	if len(domainId) > 0 {
 		domain, err := TenantCacheManager.FetchDomainByIdOrName(ctx, domainId)
 		if err != nil {

--- a/pkg/cloudcommon/db/virtualresource.go
+++ b/pkg/cloudcommon/db/virtualresource.go
@@ -79,6 +79,12 @@ func (manager *SVirtualResourceBaseManager) GetIVirtualModelManager() IVirtualMo
 }
 */
 
+func (manager *SVirtualResourceBaseManager) FilterByName(q *sqlchemy.SQuery, name string) *sqlchemy.SQuery {
+	q = manager.SStatusStandaloneResourceBaseManager.FilterByName(q, name)
+	q = q.Filter(sqlchemy.OR(sqlchemy.IsNull(q.Field("pending_deleted")), sqlchemy.IsFalse(q.Field("pending_deleted"))))
+	return q
+}
+
 func (manager *SVirtualResourceBaseManager) FilterBySystemAttributes(q *sqlchemy.SQuery, userCred mcclient.TokenCredential, query jsonutils.JSONObject, scope rbacutils.TRbacScope) *sqlchemy.SQuery {
 	q = manager.SStatusStandaloneResourceBaseManager.FilterBySystemAttributes(q, userCred, query, scope)
 

--- a/pkg/compute/models/loadbalancerbackends.go
+++ b/pkg/compute/models/loadbalancerbackends.go
@@ -32,6 +32,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/util/rand"
 )
 
 type SLoadbalancerBackendManager struct {
@@ -212,13 +213,16 @@ func (man *SLoadbalancerBackendManager) ValidateCreateData(ctx context.Context, 
 	default:
 		return nil, fmt.Errorf("internal error: unexpected backend type %s", backendType)
 	}
-	// name it
-	//
-	// NOTE it's okay for name to be not unique.
-	//
-	//  - Mix in loadbalancer name if needed
-	//  - Use name from input query
-	name := fmt.Sprintf("%s-%s-%s", backendGroup.Name, backendType, basename)
+	name, _ := data.GetString("name")
+	if name == "" {
+		// name it
+		//
+		// NOTE it's okay for name to be not unique.
+		//
+		//  - Mix in loadbalancer name if needed
+		//  - Use name from input query
+		name = fmt.Sprintf("%s-%s-%s-%s", backendGroup.Name, backendType, basename, rand.String(4))
+	}
 	data.Set("name", jsonutils.NewString(name))
 	if _, err := man.SVirtualResourceBaseManager.ValidateCreateData(ctx, userCred, ownerId, query, data); err != nil {
 		return nil, err

--- a/pkg/util/rand/rand.go
+++ b/pkg/util/rand/rand.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UTC().UnixNano())),
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}

--- a/pkg/util/rand/rand_test.go
+++ b/pkg/util/rand/rand_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rand
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+const (
+	maxRangeTestCount = 500
+	testStringLength  = 32
+)
+
+func TestString(t *testing.T) {
+	valid := "0123456789abcdefghijklmnopqrstuvwxyz"
+	for _, l := range []int{0, 1, 2, 10, 123} {
+		s := String(l)
+		if len(s) != l {
+			t.Errorf("expected string of size %d, got %q", l, s)
+		}
+		for _, c := range s {
+			if !strings.ContainsRune(valid, c) {
+				t.Errorf("expected valid characters, got %v", c)
+			}
+		}
+	}
+}
+
+// Confirm that panic occurs on invalid input.
+func TestRangePanic(t *testing.T) {
+	defer func() {
+		if err := recover(); err == nil {
+			t.Errorf("Panic didn't occur!")
+		}
+	}()
+	// Should result in an error...
+	Intn(0)
+}
+
+func TestIntn(t *testing.T) {
+	// 0 is invalid.
+	for _, max := range []int{1, 2, 10, 123} {
+		inrange := Intn(max)
+		if inrange < 0 || inrange > max {
+			t.Errorf("%v out of range (0,%v)", inrange, max)
+		}
+	}
+}
+
+func TestPerm(t *testing.T) {
+	Seed(5)
+	rand.Seed(5)
+	for i := 1; i < 20; i++ {
+		actual := Perm(i)
+		expected := rand.Perm(i)
+		for j := 0; j < i; j++ {
+			if actual[j] != expected[j] {
+				t.Errorf("Perm call result is unexpected")
+			}
+		}
+	}
+}
+
+func TestIntnRange(t *testing.T) {
+	// 0 is invalid.
+	for min, max := range map[int]int{1: 2, 10: 123, 100: 500} {
+		for i := 0; i < maxRangeTestCount; i++ {
+			inrange := IntnRange(min, max)
+			if inrange < min || inrange >= max {
+				t.Errorf("%v out of range (%v,%v)", inrange, min, max)
+			}
+		}
+	}
+}
+
+func TestInt63nRange(t *testing.T) {
+	// 0 is invalid.
+	for min, max := range map[int64]int64{1: 2, 10: 123, 100: 500} {
+		for i := 0; i < maxRangeTestCount; i++ {
+			inrange := Int63nRange(min, max)
+			if inrange < min || inrange >= max {
+				t.Errorf("%v out of range (%v,%v)", inrange, min, max)
+			}
+		}
+	}
+}
+
+func BenchmarkRandomStringGeneration(b *testing.B) {
+	b.ResetTimer()
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = String(testStringLength)
+	}
+	b.StopTimer()
+	if len(s) == 0 {
+		b.Fatal(s)
+	}
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

- lb backend 同一个 backend 不同端口时名称 duplicate
- region pending deleted virtual resource 不能通过 name 查询

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.10.0

/area region
/cc @swordqiu @yousong 