### PR TITLE
scheduler: set input networks domain if empty

### DIFF
--- a/pkg/scheduler/api/sched.go
+++ b/pkg/scheduler/api/sched.go
@@ -57,6 +57,13 @@ func FetchSchedInfo(req *http.Request) (*SchedInfo, error) {
 
 	data := NewSchedInfo(input)
 
+	domainId := data.Domain
+	for _, net := range data.Networks {
+		if net.Domain == "" {
+			net.Domain = domainId
+		}
+	}
+
 	return data, nil
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.10.0

/area scheduler