### PR TITLE
避免因cloudprovider disable导致账号同步失效

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -1322,10 +1322,12 @@ func (account *SCloudaccount) syncAccountStatus(ctx context.Context, userCred mc
 	account.markAccountConnected(ctx, userCred)
 	providers := account.importAllSubaccounts(ctx, userCred, subaccounts)
 	for i := range providers {
-		_, err := providers[i].prepareCloudproviderRegions(ctx, userCred)
-		if err != nil {
-			log.Errorf("syncCloudproviderRegion fail %s", err)
-			return err
+		if providers[i].Enabled {
+			_, err := providers[i].prepareCloudproviderRegions(ctx, userCred)
+			if err != nil {
+				log.Errorf("syncCloudproviderRegion fail %s", err)
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免因cloudprovider disable导致账号同步失效

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.10.0
- release/2.9.0
- release/2.8.0

/area region
/cc @swordqiu @yousong 

