### PR TITLE
Bugfix: natgateway ouput and snat dnap create parameters

### DIFF
--- a/docs/schemas/natgateway.yaml
+++ b/docs/schemas/natgateway.yaml
@@ -51,7 +51,7 @@ NatGateway:
     nat_spec:
       type: string
       description: NAT网关规格
-      example: Small
+      example: small
     region:
       type: string
       description: 所属的区域

--- a/pkg/apis/compute/nat.go
+++ b/pkg/apis/compute/nat.go
@@ -1,0 +1,27 @@
+package compute
+
+import "yunion.io/x/onecloud/pkg/apis"
+
+type SNatSCreateInput struct {
+	apis.Meta
+
+	Name         string
+	NatgatewayId string
+	NetWorkId    string
+	Ip           string
+	ExternalIpId string
+	SourceCidr   string
+}
+
+type SNatDCreateInput struct {
+	apis.Meta
+
+	Name         string
+	NatgatewayId string
+	InternalIp   string
+	InternalPort int
+	ExternalIp   string
+	ExternalIpId string
+	ExternalPort int
+	IpProtocol   string
+}

--- a/pkg/compute/models/natgateways.go
+++ b/pkg/compute/models/natgateways.go
@@ -58,7 +58,7 @@ type SNatGateway struct {
 	SBillingResourceBase
 
 	VpcId   string `width:"36" charset:"ascii" nullable:"false" list:"user" create:"optional"`
-	NatSpec string `list:"user" get:"user" list:"user" create:"optional"` // NAT规格
+	NatSpec string `list:"user" create:"optional"` // NAT规格
 }
 
 func (manager *SNatGetewayManager) GetContextManagers() [][]db.IModelManager {
@@ -153,6 +153,8 @@ func (self *SNatGateway) GetExtraDetails(ctx context.Context, userCred mcclient.
 	if err != nil {
 		return nil, err
 	}
+	spec := self.GetRegion().GetDriver().DealNatGatewaySpec(self.NatSpec)
+	extra.Add(jsonutils.NewString(spec), "nat_spec")
 	return extra, nil
 }
 
@@ -172,6 +174,8 @@ func (self *SNatGateway) GetCustomizeColumns(ctx context.Context, userCred mccli
 		return extra
 	}
 	extra.Add(jsonutils.NewString(vpc.Name), "vpc")
+	spec := self.GetRegion().GetDriver().DealNatGatewaySpec(self.NatSpec)
+	extra.Add(jsonutils.NewString(spec), "nat_spec")
 	return extra
 }
 

--- a/pkg/compute/models/regiondrivers.go
+++ b/pkg/compute/models/regiondrivers.go
@@ -97,6 +97,9 @@ type IRegionDriver interface {
 	RequestApplySnapshotPolicy(ctx context.Context, userCred mcclient.TokenCredential, sp *SSnapshotPolicy, task taskman.ITask, diskId string) error
 	RequestCancelSnapshotPolicy(ctx context.Context, userCred mcclient.TokenCredential, sp *SSnapshotPolicy, task taskman.ITask, diskId string) error
 	OnSnapshotDelete(ctx context.Context, snapshot *SSnapshot, task taskman.ITask, data jsonutils.JSONObject) error
+
+	//Nat gateway
+	DealNatGatewaySpec(spec string) string
 }
 
 var regionDrivers map[string]IRegionDriver

--- a/pkg/compute/regiondrivers/aliyun.go
+++ b/pkg/compute/regiondrivers/aliyun.go
@@ -841,3 +841,19 @@ func (self *SAliyunRegionDriver) ValidateSnapshotCreate(ctx context.Context, use
 	}
 	return nil
 }
+
+func (self *SAliyunRegionDriver) DealNatGatwaySpec(spec string) string {
+
+	switch spec {
+	case "Small":
+		return "small"
+	case "Midele":
+		return "middle"
+	case "Large":
+		return "large"
+	case "XLarge":
+		return "xlarge"
+	}
+	//can arrive
+	return ""
+}

--- a/pkg/compute/regiondrivers/huawei.go
+++ b/pkg/compute/regiondrivers/huawei.go
@@ -1457,3 +1457,19 @@ func (self *SHuaWeiRegionDriver) RequestCreateLoadbalancerListenerRule(ctx conte
 	})
 	return nil
 }
+
+func (self *SHuaWeiRegionDriver) DealNatGatwaySpec(spec string) string {
+
+	switch spec {
+	case "1":
+		return "small"
+	case "2":
+		return "middle"
+	case "3":
+		return "large"
+	case "4":
+		return "xlarge"
+	}
+	//can arrive
+	return ""
+}

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -814,3 +814,7 @@ func (self *SKVMRegionDriver) OnSnapshotDelete(ctx context.Context, snapshot *mo
 	task.ScheduleRun(data)
 	return nil
 }
+
+func (self *SKVMRegionDriver) DealNatGatewaySpec(spec string) string {
+	return spec
+}

--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -1232,3 +1232,7 @@ func (self *SManagedVirtualizationRegionDriver) OnSnapshotDelete(ctx context.Con
 	task.ScheduleRun(data)
 	return nil
 }
+
+func (self *SManagedVirtualizationRegionDriver) DealNatGatewaySpec(spec string) string {
+	return spec
+}

--- a/pkg/multicloud/huawei/natgateway.go
+++ b/pkg/multicloud/huawei/natgateway.go
@@ -55,18 +55,19 @@ func (gateway *SNatGateway) GetStatus() string {
 }
 
 func (gateway *SNatGateway) GetNatSpec() string {
-	switch gateway.Spec {
-	case "1":
-		return "small"
-	case "2":
-		return "middle"
-	case "3":
-		return "large"
-	case "4":
-		return "xlarge"
-	}
-	// can't arrive
-	return ""
+	return gateway.Spec
+	//switch gateway.Spec {
+	//case "1":
+	//	return "small"
+	//case "2":
+	//	return "middle"
+	//case "3":
+	//	return "large"
+	//case "4":
+	//	return "xlarge"
+	//}
+	//// can't arrive
+	//return ""
 }
 
 func (gateway *SNatGateway) GetDescription() string {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 创建snat和dnat时，前端传来参数中的eip id应该是id不是externalid，添加检验的eip的函数
2. natgateway的spec，应该做成sku，但是现在不用支持创建，所以，暂时用driver来控制spec的前端显示。

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12

/cc @swordqiu @zexi 
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
