### PR TITLE
Automated cherry pick of #2326: fix: azure快照的磁盘id应该小写

### DIFF
--- a/pkg/multicloud/azure/snapshot.go
+++ b/pkg/multicloud/azure/snapshot.go
@@ -180,7 +180,7 @@ func (self *SRegion) GetISnapshots() ([]cloudprovider.ICloudSnapshot, error) {
 }
 
 func (self *SSnapshot) GetDiskId() string {
-	return self.Properties.CreationData.SourceResourceID
+	return strings.ToLower(self.Properties.CreationData.SourceResourceID)
 }
 
 func (self *SSnapshot) GetDiskType() string {


### PR DESCRIPTION
Cherry pick of #2326 on release/2.11.

#2326: fix: azure快照的磁盘id应该小写