### PR TITLE
避免cacheimage refresh时同步azure镜像信息异常

### DIFF
--- a/pkg/util/azure/image.go
+++ b/pkg/util/azure/image.go
@@ -529,10 +529,12 @@ func (region *SRegion) getOfferedImage(offerId string) (SImage, error) {
 	offer := parts[1]
 	sku := parts[2]
 	version := parts[3]
-	//err := region.client.Get(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Compute/locations/%s/publishers/%s/artifacttypes/vmimage/offers/%s/skus/%s/versions/%s", region.client.subscriptionId, region.Name, publisher, offer, sku, version), nil, &image)
-	//if err != nil {
-	//	return image, err
-	//}
+	for _publish := range publisherDrivers {
+		if strings.ToLower(_publish) == publisher {
+			publisher = _publish
+			break
+		}
+	}
 	image.ID = offerId
 	image.Location = region.Name
 	image.Type = "Microsoft.Compute/vmimage"


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免cacheimage refresh时同步azure镜像信息异常

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.10.0
- release/2.9.0
- release/2.8.0

/area region
/cc @swordqiu @yousong 
