### PR TITLE
fix: 1. token add projects when no project specified 2.

### DIFF
--- a/cmd/climc/climc.go
+++ b/cmd/climc/climc.go
@@ -133,9 +133,9 @@ func newClientSession(options *BaseOptions) (*mcclient.ClientSession, error) {
 	}
 	// if len(options.OsProjectId) == 0 && len(options.OsProjectName) == 0 {
 	//    showErrorAndExit(fmt.Errorf("Missing OS_PROEJCT_ID or OS_PROJECT_NAME"))
-	if len(options.OsProjectName) == 0 {
-		return nil, fmt.Errorf("Missing OS_PROJECT_NAME")
-	}
+	// if len(options.OsProjectName) == 0 {
+	// 	return nil, fmt.Errorf("Missing OS_PROJECT_NAME")
+	// }
 
 	logLevel := "info"
 	if options.Debug {

--- a/docs/schemas/auth.yaml
+++ b/docs/schemas/auth.yaml
@@ -90,6 +90,10 @@ Token2:
               name:
                 type: string
                 description: 用户角色名称
+    tenants:
+      type: array
+      items:
+        $ref: '#/TenantV2'
     metadata:
       type: object
       properties:
@@ -257,6 +261,10 @@ TokenV3:
     user:
       type: object
       $ref: './roleassignments.yaml#/DomainObject'
+    projects:
+      type: array
+      items:
+        $ref: './roleassignments.yaml#/DomainObject'
     catalog:
       type: array
       items:

--- a/pkg/apis/compute/snapshot.go
+++ b/pkg/apis/compute/snapshot.go
@@ -21,6 +21,7 @@ type SSnapshotCreateInput struct {
 
 	Name      string `json:"name"`
 	ProjectId string `json:"project_id"`
+	DomainId  string `json:"domain_id"`
 
 	DiskId        string `json:"disk_id"`
 	StorageId     string `json:"storage_id"`
@@ -36,6 +37,7 @@ type SSnapshotPolicyCreateInput struct {
 
 	Name      string `json:"name"`
 	ProjectId string `json:"project_id"`
+	DomainId  string `json:"domain_id"`
 
 	ManagerId     string `json:"manager_id"`
 	CloudregionId string `json:"cloudregion_id"`

--- a/pkg/cloudcommon/db/interface.go
+++ b/pkg/cloudcommon/db/interface.go
@@ -244,6 +244,7 @@ type IVirtualModelManager interface {
 	IStandaloneModelManager
 
 	GetIVirtualModelManager() IVirtualModelManager
+	GetResourceCount() ([]SProjectResourceCount, error)
 }
 
 type IVirtualModel interface {

--- a/pkg/cloudcommon/db/project_resources.go
+++ b/pkg/cloudcommon/db/project_resources.go
@@ -48,7 +48,7 @@ func getAllProjectResourceCounts() (map[string][]SProjectResourceCount, error) {
 	for _, manager := range globalTables {
 		virtman, ok := manager.(IVirtualModelManager)
 		if ok {
-			resCnt, err := getProjectResourceCount(virtman)
+			resCnt, err := virtman.GetResourceCount()
 			if err != nil {
 				return nil, errors.Wrap(err, "getProjectResourceCount")
 			}
@@ -65,8 +65,13 @@ type SProjectResourceCount struct {
 	ResCount int
 }
 
-func getProjectResourceCount(virtman IVirtualModelManager) ([]SProjectResourceCount, error) {
-	virts := virtman.Query().SubQuery()
+func (virtman *SVirtualResourceBaseManager) GetResourceCount() ([]SProjectResourceCount, error) {
+	virts := virtman.Query()
+	return CalculateProjectResourceCount(virts)
+}
+
+func CalculateProjectResourceCount(query *sqlchemy.SQuery) ([]SProjectResourceCount, error) {
+	virts := query.SubQuery()
 	q := virts.Query(virts.Field("tenant_id"), sqlchemy.COUNT("res_count"))
 	q = q.IsNotEmpty("tenant_id")
 	q = q.GroupBy(virts.Field("tenant_id"))

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -886,6 +886,7 @@ func (manager *SCloudproviderManager) InitializeData() error {
 	}
 	for i := 0; i < len(providers); i += 1 {
 		_, err := db.Update(&providers[i], func() error {
+			providers[i].DomainId = auth.AdminCredential().GetProjectDomainId()
 			providers[i].ProjectId = auth.AdminCredential().GetProjectId()
 			return nil
 		})

--- a/pkg/compute/models/elasticips.go
+++ b/pkg/compute/models/elasticips.go
@@ -975,6 +975,7 @@ func (manager *SElasticipManager) AllocateEipAndAssociateVM(ctx context.Context,
 	// eip.AutoDellocate = tristate.True
 	eip.Bandwidth = bw
 	eip.ChargeType = chargeType
+	eip.DomainId = vm.DomainId
 	eip.ProjectId = vm.ProjectId
 	eip.ProjectSrc = string(db.PROJECT_SOURCE_LOCAL)
 	eip.ManagerId = host.ManagerId

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -2059,6 +2059,7 @@ func (self *SGuest) confToSchedDesc(addCpu, addMem, addDisk int) *schedapi.Sched
 			ServerConfigs: &api.ServerConfigs{
 				Hypervisor: self.Hypervisor,
 				Project:    self.ProjectId,
+				Domain:     self.DomainId,
 				PreferHost: self.HostId,
 				Disks:      []*api.DiskConfig{diskInfo},
 			},
@@ -3145,6 +3146,7 @@ func (man *SGuestManager) createImportGuest(ctx context.Context, userCred mcclie
 		return nil, httperrors.NewGeneralError(fmt.Errorf("Can't convert %#v to *SGuest model", model))
 	}
 	gst.ProjectId = userCred.GetProjectId()
+	gst.DomainId = userCred.GetProjectDomainId()
 	gst.IsSystem = desc.IsSystem
 	gst.Id = desc.Id
 	gst.Name = desc.Name

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4223,6 +4223,7 @@ func (self *SGuest) ToSchedDesc() *schedapi.ScheduleInput {
 		desc.HostId = self.HostId
 	}
 	config.Project = self.ProjectId
+	config.Domain = self.DomainId
 	/*tags := self.GetApptags()
 	for i := 0; i < len(tags); i++ {
 		desc.Set(tags[i], jsonutils.JSONTrue)
@@ -4414,6 +4415,7 @@ func (self *SGuest) toCreateInput() *api.ServerCreateInput {
 	r.Hypervisor = self.Hypervisor
 	r.InstanceType = self.InstanceType
 	r.Project = self.ProjectId
+	r.Domain = self.DomainId
 	r.Count = 1
 	r.Disks = self.ToDisksConfig()
 	r.Networks = self.ToNetworksConfig()

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -3053,6 +3053,7 @@ func (self *SHost) PerformInitialize(
 	guest.Hypervisor = api.HYPERVISOR_BAREMETAL
 	guest.HostId = self.Id
 	guest.ProjectId = userCred.GetProjectId()
+	guest.DomainId = userCred.GetProjectDomainId()
 	guest.Status = api.VM_RUNNING
 	guest.OsType = "Linux"
 	guest.SetModelManager(GuestManager, guest)

--- a/pkg/compute/models/loadbalanceracls.go
+++ b/pkg/compute/models/loadbalanceracls.go
@@ -497,3 +497,8 @@ func (acl *SLoadbalancerAcl) SyncWithCloudLoadbalancerAcl(ctx context.Context, u
 
 	return nil
 }
+
+func (manager *SLoadbalancerAclManager) GetResourceCount() ([]db.SProjectResourceCount, error) {
+	virts := manager.Query().IsFalse("pending_deleted")
+	return db.CalculateProjectResourceCount(virts)
+}

--- a/pkg/compute/models/loadbalancerbackendgroups.go
+++ b/pkg/compute/models/loadbalancerbackendgroups.go
@@ -567,3 +567,8 @@ func (manager *SLoadbalancerBackendGroupManager) initBackendGroupRegion() error 
 	}
 	return nil
 }
+
+func (manager *SLoadbalancerBackendGroupManager) GetResourceCount() ([]db.SProjectResourceCount, error) {
+	virts := manager.Query().IsFalse("pending_deleted")
+	return db.CalculateProjectResourceCount(virts)
+}

--- a/pkg/compute/models/loadbalancerbackends.go
+++ b/pkg/compute/models/loadbalancerbackends.go
@@ -598,3 +598,8 @@ func (manager *SLoadbalancerBackendManager) InitializeData() error {
 	}
 	return nil
 }
+
+func (manager *SLoadbalancerBackendManager) GetResourceCount() ([]db.SProjectResourceCount, error) {
+	virts := manager.Query().IsFalse("pending_deleted")
+	return db.CalculateProjectResourceCount(virts)
+}

--- a/pkg/compute/models/loadbalancercertificates.go
+++ b/pkg/compute/models/loadbalancercertificates.go
@@ -476,3 +476,8 @@ func (lbcert *SLoadbalancerCertificate) SyncWithCloudLoadbalancerCertificate(ctx
 
 	return nil
 }
+
+func (manager *SLoadbalancerCertificateManager) GetResourceCount() ([]db.SProjectResourceCount, error) {
+	virts := manager.Query().IsFalse("pending_deleted")
+	return db.CalculateProjectResourceCount(virts)
+}

--- a/pkg/compute/models/loadbalancerlistenerrules.go
+++ b/pkg/compute/models/loadbalancerlistenerrules.go
@@ -468,3 +468,8 @@ func (manager *SLoadbalancerListenerRuleManager) InitializeData() error {
 	}
 	return nil
 }
+
+func (manager *SLoadbalancerListenerRuleManager) GetResourceCount() ([]db.SProjectResourceCount, error) {
+	virts := manager.Query().IsFalse("pending_deleted")
+	return db.CalculateProjectResourceCount(virts)
+}

--- a/pkg/compute/models/loadbalancerlisteners.go
+++ b/pkg/compute/models/loadbalancerlisteners.go
@@ -960,3 +960,8 @@ func (manager *SLoadbalancerListenerManager) InitializeData() error {
 	}
 	return nil
 }
+
+func (manager *SLoadbalancerListenerManager) GetResourceCount() ([]db.SProjectResourceCount, error) {
+	virts := manager.Query().IsFalse("pending_deleted")
+	return db.CalculateProjectResourceCount(virts)
+}

--- a/pkg/compute/models/loadbalancers.go
+++ b/pkg/compute/models/loadbalancers.go
@@ -769,3 +769,8 @@ func (man *SLoadbalancerManager) InitializeData() error {
 	}
 	return nil
 }
+
+func (manager *SLoadbalancerManager) GetResourceCount() ([]db.SProjectResourceCount, error) {
+	virts := manager.Query().IsFalse("pending_deleted")
+	return db.CalculateProjectResourceCount(virts)
+}

--- a/pkg/compute/models/managedresource.go
+++ b/pkg/compute/models/managedresource.go
@@ -62,9 +62,11 @@ func (self *SManagedResourceBase) GetCustomizeColumns(ctx context.Context, userC
 	}
 	if len(provider.ProjectId) > 0 {
 		info["manager_project_id"] = provider.ProjectId
+		info["manager_project_domain_id"] = provider.DomainId
 		tc, err := db.TenantCacheManager.FetchTenantById(appctx.Background, provider.ProjectId)
 		if err == nil {
-			info["manager_project"] = tc.GetName()
+			info["manager_project"] = tc.Name
+			info["manager_project_domain"] = tc.Domain
 		}
 	}
 

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1772,6 +1772,7 @@ func (self *SNetwork) PerformSplit(ctx context.Context, userCred mcclient.TokenC
 	network.IsPublic = self.IsPublic
 	network.Status = self.Status
 	network.ProjectId = self.ProjectId
+	network.DomainId = self.DomainId
 	// network.UserId = self.UserId
 	network.IsSystem = self.IsSystem
 	network.Description = self.Description

--- a/pkg/compute/models/routetables.go
+++ b/pkg/compute/models/routetables.go
@@ -462,6 +462,7 @@ func (man *SRouteTableManager) newRouteTableFromCloud(userCred mcclient.TokenCre
 	routeTable.ExternalId = cloudRouteTable.GetGlobalId()
 	routeTable.Description = cloudRouteTable.GetDescription()
 	routeTable.ProjectId = userCred.GetProjectId()
+	routeTable.DomainId = userCred.GetProjectDomainId()
 	routeTable.SetModelManager(man, routeTable)
 	return routeTable, nil
 }

--- a/pkg/compute/models/secgroups.go
+++ b/pkg/compute/models/secgroups.go
@@ -330,7 +330,8 @@ func (self *SSecurityGroup) PerformClone(ctx context.Context, userCred mcclient.
 
 	secgroup.Name = name
 	secgroup.Description, _ = data.GetString("description")
-	secgroup.ProjectId = userCred.GetTenantId()
+	secgroup.ProjectId = userCred.GetProjectId()
+	secgroup.DomainId = userCred.GetProjectDomainId()
 
 	err = SecurityGroupManager.TableSpec().Insert(secgroup)
 	if err != nil {
@@ -511,6 +512,7 @@ func (manager *SSecurityGroupManager) newFromCloudSecgroup(ctx context.Context, 
 	secgroup.Name = newName
 	secgroup.Description = extSec.GetDescription()
 	secgroup.ProjectId = userCred.GetProjectId()
+	secgroup.DomainId = userCred.GetProjectDomainId()
 
 	if err := manager.TableSpec().Insert(&secgroup); err != nil {
 		return nil, err
@@ -575,6 +577,7 @@ func (manager *SSecurityGroupManager) InitializeData() error {
 		secGrp.Id = "default"
 		secGrp.Name = "Default"
 		secGrp.ProjectId = auth.AdminCredential().GetProjectId()
+		secGrp.DomainId = auth.AdminCredential().GetProjectDomainId()
 		// secGrp.IsEmulated = false
 		secGrp.IsPublic = true
 		err = manager.TableSpec().Insert(secGrp)

--- a/pkg/compute/models/snapshotpolicy.go
+++ b/pkg/compute/models/snapshotpolicy.go
@@ -71,6 +71,7 @@ func (manager *SSnapshotPolicyManager) ValidateCreateData(ctx context.Context, u
 		return nil, httperrors.NewInputParameterError("Unmarshal input failed %s", err)
 	}
 	input.ProjectId = ownerId.GetProjectId()
+	input.DomainId = ownerId.GetProjectDomainId()
 
 	err = db.NewNameValidator(manager, ownerId, input.Name)
 	if err != nil {

--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -295,6 +295,7 @@ func (manager *SSnapshotManager) ValidateCreateData(ctx context.Context, userCre
 	input := &api.SSnapshotCreateInput{}
 	input.Name = snapshotName
 	input.ProjectId = ownerId.GetProjectId()
+	input.DomainId = ownerId.GetProjectDomainId()
 	input.DiskId = disk.Id
 	input.CreatedBy = api.SNAPSHOT_MANUAL
 	input.Size = disk.DiskSize
@@ -435,6 +436,7 @@ func (self *SSnapshotManager) CreateSnapshot(ctx context.Context, userCred mccli
 	snapshot := &SSnapshot{}
 	snapshot.SetModelManager(self, snapshot)
 	snapshot.ProjectId = userCred.GetProjectId()
+	snapshot.DomainId = userCred.GetProjectDomainId()
 	snapshot.DiskId = disk.Id
 	if len(disk.ExternalId) == 0 {
 		snapshot.StorageId = disk.StorageId
@@ -795,4 +797,9 @@ func (self *SSnapshot) getCloudProviderInfo() SCloudProviderInfo {
 	region := self.GetRegion()
 	provider := self.GetCloudprovider()
 	return MakeCloudProviderInfo(region, nil, provider)
+}
+
+func (manager *SSnapshotManager) GetResourceCount() ([]db.SProjectResourceCount, error) {
+	virts := manager.Query().IsFalse("fake_deleted")
+	return db.CalculateProjectResourceCount(virts)
 }

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -215,6 +215,7 @@ func (self *SKVMRegionDriver) RequestCreateLoadbalancerBackendGroup(ctx context.
 			}
 			loadbalancerBackend.Status = api.LB_STATUS_ENABLED
 			loadbalancerBackend.ProjectId = userCred.GetProjectId()
+			loadbalancerBackend.DomainId = userCred.GetProjectDomainId()
 			loadbalancerBackend.Name = fmt.Sprintf("%s-%s-%s", lbbg.Name, backend.BackendType, backend.Name)
 			if err := models.LoadbalancerBackendManager.TableSpec().Insert(&loadbalancerBackend); err != nil {
 				return nil, err

--- a/pkg/keystone/tokens/token.go
+++ b/pkg/keystone/tokens/token.go
@@ -270,6 +270,17 @@ func (t *SAuthToken) getTokenV3(
 		if project != nil || domain != nil {
 			return nil, ErrUserNotInProject
 		}
+		extProjs, err := models.ProjectManager.FetchUserProjects(user.Id)
+		if err != nil {
+			return nil, errors.Wrap(err, "models.ProjectManager.FetchUserProjects")
+		}
+		token.Token.Projects = make([]mcclient.KeystoneProjectV3, len(extProjs))
+		for i := range extProjs {
+			token.Token.Projects[i].Id = extProjs[i].Id
+			token.Token.Projects[i].Name = extProjs[i].Name
+			token.Token.Projects[i].Domain.Id = extProjs[i].DomainId
+			token.Token.Projects[i].Domain.Name = extProjs[i].DomainName
+		}
 	} else {
 		if project != nil {
 			token.Token.IsDomain = false
@@ -326,6 +337,18 @@ func (t *SAuthToken) getTokenV2(
 	if len(roles) == 0 {
 		if project != nil {
 			return nil, ErrUserNotInProject
+		}
+		extProjs, err := models.ProjectManager.FetchUserProjects(user.Id)
+		if err != nil {
+			return nil, errors.Wrap(err, "models.ProjectManager.FetchUserProjects")
+		}
+		token.Tenants = make([]mcclient.KeystoneTenantV2, len(extProjs))
+		for i := range extProjs {
+			token.Tenants[i].Id = extProjs[i].Id
+			token.Tenants[i].Name = extProjs[i].Name
+			token.Tenants[i].Domain.Id = extProjs[i].DomainId
+			token.Tenants[i].Domain.Name = extProjs[i].DomainName
+			token.Tenants[i].Enabled = true
 		}
 	} else {
 		token.Token.Tenant.Id = project.Id

--- a/pkg/mcclient/token2.go
+++ b/pkg/mcclient/token2.go
@@ -79,6 +79,7 @@ type TokenCredentialV2 struct {
 	Token          KeystoneTokenV2
 	ServiceCatalog KeystoneServiceCatalogV2
 	User           KeystoneUserV2
+	Tenants        []KeystoneTenantV2
 	Metadata       KeystoneMetadataV2
 	Context        SAuthContext
 }

--- a/pkg/mcclient/token3.go
+++ b/pkg/mcclient/token3.go
@@ -76,6 +76,7 @@ type KeystoneTokenV3 struct {
 	IssuedAt  time.Time                `json:"issued_at"`
 	Methods   []string                 `json:"methods"`
 	Project   KeystoneProjectV3        `json:"project"`
+	Projects  []KeystoneProjectV3      `json:"projects"`
 	Roles     []KeystoneRoleV3         `json:"roles"`
 	User      KeystoneUserV3           `json:"user"`
 	Catalog   KeystoneServiceCatalogV3 `json:"catalog"`


### PR DESCRIPTION
IVirtualResourceManager add GetResourceCount() method 3. domainId not
initialized occasionally

**这个 PR 实现什么功能/修复什么问题**:
1. 部分虚拟资源创建时未设置DomainId，导致DomainId设置为default
2. 当用户认证无项目时，token中携带该用户加入的项目列表
3. IVirtualResourceManager增加GetResourceCount的接口，允许各种资源个性化获取项目下资源数量的方式

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11.0