### PR TITLE
lbagent: 启动时全量取API数据

### DIFF
--- a/pkg/lbagent/api.go
+++ b/pkg/lbagent/api.go
@@ -195,20 +195,22 @@ func (h *ApiHelper) agentPeek(ctx context.Context) *agentPeekResult {
 
 func (h *ApiHelper) runInit(ctx context.Context) {
 	h.haState = <-h.haStateProvider.StateChannel()
-	r := h.agentPeek(ctx)
-	if r == nil {
-		return
-	}
-	if !r.staleInFuture(h.opts.ApiLbagentHbTimeoutRelaxation) {
-		log.Warningf("agent will stale in %d seconds, ignore old corpus",
-			h.opts.ApiLbagentHbTimeoutRelaxation)
-	} else {
-		h.doHb(ctx)
-		corpus, err := h.loadLocalData(ctx)
-		if err == nil {
-			h.corpus = corpus
+	if false {
+		r := h.agentPeek(ctx)
+		if r == nil {
+			return
+		}
+		if !r.staleInFuture(h.opts.ApiLbagentHbTimeoutRelaxation) {
+			log.Warningf("agent will stale in %d seconds, ignore old corpus",
+				h.opts.ApiLbagentHbTimeoutRelaxation)
 		} else {
-			log.Errorf("load local api data failed: %s", err)
+			h.doHb(ctx)
+			corpus, err := h.loadLocalData(ctx)
+			if err == nil {
+				h.corpus = corpus
+			} else {
+				log.Errorf("load local api data failed: %s", err)
+			}
 		}
 	}
 	// better reload now because agent data is not in corpus yet


### PR DESCRIPTION


**这个 PR 实现什么功能/修复什么问题**:

lbagent: 启动时全量取API数据

此变更之后，data/目录内容更多服务于调试作用

**是否需要 backport 到之前的 release 分支**:

- release/2.8.0

/cc @ioito 
/cc @swordqiu 
/cc @Zexi 