### PR TITLE
region: fix server create params missing data

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4280,12 +4280,17 @@ func (self *SGuest) ToCreateInput(userCred mcclient.TokenCredential) *api.Server
 	if genInput.ResourceType != "" {
 		userInput.ResourceType = genInput.ResourceType
 	}
+	if genInput.InstanceType != "" {
+		userInput.InstanceType = genInput.InstanceType
+	}
 	if genInput.PreferRegion != "" {
 		userInput.PreferRegion = genInput.PreferRegion
 	}
 	if genInput.PreferZone != "" {
 		userInput.PreferZone = genInput.PreferZone
 	}
+	// clean GenerateName
+	userInput.GenerateName = ""
 	return userInput
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复创建相同配置没有 sku 的问题

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.10
- release/2.11

/area region
/cc @wanyaoqi 