### PR TITLE
Automated cherry pick of #2207: fix: bucket GetShortDesc includes cloudproviderinfo

### DIFF
--- a/cmd/climc/shell/events.go
+++ b/cmd/climc/shell/events.go
@@ -151,8 +151,18 @@ func init() {
 		return doComputeEventList(s, &nargs)
 	})
 
-	R(&TypeEventListOptions{}, "vcenter-event", "Show operation event logs of vcenter", func(s *mcclient.ClientSession, args *TypeEventListOptions) error {
-		nargs := EventListOptions{BaseEventListOptions: args.BaseEventListOptions, Id: args.ID, Type: []string{"vcenter"}}
+	R(&TypeEventListOptions{}, "cloud-provider-event", "Show operation event logs of cloudprovider", func(s *mcclient.ClientSession, args *TypeEventListOptions) error {
+		nargs := EventListOptions{BaseEventListOptions: args.BaseEventListOptions, Id: args.ID, Type: []string{"cloudprovider"}}
+		return doComputeEventList(s, &nargs)
+	})
+
+	R(&TypeEventListOptions{}, "cloud-account-event", "Show operation event logs of cloudaccount", func(s *mcclient.ClientSession, args *TypeEventListOptions) error {
+		nargs := EventListOptions{BaseEventListOptions: args.BaseEventListOptions, Id: args.ID, Type: []string{"cloudaccount"}}
+		return doComputeEventList(s, &nargs)
+	})
+
+	R(&TypeEventListOptions{}, "bucket-event", "Show operation event logs of bucket", func(s *mcclient.ClientSession, args *TypeEventListOptions) error {
+		nargs := EventListOptions{BaseEventListOptions: args.BaseEventListOptions, Id: args.ID, Type: []string{"bucket"}}
 		return doComputeEventList(s, &nargs)
 	})
 

--- a/pkg/compute/models/buckets.go
+++ b/pkg/compute/models/buckets.go
@@ -213,10 +213,15 @@ func (bucket *SBucket) getStats() cloudprovider.SBucketStats {
 
 func (bucket *SBucket) GetShortDesc(ctx context.Context) *jsonutils.JSONDict {
 	desc := bucket.SVirtualResourceBase.GetShortDesc(ctx)
+
 	desc.Add(jsonutils.NewInt(bucket.SizeBytes), "size_bytes")
 	desc.Add(jsonutils.NewInt(int64(bucket.ObjectCnt)), "object_cnt")
 	desc.Add(jsonutils.NewString(bucket.Acl), "acl")
 	desc.Add(jsonutils.NewString(bucket.StorageClass), "storage_class")
+
+	info := bucket.getCloudProviderInfo()
+	desc.Update(jsonutils.Marshal(&info))
+
 	return desc
 }
 


### PR DESCRIPTION
Cherry pick of #2207 on release/2.11.

#2207: fix: bucket GetShortDesc includes cloudproviderinfo