### PR TITLE
Automated cherry pick of #2293: baremetal: raid disk inode inconsistent due to mkfs.ext4 largefile option

### DIFF
--- a/pkg/baremetal/utils/disktool/disktool.go
+++ b/pkg/baremetal/utils/disktool/disktool.go
@@ -108,7 +108,8 @@ func (p *Partition) Format(fs string, uuid string) error {
 		cmdUUID = []string{"/usr/sbin/tune2fs", "-U", uuid}
 	case "ext4":
 		// for baremetal, force 64bit support large disks
-		cmd = []string{"/usr/sbin/mkfs.ext4", "-O", "64bit", "-E", "lazy_itable_init=1", "-T", "largefile"}
+		//cmd = []string{"/usr/sbin/mkfs.ext4", "-O", "64bit", "-E", "lazy_itable_init=1", "-T", "largefile"}
+		cmd = []string{"/usr/sbin/mkfs.ext4", "-O", "64bit", "-E", "lazy_itable_init=1"}
 		cmdUUID = []string{"/usr/sbin/tune2fs", "-U", uuid}
 	case "ext4dev":
 		cmd = []string{"/usr/sbin/mkfs.ext4dev", "-E", "lazy_itable_init=1"}


### PR DESCRIPTION
Cherry pick of #2293 on release/2.10.0.

#2293: baremetal: raid disk inode inconsistent due to mkfs.ext4 largefile option