### PR TITLE
scheduler: fix disk or net specify resource id execute schedtag filter

### DIFF
--- a/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
@@ -56,6 +56,10 @@ func (d diskW) ResourceKeyword() string {
 	return "storage"
 }
 
+func (d diskW) IsSpecifyResource() bool {
+	return d.Storage != ""
+}
+
 func (d diskW) GetSchedtags() []*computeapi.SchedtagConfig {
 	return d.DiskConfig.Schedtags
 }

--- a/pkg/scheduler/algorithm/predicates/network_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/network_schedtag_predicate.go
@@ -59,6 +59,10 @@ func (n netW) ResourceKeyword() string {
 	return "network"
 }
 
+func (n netW) IsSpecifyResource() bool {
+	return n.Network != ""
+}
+
 func (n netW) GetSchedtags() []*computeapi.SchedtagConfig {
 	return n.NetworkConfig.Schedtags
 }

--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -282,6 +282,7 @@ func (p *PredicatedSchedtagResource) hasAvoidTags() bool {
 type ISchedtagCustomer interface {
 	JSON(interface{}) *jsonutils.JSONDict
 	Keyword() string
+	IsSpecifyResource() bool
 	GetSchedtags() []*computeapi.SchedtagConfig
 	ResourceKeyword() string
 }
@@ -330,7 +331,7 @@ func (p *BaseSchedtagPredicate) check(input ISchedtagCustomer, candidate ISchedt
 	res := &PredicatedSchedtagResource{
 		ISchedtagCandidateResource: candidate,
 	}
-	if shouldExec {
+	if shouldExec && !input.IsSpecifyResource() {
 		if err := tagPredicate.Check(
 			SchedtagResourceW{
 				candidater: candidate,


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复磁盘或者网络指定对应资源时，调度标签继续生效的问题

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- 2.10

/cc @swordqiu 
/area scheduler 
