### PR TITLE
Automated cherry pick of #1808: scheduler: esxi and zstack hypervisor do cpu and memory filter

### DIFF
--- a/pkg/compute/guestdrivers/esxi.go
+++ b/pkg/compute/guestdrivers/esxi.go
@@ -42,9 +42,11 @@ func init() {
 	models.RegisterGuestDriver(&driver)
 }
 
-func (self *SESXiGuestDriver) DoScheduleSKUFilter() bool {
-	return false
-}
+func (self *SESXiGuestDriver) DoScheduleCPUFilter() bool { return true }
+
+func (self *SESXiGuestDriver) DoScheduleMemoryFilter() bool { return true }
+
+func (self *SESXiGuestDriver) DoScheduleSKUFilter() bool { return false }
 
 func (self *SESXiGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_ESXI

--- a/pkg/compute/guestdrivers/zstack.go
+++ b/pkg/compute/guestdrivers/zstack.go
@@ -38,6 +38,10 @@ func init() {
 	models.RegisterGuestDriver(&driver)
 }
 
+func (self *SZStackGuestDriver) DoScheduleCPUFilter() bool { return true }
+
+func (self *SZStackGuestDriver) DoScheduleMemoryFilter() bool { return true }
+
 func (self *SZStackGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_ZSTACK
 }


### PR DESCRIPTION
Cherry pick of #1808 on release/2.11.0.

#1808: scheduler: esxi and zstack hypervisor do cpu and memory filter