### PR TITLE
Automated cherry pick of #2573: policy: 将lb集群相关资源归入系统资源类

### DIFF
--- a/pkg/cloudcommon/policy/resources.go
+++ b/pkg/cloudcommon/policy/resources.go
@@ -35,6 +35,8 @@ var (
 		"reservedips",
 		"dnsrecords",
 		"metadatas",
+		"loadbalancerclusters",
+		"loadbalanceragents",
 	}
 	computeDomainResources = []string{
 		"cloudaccounts",


### PR DESCRIPTION
Cherry pick of #2573 on release/2.10.0.

#2573: policy: 将lb集群相关资源归入系统资源类