### PR TITLE
Automated cherry pick of #1230: fix cache image failed error

### DIFF
--- a/pkg/hostman/storageman/imagecache_local.go
+++ b/pkg/hostman/storageman/imagecache_local.go
@@ -166,7 +166,7 @@ func (l *SLocalImageCache) prepare(ctx context.Context, zone, srcUrl, format str
 	if len(format) == 0 {
 		format = "qcow2"
 	}
-	url += fmt.Sprintf("?format=%s", format)
+	url += fmt.Sprintf("?format=%s&scope=system", format)
 
 	l.remoteFile = remotefile.NewRemoteFile(ctx, url,
 		l.GetPath(), false, "", -1, nil, l.GetTmpPath(), srcUrl)


### PR DESCRIPTION
Cherry pick of #1230 on release/2.8.0.

#1230: fix cache image failed error