### PR TITLE
fix: get keypair info fail after rebuild-root

### DIFF
--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	"yunion.io/x/onecloud/pkg/util/cloudinit"
+	"yunion.io/x/onecloud/pkg/util/seclib2"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
@@ -450,7 +451,17 @@ func (self *SManagedVirtualizedGuestDriver) RemoteDeployGuestForDeploy(ctx conte
 			desc.Password = ""
 		}
 
-		return iVM.DeployVM(ctx, desc.Name, desc.Password, desc.PublicKey, deleteKeypair, desc.Description)
+		e := iVM.DeployVM(ctx, desc.Name, desc.Password, desc.PublicKey, deleteKeypair, desc.Description)
+		if e != nil {
+			return e
+		}
+
+		//解绑秘钥后需要重置密码
+		if deleteKeypair {
+			desc.Password = seclib2.RandomPassword2(12)
+			return iVM.DeployVM(ctx, desc.Name, desc.Password, desc.PublicKey, false, desc.Description)
+		}
+		return nil
 	}()
 	if err != nil {
 		return nil, err

--- a/pkg/compute/guestdrivers/utils.go
+++ b/pkg/compute/guestdrivers/utils.go
@@ -51,7 +51,7 @@ func fetchIVMinfo(desc cloudprovider.SManagedVMCreateConfig, iVM cloudprovider.I
 
 	//避免在rebuild_root时绑定秘钥,没有account信息
 	data.Add(jsonutils.NewString(account), "account")
-	if len(passwd) > 0 {
+	if len(passwd) > 0 || len(publicKey) > 0 {
 		var encpasswd string
 		var err error
 		if len(publicKey) > 0 {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 修复重装系统时指定秘钥后获取login-info失败
2. 解绑公有云私有云秘钥后重置密码

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.10.0

/area region
/cc @swordqiu @yousong 
