### PR TITLE
fix: 宿主机下线时，需要将宿主机底下的虚拟机状态设为unknown

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -1369,6 +1369,13 @@ func (self *SHost) syncRemoveCloudHost(ctx context.Context, userCred mcclient.To
 		if err == nil {
 			_, err = self.PerformDisable(ctx, userCred, nil, nil)
 		}
+		guests := self.GetGuests()
+		for _, guest := range guests {
+			err = guest.SetStatus(userCred, api.VM_UNKNOWN, "sync to delete")
+			if err != nil {
+				return err
+			}
+		}
 	} else {
 		err = self.RealDelete(ctx, userCred)
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
宿主机下线时，需要将宿主机底下的虚拟机状态设为unknown

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @swordqiu @yousong 
