### PR TITLE
Bugfix: nat task pass paramters through task.Params pass

### DIFF
--- a/pkg/compute/tasks/natdentry_create_task.go
+++ b/pkg/compute/tasks/natdentry_create_task.go
@@ -52,7 +52,7 @@ func (self *SNatDEntryCreateTask) OnInit(ctx context.Context, obj db.IStandalone
 		return
 	}
 
-	externalIPID, err := body.GetString("external_ip_id")
+	externalIPID, err := self.Params.GetString("external_ip_id")
 	// construct a DNat RUle
 	dnatRule := cloudprovider.SNatDRule{
 		Protocol:     dnatEntry.IpProtocol,

--- a/pkg/compute/tasks/natsentry_create_task.go
+++ b/pkg/compute/tasks/natsentry_create_task.go
@@ -52,7 +52,7 @@ func (self *SNatSEntryCreateTask) OnInit(ctx context.Context, obj db.IStandalone
 		return
 	}
 
-	externalIPID, err := body.GetString("external_ip_id")
+	externalIPID, err := self.Params.GetString("external_ip_id")
 	// construct a DNat RUle
 	snatRule := cloudprovider.SNatSRule{
 		SourceCIDR:   snatEntry.SourceCIDR,


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. NewTask传递参数的时候，参数会放到STask.Param里面，而不是OnInit函数的第三个参数里面

**是否需要 backport 到之前的 release 分支**:
- release/2.11
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
