### PR TITLE
baremetal: mkfs.ext4 add '-T largefile' option

### DIFF
--- a/pkg/baremetal/utils/disktool/disktool.go
+++ b/pkg/baremetal/utils/disktool/disktool.go
@@ -108,7 +108,7 @@ func (p *Partition) Format(fs string, uuid string) error {
 		cmdUUID = []string{"/usr/sbin/tune2fs", "-U", uuid}
 	case "ext4":
 		// for baremetal, force 64bit support large disks
-		cmd = []string{"/usr/sbin/mkfs.ext4", "-O", "64bit", "-E", "lazy_itable_init=1"}
+		cmd = []string{"/usr/sbin/mkfs.ext4", "-O", "64bit", "-E", "lazy_itable_init=1", "-T", "largefile"}
 		cmdUUID = []string{"/usr/sbin/tune2fs", "-U", uuid}
 	case "ext4dev":
 		cmd = []string{"/usr/sbin/mkfs.ext4dev", "-E", "lazy_itable_init=1"}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

物理机装机时格式化 ext4 分区加上 '-T largefile' 参数

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.11
- release/2.10

/area baremetal
/cc @swordqiu 