### PR TITLE
fix: project_id/domain_id was cleared after

### DIFF
--- a/pkg/cloudcommon/db/fetch.go
+++ b/pkg/cloudcommon/db/fetch.go
@@ -258,6 +258,8 @@ func FetchProjectInfo(ctx context.Context, data jsonutils.JSONObject) (mcclient.
 			ProjectId: t.Id,
 			Project:   t.Name,
 		}
+		data.(*jsonutils.JSONDict).Set("tenant_id", jsonutils.NewString(t.Id))
+		data.(*jsonutils.JSONDict).Set("domain_id", jsonutils.NewString(t.DomainId))
 		return &ownerId, nil
 	}
 	return FetchDomainInfo(ctx, data)
@@ -275,6 +277,7 @@ func FetchDomainInfo(ctx context.Context, data jsonutils.JSONObject) (mcclient.I
 			return nil, httperrors.NewGeneralError(err)
 		}
 		owner := SOwnerId{DomainId: domain.Id, Domain: domain.Name}
+		data.(*jsonutils.JSONDict).Set("domain_id", jsonutils.NewString(domain.Id))
 		return &owner, nil
 	}
 	return nil, nil


### PR DESCRIPTION
FetchProjectInfo/FetchDomainInfo called

**这个 PR 实现什么功能/修复什么问题**:
修正：调用FetchProject/DomainInfo后清除了query中的project/domain信息，导致出错

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12

/area region