### PR TITLE
ansibleserver: 添加文件支持

### DIFF
--- a/pkg/ansibleserver/models/ansibleplaybooks.go
+++ b/pkg/ansibleserver/models/ansibleplaybooks.go
@@ -82,8 +82,8 @@ func init() {
 }
 
 func (man *SAnsiblePlaybookManager) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
-	v := NewAnsiblePlaybookValidator("playbook", userCred)
-	if err := v.Validate(data); err != nil {
+	pbV := NewAnsiblePlaybookValidator("playbook", userCred)
+	if err := pbV.Validate(data); err != nil {
 		return nil, err
 	}
 	data.Set("status", jsonutils.NewString(AnsiblePlaybookStatusInit))
@@ -244,6 +244,7 @@ func (apb *SAnsiblePlaybook) runPlaybook(ctx context.Context, userCred mcclient.
 			if err != nil {
 				apb.Status = AnsiblePlaybookStatusCanceled
 			} else if runErr != nil {
+				log.Warningf("playbook %s(%s) failed: %v", apb.Name, apb.Id, runErr)
 				apb.Status = AnsiblePlaybookStatusFailed
 			} else {
 				apb.Status = AnsiblePlaybookStatusSucceeded

--- a/pkg/apis/ansible/ansible.go
+++ b/pkg/apis/ansible/ansible.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ansible
+
+import (
+	"yunion.io/x/onecloud/pkg/apis"
+	"yunion.io/x/onecloud/pkg/util/ansible"
+)
+
+type AnsiblePlaybookCreateInput struct {
+	apis.Meta
+
+	Name     string
+	Playbook ansible.Playbook
+}
+
+type AnsiblePlaybookUpdateInput AnsiblePlaybookCreateInput

--- a/pkg/mcclient/models/ansibleplaybooks.go
+++ b/pkg/mcclient/models/ansibleplaybooks.go
@@ -1,0 +1,16 @@
+package models
+
+import (
+	"time"
+
+	"yunion.io/x/onecloud/pkg/util/ansible"
+)
+
+type AnsiblePlaybook struct {
+	VirtualResource
+
+	Playbook  *ansible.Playbook
+	Output    string
+	StartTime time.Time
+	EndTime   time.Time
+}

--- a/pkg/util/ansible/playbook_test.go
+++ b/pkg/util/ansible/playbook_test.go
@@ -17,6 +17,7 @@ package ansible
 import (
 	"context"
 	"os/exec"
+	"reflect"
 	"testing"
 )
 
@@ -45,10 +46,37 @@ func TestPlaybook(t *testing.T) {
 		{
 			Name: "ping",
 		},
+		{
+			Name: "copy",
+			Args: []string{
+				"src=afile",
+				"dest=/tmp/afile",
+			},
+		},
+		{
+			Name: "copy",
+			Args: []string{
+				"src=adir/afile",
+				"dest=/tmp/adirfile",
+			},
+		},
 	}
-	err := pb.Run(context.TODO())
-	if err != nil {
-		t.Fatalf("not expecting err: %v", err)
+	pb.Files = map[string][]byte{
+		"afile":      []byte("afilecontent"),
+		"adir/afile": []byte("afilecontent under adir"),
 	}
-	t.Logf("%s", pb.Output())
+
+	t.Run("copy", func(t *testing.T) {
+		pb2 := pb.Copy()
+		if !reflect.DeepEqual(pb2, pb) {
+			t.Errorf("copy and the original should be equal")
+		}
+	})
+	t.Run("run", func(t *testing.T) {
+		err := pb.Run(context.TODO())
+		t.Logf("%s", pb.Output())
+		if err != nil {
+			t.Fatalf("not expecting err: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
mcclient: models: 添加ansibleplaybooks
mcclient: ansibleplaybooks: 使用apis.XxxInput
apis: add ansible
mcclient: options: ansibleplaybooks: 支持指定文件
pkg: ansible: 添加文件内容支持
ansibleserver: 在pb执行失败时打出警告日志
```

**是否需要 backport 到之前的 release 分支**:

- release/2.10.0