### PR TITLE
Automated cherry pick of #1339: fix zstack mini disk size

### DIFF
--- a/pkg/util/zstack/image.go
+++ b/pkg/util/zstack/image.go
@@ -172,7 +172,7 @@ func (image *SImage) GetOsArch() string {
 }
 
 func (image *SImage) GetMinOsDiskSizeGb() int {
-	return 10
+	return image.Size / 1024 / 1024 / 1024
 }
 
 func (image *SImage) GetImageFormat() string {


### PR DESCRIPTION
Cherry pick of #1339 on release/2.10.0.

#1339: fix zstack mini disk size