### PR TITLE
Automated cherry pick of #2079: fix: cloudaccount and cloudprovider not in same domain

### DIFF
--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -298,15 +298,17 @@ func (self *SCloudprovider) syncProject(ctx context.Context, userCred mcclient.T
 		return errors.Wrap(err, "db.TenantCacheManager.FetchTenantByIdOrName")
 	}
 
+	account := self.GetCloudaccount()
+	if account == nil {
+		return errors.Error("no valid cloudaccount???")
+	}
+
 	var projectId, domainId string
-	if err == sql.ErrNoRows { // create one
+	if err == sql.ErrNoRows || tenant.DomainId != account.DomainId { // create one
 		s := auth.GetAdminSession(ctx, options.Options.Region, "")
 		params := jsonutils.NewDict()
-		params.Add(jsonutils.NewString(self.Name), "name")
-		account := self.GetCloudaccount()
-		if account == nil {
-			return errors.Error("no valid cloudaccount???")
-		}
+		params.Add(jsonutils.NewString(self.Name), "generate_name")
+
 		domainId = account.DomainId
 		params.Add(jsonutils.NewString(domainId), "domain_id")
 		params.Add(jsonutils.NewString(fmt.Sprintf("auto create from cloud provider %s (%s)", self.Name, self.Id)), "description")


### PR DESCRIPTION
Cherry pick of #2079 on release/2.10.0.

#2079: fix: cloudaccount and cloudprovider not in same domain