### PR TITLE
zstack using shell to init image password

### DIFF
--- a/pkg/compute/guestdrivers/zstack.go
+++ b/pkg/compute/guestdrivers/zstack.go
@@ -137,6 +137,10 @@ func (self *SZStackGuestDriver) IsNeedInjectPasswordByCloudInit(desc *cloudprovi
 	return true
 }
 
+func (self *SZStackGuestDriver) GetUserDataType() string {
+	return cloudprovider.CLOUD_SHELL
+}
+
 func (self *SZStackGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManagedVMCreateConfig) string {
 	userName := "root"
 	if desc.ImageType == "system" && desc.OsType == "Windows" {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
兼容 zstack 0.7.5 cloud-init初始化密码

**是否需要 backport 到之前的 release 分支**:
- release/2.11.0
- release/2.10.0

/area region

/cc @swordqiu @yousong 

