### PR TITLE
fix: quota encode json allowing zero value

### DIFF
--- a/pkg/cloudcommon/db/quotas/handler.go
+++ b/pkg/cloudcommon/db/quotas/handler.go
@@ -116,7 +116,9 @@ func (manager *SQuotaBaseManager) queryQuota(ctx context.Context, scope rbacutil
 
 	ret.Update(quota.ToJSON(""))
 	ret.Update(usage.ToJSON("usage"))
-	ret.Update(pending.ToJSON("pending"))
+	if !pending.IsEmpty() {
+		ret.Update(pending.ToJSON("pending"))
+	}
 
 	if scope == rbacutils.ScopeDomain {
 		total, err := manager.getDomainTotalQuota(ctx, ownerId.GetProjectDomainId(), nil)

--- a/pkg/compute/models/quotas.go
+++ b/pkg/compute/models/quotas.go
@@ -296,41 +296,41 @@ func keyName(prefix, name string) string {
 
 func (self *SQuota) ToJSON(prefix string) jsonutils.JSONObject {
 	ret := jsonutils.NewDict()
-	if self.Cpu > 0 {
-		ret.Add(jsonutils.NewInt(int64(self.Cpu)), keyName(prefix, "cpu"))
-	}
-	if self.Memory > 0 {
-		ret.Add(jsonutils.NewInt(int64(self.Memory)), keyName(prefix, "memory"))
-	}
-	if self.Storage > 0 {
-		ret.Add(jsonutils.NewInt(int64(self.Storage)), keyName(prefix, "storage"))
-	}
-	if self.Port > 0 {
-		ret.Add(jsonutils.NewInt(int64(self.Port)), keyName(prefix, "port"))
-	}
-	if self.Eip > 0 {
-		ret.Add(jsonutils.NewInt(int64(self.Eip)), keyName(prefix, "eip"))
-	}
-	if self.Eport > 0 {
-		ret.Add(jsonutils.NewInt(int64(self.Eport)), keyName(prefix, "eport"))
-	}
-	if self.Bw > 0 {
-		ret.Add(jsonutils.NewInt(int64(self.Bw)), keyName(prefix, "bw"))
-	}
-	if self.Ebw > 0 {
-		ret.Add(jsonutils.NewInt(int64(self.Ebw)), keyName(prefix, "ebw"))
-	}
-	if self.Group > 0 {
-		ret.Add(jsonutils.NewInt(int64(self.Group)), keyName(prefix, "group"))
-	}
-	if self.Secgroup > 0 {
-		ret.Add(jsonutils.NewInt(int64(self.Secgroup)), keyName(prefix, "secgroup"))
-	}
-	if self.IsolatedDevice > 0 {
-		ret.Add(jsonutils.NewInt(int64(self.IsolatedDevice)), keyName(prefix, "isolated_device"))
-	}
-	if self.Snapshot > 0 {
-		ret.Add(jsonutils.NewInt(int64(self.Snapshot)), keyName(prefix, "snapshot"))
-	}
+	// if self.Cpu > 0 {
+	ret.Add(jsonutils.NewInt(int64(self.Cpu)), keyName(prefix, "cpu"))
+	//}
+	// if self.Memory > 0 {
+	ret.Add(jsonutils.NewInt(int64(self.Memory)), keyName(prefix, "memory"))
+	//}
+	//if self.Storage > 0 {
+	ret.Add(jsonutils.NewInt(int64(self.Storage)), keyName(prefix, "storage"))
+	//}
+	//if self.Port > 0 {
+	ret.Add(jsonutils.NewInt(int64(self.Port)), keyName(prefix, "port"))
+	//}
+	//if self.Eip > 0 {
+	ret.Add(jsonutils.NewInt(int64(self.Eip)), keyName(prefix, "eip"))
+	//}
+	//if self.Eport > 0 {
+	ret.Add(jsonutils.NewInt(int64(self.Eport)), keyName(prefix, "eport"))
+	//}
+	//if self.Bw > 0 {
+	ret.Add(jsonutils.NewInt(int64(self.Bw)), keyName(prefix, "bw"))
+	//}
+	//if self.Ebw > 0 {
+	ret.Add(jsonutils.NewInt(int64(self.Ebw)), keyName(prefix, "ebw"))
+	//}
+	//if self.Group > 0 {
+	ret.Add(jsonutils.NewInt(int64(self.Group)), keyName(prefix, "group"))
+	//}
+	//if self.Secgroup > 0 {
+	ret.Add(jsonutils.NewInt(int64(self.Secgroup)), keyName(prefix, "secgroup"))
+	//}
+	//if self.IsolatedDevice > 0 {
+	ret.Add(jsonutils.NewInt(int64(self.IsolatedDevice)), keyName(prefix, "isolated_device"))
+	//}
+	//if self.Snapshot > 0 {
+	ret.Add(jsonutils.NewInt(int64(self.Snapshot)), keyName(prefix, "snapshot"))
+	//}
 	return ret
 }

--- a/pkg/image/models/quotas.go
+++ b/pkg/image/models/quotas.go
@@ -108,8 +108,8 @@ func (self *SQuota) Exceed(request quotas.IQuota, quota quotas.IQuota) error {
 
 func (self *SQuota) ToJSON(prefix string) jsonutils.JSONObject {
 	ret := jsonutils.NewDict()
-	if self.Image > 0 {
-		ret.Add(jsonutils.NewInt(int64(self.Image)), quotas.KeyName(prefix, "image"))
-	}
+	// if self.Image > 0 {
+	ret.Add(jsonutils.NewInt(int64(self.Image)), quotas.KeyName(prefix, "image"))
+	// }
 	return ret
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
配额编码为json字符串时会携带0的配额指标

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11.0