### PR TITLE
fix: network is_public init value set to true for domain scope

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1324,8 +1324,10 @@ func isOverlapNetworks(nets []SNetwork, startIp netutils.IPV4Addr, endIp netutil
 func (self *SNetwork) CustomizeCreate(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data jsonutils.JSONObject) error {
 	if db.IsAdminAllowCreate(userCred, self.GetModelManager()) && ownerId.GetProjectId() == userCred.GetProjectId() && self.ServerType == api.NETWORK_TYPE_GUEST {
 		self.IsPublic = true
+		self.PublicScope = string(rbacutils.ScopeDomain)
 	} else {
 		self.IsPublic = false
+		self.PublicScope = string(rbacutils.ScopeNone)
 	}
 	return self.SSharableVirtualResourceBase.CustomizeCreate(ctx, userCred, ownerId, query, data)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：network创建时刻的is_public/public_scope的设置

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/cc @wanyaoqi 