### PR TITLE
lbclusters: 创建时仅允许指定OneCloud Zone

### DIFF
--- a/pkg/compute/models/loadbalancerclusters.go
+++ b/pkg/compute/models/loadbalancerclusters.go
@@ -57,6 +57,9 @@ func (man *SLoadbalancerClusterManager) ValidateCreateData(ctx context.Context, 
 	if err := zoneV.Validate(data); err != nil {
 		return nil, err
 	}
+	if zone := zoneV.Model.(*SZone); zone.ExternalId != "" {
+		return nil, httperrors.NewInputParameterError("allow only internal zone, got %s(%s)", zone.Name, zone.Id)
+	}
 	return man.SStandaloneResourceBaseManager.ValidateCreateData(ctx, userCred, ownerId, query, data)
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

lbclusters: 创建时仅允许指定OneCloud Zone

**是否需要 backport 到之前的 release 分支**:

- release/2.10.0

/area region
/cc @swordqiu @ioito 