### PR TITLE
fix: qcloud/aws temp url not working

### DIFF
--- a/pkg/cloudprovider/objectstore.go
+++ b/pkg/cloudprovider/objectstore.go
@@ -228,6 +228,17 @@ func GetIObjects(bucket ICloudBucket, objectPrefix string, isRecursive bool) ([]
 	return ret, nil
 }
 
+func GetIObject(bucket ICloudBucket, objectPrefix string) (ICloudObject, error) {
+	objects, err := GetIObjects(bucket, objectPrefix, true)
+	if err != nil {
+		return nil, errors.Wrap(err, "GetIObjects")
+	}
+	if len(objects) > 0 && objects[0].GetKey() == objectPrefix {
+		return objects[0], nil
+	}
+	return nil, ErrNotFound
+}
+
 func Makedir(ctx context.Context, bucket ICloudBucket, key string) error {
 	segs := make([]string, 0)
 	for _, seg := range strings.Split(key, "/") {

--- a/pkg/multicloud/aws/bucket.go
+++ b/pkg/multicloud/aws/bucket.go
@@ -277,5 +277,9 @@ func (b *SBucket) GetTempUrl(method string, key string, expire time.Duration) (s
 	default:
 		return "", errors.Error("unsupported method")
 	}
-	return request.Presign(expire)
+	url, _, err := request.PresignRequest(expire)
+	if err != nil {
+		return "", errors.Wrap(err, "request.PresignRequest")
+	}
+	return url, nil
 }

--- a/pkg/multicloud/objectstore/shell.go
+++ b/pkg/multicloud/objectstore/shell.go
@@ -229,14 +229,11 @@ func S3Shell() {
 		if err != nil {
 			return err
 		}
-		objects, err := bucket.GetIObjects(args.KEY, false)
+		object, err := cloudprovider.GetIObject(bucket, args.KEY)
 		if err != nil {
 			return err
 		}
-		if len(objects) == 0 {
-			return cloudprovider.ErrNotFound
-		}
-		fmt.Println(objects[0].GetAcl())
+		fmt.Println(object.GetAcl())
 		return nil
 	})
 
@@ -250,14 +247,11 @@ func S3Shell() {
 		if err != nil {
 			return err
 		}
-		objects, err := bucket.GetIObjects(args.KEY, false)
+		object, err := cloudprovider.GetIObject(bucket, args.KEY)
 		if err != nil {
 			return err
 		}
-		if len(objects) == 0 {
-			return cloudprovider.ErrNotFound
-		}
-		err = objects[0].SetAcl(cloudprovider.TBucketACLType(args.ACL))
+		err = object.SetAcl(cloudprovider.TBucketACLType(args.ACL))
 		if err != nil {
 			return err
 		}

--- a/pkg/multicloud/qcloud/bucket.go
+++ b/pkg/multicloud/qcloud/bucket.go
@@ -256,8 +256,8 @@ func (b *SBucket) GetTempUrl(method string, key string, expire time.Duration) (s
 		return "", errors.Wrap(err, "GetCosClient")
 	}
 	url, err := coscli.Object.GetPresignedURL(context.Background(), method, key,
-		b.region.client.SecretKey,
 		b.region.client.SecretID,
+		b.region.client.SecretKey,
 		expire, nil)
 	if err != nil {
 		return "", errors.Wrap(err, "coscli.Object.GetPresignedURL")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：qcloud/aws temp url失效（AWS中国似乎temp url一直无效）

**是否需要 backport 到之前的 release 分支**:
- release/2.11