### PR TITLE
scheduler: sku not unmarshal to ServerConfigs

### DIFF
--- a/pkg/cloudcommon/cmdline/helper.go
+++ b/pkg/cloudcommon/cmdline/helper.go
@@ -294,6 +294,10 @@ func FetchServerConfigsByJSON(obj jsonutils.JSONObject) (*compute.ServerConfigs,
 		return nil, err
 	}
 
+	if instanceType, _ := obj.GetString("sku"); instanceType != "" {
+		conf.InstanceType = instanceType
+	}
+
 	var err error
 	conf.Disks, err = FetchDiskConfigsByJSON(obj)
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

调度的 forecast 接口没有感知到 sku 参数

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- 2.10

/cc @wanyaoqi 