### PR TITLE
Hotfix/qx aws secgroupids

### DIFF
--- a/pkg/compute/models/cloudsync.go
+++ b/pkg/compute/models/cloudsync.go
@@ -213,6 +213,13 @@ func syncVpcSecGroup(ctx context.Context, userCred mcclient.TokenCredential, syn
 
 	_, _, result := SecurityGroupCacheManager.SyncSecurityGroupCaches(ctx, userCred, provider, secgroups, localVpc)
 	syncResults.Add(SecurityGroupCacheManager, result)
+
+	msg := result.Result()
+	notes := fmt.Sprintf("SyncSecurityGroupCaches for VPC %s result: %s", localVpc.Name, msg)
+	log.Infof(notes)
+	if result.IsError() {
+		return
+	}
 }
 
 func syncVpcRouteTables(ctx context.Context, userCred mcclient.TokenCredential, syncResults SSyncResultSet, provider *SCloudprovider, localVpc *SVpc, remoteVpc cloudprovider.ICloudVpc, syncRange *SSyncRange) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 添加安全组同步日志
2. 修复仅同步同一vpc底下的一个安全组问题

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.10.0
- release/2.9.0
- release/2.8.0

/area region
/cc @swordqiu @yousong 

