### PR TITLE
fix: 1. project quota-list not include domain quota 2. do not check

### DIFF
--- a/pkg/keystone/models/policies.go
+++ b/pkg/keystone/models/policies.go
@@ -110,9 +110,6 @@ func (manager *SPolicyManager) ValidateCreateData(ctx context.Context, userCred 
 	if err != nil {
 		return nil, httperrors.NewInputParameterError("fail to decode policy data")
 	}
-	/*if policy.IsSystemWidePolicy() && policyman.PolicyManager.Allow(rbacutils.ScopeSystem, userCred, consts.GetServiceType(), manager.KeywordPlural(), policyman.PolicyActionCreate) == rbacutils.Deny {
-		return nil, httperrors.NewNotSufficientPrivilegeError("not allow to create system-wide policy")
-	}*/
 	err = db.ValidateCreateDomainId(ownerId.GetProjectDomainId())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
conformance between project and domain quota

**这个 PR 实现什么功能/修复什么问题**:
修正：关闭非default域下项目后，域配额不再生效，不再检查域配额和项目配额的一致性，列出域下的项目配额时，不再返回域配额。

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11