### PR TITLE
fix: 1. aws s3 fail to mkdir 2. put object requires acl

### DIFF
--- a/cmd/climc/shell/buckets.go
+++ b/cmd/climc/shell/buckets.go
@@ -157,8 +157,8 @@ func init() {
 		KEY  string `help:"Key of object to upload"`
 		Path string `help:"Path to file to upload" required:"true"`
 
-		ContentLength int64  `help:"Content lenght (bytes)"`
-		ContentType   string `help:"Content type" required:"true"`
+		ContentLength int64  `help:"Content lenght (bytes)" default:"-1"`
+		ContentType   string `help:"Content type"`
 		StorageClass  string `help:"storage CLass"`
 		Acl           string `help:"object acl." choices:"private|public-read|public-read-write"`
 	}
@@ -182,7 +182,7 @@ func init() {
 			body = os.Stdin
 		}
 
-		if args.ContentLength <= 0 {
+		if args.ContentLength < 0 {
 			return fmt.Errorf("required content-length")
 		}
 

--- a/cmd/climc/shell/cloudproviders.go
+++ b/cmd/climc/shell/cloudproviders.go
@@ -28,7 +28,11 @@ func init() {
 
 	type CloudproviderListOptions struct {
 		options.BaseListOptions
+
 		Usable bool `help:"Vpc & Network usable"`
+
+		HasObjectStorage bool `help:"filter cloudproviders that has object storage"`
+		NoObjectStorage  bool `help:"filter cloudproviders that has no object storage"`
 	}
 	R(&CloudproviderListOptions{}, "cloud-provider-list", "List cloud providers", func(s *mcclient.ClientSession, args *CloudproviderListOptions) error {
 		var params *jsonutils.JSONDict
@@ -41,6 +45,12 @@ func init() {
 
 			if args.Usable {
 				params.Add(jsonutils.NewBool(true), "usable")
+			}
+
+			if args.HasObjectStorage {
+				params.Add(jsonutils.JSONTrue, "has_object_storage")
+			} else if args.NoObjectStorage {
+				params.Add(jsonutils.JSONFalse, "has_object_storage")
 			}
 		}
 		result, err := modules.Cloudproviders.List(s, params)

--- a/pkg/cloudprovider/objectstore.go
+++ b/pkg/cloudprovider/objectstore.go
@@ -327,3 +327,17 @@ func UploadObject(ctx context.Context, bucket ICloudBucket, key string, blocksz 
 	}
 	return nil
 }
+
+func DeletePrefix(ctx context.Context, bucket ICloudBucket, prefix string) error {
+	objs, err := bucket.GetIObjects(prefix, true)
+	if err != nil {
+		return errors.Wrap(err, "bucket.GetIObjects")
+	}
+	for i := range objs {
+		err := bucket.DeleteObject(ctx, objs[i].GetKey())
+		if err != nil {
+			return errors.Wrap(err, "bucket.DeleteObject")
+		}
+	}
+	return nil
+}

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -1010,6 +1010,17 @@ func (manager *SCloudproviderManager) ListItemFilter(ctx context.Context, q *sql
 		q = q.Filter(sqlchemy.IsTrue(cloudaccounts.Field("is_on_premise")))
 	}
 
+	if query.Contains("has_object_storage") {
+		hasObjectStorage, _ := query.Bool("has_object_storage")
+		cloudaccounts := CloudaccountManager.Query().SubQuery()
+		q = q.Join(cloudaccounts, sqlchemy.Equals(cloudaccounts.Field("id"), q.Field("cloudaccount_id")))
+		if hasObjectStorage {
+			q = q.Filter(sqlchemy.IsTrue(cloudaccounts.Field("has_object_storage")))
+		} else {
+			q = q.Filter(sqlchemy.IsFalse(cloudaccounts.Field("has_object_storage")))
+		}
+	}
+
 	return q, nil
 }
 

--- a/pkg/multicloud/aws/bucket.go
+++ b/pkg/multicloud/aws/bucket.go
@@ -210,7 +210,7 @@ func (b *SBucket) GetIObjects(prefix string, isRecursive bool) ([]cloudprovider.
 }
 
 func (b *SBucket) PutObject(ctx context.Context, key string, body io.Reader, sizeBytes int64, contType string, cannedAcl cloudprovider.TBucketACLType, storageClassStr string) error {
-	if sizeBytes <= 0 {
+	if sizeBytes < 0 {
 		return errors.Error("content length expected")
 	}
 	s3cli, err := b.region.GetS3Client()

--- a/pkg/util/fileutils2/seeker_test.go
+++ b/pkg/util/fileutils2/seeker_test.go
@@ -21,25 +21,29 @@ import (
 )
 
 func TestNewReadSeeker(t *testing.T) {
-	testStr := "This is a test reader string"
-	seeker, err := NewReadSeeker(strings.NewReader(testStr), int64(len(testStr)))
-	if err != nil {
-		t.Fatalf("NewReadSeeker error %s", err)
-	}
-	defer seeker.Close()
-	buf1 := make([]byte, 1024)
-	n, err := seeker.Read(buf1)
-	if n != len(testStr) {
-		t.Fatalf("read buf1 error %s", err)
-	}
-	buf2 := make([]byte, 1024)
-	n, err = seeker.Read(buf2)
-	if n != 0 {
-		t.Fatalf("read buf2 should fail")
-	}
-	seeker.Seek(0, io.SeekStart)
-	n, err = seeker.Read(buf2)
-	if n != len(testStr) {
-		t.Fatalf("read buf2 error %s", err)
+	for _, testStr := range []string{
+		"This is a test reader string",
+		"",
+	} {
+		seeker, err := NewReadSeeker(strings.NewReader(testStr), int64(len(testStr)))
+		if err != nil {
+			t.Fatalf("NewReadSeeker error %s", err)
+		}
+		defer seeker.Close()
+		buf1 := make([]byte, 1024)
+		n, err := seeker.Read(buf1)
+		if n != len(testStr) {
+			t.Fatalf("read buf1 error %s", err)
+		}
+		buf2 := make([]byte, 1024)
+		n, err = seeker.Read(buf2)
+		if n != 0 {
+			t.Fatalf("read buf2 should fail")
+		}
+		seeker.Seek(0, io.SeekStart)
+		n, err = seeker.Read(buf2)
+		if n != len(testStr) {
+			t.Fatalf("read buf2 error %s", err)
+		}
 	}
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
若干修正和改进：1. AWS mkdir失败 2. 递归删除对象 3. cloudprovider列表支持has_object_storage过滤器

**是否需要 backport 到之前的 release 分支**:
- release/2.11

/area region