### PR TITLE
私有云或公有云镜像windows默认用户名都是Administrator

### DIFF
--- a/pkg/compute/guestdrivers/aliyun.go
+++ b/pkg/compute/guestdrivers/aliyun.go
@@ -153,7 +153,7 @@ func (self *SAliyunGuestDriver) GetGuestInitialStateAfterRebuild() string {
 
 func (self *SAliyunGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManagedVMCreateConfig) string {
 	userName := "root"
-	if desc.ImageType == "system" && desc.OsType == "Windows" {
+	if desc.OsType == "Windows" {
 		userName = "Administrator"
 	}
 	return userName

--- a/pkg/compute/guestdrivers/base.go
+++ b/pkg/compute/guestdrivers/base.go
@@ -273,7 +273,7 @@ func (self *SBaseGuestDriver) GetUserDataType() string {
 
 func (self *SBaseGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManagedVMCreateConfig) string {
 	userName := "root"
-	if desc.ImageType == "system" && desc.OsType == "Windows" {
+	if desc.OsType == "Windows" {
 		userName = "Administrator"
 	}
 	return userName

--- a/pkg/compute/guestdrivers/huawei.go
+++ b/pkg/compute/guestdrivers/huawei.go
@@ -110,9 +110,9 @@ func (self *SHuaweiGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManag
 		if desc.OsDistribution == "Ubuntu" {
 			userName = "ubuntu"
 		}
-		if desc.OsType == "Windows" {
-			userName = "Administrator"
-		}
+	}
+	if desc.OsType == "Windows" {
+		userName = "Administrator"
 	}
 	return userName
 }

--- a/pkg/compute/guestdrivers/qcloud.go
+++ b/pkg/compute/guestdrivers/qcloud.go
@@ -171,9 +171,9 @@ func (self *SQcloudGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManag
 		if desc.OsDistribution == "Ubuntu" {
 			userName = "ubuntu"
 		}
-		if desc.OsType == "Windows" {
-			userName = "Administrator"
-		}
+	}
+	if desc.OsType == "Windows" {
+		userName = "Administrator"
 	}
 	return userName
 }

--- a/pkg/compute/guestdrivers/zstack.go
+++ b/pkg/compute/guestdrivers/zstack.go
@@ -143,7 +143,7 @@ func (self *SZStackGuestDriver) GetUserDataType() string {
 
 func (self *SZStackGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManagedVMCreateConfig) string {
 	userName := "root"
-	if desc.ImageType == "system" && desc.OsType == "Windows" {
+	if desc.OsType == "Windows" {
 		userName = "Administrator"
 	}
 	return userName


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
私有云或公有云镜像windows默认用户名都是Administrator

**是否需要 backport 到之前的 release 分支**:
- release/2.11.0
- release/2.10.0

/area region

/cc @swordqiu @yousong 