### PR TITLE
fix: 1. get object acl not found 2. distinguish primary url for bucket

### DIFF
--- a/docs/identity/auth_v3.yaml
+++ b/docs/identity/auth_v3.yaml
@@ -5,6 +5,11 @@ get:
   responses:
     200:
       description: keystone v3 token信息
+      headers:
+        X-Subject-Token:
+          schema:
+            type: string
+          description: 验证成功的token
       schema:
         $ref: "../schemas/auth.yaml#/Auth3Response"
   tags:
@@ -21,6 +26,11 @@ post:
   responses:
     200:
       description: keystone v3 token信息
+      headers:
+        X-Subject-Token:
+          schema:
+            type: string
+          description: 认证成功的token
       schema:
         $ref: "../schemas/auth.yaml#/Auth3Response"
   tags:

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -441,7 +441,7 @@ paths:
     $ref: "./bucket/makedir.yaml"
   /buckets/{bucketName}/upload:
     $ref: "./bucket/uploadobject.yaml"
-  /buckets/{bucketName}/tempurl:
+  /buckets/{bucketName}/temp-url:
     $ref: "./bucket/tempurl.yaml"
   /buckets/{bucketName}/acl:
     $ref: "./bucket/acl.yaml"

--- a/pkg/cloudprovider/objectstore.go
+++ b/pkg/cloudprovider/objectstore.go
@@ -53,6 +53,7 @@ func (s SBucketStats) Equals(s2 SBucketStats) bool {
 type SBucketAccessUrl struct {
 	Url         string
 	Description string
+	Primary     bool
 }
 
 type SBaseCloudObject struct {

--- a/pkg/compute/models/buckets.go
+++ b/pkg/compute/models/buckets.go
@@ -841,7 +841,7 @@ func (bucket *SBucket) GetDetailsAcl(
 	if len(objKey) == 0 {
 		acl = iBucket.GetAcl()
 	} else {
-		objects, err := iBucket.GetIObjects(objKey, false)
+		objects, err := iBucket.GetIObjects(objKey, true)
 		if err != nil {
 			return nil, httperrors.NewInternalServerError("iBucket.GetIObjects error %s", err)
 		}

--- a/pkg/multicloud/aliyun/bucket.go
+++ b/pkg/multicloud/aliyun/bucket.go
@@ -89,6 +89,7 @@ func (b *SBucket) GetAccessUrls() []cloudprovider.SBucketAccessUrl {
 		{
 			Url:         fmt.Sprintf("%s.%s", b.Name, b.region.getOSSExternalDomain()),
 			Description: "ExtranetEndpoint",
+			Primary:     true,
 		},
 		{
 			Url:         fmt.Sprintf("%s.%s", b.Name, b.region.getOSSInternalDomain()),

--- a/pkg/multicloud/aws/bucket.go
+++ b/pkg/multicloud/aws/bucket.go
@@ -135,6 +135,7 @@ func (b *SBucket) GetAccessUrls() []cloudprovider.SBucketAccessUrl {
 		{
 			Url:         fmt.Sprintf("https://%s.%s", b.Name, b.region.getS3Endpoint()),
 			Description: "bucket domain",
+			Primary:     true,
 		},
 		{
 			Url:         fmt.Sprintf("https://%s/%s", b.region.getS3Endpoint(), b.Name),

--- a/pkg/multicloud/azure/storageaccount.go
+++ b/pkg/multicloud/azure/storageaccount.go
@@ -766,6 +766,7 @@ func (ep SStorageEndpoints) getUrls(prefix string) []cloudprovider.SBucketAccess
 		ret = append(ret, cloudprovider.SBucketAccessUrl{
 			Url:         ep.Blob,
 			Description: getDesc(prefix, "blob"),
+			Primary:     true,
 		})
 	}
 	if len(ep.Queue) > 0 {

--- a/pkg/multicloud/huawei/bucket.go
+++ b/pkg/multicloud/huawei/bucket.go
@@ -137,6 +137,7 @@ func (b *SBucket) GetAccessUrls() []cloudprovider.SBucketAccessUrl {
 		{
 			Url:         fmt.Sprintf("https://%s.%s", b.Name, b.region.getOBSEndpoint()),
 			Description: "bucket url",
+			Primary:     true,
 		},
 		{
 			Url:         fmt.Sprintf("https://%s/%s", b.region.getOBSEndpoint(), b.Name),

--- a/pkg/multicloud/objectstore/buckets.go
+++ b/pkg/multicloud/objectstore/buckets.go
@@ -105,6 +105,7 @@ func (bucket *SBucket) GetAccessUrls() []cloudprovider.SBucketAccessUrl {
 		{
 			Url:         path.Join(bucket.client.endpoint, bucket.Name),
 			Description: fmt.Sprintf("%s", bucket.Location),
+			Primary:     true,
 		},
 	}
 }

--- a/pkg/multicloud/qcloud/bucket.go
+++ b/pkg/multicloud/qcloud/bucket.go
@@ -142,6 +142,7 @@ func (b *SBucket) GetAccessUrls() []cloudprovider.SBucketAccessUrl {
 		{
 			Url:         b.getBucketUrl(),
 			Description: "bucket domain",
+			Primary:     true,
 		},
 		{
 			Url:         fmt.Sprintf("https://%s/%s", b.region.getCosEndpoint(), b.getFullName()),

--- a/pkg/multicloud/ucloud/ufile.go
+++ b/pkg/multicloud/ucloud/ufile.go
@@ -294,9 +294,14 @@ func (b *SBucket) getSrcUrl() string {
 func (b *SBucket) GetAccessUrls() []cloudprovider.SBucketAccessUrl {
 	ret := make([]cloudprovider.SBucketAccessUrl, 0)
 	for i, u := range b.Domain.Src {
+		primary := false
+		if i == 0 {
+			primary = true
+		}
 		ret = append(ret, cloudprovider.SBucketAccessUrl{
 			Url:         u,
 			Description: fmt.Sprintf("src%d", i),
+			Primary:     primary,
 		})
 	}
 	for i, u := range b.Domain.CDN {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：1. get object acl报404 2. bucket access urls增加primary字段区分主要的bucket url
3. swagger文档的bug

**是否需要 backport 到之前的 release 分支**:
- release/2.11

/area region