### PR TITLE
避免重装系统时绑定秘钥后没有account信息

### DIFF
--- a/pkg/compute/guestdrivers/utils.go
+++ b/pkg/compute/guestdrivers/utils.go
@@ -48,12 +48,13 @@ func fetchIVMinfo(desc cloudprovider.SManagedVMCreateConfig, iVM cloudprovider.I
 
 	data.Add(jsonutils.NewString(iVM.GetOSType()), "os")
 
+	//避免在rebuild_root时绑定秘钥,没有account信息
+	data.Add(jsonutils.NewString(account), "account")
 	if len(passwd) > 0 {
 		encpasswd, err := utils.EncryptAESBase64(guestId, passwd)
 		if err != nil {
 			log.Errorf("encrypt password failed %s", err)
 		}
-		data.Add(jsonutils.NewString(account), "account")
 		data.Add(jsonutils.NewString(encpasswd), "key")
 	}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免重装系统时绑定秘钥后没有account信息

**是否需要 backport 到之前的 release 分支**:
- release/2.11.0
- release/2.10.0
- release/2.9.0
- release/2.8.0

/area region

/cc @swordqiu @yousong 
