### PR TITLE
fix: 避免admin=false时,不显示其余项目下的标签信息

### DIFF
--- a/pkg/cloudcommon/db/metadata.go
+++ b/pkg/cloudcommon/db/metadata.go
@@ -163,7 +163,7 @@ func (manager *SMetadataManager) ListItemFilter(ctx context.Context, q *sqlchemy
 			prefix := sqlchemy.NewStringField(fmt.Sprintf("%s::", man.Keyword()))
 			field := sqlchemy.CONCAT(man.Keyword(), prefix, resourceView.Field("id"))
 			sq := resourceView.Query(field)
-			if !admin || !IsAllowList(rbacutils.ScopeSystem, userCred, man) {
+			if !admin && !IsAllowList(rbacutils.ScopeSystem, userCred, man) {
 				sq = man.FilterByOwner(sq, userCred, man.ResourceScope())
 			}
 			conditions = append(conditions, sqlchemy.In(q.Field("id"), sq))


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免admin=false时,不显示其余项目下的标签信息

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @swordqiu @yousong 
