### PR TITLE
fix: no need to specify query scope when get with parameters

### DIFF
--- a/pkg/cloudcommon/db/fetch.go
+++ b/pkg/cloudcommon/db/fetch.go
@@ -370,6 +370,8 @@ func FetchCheckQueryOwnerScope(ctx context.Context, userCred mcclient.TokenCrede
 			if isAdmin && allowScope.HigherThan(rbacutils.ScopeProject) {
 				queryScope = allowScope
 			}
+		} else if action == policy.PolicyActionGet {
+			queryScope = allowScope
 		}
 		if resScope.HigherThan(queryScope) {
 			queryScope = resScope

--- a/pkg/util/qcloud/region.go
+++ b/pkg/util/qcloud/region.go
@@ -173,7 +173,7 @@ func (self *SRegion) CreateILoadBalancer(loadbalancer *cloudprovider.SLoadbalanc
 		"VpcId":            loadbalancer.VpcID,
 	}
 
-	if loadbalancer.AddressType != api.LB_ADDR_TYPE_INTERNET  {
+	if loadbalancer.AddressType != api.LB_ADDR_TYPE_INTERNET {
 		params["SubnetId"] = loadbalancer.NetworkID
 	}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：当跨域获取item详情时，不再需要在query中指定scope

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0