### PR TITLE
Automated cherry pick of #1783: glance: fix duplicate data for node db_stats

### DIFF
--- a/pkg/image/service/service.go
+++ b/pkg/image/service/service.go
@@ -110,7 +110,6 @@ func StartService() {
 		cron.Start()
 	}
 
-	cloudcommon.AppDBInit(app)
 	app_common.ServeForeverWithCleanup(app, baseOpts, func() {
 		cloudcommon.CloseDB()
 


### PR DESCRIPTION
Cherry pick of #1783 on release/2.11.0.

#1783: glance: fix duplicate data for node db_stats