### PR TITLE
Automated cherry pick of #1885: fix: validate info when importing ldap user/group/domain

### DIFF
--- a/pkg/keystone/driver/ldap/info.go
+++ b/pkg/keystone/driver/ldap/info.go
@@ -30,3 +30,7 @@ type SGroupInfo struct {
 	SDomainInfo
 	Members []string
 }
+
+func (info SDomainInfo) isValid() bool {
+	return len(info.DN) > 0 && len(info.Id) > 0 && len(info.Name) > 0
+}


### PR DESCRIPTION
Cherry pick of #1885 on release/2.10.0.

#1885: fix: validate info when importing ldap user/group/domain