### PR TITLE
climc: add --output-format support

### DIFF
--- a/cmd/climc/climc.go
+++ b/cmd/climc/climc.go
@@ -61,6 +61,7 @@ type BaseOptions struct {
 	OsZoneName     string `default:"$OS_ZONE_NAME" help:"Defaults to env[OS_ZONE_NAME]"`
 	OsEndpointType string `default:"$OS_ENDPOINT_TYPE|internalURL" help:"Defaults to env[OS_ENDPOINT_TYPE] or internalURL" choices:"publicURL|internalURL|adminURL"`
 	ApiVersion     string `default:"$API_VERSION" help:"override default modules service api version"`
+	OutputFormat   string `default:"$CLIMC_OUTPUT_FORMAT|table" choices:"table|kv|json|flatten-table|flatten-kv" help:"output format"`
 	SUBCOMMAND     string `help:"climc subcommand" subcommand:"true"`
 }
 
@@ -274,6 +275,7 @@ func main() {
 		return
 	}
 
+	shell.OutputFormat(options.OutputFormat)
 	ensureSessionFactory := func() *mcclient.ClientSession {
 		session, err := newClientSession(options)
 		if err != nil {

--- a/cmd/climc/shell/utils.go
+++ b/cmd/climc/shell/utils.go
@@ -15,6 +15,9 @@
 package shell
 
 import (
+	"fmt"
+	"os"
+	"sort"
 	"strings"
 
 	"yunion.io/x/jsonutils"
@@ -24,12 +27,64 @@ import (
 	"yunion.io/x/onecloud/pkg/util/printutils"
 )
 
+const (
+	OUTPUT_FORMAT_TABLE         = "table"         // pretty table
+	OUTPUT_FORMAT_FLATTEN_TABLE = "flatten-table" // pretty table with flattened keys
+	OUTPUT_FORMAT_JSON          = "json"          // json string
+	OUTPUT_FORMAT_KV            = "kv"            // "key: value" as separate line
+	OUTPUT_FORMAT_FLATTEN_KV    = "flatten-kv"    // kv with flattened keys
+)
+
+var outputFormat = OUTPUT_FORMAT_TABLE
+
+func OutputFormat(s string) {
+	outputFormat = s
+}
+
 func printList(list *modules.ListResult, columns []string) {
 	printutils.PrintJSONList(list, columns)
 }
 
 func printObject(obj jsonutils.JSONObject) {
-	printutils.PrintJSONObject(obj)
+	switch outputFormat {
+	case OUTPUT_FORMAT_TABLE:
+		printutils.PrintJSONObject(obj)
+	case OUTPUT_FORMAT_KV:
+		printObjectFmtKv(obj)
+	case OUTPUT_FORMAT_JSON:
+		fmt.Print(obj.String())
+		fmt.Print("\n")
+	case OUTPUT_FORMAT_FLATTEN_TABLE:
+		printObjectRecursive(obj)
+	case OUTPUT_FORMAT_FLATTEN_KV:
+		printObjectRecursiveEx(obj, printObjectFmtKv)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown output format: %q\n", outputFormat)
+	}
+}
+
+func printObjectFmtKv(obj jsonutils.JSONObject) {
+	m, _ := obj.GetMap()
+	maxWidth := 0
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+		if maxWidth < len(k) {
+			maxWidth = len(k)
+		}
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		var s string
+		objV := m[k]
+		if objS, ok := objV.(*jsonutils.JSONString); ok {
+			s, _ = objS.GetString()
+			s = strings.TrimRight(s, "\n")
+		} else {
+			s = objV.String()
+		}
+		fmt.Printf("%*s: %s\n", maxWidth, k, s)
+	}
 }
 
 func printObjectRecursive(obj jsonutils.JSONObject) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

允许指定`printObject()`的输出格式

**是否需要 backport 到之前的 release 分支**:

- release/2.10.0