### PR TITLE
fix: task usercred should be utf8 charset

### DIFF
--- a/pkg/cloudcommon/db/taskman/tasks.go
+++ b/pkg/cloudcommon/db/taskman/tasks.go
@@ -80,9 +80,9 @@ type STask struct {
 	ObjName  string                   `width:"128" charset:"utf8" nullable:"false" list:"user"`               //  Column(VARCHAR(128, charset='utf8'), nullable=False)
 	ObjId    string                   `width:"128" charset:"ascii" nullable:"false" list:"user" index:"true"` // Column(VARCHAR(ID_LENGTH, charset='ascii'), nullable=False)
 	TaskName string                   `width:"64" charset:"ascii" nullable:"false" list:"user"`               // Column(VARCHAR(64, charset='ascii'), nullable=False)
-	UserCred mcclient.TokenCredential `width:"1024" charset:"ascii" nullable:"false" get:"user"`              // Column(VARCHAR(1024, charset='ascii'), nullable=False)
+	UserCred mcclient.TokenCredential `width:"1024" charset:"utf8" nullable:"false" get:"user"`               // Column(VARCHAR(1024, charset='ascii'), nullable=False)
 	// OwnerCred string `width:"512" charset:"ascii" nullable:"true"` // Column(VARCHAR(512, charset='ascii'), nullable=True)
-	Params *jsonutils.JSONDict `charset:"ascii" length:"medium" nullable:"false" get:"user"` // Column(MEDIUMTEXT(charset='ascii'), nullable=False)
+	Params *jsonutils.JSONDict `charset:"utf8" length:"medium" nullable:"false" get:"user"` // Column(MEDIUMTEXT(charset='ascii'), nullable=False)
 
 	Stage string `width:"64" charset:"ascii" nullable:"false" default:"on_init" list:"user"` // Column(VARCHAR(64, charset='ascii'), nullable=False, default='on_init')
 

--- a/pkg/logger/models/actionlog.go
+++ b/pkg/logger/models/actionlog.go
@@ -67,7 +67,7 @@ func (action *SActionlog) CustomizeCreate(ctx context.Context, userCred mcclient
 	if action.StartTime.IsZero() {
 		action.StartTime = now
 	}
-	return nil
+	return action.SOpsLog.CustomizeCreate(ctx, userCred, ownerId, query, data)
 }
 
 // Websockets 不再拉取 ActionLog 的消息，因此注释掉如下代码


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：操作日志中文项目乱码（task的userCred字符集错误导致）

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0
- release/2.9.0
- release/2.10.0
- release/2.11.0