### PR TITLE
Automated cherry pick of #1910: fix: 避免镜像同步到私有云自定义镜像里面

### DIFF
--- a/pkg/util/openstack/image.go
+++ b/pkg/util/openstack/image.go
@@ -136,12 +136,7 @@ func (image *SImage) Refresh() error {
 }
 
 func (image *SImage) GetImageType() string {
-	switch image.Visibility {
-	case "public":
-		return cloudprovider.CachedImageTypeSystem
-	default:
-		return cloudprovider.CachedImageTypeCustomized
-	}
+	return cloudprovider.CachedImageTypeSystem
 }
 
 func (image *SImage) GetSize() int64 {


### PR DESCRIPTION
Cherry pick of #1910 on release/2.8.0.

#1910: fix: 避免镜像同步到私有云自定义镜像里面