### PR TITLE
Automated cherry pick of #2442: nat delele should overvide Delete() and call RealDelete() after delete cloud resource successfully

### DIFF
--- a/pkg/apis/compute/natgateway.go
+++ b/pkg/apis/compute/natgateway.go
@@ -20,6 +20,7 @@ const (
 	NAT_STATUS_DEPLOYING     = "deploying" //配置中
 	NAT_STATUS_UNKNOWN       = "unknown"
 	NAT_STATUS_FAILED        = "failed"
+	NAT_STATUS_START_DELETE  = "start_delete"
 	NAT_STATUS_DELETED       = "deleted"
 	NAT_STATUS_DELETING      = "deleting"
 	NAT_STATUS_DELETE_FAILED = "delete_failed"

--- a/pkg/compute/models/purge.go
+++ b/pkg/compute/models/purge.go
@@ -995,6 +995,28 @@ func (vpc *SVpc) Purge(ctx context.Context, userCred mcclient.TokenCredential) e
 	return vpc.RealDelete(ctx, userCred)
 }
 
+func (dn *SNatDEntry) Purge(ctx context.Context, userCred mcclient.TokenCredential) error {
+	lockman.LockObject(ctx, dn)
+	defer lockman.ReleaseObject(ctx, dn)
+
+	err := dn.ValidateDeleteCondition(ctx)
+	if err != nil {
+		return err
+	}
+	return dn.RealDelete(ctx, userCred)
+}
+
+func (sn *SNatSEntry) Purge(ctx context.Context, userCred mcclient.TokenCredential) error {
+	lockman.LockObject(ctx, sn)
+	defer lockman.ReleaseObject(ctx, sn)
+
+	err := sn.ValidateDeleteCondition(ctx)
+	if err != nil {
+		return err
+	}
+	return sn.RealDelete(ctx, userCred)
+}
+
 func (manager *SCloudproviderregionManager) purgeAll(ctx context.Context, userCred mcclient.TokenCredential, providerId string) error {
 	cprs, err := CloudproviderRegionManager.fetchRecordsByCloudproviderId(providerId)
 	if err != nil {

--- a/pkg/compute/tasks/natdentry_delete_task.go
+++ b/pkg/compute/tasks/natdentry_delete_task.go
@@ -58,7 +58,12 @@ func (self *SNatDEntryDeleteTask) OnInit(ctx context.Context, obj db.IStandalone
 	if err != nil {
 		self.taskFailed(ctx, dnatEntry, errors.Wrapf(err, "Delete DNat Entry '%s' failed", dnatEntry.ExternalId))
 	}
-	dnatEntry.SetStatus(self.UserCred, api.NAT_STATUS_DELETED, "")
+
+	err = dnatEntry.Purge(ctx, self.UserCred)
+	if err != nil {
+		self.taskFailed(ctx, dnatEntry, err)
+		return
+	}
 
 	logclient.AddActionLogWithStartable(self, dnatEntry, logclient.ACT_DELETE, nil, self.UserCred, true)
 	self.SetStageComplete(ctx, nil)

--- a/pkg/compute/tasks/natsentry_delete_task.go
+++ b/pkg/compute/tasks/natsentry_delete_task.go
@@ -58,7 +58,12 @@ func (self *SNatSEntryDeleteTask) OnInit(ctx context.Context, obj db.IStandalone
 	if err != nil {
 		self.taskFailed(ctx, snatEntry, errors.Wrapf(err, "Delete SNat Entry '%s' failed", snatEntry.ExternalId))
 	}
-	snatEntry.SetStatus(self.UserCred, api.NAT_STATUS_DELETED, "")
+
+	err = snatEntry.Purge(ctx, self.UserCred)
+	if err != nil {
+		self.taskFailed(ctx, snatEntry, err)
+		return
+	}
 
 	logclient.AddActionLogWithStartable(self, snatEntry, logclient.ACT_DELETE, nil, self.UserCred, true)
 	self.SetStageComplete(ctx, nil)


### PR DESCRIPTION
Cherry pick of #2442 on release/2.11.

#2442: nat delele should overvide Delete() and call RealDelete() after delete cloud resource successfully