### PR TITLE
Automated cherry pick of #2536: fix: bucket mkdir may create path with empty whitespaces

### DIFF
--- a/pkg/compute/models/buckets.go
+++ b/pkg/compute/models/buckets.go
@@ -630,10 +630,7 @@ func (bucket *SBucket) PerformMakedir(
 	data jsonutils.JSONObject,
 ) (jsonutils.JSONObject, error) {
 	key, _ := data.GetString("key")
-	for len(key) > 0 && key[len(key)-1] == '/' {
-		key = key[:len(key)-1]
-	}
-
+	key = strings.Trim(key, " /")
 	if len(key) == 0 {
 		return nil, httperrors.NewInputParameterError("empty directory name")
 	}


### PR DESCRIPTION
Cherry pick of #2536 on release/2.12.

#2536: fix: bucket mkdir may create path with empty whitespaces