### PR TITLE
avoid duplicate network name

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -564,15 +564,12 @@ func (self *SNetwork) SyncWithCloudNetwork(ctx context.Context, userCred mcclien
 	vpc := self.GetWire().getVpc()
 	diff, err := db.UpdateWithLock(ctx, self, func() error {
 		extNet.Refresh()
-		self.Name = extNet.GetName()
 		self.Status = extNet.GetStatus()
 		self.GuestIpStart = extNet.GetIpStart()
 		self.GuestIpEnd = extNet.GetIpEnd()
 		self.GuestIpMask = extNet.GetIpMask()
 		self.GuestGateway = extNet.GetGateway()
 		self.ServerType = extNet.GetServerType()
-		// self.IsPublic = extNet.GetIsPublic()
-		// self.PublicScope = string(extNet.GetPublicScope())
 
 		self.AllocTimoutSeconds = extNet.GetAllocTimeoutSeconds()
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免子网重名

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.9.0
- release/2.8.0

/cc @swordqiu @yousong 
