### PR TITLE
lbbackends: 若backend guest已删除getVpc返回空且不报错

### DIFF
--- a/pkg/compute/models/loadbalancerbackends.go
+++ b/pkg/compute/models/loadbalancerbackends.go
@@ -16,6 +16,7 @@ package models
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -362,7 +363,10 @@ func (lbb *SLoadbalancerBackend) getVpc(ctx context.Context) (*SVpc, error) {
 	}
 	guestM, err := GuestManager.FetchById(lbb.BackendId)
 	if err != nil {
-		theLbbJanitor.Signal()
+		if err == sql.ErrNoRows {
+			theLbbJanitor.Signal()
+			return nil, nil
+		}
 		return nil, errors.WithMessagef(err, "find guest %s", lbb.BackendId)
 	}
 	guest := guestM.(*SGuest)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

lbbackends: 若backend guest已删除getVpc返回空且不报错

**是否需要 backport 到之前的 release 分支**:

- release/2.10.0

/area region
/cc @ioito @swordqiu 