### PR TITLE
fix: validate info when importing ldap user/group/domain

### DIFF
--- a/pkg/keystone/driver/ldap/info.go
+++ b/pkg/keystone/driver/ldap/info.go
@@ -30,3 +30,7 @@ type SGroupInfo struct {
 	SDomainInfo
 	Members []string
 }
+
+func (info SDomainInfo) isValid() bool {
+	return len(info.DN) > 0 && len(info.Id) > 0 && len(info.Name) > 0
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
 修正：ldap导入用户、组、域时检查信息的有效性

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11.0

/area keystone