### PR TITLE
set default http client timeout

### DIFF
--- a/pkg/util/httputils/httputils.go
+++ b/pkg/util/httputils/httputils.go
@@ -127,7 +127,7 @@ func GetAddrPort(urlStr string) (string, int, error) {
 	}
 }
 
-func GetClient(insecure bool) *http.Client {
+func GetClient(insecure bool, timeout time.Duration) *http.Client {
 	tr := &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout: 5 * time.Second,
@@ -136,19 +136,20 @@ func GetClient(insecure bool) *http.Client {
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     &tls.Config{InsecureSkipVerify: insecure},
 	}
-	return &http.Client{Transport: tr}
+	return &http.Client{
+		Transport: tr,
+		Timeout:   timeout,
+	}
 }
 
 func GetTimeoutClient(timeout time.Duration) *http.Client {
-	client := GetClient(true)
-	client.Timeout = timeout
-	return client
+	return GetClient(true, timeout)
 }
 
 var defaultHttpClient *http.Client
 
 func init() {
-	defaultHttpClient = GetClient(true)
+	defaultHttpClient = GetClient(true, time.Second*15)
 }
 
 func GetDefaultClient() *http.Client {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
- set default http client timeout
>之前是提供了GetTimeoutClient的函数，但是大部分情况下用的是GetDefaultClient, 然而defaultClient 没有超时
这里直接设置defaultClient超时时间15s, 如果耗时请求就需要调用GetTimeoutClient，自己设置超时

@ioito 看下一zstack是否要提高一下超时时间
> yunion.io/x/onecloud/pkg/util/zstack/zstack.go 
yunion.io/x/onecloud/pkg/util/zstack/image.go
下有很多使用httputils.GetDefaultClient()的

@tb365 看一下华为
> pkg/util/huawei/client/modules/manager_base.go

**是否需要 backport 到之前的 release 分支**:
release/2.8.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
