### PR TITLE
Manual CherryPick: live migrate filter by cpu model and mircocode, fix guest backup sta...

### DIFF
--- a/pkg/apis/scheduler/api.go
+++ b/pkg/apis/scheduler/api.go
@@ -52,9 +52,6 @@ type ServerConfig struct {
 	Name        string `json:"name"`
 	GuestStatus string `json:"guest_status"`
 
-	// HostId used by migrate
-	HostId string `json:"host_id"`
-
 	// DEPRECATED
 	Metadata       map[string]string `json:"__meta__"`
 	ForGuests      []*ForGuest       `json:"for_guests"`
@@ -70,6 +67,12 @@ type ScheduleInput struct {
 	ScheduleBaseConfig
 
 	ServerConfig
+
+	// HostId used by migrate
+	HostId       string `json:"host_id"`
+	LiveMigrate  bool   `json:"live_migrate"`
+	CpuDesc      string `json:"cpu_desc"`
+	CpuMicrocode string `json:"cpu_microcode"`
 }
 
 func (input ScheduleInput) ToConditionInput() *jsonutils.JSONDict {

--- a/pkg/cloudcommon/types/types.go
+++ b/pkg/cloudcommon/types/types.go
@@ -39,10 +39,11 @@ func (info *SDMISystemInfo) ToIPMISystemInfo() *SIPMISystemInfo {
 }
 
 type SCPUInfo struct {
-	Count int    `json:"count"`
-	Model string `json:"desc"`
-	Freq  int    `json:"freq"`
-	Cache int    `json:"cache"`
+	Count     int    `json:"count"`
+	Model     string `json:"desc"`
+	Freq      int    `json:"freq"`
+	Cache     int    `json:"cache"`
+	Microcode string `json:"microcode"`
 }
 
 type SDMICPUInfo struct {

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -2649,7 +2649,7 @@ func (self *SGuest) PerformBlockStreamFailed(ctx context.Context, userCred mccli
 	if len(self.BackupHostId) > 0 {
 		self.SetMetadata(ctx, "__mirror_job_status", "failed", userCred)
 	}
-	if self.Status == api.VM_BLOCK_STREAM {
+	if self.Status == api.VM_BLOCK_STREAM || self.Status == api.VM_RUNNING {
 		reason, _ := data.GetString("reason")
 		return nil, self.SetStatus(userCred, api.VM_BLOCK_STREAM_FAIL, reason)
 	}

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1446,9 +1446,14 @@ func (self *SGuest) GetExtraDetails(ctx context.Context, userCred mcclient.Token
 }
 
 func (manager *SGuestManager) ListItemExportKeys(ctx context.Context, q *sqlchemy.SQuery, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (*sqlchemy.SQuery, error) {
+	var err error
+	q, err = manager.SModelBaseManager.ListItemExportKeys(ctx, q, userCred, query)
+	if err != nil {
+		return nil, err
+	}
+
 	exportKeys, _ := query.GetString("export_keys")
 	keys := strings.Split(exportKeys, ",")
-
 	// guest_id as filter key
 	if utils.IsInStringArray("ips", keys) {
 		guestIpsQuery := GuestnetworkManager.Query("guest_id").GroupBy("guest_id")
@@ -4066,7 +4071,7 @@ func (self *SGuest) ToSchedDesc() *schedapi.ScheduleInput {
 	self.FillDiskSchedDesc(config.ServerConfigs)
 	self.FillNetSchedDesc(config.ServerConfigs)
 	if len(self.HostId) > 0 && regutils.MatchUUID(self.HostId) {
-		config.HostId = self.HostId
+		desc.HostId = self.HostId
 	}
 	config.Project = self.ProjectId
 	/*tags := self.GetApptags()

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -152,13 +152,14 @@ type SHost struct {
 	SysInfo jsonutils.JSONObject `nullable:"true" search:"admin" list:"admin" update:"admin" create:"admin_optional"`              // Column(JSONEncodedDict, nullable=True)
 	SN      string               `width:"128" charset:"ascii" nullable:"true" list:"admin" update:"admin" create:"admin_optional"` // Column(VARCHAR(128, charset='ascii'), nullable=True)
 
-	CpuCount    int8    `nullable:"true" list:"admin" update:"admin" create:"admin_optional"`                           // Column(TINYINT, nullable=True) # cpu count
-	NodeCount   int8    `nullable:"true" list:"admin" update:"admin" create:"admin_optional"`                           // Column(TINYINT, nullable=True)
-	CpuDesc     string  `width:"64" charset:"ascii" nullable:"true" get:"admin" update:"admin" create:"admin_optional"` // Column(VARCHAR(64, charset='ascii'), nullable=True)
-	CpuMhz      int     `nullable:"true" get:"admin" update:"admin" create:"admin_optional"`                            // Column(Integer, nullable=True) # cpu MHz
-	CpuCache    int     `nullable:"true" get:"admin" update:"admin" create:"admin_optional"`                            // Column(Integer, nullable=True) # cpu Cache in KB
-	CpuReserved int8    `nullable:"true" default:"0" list:"admin" update:"admin" create:"admin_optional"`               // Column(TINYINT, nullable=True, default=0)
-	CpuCmtbound float32 `nullable:"true" default:"8" list:"admin" update:"admin" create:"admin_optional"`               // = Column(Float, nullable=True)
+	CpuCount     int8    `nullable:"true" list:"admin" update:"admin" create:"admin_optional"`                           // Column(TINYINT, nullable=True) # cpu count
+	NodeCount    int8    `nullable:"true" list:"admin" update:"admin" create:"admin_optional"`                           // Column(TINYINT, nullable=True)
+	CpuDesc      string  `width:"64" charset:"ascii" nullable:"true" get:"admin" update:"admin" create:"admin_optional"` // Column(VARCHAR(64, charset='ascii'), nullable=True)
+	CpuMhz       int     `nullable:"true" get:"admin" update:"admin" create:"admin_optional"`                            // Column(Integer, nullable=True) # cpu MHz
+	CpuCache     int     `nullable:"true" get:"admin" update:"admin" create:"admin_optional"`                            // Column(Integer, nullable=True) # cpu Cache in KB
+	CpuReserved  int8    `nullable:"true" default:"0" list:"admin" update:"admin" create:"admin_optional"`               // Column(TINYINT, nullable=True, default=0)
+	CpuCmtbound  float32 `nullable:"true" default:"8" list:"admin" update:"admin" create:"admin_optional"`               // = Column(Float, nullable=True)
+	CpuMicrocode string  `width:"64" charset:"ascii" nullable:"true" get:"admin" update:"admin" create:"admin_optional"`
 
 	MemSize     int     `nullable:"true" list:"admin" update:"admin" create:"admin_optional"`             // Column(Integer, nullable=True) # memory size in MB
 	MemReserved int     `nullable:"true" default:"0" list:"admin" update:"admin" create:"admin_optional"` // Column(Integer, nullable=True, default=0) # memory reserved in MB

--- a/pkg/compute/tasks/guest_backup_tasks.go
+++ b/pkg/compute/tasks/guest_backup_tasks.go
@@ -192,6 +192,11 @@ func (self *GuestStartAndSyncToBackupTask) OnRequestSyncToBackup(ctx context.Con
 	self.SetStageComplete(ctx, nil)
 }
 
+func (self *GuestStartAndSyncToBackupTask) OnRequestSyncToBackupFailed(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {
+	guest.SetStatus(self.UserCred, api.VM_BLOCK_STREAM_FAIL, "OnSyncToBackup")
+	self.SetStageFailed(ctx, data.String())
+}
+
 type GuestCreateBackupTask struct {
 	SSchedTask
 }

--- a/pkg/compute/tasks/guest_live_migrate_task.go
+++ b/pkg/compute/tasks/guest_live_migrate_task.go
@@ -56,6 +56,13 @@ func (self *GuestMigrateTask) GetSchedParams() (*schedapi.ScheduleInput, error) 
 		preferHostId, _ := self.Params.GetString("prefer_host_id")
 		schedDesc.ServerConfig.PreferHost = preferHostId
 	}
+	guestStatus, _ := self.Params.GetString("guest_status")
+	if !jsonutils.QueryBoolean(self.Params, "is_rescue_mode", false) && (guestStatus == api.VM_RUNNING || guestStatus == api.VM_SUSPEND) {
+		schedDesc.LiveMigrate = true
+		host := guest.GetHost()
+		schedDesc.CpuDesc = host.CpuDesc
+		schedDesc.CpuMicrocode = host.CpuMicrocode
+	}
 	return schedDesc, nil
 }
 

--- a/pkg/compute/tasks/guest_syncstatus_task.go
+++ b/pkg/compute/tasks/guest_syncstatus_task.go
@@ -62,7 +62,7 @@ func (self *GuestSyncstatusTask) OnGetStatusSucc(ctx context.Context, guest *mod
 		statusStr = api.VM_SUSPEND
 	case cloudprovider.CloudVMStatusStopped:
 		statusStr = api.VM_READY
-	case api.VM_BLOCK_STREAM: /// XXX ???
+	case api.VM_BLOCK_STREAM, api.VM_BLOCK_STREAM_FAIL:
 		break
 	default:
 		statusStr = api.VM_UNKNOWN

--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -30,6 +30,7 @@ import (
 	"yunion.io/x/pkg/util/regutils"
 	"yunion.io/x/pkg/util/seclib"
 
+	"yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/cloudcommon/sshkeys"
 	"yunion.io/x/onecloud/pkg/hostman/guestfs"
@@ -48,11 +49,12 @@ import (
 const (
 	VNC_PORT_BASE = 5900
 
-	GUEST_RUNNING      = "running"
-	GUEST_BLOCK_STREAM = "block_stream"
-	GUEST_SUSPEND      = "suspend"
-	GUSET_STOPPED      = "stopped"
-	GUEST_NOT_FOUND    = "notfound"
+	GUEST_RUNNING           = compute.VM_RUNNING
+	GUEST_BLOCK_STREAM      = compute.VM_BLOCK_STREAM
+	GUEST_BLOCK_STREAM_FAIL = compute.VM_BLOCK_STREAM_FAIL
+	GUEST_SUSPEND           = compute.VM_SUSPEND
+	GUSET_STOPPED           = "stopped"
+	GUEST_NOT_FOUND         = "notfound"
 )
 
 type SGuestManager struct {
@@ -360,8 +362,15 @@ func (m *SGuestManager) Status(sid string) string {
 
 func (m *SGuestManager) GetStatus(sid string) string {
 	if guest, ok := m.Servers[sid]; ok {
-		if guest.Monitor != nil && guest.IsMaster() && !guest.IsMirrorJobSucc() {
-			return GUEST_BLOCK_STREAM
+		if guest.IsRunning() && guest.Monitor != nil && guest.IsMaster() {
+			mirrorStatus := guest.MirrorJobStatus()
+			if mirrorStatus.InProcess() {
+				return GUEST_BLOCK_STREAM
+			} else if mirrorStatus.IsFailed() {
+				timeutils2.AddTimeout(1*time.Second,
+					func() { guest.SyncMirrorJobFailed("Block job missing") })
+				return GUEST_BLOCK_STREAM_FAIL
+			}
 		}
 		if guest.IsRunning() {
 			return GUEST_RUNNING

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -741,6 +741,7 @@ func (h *SHostInfo) updateHostRecord(hostId string) {
 	content.Set("cpu_count", jsonutils.NewInt(int64(h.Cpu.cpuInfoProc.Count)))
 	content.Set("node_count", jsonutils.NewInt(int64(h.Cpu.cpuInfoDmi.Nodes)))
 	content.Set("cpu_desc", jsonutils.NewString(h.Cpu.cpuInfoProc.Model))
+	content.Set("cpu_microcode", jsonutils.NewString(h.Cpu.cpuInfoProc.Microcode))
 	content.Set("cpu_mhz", jsonutils.NewInt(int64(h.Cpu.cpuInfoProc.Freq)))
 	content.Set("cpu_cache", jsonutils.NewInt(int64(h.Cpu.cpuInfoProc.Cache)))
 	content.Set("mem_size", jsonutils.NewInt(int64(h.Mem.MemInfo.Total)))
@@ -1351,6 +1352,8 @@ func NewHostInfo() (*SHostInfo, error) {
 	} else {
 		res.Cpu = cpu
 	}
+
+	log.Infof("CPU Model %s Microcode %s", cpu.cpuInfoProc.Model, cpu.cpuInfoProc.Microcode)
 
 	mem, err := DetectMemoryInfo()
 	if err != nil {

--- a/pkg/scheduler/algorithm/predicates/error.go
+++ b/pkg/scheduler/algorithm/predicates/error.go
@@ -31,14 +31,16 @@ const (
 	ErrNoEnoughAvailableGPUs = `no enough available GPUs`
 	ErrNotSupportNest        = `nested function not supported`
 
-	ErrRequireMvs                      = `require mvs`
-	ErrRequireNoMvs                    = `require not mvs`
-	ErrHostIsSpecifiedForMigration     = `host_id specified for migration`
-	ErrMoreThanOneSizeUnspecificSplit  = `more than 1 size unspecific split`
-	ErrNoMoreSpaceForUnspecificSplit   = `no more space for an unspecific split`
-	ErrSubtotalOfSplitExceedsDiskSize  = `subtotal of split exceeds disk size`
-	ErrBaremetalHasAlreadyBeenOccupied = `baremetal has already been occupied`
-	ErrPrepaidHostOccupied             = `prepaid host occupied`
+	ErrRequireMvs                             = `require mvs`
+	ErrRequireNoMvs                           = `require not mvs`
+	ErrHostIsSpecifiedForMigration            = `host_id specified for migration`
+	ErrHostCpuModelIsNotMatchForLiveMigrate   = `host cpu mode not match for live migrate`
+	ErrHostCpuMicrocodeNotMatchForLiveMigrate = `host cpu microcode not match for live migrate`
+	ErrMoreThanOneSizeUnspecificSplit         = `more than 1 size unspecific split`
+	ErrNoMoreSpaceForUnspecificSplit          = `no more space for an unspecific split`
+	ErrSubtotalOfSplitExceedsDiskSize         = `subtotal of split exceeds disk size`
+	ErrBaremetalHasAlreadyBeenOccupied        = `baremetal has already been occupied`
+	ErrPrepaidHostOccupied                    = `prepaid host occupied`
 
 	ErrUnknown = `unknown error`
 )

--- a/pkg/scheduler/cache/candidate/base.go
+++ b/pkg/scheduler/cache/candidate/base.go
@@ -64,6 +64,10 @@ func (b baseHostGetter) Zone() *computemodels.SZone {
 	return b.h.Zone
 }
 
+func (b baseHostGetter) Host() *computemodels.SHost {
+	return b.h.SHost
+}
+
 func (b baseHostGetter) Cloudprovider() *computemodels.SCloudprovider {
 	return b.h.Cloudprovider
 }

--- a/pkg/scheduler/core/types.go
+++ b/pkg/scheduler/core/types.go
@@ -56,6 +56,7 @@ type CandidatePropertyGetter interface {
 	Id() string
 	Name() string
 	Zone() *computemodels.SZone
+	Host() *computemodels.SHost
 	Cloudprovider() *computemodels.SCloudprovider
 	Region() *computemodels.SCloudregion
 	HostType() string

--- a/pkg/util/sysutils/sysutils.go
+++ b/pkg/util/sysutils/sysutils.go
@@ -78,9 +78,10 @@ func ParseDMISysinfo(lines []string) (*types.SDMISystemInfo, error) {
 func ParseCPUInfo(lines []string) (*types.SCPUInfo, error) {
 	cnt := 0
 	var (
-		model string
-		freq  string
-		cache string
+		model     string
+		freq      string
+		cache     string
+		microcode string
 	)
 	lv := func(line string) string {
 		return strings.TrimSpace(line[strings.Index(line, ":")+1:])
@@ -94,6 +95,9 @@ func ParseCPUInfo(lines []string) (*types.SCPUInfo, error) {
 		}
 		if len(cache) == 0 && strings.HasPrefix(line, "cache size") {
 			cache = strings.TrimSpace(line[strings.Index(line, ":")+1 : strings.Index(line, " KB")])
+		}
+		if len(microcode) == 0 && strings.HasPrefix(line, "microcode") {
+			microcode = lv(line)
 		}
 		if strings.HasPrefix(line, "processor") {
 			cnt += 1
@@ -110,8 +114,9 @@ func ParseCPUInfo(lines []string) (*types.SCPUInfo, error) {
 	}
 	model = strings.TrimSpace(model)
 	info := &types.SCPUInfo{
-		Count: cnt,
-		Model: model,
+		Count:     cnt,
+		Model:     model,
+		Microcode: microcode,
 	}
 	info.Cache, _ = strconv.Atoi(cache)
 	freqF, _ := strconv.ParseFloat(freq, 32)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
Manual CherryPick
live migrate filter by cpu model and mircocode, fix guest backup status, misc bugfix
**是否需要 backport 到之前的 release 分支**:
None
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
https://github.com/yunionio/onecloud/pull/1384