### PR TITLE
Automated cherry pick of #2276: fix: missing setup managerId for snapshot

### DIFF
--- a/pkg/apis/compute/snapshot.go
+++ b/pkg/apis/compute/snapshot.go
@@ -31,6 +31,7 @@ type SSnapshotCreateInput struct {
 	DiskType      string `json:"disk_type"`
 	CloudregionId string `json:"cloudregion_id"`
 	OutOfChain    bool   `json:"out_of_chain"`
+	ManagerId     string `json:"manager_id"`
 }
 
 type SSnapshotPolicyCreateInput struct {

--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -281,6 +281,10 @@ func (manager *SSnapshotManager) ValidateCreateData(ctx context.Context, userCre
 	if cloudregion := storage.GetRegion(); cloudregion != nil {
 		input.CloudregionId = cloudregion.GetId()
 	}
+	provider := disk.GetCloudprovider()
+	if provider != nil {
+		input.ManagerId = provider.Id
+	}
 	return input.JSON(input), nil
 }
 


### PR DESCRIPTION
Cherry pick of #2276 on release/2.10.0.

#2276: fix: missing setup managerId for snapshot