### PR TITLE
feature: allow keystone reset sysadmin password at boot

### DIFF
--- a/pkg/keystone/models/users.go
+++ b/pkg/keystone/models/users.go
@@ -178,6 +178,19 @@ func (manager *SUserManager) initSysUser() error {
 		return errors.Wrap(err, "query")
 	}
 	if cnt == 1 {
+		// if ResetAdminUserPassword is true, reset sysadmin password
+		if options.Options.ResetAdminUserPassword {
+			usr := SUser{}
+			usr.SetModelManager(manager, &usr)
+			err = q.First(&usr)
+			if err != nil {
+				return errors.Wrap(err, "ResetAdminUserPassword Query user")
+			}
+			err = usr.initLocalData(options.Options.BootstrapAdminUserPassword)
+			if err != nil {
+				return errors.Wrap(err, "initLocalData")
+			}
+		}
 		return nil
 	}
 	if cnt > 2 {

--- a/pkg/keystone/options/options.go
+++ b/pkg/keystone/options/options.go
@@ -31,6 +31,7 @@ type SKeystoneOptions struct {
 	// SetupStateKey          bool   `help:"setup standalone fernet keys for openid state" token:"setup_state_key"`
 
 	BootstrapAdminUserPassword string `help:"bootstreap sysadmin user password" default:"sysadmin"`
+	ResetAdminUserPassword     bool   `help:"reset sysadmin password if exists and this option is true"`
 
 	AutoSyncIntervalSeconds int `help:"frequency to check auto sync tasks" default:"30"`
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
允许keystone启动时候重置sysadmin的密码

**是否需要 backport 到之前的 release 分支**:
NONE

/area keystone
/cc @Zexi 