### PR TITLE
secgroup-list remove rules

### DIFF
--- a/cmd/climc/shell/secgroups.go
+++ b/cmd/climc/shell/secgroups.go
@@ -26,7 +26,9 @@ import (
 
 func init() {
 	type SecGroupsListOptions struct {
-		Equals string `help:"Secgroup ID or Name, filter secgroups whose rules equals the specified one"`
+		Equals       string `help:"Secgroup ID or Name, filter secgroups whose rules equals the specified one"`
+		OrderByCache string `help:"Order by cache count" choices:"desc|asc"`
+		OrderByGuest string `help:"Order by guest count" choices:"desc|asc"`
 		options.BaseListOptions
 	}
 
@@ -42,6 +44,12 @@ func init() {
 		}
 		if len(args.Equals) > 0 {
 			params.Add(jsonutils.NewString(args.Equals), "equals")
+		}
+		if len(args.OrderByCache) > 0 {
+			params.Add(jsonutils.NewString(args.OrderByCache), "order_by_cache")
+		}
+		if len(args.OrderByGuest) > 0 {
+			params.Add(jsonutils.NewString(args.OrderByGuest), "order_by_guest")
 		}
 		result, err := modules.SecGroups.List(s, params)
 		if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
支持安全组根据cache和guest数量排序

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/cc @swordqiu 