### PR TITLE
fix: sync status after guest sync conf

### DIFF
--- a/pkg/compute/tasks/guest_change_config_task.go
+++ b/pkg/compute/tasks/guest_change_config_task.go
@@ -239,7 +239,7 @@ func (self *GuestChangeConfigTask) OnGuestChangeCpuMemSpecCompleteFailed(ctx con
 func (self *GuestChangeConfigTask) OnGuestChangeCpuMemSpecFinish(ctx context.Context, guest *models.SGuest) {
 	models.HostManager.ClearSchedDescCache(guest.HostId)
 	self.SetStage("OnSyncConfigComplete", nil)
-	err := guest.StartSyncTask(ctx, self.UserCred, false, self.GetTaskId())
+	err := guest.StartSyncTaskWithoutSyncstatus(ctx, self.UserCred, false, self.GetTaskId())
 	if err != nil {
 		self.markStageFailed(ctx, guest, fmt.Sprintf("StartSyncstatus fail %s", err))
 		return


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免同步虚拟机状态两次，导致第二次change-config task未完成时虚拟机状态已经是ready

**是否需要 backport 到之前的 release 分支**:
- release/2.8.0

/area region
/cc @swordqiu @yousong 
