### PR TITLE
Automated cherry pick of #2029: fix: avoid region2 panic when update openstack storage

### DIFF
--- a/pkg/compute/models/storagedrivers.go
+++ b/pkg/compute/models/storagedrivers.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/log"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -50,6 +49,5 @@ func GetStorageDriver(storageType string) IStorageDriver {
 	if ok {
 		return driver
 	}
-	log.Fatalf("Unsupported storageType %s", storageType)
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #2029 on release/2.10.0.

#2029: fix: avoid region2 panic when update openstack storage