### PR TITLE
feature: secgroups get distinct tenant

### DIFF
--- a/pkg/compute/models/secgroups.go
+++ b/pkg/compute/models/secgroups.go
@@ -95,6 +95,19 @@ func (manager *SSecurityGroupManager) ListItemFilter(ctx context.Context, q *sql
 	return q, nil
 }
 
+func (manager *SSecurityGroupManager) QueryDistinctExtraField(q *sqlchemy.SQuery, field string) (*sqlchemy.SQuery, error) {
+	switch field {
+	case "tenant":
+		tenantCacheQuery := db.TenantCacheManager.Query("name", "id").Distinct().SubQuery()
+		q.AppendField(tenantCacheQuery.Field("name", "tenant"))
+		q = q.Join(tenantCacheQuery, sqlchemy.Equals(q.Field("tenant_id"), tenantCacheQuery.Field("id")))
+		q.GroupBy(tenantCacheQuery.Field("name"))
+	default:
+		return nil, httperrors.NewBadRequestError("unsupport field %s", field)
+	}
+	return q, nil
+}
+
 func (manager *SSecurityGroupManager) OrderByExtraFields(ctx context.Context, q *sqlchemy.SQuery, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (*sqlchemy.SQuery, error) {
 	q, err := manager.SVirtualResourceBaseManager.OrderByExtraFields(ctx, q, userCred, query)
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
feature: secgroups get distinct tenant
**是否需要 backport 到之前的 release 分支**:
release/2.10.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/cc @Zexi @swordqiu 
/area region