### PR TITLE
Automated cherry pick of #2465: fix: a join update is allowed if one of the joint models is allowed to update

### DIFF
--- a/pkg/cloudcommon/db/rbac.go
+++ b/pkg/cloudcommon/db/rbac.go
@@ -72,7 +72,7 @@ func isObjectRbacAllowed(model IModel, userCred mcclient.TokenCredential, action
 }
 
 func isJointObjectRbacAllowed(item IJointModel, userCred mcclient.TokenCredential, action string, extra ...string) bool {
-	return isObjectRbacAllowed(item.Master(), userCred, action, extra...) && isObjectRbacAllowed(item.Slave(), userCred, action, extra...)
+	return isObjectRbacAllowed(item.Master(), userCred, action, extra...) || isObjectRbacAllowed(item.Slave(), userCred, action, extra...)
 }
 
 func isClassRbacAllowed(manager IModelManager, userCred mcclient.TokenCredential, objOwnerId mcclient.IIdentityProvider, action string, extra ...string) bool {


### PR DESCRIPTION
Cherry pick of #2465 on release/2.10.0.

#2465: fix: a join update is allowed if one of the joint models is allowed to update