### PR TITLE
hotfix: 避免上传镜像后,再次获取镜像列表因网络原因导致任务失败

### DIFF
--- a/pkg/compute/guestdrivers/zstack.go
+++ b/pkg/compute/guestdrivers/zstack.go
@@ -44,6 +44,8 @@ func (self *SZStackGuestDriver) DoScheduleMemoryFilter() bool { return true }
 
 func (self *SZStackGuestDriver) DoScheduleSKUFilter() bool { return false }
 
+func (self *SZStackGuestDriver) DoScheduleStorageFilter() bool { return true }
+
 func (self *SZStackGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_ZSTACK
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免上传镜像后,再次获取镜像列表因网络原因导致任务失败

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @swordqiu @yousong 
