### PR TITLE
Automated cherry pick of #2264: fix: qcloud storagecache bucket name too long

### DIFF
--- a/pkg/cloudprovider/objectstore.go
+++ b/pkg/cloudprovider/objectstore.go
@@ -28,8 +28,8 @@ import (
 type TBucketACLType string
 
 const (
-	// 100 MB
-	MAX_PUT_OBJECT_SIZEBYTES = int64(1000 * 1000 * 100)
+	// 50 MB
+	MAX_PUT_OBJECT_SIZEBYTES = int64(1000 * 1000 * 50)
 
 	// ACLDefault = TBucketACLType("default")
 

--- a/pkg/compute/hostdrivers/managedvirtual.go
+++ b/pkg/compute/hostdrivers/managedvirtual.go
@@ -336,7 +336,8 @@ func (self *SManagedVirtualizationHostDriver) RequestRebuildDiskOnStorage(ctx co
 
 func (driver *SManagedVirtualizationHostDriver) IsReachStoragecacheCapacityLimit(host *models.SHost, cachedImages []models.SCachedimage) bool {
 	quota := host.GetHostDriver().GetStoragecacheQuota(host)
-	if quota > 0 && len(cachedImages) >= quota {
+	log.Debugf("Cached image total: %d quota: %d", len(cachedImages), quota)
+	if quota > 0 && len(cachedImages)+1 >= quota {
 		return true
 	}
 	return false

--- a/pkg/multicloud/qcloud/storagecache.go
+++ b/pkg/multicloud/qcloud/storagecache.go
@@ -167,7 +167,10 @@ func (self *SStoragecache) uploadImage(ctx context.Context, userCred mcclient.To
 		return "", err
 	}
 
-	bucketName := strings.ToLower(fmt.Sprintf("imgcache-%s-%s", self.region.GetId(), image.ImageId))
+	bucketName := strings.ReplaceAll(strings.ToLower(self.region.GetId()+image.ImageId), "-", "")
+	if len(bucketName) > 40 {
+		bucketName = bucketName[:40]
+	}
 	exists, _ := self.region.IBucketExist(bucketName)
 	if !exists {
 		log.Debugf("Bucket %s not exists, to create ...", bucketName)


### PR DESCRIPTION
Cherry pick of #2264 on release/2.11.

#2264: fix: qcloud storagecache bucket name too long