### PR TITLE
Automated cherry pick of #1840: 卸载磁盘时忽略云上磁盘已经被删除的错误

### DIFF
--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -163,6 +163,10 @@ func (self *SManagedVirtualizedGuestDriver) RequestDetachDisk(ctx context.Contex
 		}
 		err = iVM.DetachDisk(ctx, disk.ExternalId)
 		if err != nil {
+			//忽略云上磁盘已经被删除错误
+			if err == cloudprovider.ErrNotFound {
+				return nil, nil
+			}
 			return nil, errors.Wrapf(err, "iVM.DetachDisk")
 		}
 


### PR DESCRIPTION
Cherry pick of #1840 on release/2.10.0.

#1840: 卸载磁盘时忽略云上磁盘已经被删除的错误