### PR TITLE
scheduler: esxi and zstack hypervisor do cpu and memory filter

### DIFF
--- a/pkg/compute/guestdrivers/esxi.go
+++ b/pkg/compute/guestdrivers/esxi.go
@@ -42,9 +42,11 @@ func init() {
 	models.RegisterGuestDriver(&driver)
 }
 
-func (self *SESXiGuestDriver) DoScheduleSKUFilter() bool {
-	return false
-}
+func (self *SESXiGuestDriver) DoScheduleCPUFilter() bool { return true }
+
+func (self *SESXiGuestDriver) DoScheduleMemoryFilter() bool { return true }
+
+func (self *SESXiGuestDriver) DoScheduleSKUFilter() bool { return false }
 
 func (self *SESXiGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_ESXI

--- a/pkg/compute/guestdrivers/zstack.go
+++ b/pkg/compute/guestdrivers/zstack.go
@@ -38,6 +38,10 @@ func init() {
 	models.RegisterGuestDriver(&driver)
 }
 
+func (self *SZStackGuestDriver) DoScheduleCPUFilter() bool { return true }
+
+func (self *SZStackGuestDriver) DoScheduleMemoryFilter() bool { return true }
+
 func (self *SZStackGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_ZSTACK
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

scheduler: vmware 和 zstack 需要做 cpu 和 memory 的 filter

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.10.0

/area scheduler
/cc @swordqiu @ioito 