### PR TITLE
Automated cherry pick of #1216: scheduler: set input networks domain if empty

### DIFF
--- a/pkg/scheduler/api/sched.go
+++ b/pkg/scheduler/api/sched.go
@@ -57,6 +57,13 @@ func FetchSchedInfo(req *http.Request) (*SchedInfo, error) {
 
 	data := NewSchedInfo(input)
 
+	domainId := data.Domain
+	for _, net := range data.Networks {
+		if net.Domain == "" {
+			net.Domain = domainId
+		}
+	}
+
 	return data, nil
 }
 


### PR DESCRIPTION
Cherry pick of #1216 on release/2.10.0.

#1216: scheduler: set input networks domain if empty