### PR TITLE
Automated cherry pick of #1770: scheduler: schedtag predicate match resources then do filter

### DIFF
--- a/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
@@ -52,6 +52,10 @@ func (d diskW) Keyword() string {
 	return "disk"
 }
 
+func (d diskW) ResourceKeyword() string {
+	return "storage"
+}
+
 func (d diskW) GetSchedtags() []*computeapi.SchedtagConfig {
 	return d.DiskConfig.Schedtags
 }
@@ -70,6 +74,10 @@ func (p *DiskSchedtagPredicate) GetResources(c core.Candidater) []ISchedtagCandi
 		ret = append(ret, storage)
 	}
 	return ret
+}
+
+func (p *DiskSchedtagPredicate) IsResourceMatchInput(input ISchedtagCustomer, res ISchedtagCandidateResource) bool {
+	return true
 }
 
 func (p *DiskSchedtagPredicate) IsResourceFitInput(u *core.Unit, c core.Candidater, res ISchedtagCandidateResource, input ISchedtagCustomer) core.PredicateFailureReason {

--- a/pkg/scheduler/algorithm/predicates/network_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/network_schedtag_predicate.go
@@ -55,6 +55,10 @@ func (n netW) Keyword() string {
 	return "net"
 }
 
+func (n netW) ResourceKeyword() string {
+	return "network"
+}
+
 func (n netW) GetSchedtags() []*computeapi.SchedtagConfig {
 	return n.NetworkConfig.Schedtags
 }
@@ -73,6 +77,17 @@ func (p *NetworkSchedtagPredicate) GetResources(c core.Candidater) []ISchedtagCa
 		ret = append(ret, network)
 	}
 	return ret
+}
+
+func (p *NetworkSchedtagPredicate) IsResourceMatchInput(input ISchedtagCustomer, res ISchedtagCandidateResource) bool {
+	net := input.(*netW)
+	network := res.(*api.CandidateNetwork)
+	if net.Network != "" {
+		if !(network.Id == net.Network || network.Name == net.Network) {
+			return false
+		}
+	}
+	return true
 }
 
 func (p *NetworkSchedtagPredicate) IsResourceFitInput(u *core.Unit, c core.Candidater, res ISchedtagCandidateResource, input ISchedtagCustomer) core.PredicateFailureReason {


### PR DESCRIPTION
Cherry pick of #1770 on release/2.10.0.

#1770: scheduler: schedtag predicate match resources then do filter