### PR TITLE
Automated cherry pick of #1265: avoid openstack zone externalid equals

### DIFF
--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -186,6 +186,26 @@ func (self *SVpc) GetRegion() (*SCloudregion, error) {
 	return region.(*SCloudregion), nil
 }
 
+func (self *SVpc) getZoneByExternalId(externalId string) (*SZone, error) {
+	region, err := self.GetRegion()
+	if err != nil {
+		return nil, err
+	}
+	zones := []SZone{}
+	q := ZoneManager.Query().Equals("cloudregion_id", region.Id).Equals("external_id", externalId)
+	err = db.FetchModelObjects(ZoneManager, q, &zones)
+	if err != nil {
+		return nil, err
+	}
+	if len(zones) == 1 {
+		return &zones[0], nil
+	}
+	if len(zones) == 0 {
+		return nil, fmt.Errorf("failed to found zone by externalId %s in cloudregion %s(%s)", externalId, region.Name, region.Id)
+	}
+	return nil, fmt.Errorf("found %d duplicate zones by externalId %s in cloudregion %s(%s)", len(zones), externalId, region.Name, region.Id)
+}
+
 func (self *SVpc) GetCustomizeColumns(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) *jsonutils.JSONDict {
 	extra := self.SEnabledStatusStandaloneResourceBase.GetCustomizeColumns(ctx, userCred, query)
 	return self.getMoreDetails(extra)

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -279,13 +279,12 @@ func (manager *SWireManager) newFromCloudWire(ctx context.Context, userCred mccl
 	wire.VpcId = vpc.Id
 	izone := extWire.GetIZone()
 	if izone != nil {
-		zoneObj, err := ZoneManager.FetchByExternalId(izone.GetGlobalId())
+		zone, err := vpc.getZoneByExternalId(izone.GetGlobalId())
 		if err != nil {
 			log.Errorf("cannot find zone for wire %s", err)
 			return nil, err
 		}
-
-		wire.ZoneId = zoneObj.(*SZone).Id
+		wire.ZoneId = zone.Id
 	}
 
 	wire.IsEmulated = extWire.IsEmulated()


### PR DESCRIPTION
Cherry pick of #1265 on release/2.8.0.

#1265: avoid openstack zone externalid equals