### PR TITLE
Automated cherry pick of #2234: fix: no need to inject password by cloud-init for qcloud

### DIFF
--- a/pkg/compute/guestdrivers/qcloud.go
+++ b/pkg/compute/guestdrivers/qcloud.go
@@ -217,10 +217,6 @@ func (self *SQcloudGuestDriver) GetGuestInitialStateAfterRebuild() string {
 	return api.VM_RUNNING
 }
 
-func (self *SQcloudGuestDriver) IsNeedInjectPasswordByCloudInit(desc *cloudprovider.SManagedVMCreateConfig) bool {
-	return true
-}
-
 func (self *SQcloudGuestDriver) GetUserDataType() string {
 	return cloudprovider.CLOUD_SHELL
 }


### PR DESCRIPTION
Cherry pick of #2234 on release/2.10.0.

#2234: fix: no need to inject password by cloud-init for qcloud