### PR TITLE
Automated cherry pick of #2017: fix list order by

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -512,6 +512,9 @@ func ListItems(manager IModelManager, ctx context.Context, userCred mcclient.Tok
 		orderBy = append(orderBy, primaryCol.Name())
 	} else if manager.TableSpec().ColumnSpec("created_at") != nil {
 		orderBy = append(orderBy, "created_at")
+		if primaryCol != nil {
+			orderBy = append(orderBy, primaryCol.Name())
+		}
 	}
 	for _, orderByField := range orderBy {
 		colSpec := manager.TableSpec().ColumnSpec(orderByField)


### PR DESCRIPTION
Cherry pick of #2017 on release/2.10.0.

#2017: fix list order by