### PR TITLE
region: fix baremetal specs not found when domain_id specify

### DIFF
--- a/pkg/compute/models/managedresource.go
+++ b/pkg/compute/models/managedresource.go
@@ -143,10 +143,13 @@ func managedResourceFilterByDomain(q *sqlchemy.SQuery, query jsonutils.JSONObjec
 		subq = subq.Join(accounts, sqlchemy.Equals(providers.Field("cloudaccount_id"), accounts.Field("id")))
 		subq = subq.Filter(sqlchemy.Equals(accounts.Field("domain_id"), domain.GetId()))
 		if len(filterField) == 0 {
-			q = q.Filter(sqlchemy.In(q.Field("manager_id"), subq.SubQuery()))
+			q = q.Filter(sqlchemy.OR(
+				sqlchemy.IsNullOrEmpty(q.Field("manager_id")),
+				sqlchemy.In(q.Field("manager_id"), subq.SubQuery()),
+			))
 		} else {
 			sq := subqFunc()
-			sq = sq.Filter(sqlchemy.In(sq.Field("manager_id"), subq.SubQuery()))
+			sq = sq.Filter(sqlchemy.OR(sqlchemy.In(sq.Field("manager_id"), subq.SubQuery()), sqlchemy.IsNullOrEmpty(sq.Field("manager_id"))))
 			q = q.Filter(sqlchemy.In(q.Field(filterField), sq.SubQuery()))
 		}
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复：当指定 domain 的时候，capability 接口没有返回 baremetal 的 spec 信息

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.10

/cc @swordqiu 