### PR TITLE
baremetal: fix msdos last primary partition not resized

### DIFF
--- a/pkg/baremetal/utils/disktool/disktool.go
+++ b/pkg/baremetal/utils/disktool/disktool.go
@@ -424,7 +424,7 @@ func (ps *DiskPartitions) ResizePartition(offsetMB int64) error {
 			}
 		} else {
 			cmd = fmt.Sprintf("/usr/sbin/parted -a none -s %s -- unit s rm %d mkpart %s", part.disk.dev, part.index, part.diskType)
-			cmd = fmt.Sprintf("%s %d %d", cmd, part.start, part.end)
+			cmd = fmt.Sprintf("%s %d %d", cmd, part.start, end)
 			if part.bootable {
 				cmd = fmt.Sprintf("%s set %d boot on", cmd, part.index)
 			}

--- a/pkg/util/dhcp/helpers.go
+++ b/pkg/util/dhcp/helpers.go
@@ -173,7 +173,7 @@ func IsPXERequest(pkt Packet) bool {
 	//}
 
 	if pkt.GetOptionValue(OptionClientArchitecture) == nil {
-		log.Debugf("not a PXE boot request (missing option 93)")
+		log.Debugf("%s not a PXE boot request (missing option 93)", pkt.CHAddr().String())
 		return false
 	}
 	return true


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

baremetal: 修复当 msdos 磁盘的最后一块分区是 primary 时，没有 resize

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.10

/area baremetal
/cc @swordqiu 