### PR TITLE
Automated cherry pick of #2169: hotfix: 将 websocket 的 broadcast 接口里 topic 这个必选变量设为位置参数; 其他参数给了默认值,非必填

### DIFF
--- a/cmd/climc/shell/notification.go
+++ b/cmd/climc/shell/notification.go
@@ -58,22 +58,20 @@ func init() {
 		return nil
 	})
 	type NotificationBroadcastOptions struct {
-
-		// CONTACTTYPE string `help:"User's contacts type, cloud be email|mobile|dingtalk|/webconsole" choices:"email|mobile|dingtalk|webconsole"`
-		TOPIC    string `help:"Title or topic of the notification"`
-		PRIORITY string `help:"Priority of the notification maybe normal|important|fatal" choices:"normal|important|fatal"`
-		MSG      string `help:"The content of the notification"`
+		// only TOPIC is required
+		Topic    string `required:"true" help:"Title or topic of the notification"`
+		Priority string `help:"Priority of the notification maybe normal|important|fatal" choices:"normal|important|fatal" default:"normal"`
+		Msg      string `help:"The content of the notification" `
 		Remark   string `help:"Remark or description of the notification"`
-		// Group    bool   `help:"Send to group"`
 	}
 
 	R(&NotificationBroadcastOptions{}, "notify-broadcast", "Send a notification to all online users", func(s *mcclient.ClientSession, args *NotificationBroadcastOptions) error {
 		msg := notify.SNotifyMessage{}
 		msg.Broadcast = true
 		msg.ContactType = notify.TNotifyChannel("webconsole")
-		msg.Topic = args.TOPIC
-		msg.Priority = notify.TNotifyPriority(args.PRIORITY)
-		msg.Msg = args.MSG
+		msg.Topic = args.Topic
+		msg.Priority = notify.TNotifyPriority(args.Priority)
+		msg.Msg = args.Msg
 		msg.Remark = args.Remark
 
 		err := notify.Notifications.Send(s, msg)


### PR DESCRIPTION
Cherry pick of #2169 on release/2.10.0.

#2169: hotfix: 将 websocket 的 broadcast 接口里 topic 这个必选变量设为位置参数; 其他参数给了默认值,非必填