### PR TITLE
webconsole: update aliyun vnc base url

### DIFF
--- a/pkg/webconsole/handlers.go
+++ b/pkg/webconsole/handlers.go
@@ -241,7 +241,7 @@ func handleDataSession(sData session.ISessionData, w http.ResponseWriter, connPa
 }
 
 func handleCommandSession(cmd command.ICommand, w http.ResponseWriter) {
-	handleDataSession(cmd, w, nil)
+	handleDataSession(session.WrapCommandSession(cmd), w, nil)
 }
 
 func sendJSON(w http.ResponseWriter, body jsonutils.JSONObject) {

--- a/pkg/webconsole/server/websockify_server.go
+++ b/pkg/webconsole/server/websockify_server.go
@@ -89,6 +89,10 @@ func (s *WebsockifyServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *WebsockifyServer) doProxy(wsConn *websocket.Conn, tcpConn net.Conn) {
+	s.Session.RegisterDuplicateHook(func() {
+		wsConn.Close()
+		tcpConn.Close()
+	})
 	go s.wsToTcp(wsConn, tcpConn)
 	s.tcpToWs(wsConn, tcpConn)
 }

--- a/pkg/webconsole/session/remote_console.go
+++ b/pkg/webconsole/session/remote_console.go
@@ -123,6 +123,10 @@ func (info *RemoteConsoleInfo) GetPassword() string {
 	return info.VncPassword
 }
 
+func (info *RemoteConsoleInfo) GetId() string {
+	return info.Id
+}
+
 func (info *RemoteConsoleInfo) getConnParamsURL(baseURL string, params url.Values) string {
 	if params == nil {
 		params = url.Values{}
@@ -142,7 +146,7 @@ func (info *RemoteConsoleInfo) getAliyunURL() (string, error) {
 	if info.OsName == "Windows" {
 		isWindows = "True"
 	}
-	base := "https://g.alicdn.com/aliyun/ecs-console-vnc/0.0.7/index.html"
+	base := "https://g.alicdn.com/aliyun/ecs-console-vnc2/0.0.5/index.html"
 	params := url.Values{
 		"vncUrl":     {info.Url},
 		"instanceId": {info.InstanceId},


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

- 更新 aliyun vnc 连接地址
- 确保同一虚拟机只能打开一个 vnc 链接

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.10.0

/area webconsole
/cc @swordqiu 