### PR TITLE
Automated cherry pick of #2603: mcclient: ansibleplaybooks: 注册为v2接口

### DIFF
--- a/pkg/mcclient/modules/mod_ansibleplaybooks.go
+++ b/pkg/mcclient/modules/mod_ansibleplaybooks.go
@@ -37,5 +37,5 @@ func init() {
 			[]string{},
 		),
 	}
-	register(&AnsiblePlaybooks)
+	registerV2(&AnsiblePlaybooks)
 }


### PR DESCRIPTION
Cherry pick of #2603 on release/2.12.

#2603: mcclient: ansibleplaybooks: 注册为v2接口