### PR TITLE
fix: imported esxi VM fail to rebuild root

### DIFF
--- a/pkg/compute/guestdrivers/esxi.go
+++ b/pkg/compute/guestdrivers/esxi.go
@@ -163,6 +163,11 @@ func (self *SESXiGuestDriver) RequestDeployGuestOnHost(ctx context.Context, gues
 
 	config.Add(jsonutils.NewString(host.AccessIp), "host_ip")
 	config.Add(jsonutils.NewString(guest.Id), "guest_id")
+	extId := guest.Id
+	if len(guest.ExternalId) > 0 {
+		extId = guest.ExternalId
+	}
+	config.Add(jsonutils.NewString(extId), "guest_ext_id")
 
 	accessInfo, err := host.GetCloudaccount().GetVCenterAccessInfo(storage.ExternalId)
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：导入的ESXi虚拟机重置系统盘失败，原因为ExternalId和GuestId不一致

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11