### PR TITLE
climc: deploy k8s cluster on kinds of hypervisor

### DIFF
--- a/cmd/climc/shell/images.go
+++ b/cmd/climc/shell/images.go
@@ -49,7 +49,7 @@ type ImageOptionalOptions struct {
 	OsLang             string   `help:"OS Language" choices:"zh_CN|en_US"`
 	Preference         int64    `help:"Disk preferences"`
 	Notes              string   `help:"Notes about the image"`
-	Hypervisor         []string `help:"Prefer hypervisor type" choices:"kvm|esxi|baremetal|container"`
+	Hypervisor         []string `help:"Prefer hypervisor type" choices:"kvm|esxi|baremetal|container|openstack"`
 	DiskDriver         string   `help:"Perfer disk driver" choices:"virtio|scsi|pvscsi|ide|sata"`
 	NetDriver          string   `help:"Preferred network driver" choices:"virtio|e1000|vmxnet3"`
 }

--- a/pkg/mcclient/modules/k8s/machine.go
+++ b/pkg/mcclient/modules/k8s/machine.go
@@ -24,7 +24,7 @@ var (
 
 func init() {
 	KubeMachines = NewResourceManager("kubemachine", "kubemachines",
-		NewResourceCols("role", "first_node", "cluster", "provider", "resource_type", "status", "address"),
+		NewResourceCols("role", "first_node", "cluster", "provider", "resource_type", "status", "address", "hypervisor"),
 		NewColumns())
 	modules.Register(KubeMachines)
 }

--- a/pkg/mcclient/options/k8s/cluster.go
+++ b/pkg/mcclient/options/k8s/cluster.go
@@ -73,11 +73,12 @@ func (o ClusterCreateOptions) Params() *jsonutils.JSONDict {
 }
 
 type AddMachineOptions struct {
-	Machine       []string `help:"Machine create desc, e.g. host01:baremetal:controlplane"`
-	MachineNet    string   `help:"Machine net config"`
-	MachineDisk   string   `help:"Machine root disk size, e.g. 100G"`
-	MachineCpu    int      `help:"Machine cpu count"`
-	MachineMemory string   `help:"Machine memory size, e.g. 1G"`
+	Machine           []string `help:"Machine create desc, e.g. host01:baremetal:controlplane"`
+	MachineNet        string   `help:"Machine net config"`
+	MachineDisk       string   `help:"Machine root disk size, e.g. 100G"`
+	MachineCpu        int      `help:"Machine cpu count"`
+	MachineMemory     string   `help:"Machine memory size, e.g. 1G"`
+	MachineHypervisor string   `help:"Machine hypervisor, e.g. kvm, openstack"`
 }
 
 type KubeClusterCreateOptions struct {
@@ -95,7 +96,7 @@ type KubeClusterCreateOptions struct {
 	AddMachineOptions
 }
 
-func parseMachineDesc(desc string, disk string, netConf string, ncpu int, memorySize string) (*MachineCreateOptions, error) {
+func parseMachineDesc(desc string, disk string, netConf string, ncpu int, memorySize string, hypervisor string) (*MachineCreateOptions, error) {
 	matchType := func(p string) bool {
 		switch p {
 		case "baremetal", "vm":
@@ -133,6 +134,7 @@ func parseMachineDesc(desc string, disk string, netConf string, ncpu int, memory
 	mo.Cpu = ncpu
 	mo.Memory = memorySize
 	mo.Net = netConf
+	mo.Hypervisor = hypervisor
 	return mo, nil
 }
 
@@ -254,7 +256,7 @@ func (o AddMachineOptions) Params() (*jsonutils.JSONArray, error) {
 		return machineObjs, nil
 	}
 	for _, m := range o.Machine {
-		machine, err := parseMachineDesc(m, o.MachineDisk, o.MachineNet, o.MachineCpu, o.MachineMemory)
+		machine, err := parseMachineDesc(m, o.MachineDisk, o.MachineNet, o.MachineCpu, o.MachineMemory, o.MachineHypervisor)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/mcclient/options/k8s/machine.go
+++ b/pkg/mcclient/options/k8s/machine.go
@@ -24,15 +24,16 @@ import (
 )
 
 type MachineCreateOptions struct {
-	CLUSTER  string `help:"Cluster id"`
-	ROLE     string `help:"Machine role" choices:"node|controlplane"`
-	Type     string `help:"Resource type" choices:"vm|baremetal" json:"resource_type"`
-	Instance string `help:"VM or host instance id" json:"resource_id"`
-	Name     string `help:"Name of node"`
-	Disk     string `help:"VM root disk size, e.g. 100G"`
-	Net      string `help:"VM network config"`
-	Cpu      int    `help:"VM cpu count"`
-	Memory   string `help:"VM memory size, e.g. 1G"`
+	CLUSTER    string `help:"Cluster id"`
+	ROLE       string `help:"Machine role" choices:"node|controlplane"`
+	Type       string `help:"Resource type" choices:"vm|baremetal" json:"resource_type"`
+	Instance   string `help:"VM or host instance id" json:"resource_id"`
+	Name       string `help:"Name of node"`
+	Disk       string `help:"VM root disk size, e.g. 100G"`
+	Net        string `help:"VM network config"`
+	Cpu        int    `help:"VM cpu count"`
+	Memory     string `help:"VM memory size, e.g. 1G"`
+	Hypervisor string `help:"VM hypervisor"`
 }
 
 func (o MachineCreateOptions) Params() (*jsonutils.JSONDict, error) {
@@ -78,6 +79,7 @@ func (o MachineCreateOptions) Params() (*jsonutils.JSONDict, error) {
 	if o.Cpu > 0 {
 		vmConfig.Add(jsonutils.NewInt(int64(o.Cpu)), "vcpu_count")
 	}
+	vmConfig.Add(jsonutils.NewString(o.Hypervisor), "hypervisor")
 	params.Add(vmConfig, "config", "vm")
 	return params, nil
 }

--- a/pkg/mcclient/options/servers.go
+++ b/pkg/mcclient/options/servers.go
@@ -39,7 +39,7 @@ type ServerListOptions struct {
 	Gpu                *bool  `help:"Show gpu servers"`
 	Secgroup           string `help:"Secgroup ID or Name"`
 	AdminSecgroup      string `help:"AdminSecgroup ID or Name"`
-	Hypervisor         string `help:"Show server of hypervisor" choices:"kvm|esxi|container|baremetal|aliyun|azure|aws|huawei|ucloud|zstack"`
+	Hypervisor         string `help:"Show server of hypervisor" choices:"kvm|esxi|container|baremetal|aliyun|azure|aws|huawei|ucloud|zstack|openstack"`
 	Region             string `help:"Show servers in cloudregion"`
 	WithEip            *bool  `help:"Show Servers with EIP"`
 	WithoutEip         *bool  `help:"Show Servers without EIP"`


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

climc 支持创建不同 hypervisor 集群的选项

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/cc @wanyaoqi 
/area climc