### PR TITLE
validators: errors: 使用msgFmt而非包含{NN}的msgTmpl

### DIFF
--- a/pkg/cloudcommon/validators/errors.go
+++ b/pkg/cloudcommon/validators/errors.go
@@ -98,7 +98,7 @@ func newInvalidStructError(key string, err error) error {
 	params := []interface{}{key}
 	jsonClientErr, ok := err.(*httputils.JSONClientError)
 	if ok {
-		errFmt += jsonClientErr.Data.Id
+		errFmt += httperrors.MsgTmplToFmt(jsonClientErr.Data.Id)
 		for _, f := range jsonClientErr.Data.Fields {
 			params = append(params, f)
 		}

--- a/pkg/httperrors/errors_test.go
+++ b/pkg/httperrors/errors_test.go
@@ -65,35 +65,44 @@ func TestVariadic(t *testing.T) {
 	}
 }
 
-func TestMsgToTemplate(t *testing.T) {
+func TestMsgFmtTmplConversion(t *testing.T) {
 	cases := []struct {
-		name   string
-		msg    string
-		params []interface{}
-		out    string
+		name    string
+		msgFmt  string
+		msgTmpl string
+		msgFmt2 string
+		params  []interface{}
+		out     string
 	}{
 		{
-			name: "non-empty msg to template",
-			msg:  "%% baremetals %s delete.time %d%",
-			out:  "% baremetals {0} delete.time {1}%",
+			name:    "empty",
+			msgFmt:  "",
+			msgTmpl: "",
+			msgFmt2: "",
 		},
 		{
-			name: "empty msg to template",
-			msg:  "",
-			out:  "",
+			name:    "non-empty",
+			msgFmt:  "%% baremetals %s delete.time %d%",
+			msgTmpl: "% baremetals {0} delete.time {1}%",
+			msgFmt2: "% baremetals %s delete.time %s%",
 		},
 		{
-			name: "non-empty with zh-utf8 characters msg to template",
-			msg:  "%% baremetals %s 中文%d ¥%%",
-			out:  "% baremetals {0} 中文{1} ¥%",
+			name:    "non-empty with zh-utf8",
+			msgFmt:  "%% baremetals %s 中文%d ¥%%",
+			msgTmpl: "% baremetals {0} 中文{1} ¥%",
+			msgFmt2: "% baremetals %s 中文%s ¥%",
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			resp := msgToTemplate(c.msg)
-			if resp != c.out {
-				t.Errorf("want %s, got %s", c.out, resp)
+			msgTmpl := msgFmtToTmpl(c.msgFmt)
+			if msgTmpl != c.msgTmpl {
+				t.Errorf("msgFmtToTmpl: want %s, got %s", c.msgTmpl, msgTmpl)
+			}
+			msgFmt2 := msgTmplToFmt(msgTmpl)
+			if msgFmt2 != c.msgFmt2 {
+				t.Errorf("msgTmplToFmt: want %s, got %s", c.msgFmt2, msgFmt2)
 			}
 		})
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:


validators: errors: 使用msgFmt而非包含{NN}的msgTmpl

**是否需要 backport 到之前的 release 分支**:

- release/2.8.0


