### PR TITLE
Automated cherry pick of #2067: fix: zstack create tcp udp secgroup rule error

### DIFF
--- a/pkg/util/zstack/securitygroup.go
+++ b/pkg/util/zstack/securitygroup.go
@@ -219,6 +219,12 @@ func (region *SRegion) AddSecurityGroupRule(secgroupId string, rules []secrules.
 			}
 		} else {
 			if protocol != "ALL" {
+				// TCP UDP端口不能为-1
+				if rule.Protocol == secrules.PROTO_TCP || rule.Protocol == secrules.PROTO_UDP &&
+					(rule.PortStart <= 0 && rule.PortEnd <= 0) {
+					rule.PortStart = 0
+					rule.PortEnd = 65535
+				}
 				ruleParam = append(ruleParam, map[string]interface{}{
 					"type":        Type,
 					"startPort":   rule.PortStart,


### PR DESCRIPTION
Cherry pick of #2067 on release/2.10.0.

#2067: fix: zstack create tcp udp secgroup rule error