### PR TITLE
Automated cherry pick of #2267: fix: qcloud storagecache bucket name too long

### DIFF
--- a/pkg/cloudprovider/objectstore.go
+++ b/pkg/cloudprovider/objectstore.go
@@ -28,8 +28,8 @@ import (
 type TBucketACLType string
 
 const (
-	// 100 MB
-	MAX_PUT_OBJECT_SIZEBYTES = int64(1000 * 1000 * 100)
+	// 50 MB
+	MAX_PUT_OBJECT_SIZEBYTES = int64(1000 * 1000 * 50)
 
 	// ACLDefault = TBucketACLType("default")
 

--- a/pkg/compute/hostdrivers/managedvirtual.go
+++ b/pkg/compute/hostdrivers/managedvirtual.go
@@ -336,7 +336,8 @@ func (self *SManagedVirtualizationHostDriver) RequestRebuildDiskOnStorage(ctx co
 
 func (driver *SManagedVirtualizationHostDriver) IsReachStoragecacheCapacityLimit(host *models.SHost, cachedImages []models.SCachedimage) bool {
 	quota := host.GetHostDriver().GetStoragecacheQuota(host)
-	if quota > 0 && len(cachedImages) >= quota {
+	log.Debugf("Cached image total: %d quota: %d", len(cachedImages), quota)
+	if quota > 0 && len(cachedImages)+1 >= quota {
 		return true
 	}
 	return false

--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -517,9 +517,11 @@ func (self *SCloudaccount) markStartSync(userCred mcclient.TokenCredential) erro
 	}
 	providers := self.GetCloudproviders()
 	for i := range providers {
-		err := providers[i].markStartingSync(userCred)
-		if err != nil {
-			return errors.Wrap(err, "providers.markStartSync")
+		if providers[i].Enabled {
+			err := providers[i].markStartingSync(userCred)
+			if err != nil {
+				return errors.Wrap(err, "providers.markStartSync")
+			}
 		}
 	}
 	return nil
@@ -547,8 +549,16 @@ func (self *SCloudaccount) MarkEndSyncWithLock(ctx context.Context, userCred mcc
 		return nil
 	}
 
+	providers := self.GetCloudproviders()
+	for i := range providers {
+		err := providers[i].cancelStartingSync(userCred)
+		if err != nil {
+			return errors.Wrap(err, "providers.cancelStartingSync")
+		}
+	}
+
 	if self.getSyncStatus2() != api.CLOUD_PROVIDER_SYNC_STATUS_IDLE {
-		return nil
+		return errors.Error("some cloud providers not idle")
 	}
 
 	return self.markEndSync(userCred)

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -679,6 +679,26 @@ func (self *SCloudprovider) markEndSync(userCred mcclient.TokenCredential) error
 	return nil
 }
 
+func (self *SCloudprovider) cancelStartingSync(userCred mcclient.TokenCredential) error {
+	if self.SyncStatus == api.CLOUD_PROVIDER_SYNC_STATUS_QUEUING {
+		cprs := self.GetCloudproviderRegions()
+		for i := range cprs {
+			err := cprs[i].cancelStartingSync(userCred)
+			if err != nil {
+				return errors.Wrap(err, "cprs[i].cancelStartingSync")
+			}
+		}
+		_, err := db.Update(self, func() error {
+			self.SyncStatus = api.CLOUD_PROVIDER_SYNC_STATUS_IDLE
+			return nil
+		})
+		if err != nil {
+			return errors.Wrap(err, "db.Update")
+		}
+	}
+	return nil
+}
+
 func (self *SCloudprovider) GetProviderFactory() (cloudprovider.ICloudProviderFactory, error) {
 	return cloudprovider.GetProviderFactory(self.Provider)
 }

--- a/pkg/multicloud/aws/aws.go
+++ b/pkg/multicloud/aws/aws.go
@@ -127,6 +127,7 @@ func (self *SAwsClient) UpdateAccount(accessKey, secret string) error {
 	if self.accessKey != accessKey || self.secret != secret {
 		self.accessKey = accessKey
 		self.secret = secret
+		self.iregions = nil
 		return self.fetchRegions()
 	} else {
 		return nil
@@ -135,6 +136,9 @@ func (self *SAwsClient) UpdateAccount(accessKey, secret string) error {
 
 // 用于初始化region信息
 func (self *SAwsClient) fetchRegions() error {
+	if self.iregions != nil {
+		return nil
+	}
 	s, err := self.getDefaultSession()
 	if err != nil {
 		return err
@@ -148,9 +152,9 @@ func (self *SAwsClient) fetchRegions() error {
 
 	regions := make([]SRegion, 0)
 	// empty iregions
-	if self.iregions != nil {
-		self.iregions = self.iregions[:0]
-	}
+	// if self.iregions != nil {
+	// 	self.iregions = self.iregions[:0]
+	// }
 
 	for _, region := range result.Regions {
 		name := *region.RegionName

--- a/pkg/multicloud/azure/azure.go
+++ b/pkg/multicloud/azure/azure.go
@@ -104,9 +104,11 @@ func NewAzureClient(providerId string, providerName string, envName, tenantId, c
 	if err != nil {
 		return nil, errors.Wrap(err, "fetchRegions")
 	}
-	err = client.fetchBuckets()
-	if err != nil {
-		return nil, errors.Wrap(err, "fetchBuckets")
+	if len(subscriptionId) > 0 {
+		err = client.fetchBuckets()
+		if err != nil {
+			return nil, errors.Wrap(err, "fetchBuckets")
+		}
 	}
 	return &client, nil
 }
@@ -903,10 +905,10 @@ func (self *SAzureClient) GetIProjects() ([]cloudprovider.ICloudProject, error) 
 	return iprojects, nil
 }
 
-func (self *SAzureClient) GetStorageClasses(regionId string) ([]string, error) {
-	iRegion, err := self.GetIRegionById(regionId)
+func (self *SAzureClient) GetStorageClasses(regionExtId string) ([]string, error) {
+	iRegion, err := self.GetIRegionById(regionExtId)
 	if err != nil {
-		return nil, errors.Wrap(err, "getDefaultRegion")
+		return nil, errors.Wrap(err, "self.GetIRegionById")
 	}
 	skus, err := iRegion.(*SRegion).GetStorageAccountSkus()
 	if err != nil {

--- a/pkg/multicloud/huawei/huawei.go
+++ b/pkg/multicloud/huawei/huawei.go
@@ -164,12 +164,17 @@ func (self *SHuaweiClient) getIBuckets() ([]cloudprovider.ICloudBucket, error) {
 	return self.iBuckets, nil
 }
 
+func getOBSEndpoint(regionId string) string {
+	return fmt.Sprintf("obs.%s.myhuaweicloud.com", regionId)
+}
+
+func (client *SHuaweiClient) getOBSClient(regionId string) (*obs.ObsClient, error) {
+	endpoint := getOBSEndpoint(regionId)
+	return obs.New(client.accessKey, client.secret, endpoint)
+}
+
 func (self *SHuaweiClient) fetchBuckets() error {
-	if len(self.iregions) == 0 {
-		return errors.Error("no region???")
-	}
-	region := self.iregions[0].(*SRegion)
-	obscli, err := region.getOBSClient()
+	obscli, err := self.getOBSClient(HUAWEI_DEFAULT_REGION)
 	if err != nil {
 		return errors.Wrap(err, "getOBSClient")
 	}
@@ -266,6 +271,7 @@ func (self *SHuaweiClient) GetIRegions() []cloudprovider.ICloudRegion {
 
 func (self *SHuaweiClient) getIRegionByRegionId(id string) (cloudprovider.ICloudRegion, error) {
 	for i := 0; i < len(self.iregions); i += 1 {
+		log.Debugf("%d ID: %s", i, self.iregions[i].GetId())
 		if self.iregions[i].GetId() == id {
 			return self.iregions[i], nil
 		}

--- a/pkg/multicloud/huawei/region.go
+++ b/pkg/multicloud/huawei/region.go
@@ -92,13 +92,12 @@ func (self *SRegion) getECSClient() (*client.Client, error) {
 }
 
 func (self *SRegion) getOBSEndpoint() string {
-	return fmt.Sprintf("obs.%s.myhuaweicloud.com", self.GetId())
+	return getOBSEndpoint(self.GetId())
 }
 
 func (self *SRegion) getOBSClient() (*obs.ObsClient, error) {
 	if self.obsClient == nil {
-		endpoint := self.getOBSEndpoint()
-		obsClient, err := obs.New(self.client.accessKey, self.client.secret, endpoint)
+		obsClient, err := self.client.getOBSClient(self.GetId())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/multicloud/qcloud/qcloud.go
+++ b/pkg/multicloud/qcloud/qcloud.go
@@ -525,7 +525,7 @@ func (client *SQcloudClient) verifyAppId() error {
 		return errors.Wrap(err, "getDefaultRegion")
 	}
 	bucket := SBucket{
-		region: region.(*SRegion),
+		region: region,
 		Name:   "yuniondocument",
 	}
 	cli, err := client.getCosClient(&bucket)
@@ -602,11 +602,12 @@ func (client *SQcloudClient) GetIRegions() []cloudprovider.ICloudRegion {
 	return client.iregions
 }
 
-func (client *SQcloudClient) getDefaultRegion() (cloudprovider.ICloudRegion, error) {
-	if len(client.iregions) > 0 {
-		return client.iregions[0], nil
+func (client *SQcloudClient) getDefaultRegion() (*SRegion, error) {
+	iregion, err := client.getIRegionByRegionId(QCLOUD_DEFAULT_REGION)
+	if err != nil {
+		return nil, errors.Wrap(err, "getIRegionByRegionId")
 	}
-	return nil, cloudprovider.ErrNotFound
+	return iregion.(*SRegion), nil
 }
 
 func (client *SQcloudClient) getIRegionByRegionId(id string) (cloudprovider.ICloudRegion, error) {

--- a/pkg/multicloud/qcloud/storagecache.go
+++ b/pkg/multicloud/qcloud/storagecache.go
@@ -167,7 +167,10 @@ func (self *SStoragecache) uploadImage(ctx context.Context, userCred mcclient.To
 		return "", err
 	}
 
-	bucketName := strings.ToLower(fmt.Sprintf("imgcache-%s-%s", self.region.GetId(), image.ImageId))
+	bucketName := strings.ReplaceAll(strings.ToLower(self.region.GetId()+image.ImageId), "-", "")
+	if len(bucketName) > 40 {
+		bucketName = bucketName[:40]
+	}
 	exists, _ := self.region.IBucketExist(bucketName)
 	if !exists {
 		log.Debugf("Bucket %s not exists, to create ...", bucketName)


### PR DESCRIPTION
Cherry pick of #2267 on release/2.11.

#2267: fix: qcloud storagecache bucket name too long