### PR TITLE
fix guest sync status min interval

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -2201,7 +2201,7 @@ func (self *SGuest) AllowPerformSyncstatus(ctx context.Context, userCred mcclien
 
 func (self *SGuest) PerformSyncstatus(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
 	var openTask = true
-	count, err := taskman.TaskManager.QueryTasksOfObject(self, time.Now().Add(-1*time.Hour), &openTask).CountWithError()
+	count, err := taskman.TaskManager.QueryTasksOfObject(self, time.Now().Add(-3*time.Minute), &openTask).CountWithError()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix guest sync status min interval from 1 hour to 3 minute
**是否需要 backport 到之前的 release 分支**:
release/2.8.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/cc @swordqiu 