### PR TITLE
Automated cherry pick of #2131: 新增 climc notify-broadcast 接口,用于向所有在线用户发 websocket 通知

### DIFF
--- a/cmd/climc/shell/notification.go
+++ b/cmd/climc/shell/notification.go
@@ -57,7 +57,31 @@ func init() {
 		}
 		return nil
 	})
+	type NotificationBroadcastOptions struct {
 
+		// CONTACTTYPE string `help:"User's contacts type, cloud be email|mobile|dingtalk|/webconsole" choices:"email|mobile|dingtalk|webconsole"`
+		TOPIC    string `help:"Title or topic of the notification"`
+		PRIORITY string `help:"Priority of the notification maybe normal|important|fatal" choices:"normal|important|fatal"`
+		MSG      string `help:"The content of the notification"`
+		Remark   string `help:"Remark or description of the notification"`
+		// Group    bool   `help:"Send to group"`
+	}
+
+	R(&NotificationBroadcastOptions{}, "notify-broadcast", "Send a notification to all online users", func(s *mcclient.ClientSession, args *NotificationBroadcastOptions) error {
+		msg := notify.SNotifyMessage{}
+		msg.Broadcast = true
+		msg.ContactType = notify.TNotifyChannel("webconsole")
+		msg.Topic = args.TOPIC
+		msg.Priority = notify.TNotifyPriority(args.PRIORITY)
+		msg.Msg = args.MSG
+		msg.Remark = args.Remark
+
+		err := notify.Notifications.Send(s, msg)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
 	/**
 	 * 修改通知发送任务的状态
 	 */

--- a/pkg/mcclient/modules/notify/mod_notification.go
+++ b/pkg/mcclient/modules/notify/mod_notification.go
@@ -33,6 +33,7 @@ type SNotifyMessage struct {
 	Priority    TNotifyPriority `json:"priority,omitempty"`
 	Msg         string          `json:"msg,omitempty"`
 	Remark      string          `json:"remark,omitempty"`
+	Broadcast   bool            `json:"broadcast,omitempty"`
 }
 
 type NotificationManager struct {
@@ -47,7 +48,7 @@ func (manager *NotificationManager) Send(s *mcclient.ClientSession, msg SNotifyM
 func init() {
 	Notifications = NotificationManager{
 		modules.NewNotifyManager("notification", "notifications",
-			[]string{"id", "uid", "contact_type", "topic", "priority", "msg", "received_at", "send_by", "status", "create_at", "update_at", "delete_at", "create_by", "update_by", "delete_by", "is_deleted", "remark"},
+			[]string{"id", "uid", "contact_type", "topic", "priority", "msg", "received_at", "send_by", "status", "create_at", "update_at", "delete_at", "create_by", "update_by", "delete_by", "is_deleted", "broadcast", "remark"},
 			[]string{}),
 	}
 


### PR DESCRIPTION
Cherry pick of #2131 on release/2.11.

#2131: 新增 climc notify-broadcast 接口,用于向所有在线用户发 websocket 通知