### PR TITLE
fix: auth through disconnected ldap IDP

### DIFF
--- a/pkg/keystone/models/projects.go
+++ b/pkg/keystone/models/projects.go
@@ -328,7 +328,7 @@ func NormalizeProjectName(name string) string {
 	for _, illChar := range []string{
 		"/", ".", " ",
 	} {
-		name = strings.ReplaceAll(name, illChar, "")
+		name = strings.Replace(name, illChar, "", -1)
 	}
 	return name
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：disconnected状态的LDAP认证成功后应该变为connected状态

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11