### PR TITLE
bugfix: fix guest get host wire from network

### DIFF
--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -284,12 +284,12 @@ func (self *SGuestnetwork) getJsonDescAtBaremetal(host *SHost) jsonutils.JSONObj
 	return self.getGeneralJsonDesc(host, network, hostwire)
 }
 
-func getHostNetworkAdminWire(host *SHost, network *SNetwork) (*SHostwire, error) {
+func guestGetHostWireFromNetwork(host *SHost, network *SNetwork) (*SHostwire, error) {
 	hostwires := host.getHostwiresOfId(network.WireId)
 	var hostWire *SHostwire
 	for i := 0; i < len(hostwires); i++ {
 		if netInter, _ := NetInterfaceManager.FetchByMac(hostwires[i].MacAddr); netInter != nil {
-			if netInter.NicType == api.NIC_TYPE_ADMIN {
+			if netInter.NicType != api.NIC_TYPE_IPMI {
 				hostWire = &hostwires[i]
 				break
 			}
@@ -304,7 +304,7 @@ func getHostNetworkAdminWire(host *SHost, network *SNetwork) (*SHostwire, error)
 
 func (self *SGuestnetwork) getJsonDescAtHost(host *SHost) jsonutils.JSONObject {
 	network := self.GetNetwork()
-	hostWire, err := getHostNetworkAdminWire(host, network)
+	hostWire, err := guestGetHostWireFromNetwork(host, network)
 	if err != nil {
 		log.Errorln(err)
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
bugfix: fix guest get host wire from network
**是否需要 backport 到之前的 release 分支**:
release/2.10.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/area region