### PR TITLE
fix: when turning off non-default-domain-projects, network public scope

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -34,6 +34,7 @@ import (
 	"yunion.io/x/sqlchemy"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
@@ -678,7 +679,11 @@ func (manager *SNetworkManager) newFromCloudNetwork(ctx context.Context, userCre
 	net.GuestGateway = extNet.GetGateway()
 	net.ServerType = extNet.GetServerType()
 	net.IsPublic = extNet.GetIsPublic()
-	net.PublicScope = string(extNet.GetPublicScope())
+	extScope := extNet.GetPublicScope()
+	if extScope == rbacutils.ScopeDomain && !consts.GetNonDefaultDomainProjects() {
+		extScope = rbacutils.ScopeSystem
+	}
+	net.PublicScope = string(extScope)
 
 	net.AllocTimoutSeconds = extNet.GetAllocTimeoutSeconds()
 


### PR DESCRIPTION
should swtich to system scope

**这个 PR 实现什么功能/修复什么问题**:
修正：关闭三级权限后，公有云网络的默认共享范围改为SystemScope

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11

/cc @ioito @tb365 