### PR TITLE
scheduler: network domain scope filter

### DIFF
--- a/pkg/scheduler/algorithm/predicates/network_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/network_schedtag_predicate.go
@@ -26,6 +26,7 @@ import (
 	schedapi "yunion.io/x/onecloud/pkg/apis/scheduler"
 	"yunion.io/x/onecloud/pkg/scheduler/api"
 	"yunion.io/x/onecloud/pkg/scheduler/core"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
 )
 
 type NetworkSchedtagPredicate struct {
@@ -102,6 +103,13 @@ func (p *NetworkSchedtagPredicate) IsResourceFitInput(u *core.Unit, _ core.Candi
 	} else {
 		if !network.IsPublic {
 			return fmt.Errorf("Network %s is private", network.Name)
+		}
+		if rbacutils.TRbacScope(network.PublicScope) == rbacutils.ScopeDomain {
+			netDomain := network.DomainId
+			reqDomain := net.Domain
+			if netDomain != reqDomain {
+				return fmt.Errorf("Network domain scope %s not owner by %s", netDomain, reqDomain)
+			}
 		}
 	}
 	if len(net.Address) > 0 {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

调度器根据 network scope domain 过滤

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.10.0

/cc @swordqiu 
/area scheduler