### PR TITLE
fix zstack mini disk size

### DIFF
--- a/pkg/util/zstack/image.go
+++ b/pkg/util/zstack/image.go
@@ -172,7 +172,7 @@ func (image *SImage) GetOsArch() string {
 }
 
 func (image *SImage) GetMinOsDiskSizeGb() int {
-	return 10
+	return image.Size / 1024 / 1024 / 1024
 }
 
 func (image *SImage) GetImageFormat() string {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
同步镜像最小磁盘大小

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/cc @swordqiu @yousong 