### PR TITLE
fix: ldap sync domain may remove local usrs

### DIFF
--- a/cmd/climc/shell/quotas.go
+++ b/cmd/climc/shell/quotas.go
@@ -61,7 +61,7 @@ func init() {
 
 	type QuotaSetOptions struct {
 		Tenant        string `help:"Tenant name or ID to set quota" json:"tenant,omitempty"`
-		ProjectDomain string `help:"Domain name or ID to set quota" json:"domain,omitempty"`
+		ProjectDomain string `help:"Domain name or ID to set quota" json:",omitempty"`
 		Action        string `help:"quota set action" choices:"add|reset|replace"`
 		Cascade       bool   `help:"cascade set quota so that auto increment domain quota if total project quota exceeds parent domain quota"`
 		QuotaBaseOptions

--- a/pkg/keystone/driver/ldap/sync.go
+++ b/pkg/keystone/driver/ldap/sync.go
@@ -265,6 +265,9 @@ func (self *SLDAPDriver) syncUsers(ctx context.Context, cli *ldaputils.SLDAPClie
 		return nil, errors.Wrap(err, "models.UserManager.FetchUserIdsInDomain")
 	}
 	for i := range deleteUsers {
+		if !deleteUsers[i].LinkedWithIdp(self.IdpId) {
+			continue
+		}
 		err := deleteUsers[i].UnlinkIdp(self.IdpId)
 		if err != nil {
 			log.Errorf("deleteUser.UnlinkIdp error %s", err)
@@ -381,6 +384,9 @@ func (self *SLDAPDriver) syncGroups(ctx context.Context, cli *ldaputils.SLDAPCli
 		return errors.Wrap(err, "models.GroupManager.FetchGroupsInDomain")
 	}
 	for i := range deleteGroups {
+		if !deleteGroups[i].LinkedWithIdp(self.IdpId) {
+			continue
+		}
 		err := deleteGroups[i].UnlinkIdp(self.IdpId)
 		if err != nil {
 			log.Errorf("deleteGroup.UnlinkIdp error %s", err)

--- a/pkg/keystone/models/groups.go
+++ b/pkg/keystone/models/groups.go
@@ -252,6 +252,14 @@ func (group *SGroup) IsReadOnly() bool {
 	return false
 }
 
+func (group *SGroup) LinkedWithIdp(idpId string) bool {
+	idmap, _ := group.getIdmapping()
+	if idmap != nil && idmap.IdpId == idpId {
+		return true
+	}
+	return false
+}
+
 func (manager *SGroupManager) FetchCustomizeColumns(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, objs []db.IModel, fields stringutils2.SSortedStrings) []*jsonutils.JSONDict {
 	rows := manager.SIdentityBaseResourceManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields)
 	return expandIdpAttributes(rows, objs, fields, api.IdMappingEntityGroup)

--- a/pkg/keystone/models/users.go
+++ b/pkg/keystone/models/users.go
@@ -633,6 +633,14 @@ func (user *SUser) IsReadOnly() bool {
 	return false
 }
 
+func (user *SUser) LinkedWithIdp(idpId string) bool {
+	idmap, _ := user.getIdmapping()
+	if idmap != nil && idmap.IdpId == idpId {
+		return true
+	}
+	return false
+}
+
 func (manager *SUserManager) FetchCustomizeColumns(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, objs []db.IModel, fields stringutils2.SSortedStrings) []*jsonutils.JSONDict {
 	rows := manager.SEnabledIdentityBaseResourceManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields)
 	return expandIdpAttributes(rows, objs, fields, api.IdMappingEntityUser)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：keystone同步ldap时，会将domain下sql用户删除

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11.0