### PR TITLE
Automated cherry pick of #1486: fix azure set secgroup error

### DIFF
--- a/pkg/util/azure/instance.go
+++ b/pkg/util/azure/instance.go
@@ -1081,11 +1081,14 @@ func (self *SInstance) GetIEIP() (cloudprovider.ICloudEIP, error) {
 }
 
 func (self *SInstance) AssignSecurityGroup(secgroupId string) error {
-	return self.host.zone.region.AssiginSecurityGroup(self.ID, secgroupId)
+	return self.host.zone.region.SetSecurityGroup(self.ID, secgroupId)
 }
 
 func (self *SInstance) SetSecurityGroups(secgroupIds []string) error {
-	return cloudprovider.ErrNotSupported
+	if len(secgroupIds) == 1 {
+		return self.host.zone.region.SetSecurityGroup(self.ID, secgroupIds[0])
+	}
+	return fmt.Errorf("Unexpect segroup count %d", len(secgroupIds))
 }
 
 func (self *SInstance) GetBillingType() string {

--- a/pkg/util/azure/securitygroup.go
+++ b/pkg/util/azure/securitygroup.go
@@ -476,7 +476,7 @@ func (region *SRegion) AttachSecurityToInterfaces(secgroupId string, nicIds []st
 	return nil
 }
 
-func (region *SRegion) AssiginSecurityGroup(instanceId, secgroupId string) error {
+func (region *SRegion) SetSecurityGroup(instanceId, secgroupId string) error {
 	instance, err := region.GetInstance(instanceId)
 	if err != nil {
 		return err


### PR DESCRIPTION
Cherry pick of #1486 on release/2.8.0.

#1486: fix azure set secgroup error