### PR TITLE
hotfix: 将 websocket 的 broadcast 接口里 topic 这个必选变量设为位置参数; 其他参数给了默认值,非必填

### DIFF
--- a/cmd/climc/shell/notification.go
+++ b/cmd/climc/shell/notification.go
@@ -58,22 +58,20 @@ func init() {
 		return nil
 	})
 	type NotificationBroadcastOptions struct {
-
-		// CONTACTTYPE string `help:"User's contacts type, cloud be email|mobile|dingtalk|/webconsole" choices:"email|mobile|dingtalk|webconsole"`
-		TOPIC    string `required:"true" help:"Title or topic of the notification"`
-		PRIORITY string `help:"Priority of the notification maybe normal|important|fatal" choices:"normal|important|fatal"`
-		MSG      string `help:"The content of the notification"`
+		// only TOPIC is required
+		Topic    string `required:"true" help:"Title or topic of the notification"`
+		Priority string `help:"Priority of the notification maybe normal|important|fatal" choices:"normal|important|fatal" default:"normal"`
+		Msg      string `help:"The content of the notification" `
 		Remark   string `help:"Remark or description of the notification"`
-		// Group    bool   `help:"Send to group"`
 	}
 
 	R(&NotificationBroadcastOptions{}, "notify-broadcast", "Send a notification to all online users", func(s *mcclient.ClientSession, args *NotificationBroadcastOptions) error {
 		msg := notify.SNotifyMessage{}
 		msg.Broadcast = true
 		msg.ContactType = notify.TNotifyChannel("webconsole")
-		msg.Topic = args.TOPIC
-		msg.Priority = notify.TNotifyPriority(args.PRIORITY)
-		msg.Msg = args.MSG
+		msg.Topic = args.Topic
+		msg.Priority = notify.TNotifyPriority(args.Priority)
+		msg.Msg = args.Msg
 		msg.Remark = args.Remark
 
 		err := notify.Notifications.Send(s, msg)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
hotfix: 将 websocket 的 broadcast 接口里 topic 这个必选变量设为位置参数; 其他参数给了默认值,非必填
**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.10.0
- release/2.11