### PR TITLE
fix: zstack system disk resize

### DIFF
--- a/pkg/multicloud/zstack/disk.go
+++ b/pkg/multicloud/zstack/disk.go
@@ -313,6 +313,11 @@ func (region *SRegion) ResizeDisk(diskId string, sizeMb int64) error {
 	if err != nil {
 		return err
 	}
+
+	if disk.GetDiskSizeMB() == int(sizeMb) {
+		return nil
+	}
+
 	params := jsonutils.Marshal(map[string]interface{}{
 		fmt.Sprintf("resize%sVolume", disk.Type): map[string]int64{
 			"size": sizeMb * 1024 * 1024,

--- a/pkg/multicloud/zstack/host.go
+++ b/pkg/multicloud/zstack/host.go
@@ -334,6 +334,11 @@ func (host *SHost) CreateVM(desc *cloudprovider.SManagedVMCreateConfig) (cloudpr
 		return nil, errors.Wrapf(err, "host.zone.region.createDataDisks")
 	}
 
+	err = host.zone.region.ResizeDisk(instance.RootVolumeUUID, int64(desc.SysDisk.SizeGB)*1024)
+	if err != nil {
+		log.Warningf("failed to resize system disk %s error: %v", instance.RootVolumeUUID, err)
+	}
+
 	for i := 0; i < len(diskIds); i++ {
 		err = host.zone.region.AttachDisk(instance.UUID, diskIds[i])
 		if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复zstack系统盘根据镜像大小创建，未能和用户输入的大小保持一致问题

**是否需要 backport 到之前的 release 分支**:
- relase/2.11
- relase/2.10.0

/area region
/cc @swordqiu @yousong 
