### PR TITLE
scheduler: select networks by project domain order

### DIFF
--- a/pkg/apis/compute/api.go
+++ b/pkg/apis/compute/api.go
@@ -51,6 +51,7 @@ type NetworkConfig struct {
 	StandbyAddrCount int `json:"standby_addr_count"`
 
 	Project   string            `json:"project_id"`
+	Domain    string            `json:"domain_id"`
 	Ifname    string            `json:"ifname"`
 	Schedtags []*SchedtagConfig `json:"schedtags"`
 }

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1069,6 +1069,8 @@ func (manager *SGuestManager) ValidateCreateData(ctx context.Context, userCred m
 		if len(netConfig.Driver) == 0 {
 			netConfig.Driver = osProf.NetDriver
 		}
+		netConfig.Project = ownerId.GetProjectId()
+		netConfig.Domain = ownerId.GetProjectDomainId()
 		input.Networks[idx] = netConfig
 	}
 

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1803,3 +1803,12 @@ func (network *SNetwork) ClearSchedDescCache() error {
 	}
 	return wire.clearHostSchedDescCache()
 }
+
+func (network *SNetwork) PerformChangeOwner(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+	ret, err := network.SSharableVirtualResourceBase.PerformChangeOwner(ctx, userCred, query, data)
+	if err != nil {
+		return nil, err
+	}
+	network.ClearSchedDescCache()
+	return ret, nil
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

调度： 选择网络时按照 project, domain 排序

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.10.0