### PR TITLE
fix: no need to inject password by cloud-init for qcloud

### DIFF
--- a/pkg/compute/guestdrivers/qcloud.go
+++ b/pkg/compute/guestdrivers/qcloud.go
@@ -217,10 +217,6 @@ func (self *SQcloudGuestDriver) GetGuestInitialStateAfterRebuild() string {
 	return api.VM_RUNNING
 }
 
-func (self *SQcloudGuestDriver) IsNeedInjectPasswordByCloudInit(desc *cloudprovider.SManagedVMCreateConfig) bool {
-	return true
-}
-
 func (self *SQcloudGuestDriver) GetUserDataType() string {
 	return cloudprovider.CLOUD_SHELL
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
腾讯云不需要通过cloud-init注入密码信息

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.10.0
- release/2.9.0
- release/2.8.0

/area region
/cc @swordqiu @yousong 

