### PR TITLE
policy: 将lb集群相关资源归入系统资源类

### DIFF
--- a/pkg/cloudcommon/policy/resources.go
+++ b/pkg/cloudcommon/policy/resources.go
@@ -34,6 +34,8 @@ var (
 		"reservedips",
 		"dnsrecords",
 		"metadatas",
+		"loadbalancerclusters",
+		"loadbalanceragents",
 	}
 	computeDomainResources = []string{
 		"cloudaccounts",


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

policy: 将lb集群相关资源归入系统资源类

**是否需要 backport 到之前的 release 分支**:

- release/2.10.0

/area region
/cc @swordqiu @tb365 