### PR TITLE
Automated cherry pick of #1779: baremetal: fix msdos last primary partition not resized

### DIFF
--- a/pkg/baremetal/utils/disktool/disktool.go
+++ b/pkg/baremetal/utils/disktool/disktool.go
@@ -424,7 +424,7 @@ func (ps *DiskPartitions) ResizePartition(offsetMB int64) error {
 			}
 		} else {
 			cmd = fmt.Sprintf("/usr/sbin/parted -a none -s %s -- unit s rm %d mkpart %s", part.disk.dev, part.index, part.diskType)
-			cmd = fmt.Sprintf("%s %d %d", cmd, part.start, part.end)
+			cmd = fmt.Sprintf("%s %d %d", cmd, part.start, end)
 			if part.bootable {
 				cmd = fmt.Sprintf("%s set %d boot on", cmd, part.index)
 			}

--- a/pkg/util/dhcp/helpers.go
+++ b/pkg/util/dhcp/helpers.go
@@ -173,7 +173,7 @@ func IsPXERequest(pkt Packet) bool {
 	//}
 
 	if pkt.GetOptionValue(OptionClientArchitecture) == nil {
-		log.Debugf("not a PXE boot request (missing option 93)")
+		log.Debugf("%s not a PXE boot request (missing option 93)", pkt.CHAddr().String())
 		return false
 	}
 	return true


### PR DESCRIPTION
Cherry pick of #1779 on release/2.11.0.

#1779: baremetal: fix msdos last primary partition not resized