### PR TITLE
bugfix: remove telegraf config retention_policy

### DIFF
--- a/pkg/hostman/system_service/telegraf.go
+++ b/pkg/hostman/system_service/telegraf.go
@@ -69,7 +69,6 @@ func (s *STelegraf) GetConfig(kwargs map[string]interface{}) string {
 		conf += "[[outputs.influxdb]]\n"
 		conf += fmt.Sprintf("  urls = [%s]\n", strings.Join(urls, ", "))
 		conf += fmt.Sprintf("  database = \"%s\"\n", tdb)
-		conf += "  retention_policy = \"autogen\"\n"
 		conf += "  insecure_skip_verify = true\n"
 		conf += "\n"
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
bugfix: remove telegraf config retention_policy
**是否需要 backport 到之前的 release 分支**:
release/2.10.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/cc @swordqiu 