### PR TITLE
glance: fix duplicate data for node db_stats

### DIFF
--- a/pkg/image/service/service.go
+++ b/pkg/image/service/service.go
@@ -110,7 +110,6 @@ func StartService() {
 		cron.Start()
 	}
 
-	cloudcommon.AppDBInit(app)
 	app_common.ServeForeverWithCleanup(app, baseOpts, func() {
 		cloudcommon.CloseDB()
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

fix: glance 重复调用了 AppDBInit

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.10

/area image