### PR TITLE
ansibleserver: 直接指定IP地址时默认ansible_user指定

### DIFF
--- a/pkg/ansibleserver/models/ansibleplaybooks_validator.go
+++ b/pkg/ansibleserver/models/ansibleplaybooks_validator.go
@@ -60,7 +60,6 @@ func (v *ValidatorAnsiblePlaybook) Validate(data *jsonutils.JSONDict) error {
 		}
 		switch {
 		case regutils.MatchIP4Addr(name):
-			continue
 		case strings.HasPrefix(name, "host:"):
 			var err error
 			name = strings.TrimSpace(name[len("host:"):])


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

ansibleserver: 直接指定IP地址时默认ansible_user指定

**是否需要 backport 到之前的 release 分支**:

- release/2.10.0

/cc @zhasm 
/cc @swordqiu 