### PR TITLE
feature: server migrate to different mountpoint storage

### DIFF
--- a/pkg/compute/tasks/guest_live_migrate_task.go
+++ b/pkg/compute/tasks/guest_live_migrate_task.go
@@ -285,9 +285,8 @@ func (self *GuestMigrateTask) localStorageMigrateConf(ctx context.Context,
 	targetStorage := targetHost.GetHoststorageOfId(targetStorageId)
 	sourceStorage := sourceHost.GetHoststorageOfId(disks[0].GetDisk().StorageId)
 	if sourceStorage.MountPoint != targetStorage.MountPoint {
-		self.TaskFailed(ctx, guest, fmt.Sprintf("target host %s storage"+
-			"mount point is different with source storage", targetHost.Id))
-		return nil, true
+		// rebase disks backing file
+		body.Set("rebase_disks", jsonutils.JSONTrue)
 	}
 	body.Set("desc", targetDesc)
 	body.Set("is_local_storage", jsonutils.JSONTrue)

--- a/pkg/compute/tasks/storage_cache_image_task.go
+++ b/pkg/compute/tasks/storage_cache_image_task.go
@@ -70,7 +70,6 @@ func (self *StorageCacheImageTask) OnRelinquishLeastUsedCachedImageComplete(ctx 
 		errData := taskman.Error2TaskData(err)
 		self.OnImageCacheCompleteFailed(ctx, storageCache, errData)
 	}
-
 }
 
 func (self *StorageCacheImageTask) OnImageCacheComplete(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/hostman/guestman/guesthandlers/guesthandler.go
+++ b/pkg/hostman/guestman/guesthandlers/guesthandler.go
@@ -317,6 +317,7 @@ func guestDestPrepareMigrate(ctx context.Context, sid string, body jsonutils.JSO
 			}
 			params.TargetStorageId = targetStorageId
 		}
+		params.RebaseDisks = jsonutils.QueryBoolean(body, "rebase_disks", false)
 	}
 	hostutils.DelayTask(ctx, guestman.GetGuestManager().DestPrepareMigrate, params)
 	return nil, nil

--- a/pkg/hostman/guestman/guesthelper.go
+++ b/pkg/hostman/guestman/guesthelper.go
@@ -44,6 +44,7 @@ type SDestPrepareMigrate struct {
 	DisksUri        string
 	TargetStorageId string
 	LiveMigrate     bool
+	RebaseDisks     bool
 
 	Desc             jsonutils.JSONObject
 	DisksBackingFile jsonutils.JSONObject

--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -491,7 +491,7 @@ func (m *SGuestManager) DestPrepareMigrate(ctx context.Context, params interface
 
 		err := iStorage.DestinationPrepareMigrate(
 			ctx, migParams.LiveMigrate, migParams.DisksUri, migParams.SnapshotsUri,
-			migParams.Desc, migParams.DisksBackingFile, migParams.SrcSnapshots)
+			migParams.Desc, migParams.DisksBackingFile, migParams.SrcSnapshots, migParams.RebaseDisks)
 		if err != nil {
 			return nil, fmt.Errorf("dest prepare migrate failed %s", err)
 		}

--- a/pkg/hostman/storageman/storage_base.go
+++ b/pkg/hostman/storageman/storage_base.go
@@ -112,7 +112,8 @@ type IStorage interface {
 	GetFuseMountPath() string
 	GetImgsaveBackupPath() string
 
-	DestinationPrepareMigrate(ctx context.Context, liveMigrate bool, disksUri string, snapshotsUri string, desc, disksBackingFile, srcSnapshots jsonutils.JSONObject) error
+	DestinationPrepareMigrate(ctx context.Context, liveMigrate bool, disksUri string, snapshotsUri string,
+		desc, disksBackingFile, srcSnapshots jsonutils.JSONObject, rebaseDisks bool) error
 }
 
 type SBaseStorage struct {
@@ -320,7 +321,10 @@ func (s *SBaseStorage) CreateDiskFromSnpashot(ctx context.Context, disk IDisk, c
 	return disk.GetDiskDesc(), nil
 }
 
-func (s *SBaseStorage) DestinationPrepareMigrate(ctx context.Context, liveMigrate bool, disksUri string, snapshotsUri string, desc, disksBackingFile, srcSnapshots jsonutils.JSONObject) error {
+func (s *SBaseStorage) DestinationPrepareMigrate(
+	ctx context.Context, liveMigrate bool, disksUri string, snapshotsUri string,
+	desc, disksBackingFile, srcSnapshots jsonutils.JSONObject, rebaseDisks bool,
+) error {
 	return nil
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
feature: server migrate to different mountpoint storage
支持迁移到挂载点不一样的storage
**是否需要 backport 到之前的 release 分支**:
release/2.10.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/cc @swordqiu @Zexi 
/area region host