### PR TITLE
Automated cherry pick of #1412: baremetal listen dhcp port

### DIFF
--- a/pkg/baremetal/pxe/pxe.go
+++ b/pkg/baremetal/pxe/pxe.go
@@ -128,10 +128,7 @@ func (s *Server) Serve() error {
 		return err
 	}
 
-	dhcpSrv, _, err := dhcp.NewDHCPServer2(s.ListenIface, uint16(s.DHCPPort))
-	if err != nil {
-		return err
-	}
+	dhcpSrv := dhcp.NewDHCPServer(s.Address, s.DHCPPort)
 
 	s.errs = make(chan error)
 


### PR DESCRIPTION
Cherry pick of #1412 on release/2.10.0.

#1412: baremetal listen dhcp port