### PR TITLE
fix: turn on non-default-domain-projects by default at 2.10

### DIFF
--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -67,7 +67,7 @@ type BaseOptions struct {
 
 	CalculateQuotaUsageIntervalSeconds int `help:"interval to calculate quota usages, default 30 minutes" default:"900"`
 
-	NonDefaultDomainProjects bool `help:"allow projects in non-default domains" default:"false"`
+	NonDefaultDomainProjects bool `help:"allow projects in non-default domains" default:"true"`
 
 	structarg.BaseOptions
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
2.10默认打开3级权限，之后版本默认关闭

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/cc @yousong 
/area keystone