### PR TITLE
bugfix: fix managered disk reset not update disk size

### DIFF
--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -1186,7 +1186,20 @@ func (self *SManagedVirtualizationRegionDriver) OnDiskReset(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	return iDisk.Refresh()
+	err = iDisk.Refresh()
+	if err != nil {
+		return err
+	}
+	if disk.DiskSize != iDisk.GetDiskSizeMB() {
+		_, err := db.Update(disk, func() error {
+			disk.DiskSize = iDisk.GetDiskSizeMB()
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (self *SManagedVirtualizationRegionDriver) ValidateCreateSnapshotPolicyData(ctx context.Context, userCred mcclient.TokenCredential, data *compute.SSnapshotPolicyCreateInput) error {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
bugfix: fix managered disk reset not update disk size

**是否需要 backport 到之前的 release 分支**:
release/2.10.0

/cc @swordqiu @zexi @ioito 
/area region
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
