### PR TITLE
avoid openstack zone externalid equals

### DIFF
--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -21,6 +21,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/pkg/util/compare"
 	"yunion.io/x/pkg/util/netutils"
@@ -313,13 +314,11 @@ func (manager *SWireManager) newFromCloudWire(ctx context.Context, userCred mccl
 	wire.VpcId = vpc.Id
 	izone := extWire.GetIZone()
 	if izone != nil {
-		zoneObj, err := db.FetchByExternalId(ZoneManager, izone.GetGlobalId())
+		zone, err := vpc.getZoneByExternalId(izone.GetGlobalId())
 		if err != nil {
-			log.Errorf("cannot find zone for wire %s", err)
-			return nil, err
+			return nil, errors.Wrapf(err, "newFromCloudWire.getZoneByExternalId")
 		}
-
-		wire.ZoneId = zoneObj.(*SZone).Id
+		wire.ZoneId = zone.Id
 	}
 
 	wire.IsEmulated = extWire.IsEmulated()


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复OpenStack zone externalId相同导致同步wire失败

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.9.0
- release/2.8.0

/cc @swordqiu 