### PR TITLE
lbcluster: 添加wire亲和性质

### DIFF
--- a/cmd/climc/shell/loadbalancerclusters.go
+++ b/cmd/climc/shell/loadbalancerclusters.go
@@ -33,6 +33,18 @@ func init() {
 		printObject(lbcluster)
 		return nil
 	})
+	R(&options.LoadbalancerClusterUpdateOptions{}, "lbcluster-update", "Update lbcluster", func(s *mcclient.ClientSession, opts *options.LoadbalancerClusterUpdateOptions) error {
+		params, err := options.StructToParams(opts)
+		if err != nil {
+			return err
+		}
+		lbcluster, err := modules.LoadbalancerClusters.Update(s, opts.ID, params)
+		if err != nil {
+			return err
+		}
+		printObject(lbcluster)
+		return nil
+	})
 	R(&options.LoadbalancerClusterGetOptions{}, "lbcluster-show", "Show lbcluster", func(s *mcclient.ClientSession, opts *options.LoadbalancerClusterGetOptions) error {
 		lbcluster, err := modules.LoadbalancerClusters.Get(s, opts.ID, nil)
 		if err != nil {

--- a/pkg/compute/models/loadbalancerclusters.go
+++ b/pkg/compute/models/loadbalancerclusters.go
@@ -53,6 +53,26 @@ type SLoadbalancerCluster struct {
 	WireId string `width:"36" charset:"ascii" nullable:"true" list:"admin" create:"optional" update:"admin"`
 }
 
+func (man *SLoadbalancerClusterManager) AllowListItems(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {
+	return db.IsAdminAllowList(userCred, man)
+}
+
+func (man *SLoadbalancerClusterManager) AllowCreateItem(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) bool {
+	return db.IsAdminAllowCreate(userCred, man)
+}
+
+func (lbc *SLoadbalancerCluster) AllowGetDetails(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {
+	return db.IsAdminAllowGet(userCred, lbc)
+}
+
+func (lbc *SLoadbalancerCluster) AllowUpdateItem(ctx context.Context, userCred mcclient.TokenCredential) bool {
+	return db.IsAdminAllowUpdate(userCred, lbc)
+}
+
+func (lbc *SLoadbalancerCluster) AllowDeleteItem(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) bool {
+	return db.IsAdminAllowDelete(userCred, lbc)
+}
+
 func (man *SLoadbalancerClusterManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQuery, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (*sqlchemy.SQuery, error) {
 	q, err := man.SStandaloneResourceBaseManager.ListItemFilter(ctx, q, userCred, query)
 	if err != nil {

--- a/pkg/compute/models/loadbalancerclusters.go
+++ b/pkg/compute/models/loadbalancerclusters.go
@@ -53,6 +53,22 @@ type SLoadbalancerCluster struct {
 	WireId string `width:"36" charset:"ascii" nullable:"true" list:"admin" create:"optional" update:"admin"`
 }
 
+func (man *SLoadbalancerClusterManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQuery, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (*sqlchemy.SQuery, error) {
+	q, err := man.SStandaloneResourceBaseManager.ListItemFilter(ctx, q, userCred, query)
+	if err != nil {
+		return nil, err
+	}
+	data := query.(*jsonutils.JSONDict)
+	q, err = validators.ApplyModelFilters(q, data, []*validators.ModelFilterOptions{
+		{Key: "zone", ModelKeyword: "zone", OwnerId: userCred},
+		{Key: "wire", ModelKeyword: "wire", OwnerId: userCred},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return q, nil
+}
+
 func (man *SLoadbalancerClusterManager) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
 	zoneV := validators.NewModelIdOrNameValidator("zone", "zone", ownerId)
 	wireV := validators.NewModelIdOrNameValidator("wire", "wire", ownerId)

--- a/pkg/mcclient/modules/mod_loadbalancerclusters.go
+++ b/pkg/mcclient/modules/mod_loadbalancerclusters.go
@@ -31,6 +31,7 @@ func init() {
 				"id",
 				"name",
 				"zone_id",
+				"wire_id",
 			},
 			[]string{},
 		),

--- a/pkg/mcclient/options/loadbalancerclusters.go
+++ b/pkg/mcclient/options/loadbalancerclusters.go
@@ -29,6 +29,9 @@ type LoadbalancerClusterUpdateOptions struct {
 
 type LoadbalancerClusterListOptions struct {
 	BaseListOptions
+
+	Zone string
+	Wire string
 }
 
 type LoadbalancerClusterGetOptions struct {

--- a/pkg/mcclient/options/loadbalancerclusters.go
+++ b/pkg/mcclient/options/loadbalancerclusters.go
@@ -18,6 +18,13 @@ type LoadbalancerClusterCreateOptions struct {
 	NAME string
 
 	Zone string
+	Wire string
+}
+
+type LoadbalancerClusterUpdateOptions struct {
+	ID string `json:"-"`
+
+	Wire string
 }
 
 type LoadbalancerClusterListOptions struct {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
lbcluster: 添加wire亲和性质
lbcluster: lbcluster-list支持--wire, --zone过滤
lbcluster: 限定仅管理员可操作
```

**是否需要 backport 到之前的 release 分支**:

- release/2.10.0

/area region
/cc @ioito @swordqiu 