### PR TITLE
Automated cherry pick of #1265: avoid openstack zone externalid equals

### DIFF
--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -308,13 +308,12 @@ func (manager *SWireManager) newFromCloudWire(ctx context.Context, userCred mccl
 	wire.VpcId = vpc.Id
 	izone := extWire.GetIZone()
 	if izone != nil {
-		zoneObj, err := ZoneManager.FetchByExternalId(izone.GetGlobalId())
+		zone, err := vpc.getZoneByExternalId(izone.GetGlobalId())
 		if err != nil {
 			log.Errorf("cannot find zone for wire %s", err)
 			return nil, err
 		}
-
-		wire.ZoneId = zoneObj.(*SZone).Id
+		wire.ZoneId = zone.Id
 	}
 
 	wire.IsEmulated = extWire.IsEmulated()


### PR DESCRIPTION
Cherry pick of #1265 on release/2.9.0.

#1265: avoid openstack zone externalid equals