### PR TITLE
fix cloud-init lock root login issue

### DIFF
--- a/pkg/util/cloudinit/cloudconfig.go
+++ b/pkg/util/cloudinit/cloudconfig.go
@@ -57,7 +57,7 @@ type SUser struct {
 	Name              string
 	Passwd            string
 	HashedPasswd      string
-	LockPasswd        string
+	LockPasswd        bool
 	SshAuthorizedKeys []string
 	Sudo              string
 }
@@ -164,7 +164,7 @@ func (u *SUser) Password(passwd string) *SUser {
 			u.Passwd = hash
 			u.HashedPasswd = hash
 		}
-		u.LockPasswd = "false"
+		u.LockPasswd = false
 	}
 	return u
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免root账号被锁

**是否需要 backport 到之前的 release 分支**:
- release/2.11.0
- release/2.10.0

/area region

/cc @swordqiu @Zexi 
