### PR TITLE
Automated cherry pick of #1380: clear scheduler cache afeter change host cmtbound

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -2516,6 +2516,14 @@ func (self *SHost) ValidateUpdateData(ctx context.Context, userCred mcclient.Tok
 	return data, nil
 }
 
+func (self *SHost) PostUpdate(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) {
+	self.SEnabledStatusStandaloneResourceBase.PostUpdate(ctx, userCred, query, data)
+
+	if data.Contains("cpu_cmtbound") || data.Contains("mem_cmtbound") {
+		self.ClearSchedDescCache()
+	}
+}
+
 func (self *SHost) UpdateDnsRecords(isAdd bool) {
 	for _, netif := range self.GetNetInterfaces() {
 		self.UpdateDnsRecord(&netif, isAdd)


### PR DESCRIPTION
Cherry pick of #1380 on release/2.8.0.

#1380: clear scheduler cache afeter change host cmtbound