### PR TITLE
Automated cherry pick of #2064: hotfix: change params from order_by_cache=asc|desc to order_by=cache & order=asc|desc

### DIFF
--- a/cmd/climc/shell/secgroups.go
+++ b/cmd/climc/shell/secgroups.go
@@ -26,9 +26,7 @@ import (
 
 func init() {
 	type SecGroupsListOptions struct {
-		Equals       string `help:"Secgroup ID or Name, filter secgroups whose rules equals the specified one"`
-		OrderByCache string `help:"Order by cache count" choices:"desc|asc"`
-		OrderByGuest string `help:"Order by guest count" choices:"desc|asc"`
+		Equals string `help:"Secgroup ID or Name, filter secgroups whose rules equals the specified one"`
 		options.BaseListOptions
 	}
 
@@ -44,12 +42,6 @@ func init() {
 		}
 		if len(args.Equals) > 0 {
 			params.Add(jsonutils.NewString(args.Equals), "equals")
-		}
-		if len(args.OrderByCache) > 0 {
-			params.Add(jsonutils.NewString(args.OrderByCache), "order_by_cache")
-		}
-		if len(args.OrderByGuest) > 0 {
-			params.Add(jsonutils.NewString(args.OrderByGuest), "order_by_guest")
 		}
 		result, err := modules.SecGroups.List(s, params)
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #2064 on release/2.10.0.

#2064: hotfix: change params from order_by_cache=asc|desc to order_by=cache & order=asc|desc