### PR TITLE
remove keypair info if rebuild-root not set keypair

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -1230,6 +1230,11 @@ func (self *SGuest) PerformRebuildRoot(ctx context.Context, userCred mcclient.To
 				return nil, httperrors.NewGeneralError(err)
 			}
 		}
+	} else {
+		err = self.setKeypairId(userCred, "")
+		if err != nil {
+			return nil, httperrors.NewGeneralError(err)
+		}
 	}
 
 	allDisks := jsonutils.QueryBoolean(data, "all_disks", false)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
重装系统时，不指定秘钥则解绑之前的秘钥

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.9.0
- release/2.8.0

/area region

/cc @swordqiu @yousong 