### PR TITLE
Automated cherry pick of #1748: fix: server-change-ipaddr may ignore errors when changing ipaddr

### DIFF
--- a/cmd/climc/shell/servernetworks.go
+++ b/cmd/climc/shell/servernetworks.go
@@ -21,6 +21,7 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/util/regutils"
 
+	"yunion.io/x/onecloud/pkg/cloudcommon/cmdline"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/mcclient/options"
@@ -220,7 +221,11 @@ func init() {
 		} else {
 			return fmt.Errorf("Please specify Ip or Mac")
 		}
-		params.Add(jsonutils.NewString(args.NETDESC), "net_desc")
+		conf, err := cmdline.ParseNetworkConfig(args.NETDESC, 0)
+		if err != nil {
+			return err
+		}
+		params.Add(conf.JSON(conf), "net_desc")
 		srv, err := modules.Servers.PerformAction(s, args.SERVER, "change-ipaddr", params)
 		if err != nil {
 			return err

--- a/cmd/climc/shell/servers.go
+++ b/cmd/climc/shell/servers.go
@@ -984,4 +984,29 @@ func init() {
 		printObject(result)
 		return nil
 	})
+
+	R(&options.ServerIdOptions{}, "server-remote-nics", "Show remote nics of a server", func(s *mcclient.ClientSession, opts *options.ServerIdOptions) error {
+		result, err := modules.Servers.GetSpecific(s, opts.ID, "remote-nics", nil)
+		if err != nil {
+			return err
+		}
+		listResult := modules.ListResult{}
+		listResult.Data, _ = result.GetArray()
+		printList(&listResult, nil)
+		return nil
+	})
+
+	type ServerSyncFixNicsOptions struct {
+		ID string   `help:"ID or name of VM" json:"-"`
+		IP []string `help:"IP address of each NIC" json:"ip"`
+	}
+	R(&ServerSyncFixNicsOptions{}, "server-sync-fix-nics", "Fix missing IP for each nics after syncing VNICS", func(s *mcclient.ClientSession, opts *ServerSyncFixNicsOptions) error {
+		params := jsonutils.Marshal(opts)
+		result, err := modules.Servers.PerformAction(s, opts.ID, "sync-fix-nics", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
 }

--- a/pkg/apis/compute/api.go
+++ b/pkg/apis/compute/api.go
@@ -45,6 +45,8 @@ type NetworkConfig struct {
 	Reserved bool   `json:"reserved"`
 	NetType  string `json:"net_type"`
 
+	RequireDesignatedIP bool `json:"require_designated_ip"`
+
 	RequireTeaming bool `json:"require_teaming"`
 	TryTeaming     bool `json:"try_teaming"`
 

--- a/pkg/cloudcommon/cmdline/parser.go
+++ b/pkg/cloudcommon/cmdline/parser.go
@@ -153,6 +153,8 @@ func ParseNetworkConfig(desc string, idx int) (*compute.NetworkConfig, error) {
 			netConfig.Mac = netutils.MacUnpackHex(p)
 		} else if strings.HasPrefix(p, "wire=") {
 			netConfig.Wire = p[len("wire="):]
+		} else if p == "[require_designated_ip]" {
+			netConfig.RequireDesignatedIP = true
 		} else if p == "[random_exit]" {
 			netConfig.Exit = true
 		} else if p == "[random]" {

--- a/pkg/compute/models/cloudsync.go
+++ b/pkg/compute/models/cloudsync.go
@@ -583,7 +583,7 @@ func syncVMNics(ctx context.Context, userCred mcclient.TokenCredential, provider
 		log.Errorf(msg)
 		return
 	}
-	result := localVM.SyncVMNics(ctx, userCred, host, nics)
+	result := localVM.SyncVMNics(ctx, userCred, host, nics, nil)
 	msg := result.Result()
 	notes := fmt.Sprintf("syncVMNics for VM %s result: %s", localVM.Name, msg)
 	log.Infof(notes)

--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -188,7 +188,7 @@ func (manager *SGuestnetworkManager) newGuestNetwork(ctx context.Context, userCr
 			return nil, err
 		}
 		if len(address) > 0 && ipAddr != address && requiredDesignatedIp {
-			return nil, fmt.Errorf("candidate ip %s is occupoed!", address)
+			return nil, fmt.Errorf("candidate ip %s is occupied!", address)
 		}
 		gn.IpAddr = ipAddr
 	}
@@ -698,8 +698,14 @@ func (self *SGuestnetwork) ToNetworkConfig() *api.NetworkConfig {
 		Index:   int(self.Index),
 		Network: net.Id,
 		Wire:    net.GetWire().Id,
+		Mac:     self.MacAddr,
 		Address: self.IpAddr,
+		Driver:  self.Driver,
+		BwLimit: self.BwLimit,
 		Project: net.ProjectId,
+		Domain:  net.DomainId,
+		Ifname:  self.Ifname,
+		NetType: net.ServerType,
 	}
 	return ret
 }

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -3147,7 +3147,7 @@ func (self *SHost) addNetif(ctx context.Context, userCred mcclient.TokenCredenti
 				return httperrors.NewInputParameterError("no networks on wire %s", wire)
 			}
 			for i := range swNets {
-				if swNets[i].isAddressInRange(iIpAddr) {
+				if swNets[i].IsAddressInRange(iIpAddr) {
 					findAddr = true
 					break
 				}

--- a/pkg/compute/models/loadbalancernetworks.go
+++ b/pkg/compute/models/loadbalancernetworks.go
@@ -160,7 +160,7 @@ func (m *SLoadbalancernetworkManager) syncLoadbalancerNetwork(ctx context.Contex
 	if err != nil {
 		return err
 	}
-	if !network.isAddressInRange(ip) {
+	if !network.IsAddressInRange(ip) {
 		return fmt.Errorf("address %s is not in the range of network %s(%s)", req.Address, network.Id, network.Name)
 	}
 	q := m.Query().Equals("loadbalancer_id", req.Loadbalancer.Id).Equals("network_id", req.NetworkId)

--- a/pkg/compute/models/loadbalancers.go
+++ b/pkg/compute/models/loadbalancers.go
@@ -165,7 +165,7 @@ func (man *SLoadbalancerManager) ValidateCreateData(ctx context.Context, userCre
 			if err != nil {
 				return nil, err
 			}
-			if !network.isAddressInRange(ip) {
+			if !network.IsAddressInRange(ip) {
 				return nil, httperrors.NewInputParameterError("address %s is not in the range of network %s(%s)",
 					ipS, network.Name, network.Id)
 			}

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -624,7 +624,7 @@ func (manager *SNetworkManager) newFromCloudNetwork(ctx context.Context, userCre
 	return &net, nil
 }
 
-func (self *SNetwork) isAddressInRange(address netutils.IPV4Addr) bool {
+func (self *SNetwork) IsAddressInRange(address netutils.IPV4Addr) bool {
 	return self.getIPRange().Contains(address)
 }
 
@@ -675,7 +675,7 @@ func (manager *SNetworkManager) GetOnPremiseNetworkOfIP(ipAddr string, serverTyp
 		return nil, err
 	}
 	for _, n := range nets {
-		if n.isAddressInRange(address) {
+		if n.IsAddressInRange(address) {
 			return &n, nil
 		}
 	}
@@ -797,7 +797,7 @@ func isValidNetworkInfo(userCred mcclient.TokenCredential, netConfig *api.Networ
 			if err != nil {
 				return err
 			}
-			if !net.isAddressInRange(ipAddr) {
+			if !net.IsAddressInRange(ipAddr) {
 				return httperrors.NewInputParameterError("Address %s not in range", netConfig.Address)
 			}
 			if netConfig.Reserved {
@@ -966,7 +966,7 @@ func (self *SNetwork) PerformReserveIp(ctx context.Context, userCred mcclient.To
 		if err != nil {
 			return nil, httperrors.NewInputParameterError("not a valid ip address %s: %s", ipstr, err)
 		}
-		if !self.isAddressInRange(ipAddr) {
+		if !self.IsAddressInRange(ipAddr) {
 			return nil, httperrors.NewInputParameterError("Address %s not in network", ipstr)
 		}
 		used, err := self.isAddressUsed(ipstr)
@@ -1768,7 +1768,7 @@ func (self *SNetwork) PerformSplit(ctx context.Context, userCred mcclient.TokenC
 	if err != nil {
 		return nil, err
 	}
-	if !self.isAddressInRange(iSplitIp) {
+	if !self.IsAddressInRange(iSplitIp) {
 		return nil, httperrors.NewInputParameterError("Split IP %s out of range", splitIp)
 	}
 

--- a/pkg/compute/models/networks_id_change_handlers.go
+++ b/pkg/compute/models/networks_id_change_handlers.go
@@ -45,7 +45,7 @@ func (manager *SGuestnetworkManager) handleNetworkIdChange(ctx context.Context, 
 	}
 	for _, gn := range gns {
 		addr, _ := netutils.NewIPV4Addr(gn.IpAddr)
-		if args.newNet.isAddressInRange(addr) {
+		if args.newNet.IsAddressInRange(addr) {
 			_, err = db.Update(&gn, func() error {
 				gn.NetworkId = args.newNet.Id
 				return nil
@@ -67,7 +67,7 @@ func (manager *SHostnetworkManager) handleNetworkIdChange(ctx context.Context, a
 	}
 	for _, hn := range hns {
 		addr, _ := netutils.NewIPV4Addr(hn.IpAddr)
-		if args.newNet.isAddressInRange(addr) {
+		if args.newNet.IsAddressInRange(addr) {
 			_, err = db.Update(&hn, func() error {
 				hn.NetworkId = args.newNet.Id
 				return nil
@@ -89,7 +89,7 @@ func (manager *SReservedipManager) handleNetworkIdChange(ctx context.Context, ar
 	}
 	for _, ri := range ris {
 		addr, _ := netutils.NewIPV4Addr(ri.IpAddr)
-		if args.newNet.isAddressInRange(addr) {
+		if args.newNet.IsAddressInRange(addr) {
 			_, err = db.Update(&ri, func() error {
 				ri.NetworkId = args.newNet.Id
 				return nil
@@ -111,7 +111,7 @@ func (manager *SGroupnetworkManager) handleNetworkIdChange(ctx context.Context, 
 	}
 	for _, gn := range gns {
 		addr, _ := netutils.NewIPV4Addr(gn.IpAddr)
-		if args.newNet.isAddressInRange(addr) {
+		if args.newNet.IsAddressInRange(addr) {
 			_, err = db.Update(&gn, func() error {
 				gn.NetworkId = args.newNet.Id
 				return nil
@@ -133,7 +133,7 @@ func (manager *SLoadbalancernetworkManager) handleNetworkIdChange(ctx context.Co
 	}
 	for _, lbn := range lbns {
 		addr, _ := netutils.NewIPV4Addr(lbn.IpAddr)
-		if args.newNet.isAddressInRange(addr) {
+		if args.newNet.IsAddressInRange(addr) {
 			_, err = db.Update(&lbn, func() error {
 				lbn.NetworkId = args.newNet.Id
 				return nil
@@ -155,7 +155,7 @@ func (manager *SLoadbalancerManager) handleNetworkIdChange(ctx context.Context, 
 	}
 	for _, lb := range lbs {
 		addr, _ := netutils.NewIPV4Addr(lb.Address)
-		if args.newNet.isAddressInRange(addr) {
+		if args.newNet.IsAddressInRange(addr) {
 			_, err = db.Update(&lb, func() error {
 				lb.NetworkId = args.newNet.Id
 				return nil

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -536,7 +536,7 @@ func (self *SWire) GetCandidateNetworkForIp(userCred mcclient.TokenCredential, i
 		return nil, err
 	}
 	for _, net := range netPrivates {
-		if net.isAddressInRange(ip) {
+		if net.IsAddressInRange(ip) {
 			return &net, nil
 		}
 	}
@@ -545,7 +545,7 @@ func (self *SWire) GetCandidateNetworkForIp(userCred mcclient.TokenCredential, i
 		return nil, err
 	}
 	for _, net := range netPublics {
-		if net.isAddressInRange(ip) {
+		if net.IsAddressInRange(ip) {
 			return &net, nil
 		}
 	}

--- a/pkg/compute/tasks/eip_allocate_task.go
+++ b/pkg/compute/tasks/eip_allocate_task.go
@@ -112,7 +112,7 @@ func (self *EipAllocateTask) OnInit(ctx context.Context, obj db.IStandaloneModel
 				return
 			}
 			if ipAddr != ip {
-				msg := fmt.Sprintf("candidate ip %s is occupoed!", ip)
+				msg := fmt.Sprintf("candidate ip %s is occupied!", ip)
 				self.onFailed(ctx, eip, msg)
 				return
 			}


### PR DESCRIPTION
Cherry pick of #1748 on release/2.11.0.

#1748: fix: server-change-ipaddr may ignore errors when changing ipaddr