### PR TITLE
 host 相关的 rpm 包自动添加 systemd unit service 文件

### DIFF
--- a/build/host-deployer/root/usr/lib/systemd/system/yunion-host-deployer.service
+++ b/build/host-deployer/root/usr/lib/systemd/system/yunion-host-deployer.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Yunion Host Deploy Agent
+Documentation=https://docs.yunion.cn
+After=network.target httpd.service
+
+[Service]
+Type=simple
+User=root
+Group=root
+ExecStart=/opt/yunion/bin/host-deployer --conf /etc/yunion/host.conf
+WorkingDirectory=/opt/yunion/bin
+KillMode=process
+Restart=always
+RestartSec=30
+LimitNOFILE=500000
+LimitNPROC=500000
+
+[Install]
+WantedBy=multi-user.target

--- a/build/host-deployer/vars
+++ b/build/host-deployer/vars
@@ -1,1 +1,2 @@
 DESCRIPTION="Yunion Host Deploy Agent"
+SERVICE="yes"

--- a/build/host/root/usr/lib/systemd/system/yunion-host.service
+++ b/build/host/root/usr/lib/systemd/system/yunion-host.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Yunion Cloud Host Agent server
+Documentation=https://docs.yunion.cn
+After=network-online.target
+Wants=network-online.target
+After=network.target yunion-host-deployer.service
+
+[Service]
+Type=simple
+User=root
+Group=root
+ExecStart=/opt/yunion/bin/host --config /etc/yunion/host.conf
+WorkingDirectory=/opt/yunion/bin
+KillMode=process
+Restart=always
+RestartSec=30
+LimitNOFILE=500000
+LimitNPROC=500000
+
+[Install]
+WantedBy=multi-user.target

--- a/build/host/vars
+++ b/build/host/vars
@@ -1,1 +1,6 @@
 DESCRIPTION="Yunion Host Command Line Utility"
+SERVICE="yes"
+
+REQUIRES=(
+	"yunion-host-deployer"
+)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

host 相关的 rpm 包添加 systemd unit 文件，避免手动写这些文件

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- relase/2.10.0

/cc @swordqiu @wanyao @yousong 