### PR TITLE
Automated cherry pick of #2264: fix: qcloud storagecache bucket name too long

### DIFF
--- a/pkg/compute/hostdrivers/managedvirtual.go
+++ b/pkg/compute/hostdrivers/managedvirtual.go
@@ -336,7 +336,8 @@ func (self *SManagedVirtualizationHostDriver) RequestRebuildDiskOnStorage(ctx co
 
 func (driver *SManagedVirtualizationHostDriver) IsReachStoragecacheCapacityLimit(host *models.SHost, cachedImages []models.SCachedimage) bool {
 	quota := host.GetHostDriver().GetStoragecacheQuota(host)
-	if quota > 0 && len(cachedImages) >= quota {
+	log.Debugf("Cached image total: %d quota: %d", len(cachedImages), quota)
+	if quota > 0 && len(cachedImages)+1 >= quota {
 		return true
 	}
 	return false

--- a/pkg/util/qcloud/storagecache.go
+++ b/pkg/util/qcloud/storagecache.go
@@ -187,7 +187,10 @@ func (self *SStoragecache) uploadImage(ctx context.Context, userCred mcclient.To
 		log.Errorf("GetOssClient err %s", err)
 		return "", err
 	}
-	bucketName := strings.ToLower(fmt.Sprintf("imgcache-%s", self.region.GetId()))
+	bucketName := strings.ReplaceAll(strings.ToLower(self.region.GetId()+image.ImageId), "-", "")
+	if len(bucketName) > 40 {
+		bucketName = bucketName[:40]
+	}
 	err = cos.BucketExists(context.Background(), bucketName)
 	if err != nil {
 		log.Debugf("Bucket %s not exists, to create ...", bucketName)


### PR DESCRIPTION
Cherry pick of #2264 on release/2.10.0.

#2264: fix: qcloud storagecache bucket name too long