### PR TITLE
Automated cherry pick of #2034: remove telegraf config retention_policy

### DIFF
--- a/pkg/hostman/system_service/telegraf.go
+++ b/pkg/hostman/system_service/telegraf.go
@@ -69,7 +69,6 @@ func (s *STelegraf) GetConfig(kwargs map[string]interface{}) string {
 		conf += "[[outputs.influxdb]]\n"
 		conf += fmt.Sprintf("  urls = [%s]\n", strings.Join(urls, ", "))
 		conf += fmt.Sprintf("  database = \"%s\"\n", tdb)
-		conf += "  retention_policy = \"autogen\"\n"
 		conf += "  insecure_skip_verify = true\n"
 		conf += "\n"
 	}


### PR DESCRIPTION
Cherry pick of #2034 on release/2.10.0.

#2034: remove telegraf config retention_policy