### PR TITLE
替换有远端安全组的规则,避免网络不通

### DIFF
--- a/pkg/util/zstack/securitygroup.go
+++ b/pkg/util/zstack/securitygroup.go
@@ -312,6 +312,10 @@ func (region *SRegion) syncSecgroupRules(secgroupId string, rules []secrules.Sec
 			ruleStr := rules[i].String()
 			cmp := strings.Compare(_ruleStr, ruleStr)
 			if cmp == 0 {
+				if len(secgroup.Rules[j].RemoteSecurityGroupUUID) > 0 {
+					delRuleIds = append(delRuleIds, secgroup.Rules[j].UUID)
+					addRules = append(addRules, rules[i])
+				}
 				i++
 				j++
 			} else if cmp > 0 {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
替换有远端安全组的规则,避免网络不通

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/cc @swordqiu @yousong 