### PR TITLE
choice valid storage for storagecache

### DIFF
--- a/pkg/compute/models/storagecaches.go
+++ b/pkg/compute/models/storagecaches.go
@@ -93,6 +93,19 @@ func (self *SStoragecache) getStorages() []SStorage {
 	return storages
 }
 
+func (self *SStoragecache) getValidStorages() []SStorage {
+	storages := []SStorage{}
+	q := StorageManager.Query()
+	q = q.Equals("storagecache_id", self.Id).
+		Filter(sqlchemy.In(q.Field("status"), []string{api.STORAGE_ENABLED, api.STORAGE_ONLINE})).
+		Filter(sqlchemy.IsTrue(q.Field("enabled")))
+	err := db.FetchModelObjects(StorageManager, q, &storages)
+	if err != nil {
+		return nil
+	}
+	return storages
+}
+
 func (self *SStoragecache) getStorageNames() []string {
 	storages := self.getStorages()
 	if storages == nil {
@@ -363,7 +376,7 @@ func (self *SStoragecache) StartImageUncacheTask(ctx context.Context, userCred m
 }
 
 func (self *SStoragecache) GetIStorageCache() (cloudprovider.ICloudStoragecache, error) {
-	storages := self.getStorages()
+	storages := self.getValidStorages()
 	if len(storages) == 0 {
 		msg := "no storages for this storagecache???"
 		log.Errorf(msg)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
storagecache选择可用的storage, 避免cache公有云镜像失败

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.9.0
- release/2.8.0

/cc @swordqiu 

