### PR TITLE
pkg: ansible: 改正文件内容写入路径

### DIFF
--- a/pkg/util/ansible/playbook.go
+++ b/pkg/util/ansible/playbook.go
@@ -164,7 +164,7 @@ func (pb *Playbook) Run(ctx context.Context) (err error) {
 
 	// write out files
 	for name, content := range pb.Files {
-		path := filepath.Join(tmpdir, "files", name)
+		path := filepath.Join(tmpdir, name)
 		dir := filepath.Dir(path)
 		err = os.MkdirAll(dir, os.FileMode(0700))
 		if err != nil {


### PR DESCRIPTION


**这个 PR 实现什么功能/修复什么问题**:

模板不会在files/目录下寻找

Fixes: 5ec150e7a9 ("pkg: ansible: 添加文件内容支持")

**是否需要 backport 到之前的 release 分支**:

- release/2.10.0