### PR TITLE
fix: bucket mkdir may create path with empty whitespaces

### DIFF
--- a/pkg/compute/models/buckets.go
+++ b/pkg/compute/models/buckets.go
@@ -630,10 +630,7 @@ func (bucket *SBucket) PerformMakedir(
 	data jsonutils.JSONObject,
 ) (jsonutils.JSONObject, error) {
 	key, _ := data.GetString("key")
-	for len(key) > 0 && key[len(key)-1] == '/' {
-		key = key[:len(key)-1]
-	}
-
+	key = strings.Trim(key, " /")
 	if len(key) == 0 {
 		return nil, httperrors.NewInputParameterError("empty directory name")
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：bucket mkdir不能创建只有空格的目录

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12

/area region