### PR TITLE
filter storage not attached

### DIFF
--- a/cmd/climc/shell/hosts.go
+++ b/cmd/climc/shell/hosts.go
@@ -48,6 +48,8 @@ func init() {
 
 		Hypervisor string `help:"filter hosts by hypervisor"`
 
+		StorageNotAttached bool `help:"List hosts not attach specified storage"`
+
 		options.BaseListOptions
 	}
 	R(&HostListOptions{}, "host-list", "List hosts", func(s *mcclient.ClientSession, opts *HostListOptions) error {

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -295,6 +295,7 @@ func (manager *SHostManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQu
 	}
 
 	storageStr := jsonutils.GetAnyString(query, []string{"storage", "storage_id"})
+	notAttached := jsonutils.QueryBoolean(query, "storage_not_attached", false)
 	if len(storageStr) > 0 {
 		storage, _ := StorageManager.FetchByIdOrName(nil, storageStr)
 		if storage == nil {
@@ -302,7 +303,11 @@ func (manager *SHostManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQu
 		}
 		hoststorages := HoststorageManager.Query().SubQuery()
 		scopeQuery := hoststorages.Query(hoststorages.Field("host_id")).Equals("storage_id", storage.GetId()).SubQuery()
-		q = q.In("id", scopeQuery)
+		if !notAttached {
+			q = q.In("id", scopeQuery)
+		} else {
+			q = q.NotIn("id", scopeQuery)
+		}
 	}
 
 	q, err = managedResourceFilterByZone(q, query, "", nil)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
list hosts filter by storage not attached
**是否需要 backport 到之前的 release 分支**:
release/2.8.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
