### PR TITLE
Automated cherry pick of #2369: fix: avoid duplicate image uploading if multiple identical instances created at same time

### DIFF
--- a/pkg/multicloud/aliyun/latitud_and_longitude.go
+++ b/pkg/multicloud/aliyun/latitud_and_longitude.go
@@ -28,6 +28,7 @@ var LatitudeAndLongitude = map[string]cloudprovider.SGeographicInfo{
 	"cn-shanghai":    {Latitude: 31.230391, Longitude: 121.473701, City: api.CITY_SHANG_HAI, CountryCode: api.COUNTRY_CODE_CN},
 	"cn-shenzhen":    {Latitude: 22.543097, Longitude: 114.057861, City: api.CITY_SHEN_ZHEN, CountryCode: api.COUNTRY_CODE_CN},
 	"cn-hongkong":    {Latitude: 22.396427, Longitude: 114.109497, City: api.CITY_HONG_KONG, CountryCode: api.COUNTRY_CODE_CN},
+	"cn-chengdu":     {Latitude: 30.572815, Longitude: 104.066803, City: api.CITY_CHENG_DU, CountryCode: api.COUNTRY_CODE_CN},
 	"ap-northeast-1": {Latitude: 35.709026, Longitude: 139.731995, City: api.CITY_TOKYO, CountryCode: api.COUNTRY_CODE_JP},
 	"ap-southeast-1": {Latitude: 1.352083, Longitude: 103.819839, City: api.CITY_SINGAPORE, CountryCode: api.COUNTRY_CODE_SG},
 	"ap-southeast-2": {Latitude: -33.868820, Longitude: 151.209290, City: api.CITY_SYDNEY, CountryCode: api.COUNTRY_CODE_AU},

--- a/pkg/multicloud/aliyun/storagecache.go
+++ b/pkg/multicloud/aliyun/storagecache.go
@@ -115,12 +115,11 @@ func (self *SStoragecache) GetPath() string {
 func (self *SStoragecache) UploadImage(ctx context.Context, userCred mcclient.TokenCredential, image *cloudprovider.SImageCreateOption, isForce bool) (string, error) {
 
 	if len(image.ExternalId) > 0 {
-		log.Debugf("UploadImage: Image external ID exists %s", image.ExternalId)
-
 		status, err := self.region.GetImageStatus(image.ExternalId)
 		if err != nil {
 			log.Errorf("GetImageStatus error %s", err)
 		}
+		log.Debugf("UploadImage: Image external ID %s exists, status %s", image.ExternalId, status)
 		if status == ImageStatusAvailable && !isForce {
 			return image.ExternalId, nil
 		}

--- a/pkg/multicloud/qcloud/instance.go
+++ b/pkg/multicloud/qcloud/instance.go
@@ -570,9 +570,11 @@ func (self *SRegion) doStartVM(instanceId string) error {
 func (self *SRegion) doStopVM(instanceId string, isForce bool) error {
 	params := make(map[string]string)
 	if isForce {
-		params["ForceStop"] = "true"
+		params["ForceStop"] = "TRUE"
+		params["StopType"] = "HARD"
 	} else {
-		params["ForceStop"] = "false"
+		params["ForceStop"] = "FALSE"
+		params["StopType"] = "SOFT"
 	}
 	return self.instanceOperation(instanceId, "StopInstances", params, true)
 }

--- a/pkg/multicloud/qcloud/storagecache.go
+++ b/pkg/multicloud/qcloud/storagecache.go
@@ -137,18 +137,17 @@ func (self *SStoragecache) GetPath() string {
 
 func (self *SStoragecache) UploadImage(ctx context.Context, userCred mcclient.TokenCredential, image *cloudprovider.SImageCreateOption, isForce bool) (string, error) {
 	if len(image.ExternalId) > 0 {
-		log.Debugf("UploadImage: Image external ID exists %s", image.ExternalId)
-
 		status, err := self.region.GetImageStatus(image.ExternalId)
 		if err != nil {
 			log.Errorf("GetImageStatus error %s", err)
 		}
+		log.Debugf("ctx %p UploadImage: Image external ID %s exists, status %s", ctx, image.ExternalId, status)
 		if (status == ImageStatusNormal || status == ImageStatusUsing) && !isForce {
 			return image.ExternalId, nil
 		}
 		log.Debugf("image status: %s isForce: %v", status, isForce)
 	} else {
-		log.Debugf("UploadImage: no external ID")
+		log.Debugf("ctx %s UploadImage: no external ID", ctx)
 	}
 	return self.uploadImage(ctx, userCred, image, isForce)
 }


### PR DESCRIPTION
Cherry pick of #2369 on release/2.12.

#2369: fix: avoid duplicate image uploading if multiple identical instances created at same time