### PR TITLE
Automated cherry pick of #1924: fix: server-create may timeout if external image used

### DIFF
--- a/pkg/compute/models/cachedimages.go
+++ b/pkg/compute/models/cachedimages.go
@@ -243,7 +243,7 @@ func (manager *SCachedimageManager) GetImageById(ctx context.Context, userCred m
 	imgObj, _ := manager.FetchById(imageId)
 	if imgObj != nil {
 		cachedImage := imgObj.(*SCachedimage)
-		if !refresh && cachedImage.GetStatus() == cloudprovider.IMAGE_STATUS_ACTIVE && len(cachedImage.GetOSType()) > 0 && cachedImage.isRefreshSessionExpire() {
+		if !refresh && cachedImage.GetStatus() == cloudprovider.IMAGE_STATUS_ACTIVE && len(cachedImage.GetOSType()) > 0 && !cachedImage.isRefreshSessionExpire() {
 			return cachedImage.GetImage()
 		} else if len(cachedImage.ExternalId) > 0 { // external image, request refresh
 			return cachedImage.requestRefreshExternalImage(ctx, userCred)
@@ -266,7 +266,7 @@ func (manager *SCachedimageManager) getImageByName(ctx context.Context, userCred
 	imgObj, _ := manager.FetchByName(userCred, imageId)
 	if imgObj != nil {
 		cachedImage := imgObj.(*SCachedimage)
-		if !refresh && cachedImage.GetStatus() == cloudprovider.IMAGE_STATUS_ACTIVE && len(cachedImage.GetOSType()) > 0 && cachedImage.isRefreshSessionExpire() {
+		if !refresh && cachedImage.GetStatus() == cloudprovider.IMAGE_STATUS_ACTIVE && len(cachedImage.GetOSType()) > 0 && !cachedImage.isRefreshSessionExpire() {
 			return cachedImage.GetImage()
 		} else if len(cachedImage.ExternalId) > 0 { // external image, request refresh
 			return cachedImage.requestRefreshExternalImage(ctx, userCred)


### PR DESCRIPTION
Cherry pick of #1924 on release/2.10.0.

#1924: fix: server-create may timeout if external image used