### PR TITLE
fix create disk scheduler failed

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -80,7 +80,7 @@ type SDisk struct {
 
 	AutoDelete bool `nullable:"false" default:"false" get:"user" update:"user"` // Column(Boolean, nullable=False, default=False)
 
-	StorageId       string `width:"128" charset:"ascii" nullable:"true" list:"admin"` // Column(VARCHAR(ID_LENGTH, charset='ascii'), nullable=False)
+	StorageId       string `width:"128" charset:"ascii" nullable:"true" list:"admin" create:"optional"` // Column(VARCHAR(ID_LENGTH, charset='ascii'), nullable=False)
 	BackupStorageId string `width:"128" charset:"ascii" nullable:"true" list:"admin"`
 
 	// # backing template id and type


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复disk-create storage_id不生效问题

**是否需要 backport 到之前的 release 分支**:
- release/2.11.0
- release/2.10.0
- release/2.9.0
- release/2.8.0

/area region

/cc @swordqiu @yunion-ci-robot @Zexi @wanyaoqi 
