### PR TITLE
fix: azure快照的磁盘id应该小写

### DIFF
--- a/pkg/multicloud/azure/snapshot.go
+++ b/pkg/multicloud/azure/snapshot.go
@@ -180,7 +180,7 @@ func (self *SRegion) GetISnapshots() ([]cloudprovider.ICloudSnapshot, error) {
 }
 
 func (self *SSnapshot) GetDiskId() string {
-	return self.Properties.CreationData.SourceResourceID
+	return strings.ToLower(self.Properties.CreationData.SourceResourceID)
 }
 
 func (self *SSnapshot) GetDiskType() string {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix: azure快照的磁盘id应该小写

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0

/area region
/cc @swordqiu @yousong 
