### PR TITLE
treewide: 将default:"true"的bool字段改为tristate.TriState

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1754,7 +1754,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:04187b7fe2d9788ad901137fd8976272f464bd4080963e7a7f28aa9615d1e47a"
+  digest = "1:32f6aaab9d4749fc52eb490cf758e955994f2a77b2753976ba93533c3bcf9240"
   name = "yunion.io/x/pkg"
   packages = [
     "errors",
@@ -1788,7 +1788,7 @@
     "utils",
   ]
   pruneopts = "UT"
-  revision = "3afb7f847aad0b254d5768f961d226b24aa24cea"
+  revision = "aef5d070532643f55f6f60cf79b63b29d95c6ceb"
 
 [[projects]]
   branch = "master"

--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -79,8 +79,8 @@ type SCloudaccount struct {
 
 	// BalanceKey string `width:"256" charset:"ascii" nullable:"true" list:"domain" update:"domain" create:"domain_optional"`
 
-	IsPublicCloud *bool `nullable:"false" get:"user" create:"optional" list:"user" default:"true"`
-	IsOnPremise   bool  `nullable:"false" get:"user" create:"optional" list:"user" default:"false"`
+	IsPublicCloud tristate.TriState `nullable:"false" get:"user" create:"optional" list:"user" default:"true"`
+	IsOnPremise   bool              `nullable:"false" get:"user" create:"optional" list:"user" default:"false"`
 
 	Provider string `width:"64" charset:"ascii" list:"domain" create:"domain_required"`
 
@@ -755,7 +755,7 @@ func (self *SCloudaccount) getProjectIds() []string {
 func (self *SCloudaccount) getCloudEnv() string {
 	if self.IsOnPremise {
 		return api.CLOUD_ENV_ON_PREMISE
-	} else if self.IsPublicCloud != nil && *self.IsPublicCloud == true {
+	} else if self.IsPublicCloud.IsTrue() {
 		return api.CLOUD_ENV_PUBLIC_CLOUD
 	} else {
 		return api.CLOUD_ENV_PRIVATE_CLOUD
@@ -1229,7 +1229,7 @@ func (account *SCloudaccount) probeAccountStatus(ctx context.Context, userCred m
 	factory := manager.GetFactory()
 	diff, err := db.Update(account, func() error {
 		isPublic := factory.IsPublicCloud()
-		account.IsPublicCloud = &isPublic
+		account.IsPublicCloud = tristate.NewFromBool(isPublic)
 		account.IsOnPremise = factory.IsOnPremise()
 		account.Balance = balance
 		account.HealthStatus = status

--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -424,7 +424,7 @@ func (manager *SDiskManager) ValidateCreateData(ctx context.Context, userCred mc
 }
 
 func (manager *SDiskManager) validateDiskOnStorage(diskConfig *api.DiskConfig, storage *SStorage) error {
-	if !storage.Enabled {
+	if storage.Enabled.IsFalse() {
 		return httperrors.NewInputParameterError("Cannot create disk with disabled storage[%s]", storage.Name)
 	}
 	if !utils.IsInStringArray(storage.Status, []string{api.STORAGE_ENABLED, api.STORAGE_ONLINE}) {

--- a/pkg/compute/models/dnsrecords.go
+++ b/pkg/compute/models/dnsrecords.go
@@ -22,6 +22,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/pkg/util/regutils"
 	"yunion.io/x/sqlchemy"
 
@@ -53,8 +54,8 @@ const DNS_RECORDS_SEPARATOR = ","
 
 type SDnsRecord struct {
 	db.SAdminSharableVirtualResourceBase
-	Ttl     int  `nullable:"true" default:"1" create:"optional" list:"user" update:"user"`
-	Enabled bool `nullable:"false" default:"true" create:"optional" list:"user"`
+	Ttl     int               `nullable:"true" default:"1" create:"optional" list:"user" update:"user"`
+	Enabled tristate.TriState `nullable:"false" default:"true" create:"optional" list:"user"`
 }
 
 // GetRecordsSeparator implements IAdminSharableVirtualModelManager
@@ -431,9 +432,9 @@ func (rec *SDnsRecord) AllowPerformEnable(ctx context.Context, userCred mcclient
 }
 
 func (rec *SDnsRecord) PerformEnable(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
-	if !rec.Enabled {
+	if rec.Enabled.IsFalse() {
 		diff, err := db.Update(rec, func() error {
-			rec.Enabled = true
+			rec.Enabled = tristate.True
 			return nil
 		})
 		if err != nil {
@@ -451,9 +452,9 @@ func (rec *SDnsRecord) AllowPerformDisable(ctx context.Context, userCred mcclien
 }
 
 func (rec *SDnsRecord) PerformDisable(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
-	if rec.Enabled {
+	if rec.Enabled.IsTrue() {
 		diff, err := db.Update(rec, func() error {
-			rec.Enabled = false
+			rec.Enabled = tristate.False
 			return nil
 		})
 		if err != nil {

--- a/pkg/compute/models/dynamicschedtags.go
+++ b/pkg/compute/models/dynamicschedtags.go
@@ -21,6 +21,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/sqlchemy"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
@@ -99,7 +100,7 @@ type SDynamicschedtag struct {
 	Condition  string `width:"256" charset:"ascii" nullable:"false" list:"user" create:"required" update:"admin"`
 	SchedtagId string `width:"36" charset:"ascii" nullable:"false" list:"user" create:"required" update:"admin"`
 
-	Enabled bool `nullable:"false" default:"true" create:"optional" list:"user" update:"user"`
+	Enabled tristate.TriState `nullable:"false" default:"true" create:"optional" list:"user" update:"user"`
 }
 
 func (self *SDynamicschedtagManager) AllowListItems(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {

--- a/pkg/compute/models/host_recycle.go
+++ b/pkg/compute/models/host_recycle.go
@@ -240,7 +240,7 @@ func (self *SGuest) doPrepaidRecycleNoLock(ctx context.Context, userCred mcclien
 	fakeStorage.Cmtbound = 1.0
 	fakeStorage.ZoneId = fakeHost.ZoneId
 	fakeStorage.StoragecacheId = sysStorage.StoragecacheId
-	fakeStorage.Enabled = true
+	fakeStorage.Enabled = tristate.True
 	fakeStorage.Status = api.STORAGE_ONLINE
 	fakeStorage.Description = "fake storage for prepaid vm recycling"
 	fakeStorage.IsEmulated = true

--- a/pkg/compute/models/hoststorages.go
+++ b/pkg/compute/models/hoststorages.go
@@ -207,7 +207,7 @@ func (self *SHoststorage) getExtraDetails(extra *jsonutils.JSONDict) *jsonutils.
 	extra.Add(jsonutils.NewInt(int64(storage.GetFreeCapacity())), "free_capacity")
 	extra.Add(jsonutils.NewString(storage.StorageType), "storage_type")
 	extra.Add(jsonutils.NewString(storage.MediumType), "medium_type")
-	extra.Add(jsonutils.NewBool(storage.Enabled), "enabled")
+	extra.Add(jsonutils.NewBool(storage.Enabled.Bool()), "enabled")
 	extra.Add(jsonutils.NewFloat(float64(storage.GetOvercommitBound())), "cmtbound")
 
 	//extra.Add(jsonutils.NewInt(int64(self.GetGuestDiskCount())), "guest_disk_count")

--- a/pkg/compute/models/schedpolicies.go
+++ b/pkg/compute/models/schedpolicies.go
@@ -19,6 +19,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/pkg/utils"
 	"yunion.io/x/sqlchemy"
 
@@ -56,7 +57,7 @@ type SSchedpolicy struct {
 	SchedtagId string `width:"36" charset:"ascii" nullable:"false" list:"user" create:"required" update:"user"`
 	Strategy   string `width:"32" charset:"ascii" nullable:"false" list:"user" create:"required" update:"user"`
 
-	Enabled bool `nullable:"false" default:"true" create:"optional" list:"user" update:"user"`
+	Enabled tristate.TriState `nullable:"false" default:"true" create:"optional" list:"user" update:"user"`
 }
 
 func validateSchedpolicyInputData(data *jsonutils.JSONDict, create bool) error {

--- a/pkg/compute/models/skus.go
+++ b/pkg/compute/models/skus.go
@@ -27,6 +27,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/pkg/util/compare"
 	"yunion.io/x/pkg/utils"
 	"yunion.io/x/sqlchemy"
@@ -81,10 +82,10 @@ type SServerSku struct {
 
 	OsName string `width:"32" charset:"ascii" nullable:"false" list:"user" create:"admin_optional" update:"admin" default:"Any"` // Windows|Linux|Any
 
-	SysDiskResizable bool   `default:"true" nullable:"false" list:"user" create:"admin_optional" update:"admin"`
-	SysDiskType      string `width:"32" charset:"ascii" nullable:"false" list:"user" create:"admin_optional" update:"admin"`
-	SysDiskMinSizeGB int    `nullable:"false" list:"user" create:"admin_optional" update:"admin"` // not required。 windows比较新的版本都是50G左右。
-	SysDiskMaxSizeGB int    `nullable:"false" list:"user" create:"admin_optional" update:"admin"` // not required
+	SysDiskResizable tristate.TriState `default:"true" nullable:"false" list:"user" create:"admin_optional" update:"admin"`
+	SysDiskType      string            `width:"32" charset:"ascii" nullable:"false" list:"user" create:"admin_optional" update:"admin"`
+	SysDiskMinSizeGB int               `nullable:"false" list:"user" create:"admin_optional" update:"admin"` // not required。 windows比较新的版本都是50G左右。
+	SysDiskMaxSizeGB int               `nullable:"false" list:"user" create:"admin_optional" update:"admin"` // not required
 
 	AttachedDiskType   string `nullable:"false" list:"user" create:"admin_optional" update:"admin"`
 	AttachedDiskSizeGB int    `nullable:"false" list:"user" create:"admin_optional" update:"admin"`
@@ -96,10 +97,10 @@ type SServerSku struct {
 	NicType     string `nullable:"false" list:"user" create:"admin_optional" update:"admin"`
 	NicMaxCount int    `default:"1" nullable:"false" list:"user" create:"admin_optional" update:"admin"`
 
-	GpuAttachable bool   `default:"true" nullable:"false" list:"user" create:"admin_optional" update:"admin"`
-	GpuSpec       string `width:"128" charset:"ascii" nullable:"false" list:"user" create:"admin_optional" update:"admin"`
-	GpuCount      int    `nullable:"false" list:"user" create:"admin_optional" update:"admin"`
-	GpuMaxCount   int    `nullable:"false" list:"user" create:"admin_optional" update:"admin"`
+	GpuAttachable tristate.TriState `default:"true" nullable:"false" list:"user" create:"admin_optional" update:"admin"`
+	GpuSpec       string            `width:"128" charset:"ascii" nullable:"false" list:"user" create:"admin_optional" update:"admin"`
+	GpuCount      int               `nullable:"false" list:"user" create:"admin_optional" update:"admin"`
+	GpuMaxCount   int               `nullable:"false" list:"user" create:"admin_optional" update:"admin"`
 
 	CloudregionId string `width:"128" charset:"ascii" nullable:"false" list:"user" create:"admin_required" update:"admin"`
 	ZoneId        string `width:"128" charset:"ascii" nullable:"false" list:"user" create:"admin_optional" update:"admin"`
@@ -1017,7 +1018,7 @@ func (self *SServerSku) constructSku(extSku cloudprovider.ICloudSku) {
 
 	self.OsName = extSku.GetOsName()
 
-	self.SysDiskResizable = extSku.GetSysDiskResizable()
+	self.SysDiskResizable = tristate.NewFromBool(extSku.GetSysDiskResizable())
 	self.SysDiskType = extSku.GetSysDiskType()
 	self.SysDiskMinSizeGB = extSku.GetSysDiskMinSizeGB()
 	self.SysDiskMaxSizeGB = extSku.GetSysDiskMaxSizeGB()
@@ -1032,7 +1033,7 @@ func (self *SServerSku) constructSku(extSku cloudprovider.ICloudSku) {
 	self.NicType = extSku.GetNicType()
 	self.NicMaxCount = extSku.GetNicMaxCount()
 
-	self.GpuAttachable = extSku.GetGpuAttachable()
+	self.GpuAttachable = tristate.NewFromBool(extSku.GetGpuAttachable())
 	self.GpuSpec = extSku.GetGpuSpec()
 	self.GpuCount = extSku.GetGpuCount()
 	self.GpuMaxCount = extSku.GetGpuMaxCount()

--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -145,11 +145,11 @@ type SStorage struct {
 
 	StoragecacheId string `width:"36" charset:"ascii" nullable:"true" list:"admin" get:"admin" update:"admin" create:"optional"`
 
-	Enabled bool   `nullable:"false" default:"true" list:"user" create:"optional"`
-	Status  string `width:"36" charset:"ascii" nullable:"false" default:"offline" update:"admin" list:"user" create:"optional"`
+	Enabled tristate.TriState `nullable:"false" default:"true" list:"user" create:"optional"`
+	Status  string            `width:"36" charset:"ascii" nullable:"false" default:"offline" update:"admin" list:"user" create:"optional"`
 
 	// indicating whether system disk can be allocated in this storage
-	IsSysDiskStore bool `nullable:"false" default:"true" list:"user" create:"optional" update:"admin"`
+	IsSysDiskStore tristate.TriState `nullable:"false" default:"true" list:"user" create:"optional" update:"admin"`
 }
 
 func (manager *SStorageManager) GetContextManagers() [][]db.IModelManager {
@@ -294,9 +294,9 @@ func (self *SStorage) AllowPerformEnable(ctx context.Context, userCred mcclient.
 }
 
 func (self *SStorage) PerformEnable(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
-	if !self.Enabled {
+	if self.Enabled.IsFalse() {
 		_, err := db.Update(self, func() error {
-			self.Enabled = true
+			self.Enabled = tristate.True
 			return nil
 		})
 		if err != nil {
@@ -314,9 +314,9 @@ func (self *SStorage) AllowPerformDisable(ctx context.Context, userCred mcclient
 }
 
 func (self *SStorage) PerformDisable(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
-	if self.Enabled {
+	if self.Enabled.IsTrue() {
 		_, err := db.Update(self, func() error {
-			self.Enabled = false
+			self.Enabled = tristate.False
 			return nil
 		})
 		if err != nil {
@@ -711,11 +711,11 @@ func (self *SStorage) syncWithCloudStorage(ctx context.Context, userCred mcclien
 		self.Capacity = extStorage.GetCapacityMB()
 		self.StorageConf = extStorage.GetStorageConf()
 
-		self.Enabled = extStorage.GetEnabled()
+		self.Enabled = tristate.NewFromBool(extStorage.GetEnabled())
 
 		self.IsEmulated = extStorage.IsEmulated()
 
-		self.IsSysDiskStore = extStorage.IsSysDiskStore()
+		self.IsSysDiskStore = tristate.NewFromBool(extStorage.IsSysDiskStore())
 
 		return nil
 	})
@@ -744,12 +744,12 @@ func (manager *SStorageManager) newFromCloudStorage(ctx context.Context, userCre
 	storage.Capacity = extStorage.GetCapacityMB()
 	storage.Cmtbound = 1.0
 
-	storage.Enabled = extStorage.GetEnabled()
+	storage.Enabled = tristate.NewFromBool(extStorage.GetEnabled())
 
 	storage.IsEmulated = extStorage.IsEmulated()
 	storage.ManagerId = provider.Id
 
-	storage.IsSysDiskStore = extStorage.IsSysDiskStore()
+	storage.IsSysDiskStore = tristate.NewFromBool(extStorage.IsSysDiskStore())
 
 	err = manager.TableSpec().Insert(&storage)
 	if err != nil {

--- a/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
@@ -74,7 +74,7 @@ func (p *DiskSchedtagPredicate) GetResources(c core.Candidater) []ISchedtagCandi
 
 func (p *DiskSchedtagPredicate) IsResourceFitInput(u *core.Unit, c core.Candidater, res ISchedtagCandidateResource, input ISchedtagCustomer) error {
 	storage := res.(*api.CandidateStorage)
-	if storage.Status == computeapi.STORAGE_OFFLINE || !storage.Enabled {
+	if storage.Status == computeapi.STORAGE_OFFLINE || storage.Enabled.IsFalse() {
 		return fmt.Errorf("Storage status is %s, enable is %v", storage.Status, storage.Enabled)
 	}
 

--- a/vendor/yunion.io/x/pkg/tristate/tristate.go
+++ b/vendor/yunion.io/x/pkg/tristate/tristate.go
@@ -57,3 +57,11 @@ func (r TriState) IsTrue() bool {
 func (r TriState) IsFalse() bool {
 	return r == False
 }
+
+func NewFromBool(b bool) TriState {
+	if b {
+		return True
+	} else {
+		return False
+	}
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

treewide: 将default:"true"的bool字段改为tristate.TriState

**是否需要 backport 到之前的 release 分支**:

NONE