### PR TITLE
hotfix: change params from order_by_cache=asc|desc to order_by=cache …

### DIFF
--- a/cmd/climc/shell/secgroups.go
+++ b/cmd/climc/shell/secgroups.go
@@ -26,9 +26,7 @@ import (
 
 func init() {
 	type SecGroupsListOptions struct {
-		Equals       string `help:"Secgroup ID or Name, filter secgroups whose rules equals the specified one"`
-		OrderByCache string `help:"Order by cache count" choices:"desc|asc"`
-		OrderByGuest string `help:"Order by guest count" choices:"desc|asc"`
+		Equals string `help:"Secgroup ID or Name, filter secgroups whose rules equals the specified one"`
 		options.BaseListOptions
 	}
 
@@ -44,12 +42,6 @@ func init() {
 		}
 		if len(args.Equals) > 0 {
 			params.Add(jsonutils.NewString(args.Equals), "equals")
-		}
-		if len(args.OrderByCache) > 0 {
-			params.Add(jsonutils.NewString(args.OrderByCache), "order_by_cache")
-		}
-		if len(args.OrderByGuest) > 0 {
-			params.Add(jsonutils.NewString(args.OrderByGuest), "order_by_guest")
 		}
 		result, err := modules.SecGroups.List(s, params)
 		if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 修复未计算guestsecgroup问题
2. 将order_by_cache=asc|desc参数挪至 order_by=cache&order=desc|asc

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.10.0

/area region
/cc @swordqiu @yousong 
