### PR TITLE
Automated cherry pick of #2402: fix: sysadmin should be a system account

### DIFF
--- a/pkg/keystone/models/users.go
+++ b/pkg/keystone/models/users.go
@@ -189,7 +189,7 @@ func (manager *SUserManager) initSysUser() error {
 	usr.Name = api.SystemAdminUser
 	usr.DomainId = api.DEFAULT_DOMAIN_ID
 	usr.Enabled = tristate.True
-	usr.IsSystemAccount = tristate.False
+	usr.IsSystemAccount = tristate.True
 	usr.AllowWebConsole = tristate.False
 	usr.EnableMfa = tristate.False
 	usr.Description = "Boostrap system default admin user"


### PR DESCRIPTION
Cherry pick of #2402 on release/2.12.

#2402: fix: sysadmin should be a system account