### PR TITLE
Bugfix: nat delete

### DIFF
--- a/pkg/apis/compute/natgateway.go
+++ b/pkg/apis/compute/natgateway.go
@@ -20,6 +20,7 @@ const (
 	NAT_STATUS_DEPLOYING     = "deploying" //配置中
 	NAT_STATUS_UNKNOWN       = "unknown"
 	NAT_STATUS_FAILED        = "failed"
+	NAT_STATUS_START_DELETE  = "start_delete"
 	NAT_STATUS_DELETED       = "deleted"
 	NAT_STATUS_DELETING      = "deleting"
 	NAT_STATUS_DELETE_FAILED = "delete_failed"

--- a/pkg/compute/models/purge.go
+++ b/pkg/compute/models/purge.go
@@ -995,6 +995,28 @@ func (vpc *SVpc) Purge(ctx context.Context, userCred mcclient.TokenCredential) e
 	return vpc.RealDelete(ctx, userCred)
 }
 
+func (dn *SNatDEntry) Purge(ctx context.Context, userCred mcclient.TokenCredential) error {
+	lockman.LockObject(ctx, dn)
+	defer lockman.ReleaseObject(ctx, dn)
+
+	err := dn.ValidateDeleteCondition(ctx)
+	if err != nil {
+		return err
+	}
+	return dn.RealDelete(ctx, userCred)
+}
+
+func (sn *SNatSEntry) Purge(ctx context.Context, userCred mcclient.TokenCredential) error {
+	lockman.LockObject(ctx, sn)
+	defer lockman.ReleaseObject(ctx, sn)
+
+	err := sn.ValidateDeleteCondition(ctx)
+	if err != nil {
+		return err
+	}
+	return sn.RealDelete(ctx, userCred)
+}
+
 func (manager *SCloudproviderregionManager) purgeAll(ctx context.Context, userCred mcclient.TokenCredential, providerId string) error {
 	cprs, err := CloudproviderRegionManager.fetchRecordsByCloudproviderId(providerId)
 	if err != nil {

--- a/pkg/compute/tasks/natdentry_delete_task.go
+++ b/pkg/compute/tasks/natdentry_delete_task.go
@@ -58,7 +58,12 @@ func (self *SNatDEntryDeleteTask) OnInit(ctx context.Context, obj db.IStandalone
 	if err != nil {
 		self.taskFailed(ctx, dnatEntry, errors.Wrapf(err, "Delete DNat Entry '%s' failed", dnatEntry.ExternalId))
 	}
-	dnatEntry.SetStatus(self.UserCred, api.NAT_STATUS_DELETED, "")
+
+	err = dnatEntry.Purge(ctx, self.UserCred)
+	if err != nil {
+		self.taskFailed(ctx, dnatEntry, err)
+		return
+	}
 
 	logclient.AddActionLogWithStartable(self, dnatEntry, logclient.ACT_DELETE, nil, self.UserCred, true)
 	self.SetStageComplete(ctx, nil)

--- a/pkg/compute/tasks/natsentry_delete_task.go
+++ b/pkg/compute/tasks/natsentry_delete_task.go
@@ -58,7 +58,12 @@ func (self *SNatSEntryDeleteTask) OnInit(ctx context.Context, obj db.IStandalone
 	if err != nil {
 		self.taskFailed(ctx, snatEntry, errors.Wrapf(err, "Delete SNat Entry '%s' failed", snatEntry.ExternalId))
 	}
-	snatEntry.SetStatus(self.UserCred, api.NAT_STATUS_DELETED, "")
+
+	err = snatEntry.Purge(ctx, self.UserCred)
+	if err != nil {
+		self.taskFailed(ctx, snatEntry, err)
+		return
+	}
 
 	logclient.AddActionLogWithStartable(self, snatEntry, logclient.ACT_DELETE, nil, self.UserCred, true)
 	self.SetStageComplete(ctx, nil)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复：
nat delete 的时候应该先删除云上的资源然后，再删除本地的，所以应该override Delete函数，然后写一个realDelete函数用来删除本地的，并在delete task 中删除云上资源成功后调用这个函数，syncremove中也应该调用这个函数。

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
