### PR TITLE
Automated cherry pick of #2029: fix: avoid region2 panic when update openstack storage

### DIFF
--- a/pkg/compute/models/storagedrivers.go
+++ b/pkg/compute/models/storagedrivers.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/log"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -50,6 +49,5 @@ func GetStorageDriver(storageType string) IStorageDriver {
 	if ok {
 		return driver
 	}
-	log.Fatalf("Unsupported storageType %s", storageType)
 	return nil
 }

--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -108,7 +108,7 @@ func (self *SStorage) ValidateUpdateData(ctx context.Context, userCred mcclient.
 	if driver != nil {
 		return driver.ValidateUpdateData(ctx, userCred, data, self)
 	}
-	return nil, nil
+	return data, nil
 }
 
 func (self *SStorage) PostUpdate(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) {


### PR DESCRIPTION
Cherry pick of #2029 on release/2.11.

#2029: fix: avoid region2 panic when update openstack storage