### PR TITLE
copyright update climc fix

### DIFF
--- a/cmd/climc/shell/copyright.go
+++ b/cmd/climc/shell/copyright.go
@@ -24,9 +24,9 @@ import (
 
 func init() {
 	type CopyrightUpdateOptions struct {
-		Copyright string `help:"The copyright"`
-		Email     string `help:"The Email"`
-		Docs      string `help:"the Docs website address" required:"true"`
+		Copyright string  `help:"The copyright"`
+		Email     string  `help:"The Email"`
+		Docs      *string `help:"the Docs website address"`
 	}
 
 	R(&CopyrightUpdateOptions{}, "copyright-update", "update copyright", func(s *mcclient.ClientSession, args *CopyrightUpdateOptions) error {
@@ -35,7 +35,10 @@ func init() {
 		}
 
 		params := jsonutils.NewDict()
-		params.Add(jsonutils.NewString(args.Docs), "docs")
+		if args.Docs != nil {
+			params.Add(jsonutils.NewString(*args.Docs), "docs")
+		}
+
 		if len(args.Copyright) > 0 {
 			params.Add(jsonutils.NewString(args.Copyright), "copyright")
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
* copyright update 允许docs为空

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.10.0

/area climc