### PR TITLE
fix: post domain quota missing domain_id, post bucket missing resposne body

### DIFF
--- a/docs/bucket/buckets.yaml
+++ b/docs/bucket/buckets.yaml
@@ -23,7 +23,7 @@ post:
       required: true
       schema:
         $ref: "../schemas/bucket.yaml#/BucketCreateInput"
-  response:
+  responses:
     200:
       description: 对象存储桶信息
       schema:

--- a/docs/quotas/domainquotas.yaml
+++ b/docs/quotas/domainquotas.yaml
@@ -1,7 +1,7 @@
 get:
   summary: 获得指定域的配额
   parameters:
-    $ref: "../parameters/quota.yaml#/domain_id"
+    - $ref: "../parameters/quota.yaml#/domain_id"
   responses:
     200:
       description: 配额信息


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正API文档的两个错误：
   - POST /quotas/domains/{doman_id} 无domain_id说明
   - POST /buckets 无响应说明

**是否需要 backport 到之前的 release 分支**:
NONE