### PR TITLE
fix: server-list add is_prepaid_recycle field

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1336,6 +1336,12 @@ func (self *SGuest) GetCustomizeColumns(ctx context.Context, userCred mcclient.T
 func (self *SGuest) moreExtraInfo(extra *jsonutils.JSONDict, fields stringutils2.SSortedStrings) *jsonutils.JSONDict {
 	// extra.Add(jsonutils.NewInt(int64(self.getExtBandwidth())), "ext_bw")
 
+	if self.IsPrepaidRecycle() {
+		extra.Add(jsonutils.JSONTrue, "is_prepaid_recycle")
+	} else {
+		extra.Add(jsonutils.JSONFalse, "is_prepaid_recycle")
+	}
+
 	if len(self.BackupHostId) > 0 && (len(fields) == 0 || fields.Contains("backup_host_name") || fields.Contains("backup_host_status")) {
 		backupHost := HostManager.FetchHostById(self.BackupHostId)
 		if len(fields) == 0 || fields.Contains("backup_host_name") {
@@ -1415,12 +1421,6 @@ func (self *SGuest) GetExtraDetails(ctx context.Context, userCred mcclient.Token
 
 	if db.IsAdminAllowGet(userCred, self) {
 		extra.Add(jsonutils.NewString(self.getAdminSecurityRules()), "admin_security_rules")
-	}
-
-	if self.IsPrepaidRecycle() {
-		extra.Add(jsonutils.JSONTrue, "is_prepaid_recycle")
-	} else {
-		extra.Add(jsonutils.JSONFalse, "is_prepaid_recycle")
 	}
 
 	return self.moreExtraInfo(extra, nil), nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
server-list增加is_prepaid_recycle的字段，说明主机是否在预付费资源池

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11

/area region