### PR TITLE
fix: 避免镜像同步到私有云自定义镜像里面

### DIFF
--- a/pkg/util/openstack/image.go
+++ b/pkg/util/openstack/image.go
@@ -151,12 +151,7 @@ func (image *SImage) Refresh() error {
 }
 
 func (image *SImage) GetImageType() string {
-	switch image.Visibility {
-	case "public":
-		return cloudprovider.CachedImageTypeSystem
-	default:
-		return cloudprovider.CachedImageTypeCustomized
-	}
+	return cloudprovider.CachedImageTypeSystem
 }
 
 func (image *SImage) GetSizeByte() int64 {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免镜像同步到私有云自定义镜像里面

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.10.0
- release/2.9.0
- release/2.8.0

/area region
/cc @swordqiu @yousong 

