### PR TITLE
Automated cherry pick of #1503: fix cloud-init lock root login issue

### DIFF
--- a/pkg/util/cloudinit/cloudconfig.go
+++ b/pkg/util/cloudinit/cloudconfig.go
@@ -57,7 +57,7 @@ type SUser struct {
 	Name              string
 	Passwd            string
 	HashedPasswd      string
-	LockPasswd        string
+	LockPasswd        bool
 	SshAuthorizedKeys []string
 	Sudo              string
 }
@@ -164,7 +164,7 @@ func (u *SUser) Password(passwd string) *SUser {
 			u.Passwd = hash
 			u.HashedPasswd = hash
 		}
-		u.LockPasswd = "false"
+		u.LockPasswd = false
 	}
 	return u
 }


### PR DESCRIPTION
Cherry pick of #1503 on release/2.11.0.

#1503: fix cloud-init lock root login issue