### PR TITLE
Automated cherry pick of #1232: fix: no need to specify query scope when get with parameters

### DIFF
--- a/pkg/cloudcommon/db/fetch.go
+++ b/pkg/cloudcommon/db/fetch.go
@@ -370,6 +370,8 @@ func FetchCheckQueryOwnerScope(ctx context.Context, userCred mcclient.TokenCrede
 			if isAdmin && allowScope.HigherThan(rbacutils.ScopeProject) {
 				queryScope = allowScope
 			}
+		} else if action == policy.PolicyActionGet {
+			queryScope = allowScope
 		}
 		if resScope.HigherThan(queryScope) {
 			queryScope = resScope


### PR DESCRIPTION
Cherry pick of #1232 on release/2.10.0.

#1232: fix: no need to specify query scope when get with parameters