### PR TITLE
scheduler: fix network schedtag not set capacity

### DIFF
--- a/pkg/scheduler/algorithm/predicates/network_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/network_schedtag_predicate.go
@@ -75,7 +75,7 @@ func (p *NetworkSchedtagPredicate) GetResources(c core.Candidater) []ISchedtagCa
 	return ret
 }
 
-func (p *NetworkSchedtagPredicate) IsResourceFitInput(u *core.Unit, _ core.Candidater, res ISchedtagCandidateResource, input ISchedtagCustomer) error {
+func (p *NetworkSchedtagPredicate) IsResourceFitInput(u *core.Unit, c core.Candidater, res ISchedtagCandidateResource, input ISchedtagCustomer) error {
 	network := res.(*api.CandidateNetwork)
 	net := input.(*netW)
 	if net.Network != "" {
@@ -133,6 +133,8 @@ func (p *NetworkSchedtagPredicate) IsResourceFitInput(u *core.Unit, _ core.Candi
 	if free < req {
 		return fmt.Errorf("Network %s no free IPs, free %d, require %d", network.Name, free, req)
 	}
+	h := NewPredicateHelper(p, u, c)
+	h.SetCapacity(int64(free))
 	return nil
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

调度进行 network 过滤时设置 capacity

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.10.0

/cc @wanyaoqi 