### PR TITLE
Bugfix: natgateway snat dnat

### DIFF
--- a/cmd/climc/shell/natstable.go
+++ b/cmd/climc/shell/natstable.go
@@ -60,7 +60,8 @@ func init() {
 		params.Add(jsonutils.NewString(args.NATGATEWAYID), "natgateway_id")
 		params.Add(jsonutils.NewString(args.IP), "ip")
 		params.Add(jsonutils.NewString(args.EXTERNALIPID), "external_ip_id")
-		params.Add(jsonutils.NewString(args.SOURCECIDR), "source_cidr")
+		params.Add(jsonutils.NewString(args.SourceCIDR), "source_cidr")
+		params.Add(jsonutils.NewString(args.NetworkID), "network_id")
 
 		result, err := modules.NatSTable.Create(s, params)
 		if err != nil {

--- a/docs/natgateway/dnatentries.yaml
+++ b/docs/natgateway/dnatentries.yaml
@@ -3,9 +3,7 @@ get:
   parameters:
     - $ref: "../parameters/common.yaml#/offset"
     - $ref: "../parameters/common.yaml#/limit"
-    - $ref: "../parameters/common.yaml#/provider"
     - $ref: "../parameters/common.yaml#/account"
-    - $ref: "../parameters/common.yaml#/cloudprovider"
     - $ref: "../parameters/common.yaml#/brand"
 
     - $ref: "../parameters/natgateway.yaml#/natgateway"

--- a/docs/natgateway/snatentries.yaml
+++ b/docs/natgateway/snatentries.yaml
@@ -4,11 +4,8 @@ get:
     - $ref: "../parameters/common.yaml#/limit"
     - $ref: "../parameters/common.yaml#/offset"
     - $ref: "../parameters/common.yaml#/network"
-    - $ref: "../parameters/common.yaml#/provider"
     - $ref: "../parameters/common.yaml#/account"
-    - $ref: "../parameters/common.yaml#/cloudprovider"
     - $ref: "../parameters/common.yaml#/brand"
-
     - $ref: "../parameters/natgateway.yaml#/natgateway"
 
   responses:

--- a/docs/schemas/natgateway.yaml
+++ b/docs/schemas/natgateway.yaml
@@ -51,7 +51,7 @@ NatGateway:
     nat_spec:
       type: string
       description: NAT网关规格
-      example: Small
+      example: small
     region:
       type: string
       description: 所属的区域
@@ -335,7 +335,7 @@ SNatEntryCreate:
         network_id:
           type: string
           example: 648a6baa-9827-49b1-8831-278a889154a1
-          description: 所属网络ID
+          description: 所属网络ID(与source_cidr互斥，只需要传入一个)
         ip:
           type: string
           example: 49.4.12.184
@@ -343,8 +343,8 @@ SNatEntryCreate:
         external_ip_id:
           type: string
           example: ""
-          description: 公网IP对应的ID，除了华为云，可以为空
+          description: 公网IP对应的ID
         source_cidr:
           type: string
           example: 192.168.1.0/24
-          description: 映射到公网IP的内网网段
+          description: 映射到公网IP的内网网段(和network_id互斥，只需要传入一个）

--- a/pkg/apis/compute/nat.go
+++ b/pkg/apis/compute/nat.go
@@ -1,0 +1,27 @@
+package compute
+
+import "yunion.io/x/onecloud/pkg/apis"
+
+type SNatSCreateInput struct {
+	apis.Meta
+
+	Name         string
+	NatgatewayId string
+	NetworkId    string
+	Ip           string
+	ExternalIpId string
+	SourceCidr   string
+}
+
+type SNatDCreateInput struct {
+	apis.Meta
+
+	Name         string
+	NatgatewayId string
+	InternalIp   string
+	InternalPort int
+	ExternalIp   string
+	ExternalIpId string
+	ExternalPort int
+	IpProtocol   string
+}

--- a/pkg/apis/compute/natgateway.go
+++ b/pkg/apis/compute/natgateway.go
@@ -15,15 +15,19 @@
 package compute
 
 const (
-	NAT_STAUTS_AVAILABLE     = "available" //可用
-	NAT_STATUS_ALLOCATE      = "allocate"  //创建中
-	NAT_STATUS_DEPLOYING     = "deploying" //配置中
-	NAT_STATUS_UNKNOWN       = "unknown"
-	NAT_STATUS_FAILED        = "failed"
-	NAT_STATUS_START_DELETE  = "start_delete"
-	NAT_STATUS_DELETED       = "deleted"
-	NAT_STATUS_DELETING      = "deleting"
-	NAT_STATUS_DELETE_FAILED = "delete_failed"
+	NAT_STAUTS_AVAILABLE     = "available"     //可用
+	NAT_STATUS_ALLOCATE      = "allocate"      //创建中
+	NAT_STATUS_DEPLOYING     = "deploying"     //配置中
+	NAT_STATUS_UNKNOWN       = "unknown"       //未知状态
+	NAT_STATUS_FAILED        = "failed"        //创建失败
+	NAT_STATUS_DELETED       = "deleted"       //删除
+	NAT_STATUS_DELETING      = "deleting"      //删除中
+	NAT_STATUS_DELETE_FAILED = "delete_failed" //删除失败
+
+	NAT_SPEC_SMALL  = "small"  //小型
+	NAT_SPEC_MIDDLE = "middle" //中型
+	NAT_SPEC_LARGE  = "large"  //大型
+	NAT_SPEC_XLARGE = "xlarge" //超大型
 
 	QCLOUD_NAT_SPEC_SMALL  = "small"
 	QCLOUD_NAT_SPEC_MIDDLE = "middle"

--- a/pkg/cloudprovider/nat.go
+++ b/pkg/cloudprovider/nat.go
@@ -22,6 +22,7 @@ package cloudprovider
 
 type SNatSRule struct {
 	SourceCIDR string
+	NetworkID  string
 
 	ExternalIP   string
 	ExternalIPID string

--- a/pkg/compute/models/natgateways.go
+++ b/pkg/compute/models/natgateways.go
@@ -16,6 +16,7 @@ package models
 
 import (
 	"context"
+	"fmt"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
@@ -58,7 +59,7 @@ type SNatGateway struct {
 	SBillingResourceBase
 
 	VpcId   string `width:"36" charset:"ascii" nullable:"false" list:"user" create:"optional"`
-	NatSpec string `list:"user" get:"user" list:"user" create:"optional"` // NAT规格
+	NatSpec string `list:"user" create:"optional"` // NAT规格
 }
 
 func (manager *SNatGetewayManager) GetContextManagers() [][]db.IModelManager {
@@ -153,7 +154,7 @@ func (self *SNatGateway) GetExtraDetails(ctx context.Context, userCred mcclient.
 	if err != nil {
 		return nil, err
 	}
-	return extra, nil
+	return self.getMoreDetails(ctx, userCred, extra)
 }
 
 func (self *SNatGateway) GetCustomizeColumns(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) *jsonutils.JSONDict {
@@ -172,7 +173,17 @@ func (self *SNatGateway) GetCustomizeColumns(ctx context.Context, userCred mccli
 		return extra
 	}
 	extra.Add(jsonutils.NewString(vpc.Name), "vpc")
+	extra, _ = self.getMoreDetails(ctx, userCred, extra)
 	return extra
+}
+
+func (self *SNatGateway) getMoreDetails(ctx context.Context, userCred mcclient.TokenCredential,
+	extra *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
+
+	spec := self.GetRegion().GetDriver().DealNatGatewaySpec(self.NatSpec)
+	extra.Add(jsonutils.NewString(spec), "nat_spec")
+
+	return extra, nil
 }
 
 func (manager *SNatGetewayManager) SyncNatGateways(ctx context.Context, userCred mcclient.TokenCredential, syncOwnerId mcclient.IIdentityProvider, provider *SCloudprovider, vpc *SVpc, cloudNatGateways []cloudprovider.ICloudNatGateway) ([]SNatGateway, []cloudprovider.ICloudNatGateway, compare.SyncResult) {
@@ -386,4 +397,40 @@ func (self *SNatGateway) GetINatGateway() (cloudprovider.ICloudNatGateway, error
 		}
 	}
 	return nil, errors.Error("CloudNatGateway Not Found")
+}
+
+func (self *SNatGateway) RealDelete(ctx context.Context, userCred mcclient.TokenCredential) error {
+	dnats, err := self.GetDTable()
+	if err != nil {
+		return errors.Wrap(err, "fetch dnat table failed")
+	}
+	snats, err := self.GetSTable()
+	if err != nil {
+		return errors.Wrap(err, "fetch snat table failed")
+	}
+	for i := range dnats {
+		err = dnats[i].RealDelete(ctx, userCred)
+		if err != nil {
+			return errors.Wrapf(err, "delete dnat %s failed", dnats[i].GetId())
+		}
+	}
+	for i := range snats {
+		err = snats[i].RealDelete(ctx, userCred)
+		if err != nil {
+			return errors.Wrapf(err, "delete snat %s failed", snats[i].GetId())
+		}
+	}
+	return self.Delete(ctx, userCred)
+}
+
+func (self *SNatGateway) GetIRegion() (cloudprovider.ICloudRegion, error) {
+	provider, err := self.GetDriver()
+	if err != nil {
+		return nil, fmt.Errorf("No cloudprovider for sp %s: %s", self.Name, err)
+	}
+	region := self.GetRegion()
+	if region == nil {
+		return nil, fmt.Errorf("failed to find region for sp %s", self.Name)
+	}
+	return provider.GetIRegionById(region.ExternalId)
 }

--- a/pkg/compute/models/natstable.go
+++ b/pkg/compute/models/natstable.go
@@ -21,6 +21,7 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/compare"
+	"yunion.io/x/pkg/util/regutils"
 	"yunion.io/x/sqlchemy"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
@@ -29,6 +30,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 
@@ -57,7 +59,7 @@ type SNatSEntry struct {
 	IP         string `width:"17" charset:"ascii" list:"user" create:"required"`
 	SourceCIDR string `width:"22" charset:"ascii" list:"user" create:"required"`
 
-	NetworkId    string `width:"36" charset:"ascii" nullable:"false" list:"user" create:"optional"`
+	NetworkId    string `width:"36" charset:"ascii" list:"user" create:"optional"`
 	NatgatewayId string `width:"36" charset:"ascii" nullable:"false" list:"user" create:"required"`
 }
 
@@ -126,9 +128,62 @@ func (man *SNatSEntryManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQ
 }
 
 func (man *SNatSEntryManager) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
-	if !data.Contains("external_ip_id") {
-		return nil, errors.Error("Request body should contain key 'externalIpId'")
+	input := &api.SNatSCreateInput{}
+	err := data.Unmarshal(input)
+	if err != nil {
+		return nil, httperrors.NewInputParameterError("Unmarshal input failed %s", err)
 	}
+	if len(input.NatgatewayId) == 0 || len(input.ExternalIpId) == 0 || len(input.Ip) == 0 {
+		return nil, httperrors.NewMissingParameterError("natgateway_id or external_ip_id or ip")
+	}
+	if len(input.SourceCidr) == 0 && len(input.NetworkId) == 0 {
+		return nil, httperrors.NewMissingParameterError("sourceCIDR or network_id")
+	}
+	if len(input.SourceCidr) != 0 && len(input.NetworkId) != 0 {
+		return nil, httperrors.NewInputParameterError("Only one of that sourceCIDR and netword_id is needed")
+	}
+	if len(input.SourceCidr) != 0 {
+		if !regutils.MatchCIDR(input.SourceCidr) {
+			return nil, httperrors.NewInputParameterError("invalid sourcecidr: %s", input.SourceCidr)
+		}
+		//todo check cidr is in range vpc
+	} else {
+		model, err := NetworkManager.FetchById(input.NetworkId)
+		if err != nil {
+			return nil, errors.Wrap(err, "fetch network error")
+		}
+		if model == nil {
+			return nil, httperrors.NewInputParameterError("no such network")
+		}
+		network := model.(*SNetwork)
+		data.Add(jsonutils.NewString(network.GetExternalId()), "network_ext_id")
+	}
+
+	model, err := ElasticipManager.FetchById(input.ExternalIpId)
+	if err != nil {
+		return nil, err
+	}
+	if model == nil {
+		return nil, httperrors.NewInputParameterError("No such eip")
+	}
+	eip := model.(*SElasticip)
+	if eip.IpAddr != input.Ip {
+		return nil, errors.Error("No such eip")
+	}
+
+	// check that eip is suitable
+	if len(eip.AssociateId) != 0 {
+		if eip.AssociateId != input.NatgatewayId {
+			return nil, httperrors.NewInputParameterError("eip has been binding to another instance")
+		} else if !man.canBindIP(eip.IpAddr) {
+			return nil, httperrors.NewInputParameterError("eip has been binding to dnat rules")
+		}
+	} else {
+		data.Add(jsonutils.NewBool(true), "need_bind")
+	}
+
+	data.Remove("external_ip_id")
+	data.Add(jsonutils.NewString(eip.ExternalId), "external_ip_id")
 	return data, nil
 }
 
@@ -280,9 +335,7 @@ func (self *SNatSEntry) PostCreate(ctx context.Context, userCred mcclient.TokenC
 		return
 	}
 	// ValidateCreateData function make data must contain 'externalIpId' key
-	externalIPID, _ := data.GetString("external_ip_id")
-	taskData := jsonutils.NewDict()
-	taskData.Set("external_ip_id", jsonutils.NewString(externalIPID))
+	taskData := data.(*jsonutils.JSONDict)
 	task, err := taskman.TaskManager.NewTask(ctx, "SNatSEntryCreateTask", self, userCred, taskData, "", "", nil)
 	if err != nil {
 		log.Errorf("SNatSEntryCreateTask newTask error %s", err)
@@ -310,12 +363,15 @@ func (self *SNatSEntry) CustomizeDelete(ctx context.Context, userCred mcclient.T
 
 func (self *SNatSEntry) Delete(ctx context.Context, userCred mcclient.TokenCredential) error {
 	log.Infof("SNAT delete do nothing")
-	self.SetStatus(userCred, api.NAT_STATUS_START_DELETE, "")
+	self.SetStatus(userCred, api.NAT_STATUS_DELETING, "")
 	return nil
 }
 
 func (self *SNatSEntry) RealDelete(ctx context.Context, userCred mcclient.TokenCredential) error {
-	db.OpsLog.LogEvent(self, db.ACT_DELOCATE, self.GetShortDesc(ctx), userCred)
+	err := db.DeleteModel(ctx, userCred, self)
+	if err != nil {
+		return err
+	}
 	self.SetStatus(userCred, api.NAT_STATUS_DELETED, "real delete")
 	return nil
 }
@@ -328,4 +384,13 @@ func (self *SNatSEntry) StartDeleteVpcTask(ctx context.Context, userCred mcclien
 	}
 	task.ScheduleRun(nil)
 	return nil
+}
+
+func (self *SNatSEntryManager) canBindIP(ipAddr string) bool {
+	q := NatDEntryManager.Query().Equals("external_ip", ipAddr)
+	count, _ := q.CountWithError()
+	if count != 0 {
+		return false
+	}
+	return true
 }

--- a/pkg/compute/models/regiondrivers.go
+++ b/pkg/compute/models/regiondrivers.go
@@ -97,6 +97,10 @@ type IRegionDriver interface {
 	RequestApplySnapshotPolicy(ctx context.Context, userCred mcclient.TokenCredential, sp *SSnapshotPolicy, task taskman.ITask, diskId string) error
 	RequestCancelSnapshotPolicy(ctx context.Context, userCred mcclient.TokenCredential, sp *SSnapshotPolicy, task taskman.ITask, diskId string) error
 	OnSnapshotDelete(ctx context.Context, snapshot *SSnapshot, task taskman.ITask, data jsonutils.JSONObject) error
+
+	//Nat gateway
+	DealNatGatewaySpec(spec string) string
+	RequestBindIPToNatgateway(ctx context.Context, task taskman.ITask, natgateway *SNatGateway, needBind bool, eipID string) error
 }
 
 var regionDrivers map[string]IRegionDriver

--- a/pkg/compute/regiondrivers/aliyun.go
+++ b/pkg/compute/regiondrivers/aliyun.go
@@ -20,19 +20,22 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/util/choices"
-	"yunion.io/x/onecloud/pkg/util/rand"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/utils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/util/choices"
+	"yunion.io/x/onecloud/pkg/util/rand"
 )
 
 type SAliyunRegionDriver struct {
@@ -839,5 +842,48 @@ func (self *SAliyunRegionDriver) ValidateSnapshotCreate(ctx context.Context, use
 		return httperrors.NewBadRequestError(
 			"Snapshot for %s name can't start with auto, http:// or https://", self.GetProvider())
 	}
+	return nil
+}
+
+func (self *SAliyunRegionDriver) DealNatGatewaySpec(spec string) string {
+	switch spec {
+	case "Small":
+		return api.NAT_SPEC_SMALL
+	case "Midele":
+		return api.NAT_SPEC_MIDDLE
+	case "Large":
+		return api.NAT_SPEC_LARGE
+	case "XLarge.1":
+		return api.NAT_SPEC_XLARGE
+	}
+	//can't arrive
+	return ""
+}
+
+func (self *SAliyunRegionDriver) RequestBindIPToNatgateway(ctx context.Context, task taskman.ITask,
+	natgateway *models.SNatGateway, needBind bool, eipID string) error {
+	taskman.LocalTaskRun(task, func() (jsonutils.JSONObject, error) {
+		if !needBind {
+			return nil, nil
+		}
+		iregion, err := natgateway.GetIRegion()
+		if err != nil {
+			return nil, err
+		}
+		ieip, err := iregion.GetIEipById(eipID)
+		if err != nil {
+			return nil, errors.Wrap(err, "fetch eip failed")
+		}
+		err = ieip.Associate(natgateway.GetExternalId())
+		if err != nil {
+			return nil, errors.Wrap(err, "bind eip to natgateway")
+		}
+
+		cloudprovider.WaitStatus(ieip, api.EIP_STATUS_READY, 10*time.Second, 300*time.Second)
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
 	return nil
 }

--- a/pkg/compute/regiondrivers/base.go
+++ b/pkg/compute/regiondrivers/base.go
@@ -199,3 +199,13 @@ func (self *SBaseRegionDriver) ValidateCreateSnapshopolicyDiskData(ctx context.C
 func (self *SBaseRegionDriver) OnSnapshotDelete(ctx context.Context, snapshot *models.SSnapshot, task taskman.ITask, data jsonutils.JSONObject) error {
 	return fmt.Errorf("Not implement OnSnapshotDelete")
 }
+
+func (self *SBaseRegionDriver) DealNatGatewaySpec(spec string) string {
+	return spec
+}
+
+func (self *SBaseRegionDriver) RequestBingToNatgateway(ctx context.Context, task taskman.ITask,
+	natgateway *models.SNatGateway, needBind bool, eipID string) error {
+
+	return fmt.Errorf("Not implement RequestBindIPToNatgateway")
+}

--- a/pkg/compute/regiondrivers/huawei.go
+++ b/pkg/compute/regiondrivers/huawei.go
@@ -1457,3 +1457,18 @@ func (self *SHuaWeiRegionDriver) RequestCreateLoadbalancerListenerRule(ctx conte
 	})
 	return nil
 }
+
+func (self *SHuaWeiRegionDriver) DealNatGatewaySpec(spec string) string {
+	switch spec {
+	case "1":
+		return api.NAT_SPEC_SMALL
+	case "2":
+		return api.NAT_SPEC_MIDDLE
+	case "3":
+		return api.NAT_SPEC_LARGE
+	case "4":
+		return api.NAT_SPEC_XLARGE
+	}
+	//can't arrive
+	return ""
+}

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -814,3 +814,12 @@ func (self *SKVMRegionDriver) OnSnapshotDelete(ctx context.Context, snapshot *mo
 	task.ScheduleRun(data)
 	return nil
 }
+
+func (self *SKVMRegionDriver) DealNatGatewaySpec(spec string) string {
+	return spec
+}
+func (self *SKVMRegionDriver) RequestBindIPToNatgateway(ctx context.Context, task taskman.ITask,
+	natgateway *models.SNatGateway, needBind bool, eipID string) error {
+
+	return nil
+}

--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -1232,3 +1232,14 @@ func (self *SManagedVirtualizationRegionDriver) OnSnapshotDelete(ctx context.Con
 	task.ScheduleRun(data)
 	return nil
 }
+
+func (self *SManagedVirtualizationRegionDriver) DealNatGatewaySpec(spec string) string {
+	return spec
+}
+
+func (self *SManagedVirtualizationRegionDriver) RequestBindIPToNatgateway(ctx context.Context, task taskman.ITask,
+	natgateway *models.SNatGateway, needBind bool, eipID string) error {
+
+	task.ScheduleRun(nil)
+	return nil
+}

--- a/pkg/compute/tasks/natdentry_delete_task.go
+++ b/pkg/compute/tasks/natdentry_delete_task.go
@@ -16,8 +16,10 @@ package tasks
 
 import (
 	"context"
+	"time"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/pkg/errors"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
@@ -44,7 +46,7 @@ func (self *SNatDEntryDeleteTask) taskFailed(ctx context.Context, dnatEntry *mod
 
 func (self *SNatDEntryDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
 	dnatEntry := obj.(*models.SNatDEntry)
-	dnatEntry.SetStatus(self.UserCred, api.NAT_STATUS_ALLOCATE, "")
+	dnatEntry.SetStatus(self.UserCred, api.NAT_STATUS_DELETING, "")
 	cloudNatGateway, err := dnatEntry.GetINatGateway()
 	if err != nil {
 		self.taskFailed(ctx, dnatEntry, errors.Wrap(err, "Get NatGateway failed"))
@@ -53,10 +55,29 @@ func (self *SNatDEntryDeleteTask) OnInit(ctx context.Context, obj db.IStandalone
 	cloudNatDEntry, err := cloudNatGateway.GetINatDEntryByID(dnatEntry.ExternalId)
 	if err != nil {
 		self.taskFailed(ctx, dnatEntry, errors.Wrapf(err, "Get DNat Entry by ID '%s' failed", dnatEntry.ExternalId))
+		return
 	}
+	if cloudNatDEntry == nil {
+		err = dnatEntry.Purge(ctx, self.UserCred)
+		if err != nil {
+			self.taskFailed(ctx, dnatEntry, err)
+			return
+		}
+		logclient.AddActionLogWithStartable(self, dnatEntry, logclient.ACT_DELETE, nil, self.UserCred, true)
+		self.SetStageComplete(ctx, nil)
+		return
+	}
+
 	err = cloudNatDEntry.Delete()
 	if err != nil {
 		self.taskFailed(ctx, dnatEntry, errors.Wrapf(err, "Delete DNat Entry '%s' failed", dnatEntry.ExternalId))
+		return
+	}
+
+	err = cloudprovider.WaitDeleted(cloudNatDEntry, 10*time.Second, 300*time.Second)
+	if err != nil {
+		self.taskFailed(ctx, dnatEntry, err)
+		return
 	}
 
 	err = dnatEntry.Purge(ctx, self.UserCred)
@@ -65,6 +86,7 @@ func (self *SNatDEntryDeleteTask) OnInit(ctx context.Context, obj db.IStandalone
 		return
 	}
 
+	db.OpsLog.LogEvent(dnatEntry, db.ACT_DELETE, dnatEntry.GetShortDesc(ctx), self.UserCred)
 	logclient.AddActionLogWithStartable(self, dnatEntry, logclient.ACT_DELETE, nil, self.UserCred, true)
 	self.SetStageComplete(ctx, nil)
 }

--- a/pkg/compute/tasks/natsentry_create_task.go
+++ b/pkg/compute/tasks/natsentry_create_task.go
@@ -16,6 +16,7 @@ package tasks
 
 import (
 	"context"
+	"time"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
@@ -46,6 +47,29 @@ func (self *SNatSEntryCreateTask) TaskFailed(ctx context.Context, snatEntry *mod
 func (self *SNatSEntryCreateTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
 	snatEntry := obj.(*models.SNatSEntry)
 	snatEntry.SetStatus(self.UserCred, api.NAT_STATUS_ALLOCATE, "")
+
+	natgateway, err := snatEntry.GetNatgateway()
+	if err != nil {
+		self.TaskFailed(ctx, snatEntry, errors.Wrap(err, "fetch natgateway failed"))
+	}
+	var needBind bool
+	if self.Params.Contains("need_bind") {
+		needBind = true
+	}
+
+	self.SetStage("OnBindIPComplete", nil)
+	externalIPID, _ := self.Params.GetString("external_ip_id")
+	if err := natgateway.GetRegion().GetDriver().RequestBindIPToNatgateway(ctx, self, natgateway, needBind,
+		externalIPID); err != nil {
+
+		self.TaskFailed(ctx, snatEntry, err)
+		return
+	}
+}
+
+func (self *SNatSEntryCreateTask) OnBindIPComplete(ctx context.Context, snatEntry *models.SNatSEntry,
+	body jsonutils.JSONObject) {
+
 	cloudNatGateway, err := snatEntry.GetINatGateway()
 	if err != nil {
 		self.TaskFailed(ctx, snatEntry, errors.Wrap(err, "Get NatGateway failed"))
@@ -55,18 +79,34 @@ func (self *SNatSEntryCreateTask) OnInit(ctx context.Context, obj db.IStandalone
 	externalIPID, err := self.Params.GetString("external_ip_id")
 	// construct a DNat RUle
 	snatRule := cloudprovider.SNatSRule{
-		SourceCIDR:   snatEntry.SourceCIDR,
 		ExternalIP:   snatEntry.IP,
 		ExternalIPID: externalIPID,
 	}
-	_, err = cloudNatGateway.CreateINatSEntry(snatRule)
+	if self.Params.Contains("network_ext_id") {
+		extID, _ := self.Params.GetString("network_ext_id")
+		snatRule.NetworkID = extID
+	} else {
+		snatRule.SourceCIDR = snatEntry.SourceCIDR
+	}
+	extSnat, err := cloudNatGateway.CreateINatSEntry(snatRule)
 	if err != nil {
 		self.TaskFailed(ctx, snatEntry, errors.Wrapf(err, "Create SNat Entry '%s' failed", snatEntry.ExternalId))
 		return
 	}
+	err = db.SetExternalId(snatEntry, self.UserCred, extSnat.GetGlobalId())
+	if err != nil {
+		self.TaskFailed(ctx, snatEntry, errors.Wrap(err, "set external id failed"))
+		return
+	}
+
+	err = cloudprovider.WaitStatus(extSnat, api.NAT_STAUTS_AVAILABLE, 10*time.Second, 300*time.Second)
+	if err != nil {
+		self.TaskFailed(ctx, snatEntry, err)
+		return
+	}
 
 	snatEntry.SetStatus(self.UserCred, api.NAT_STAUTS_AVAILABLE, "")
-
+	db.OpsLog.LogEvent(snatEntry, db.ACT_ALLOCATE, snatEntry.GetShortDesc(ctx), self.UserCred)
 	logclient.AddActionLogWithStartable(self, snatEntry, logclient.ACT_ALLOCATE, nil, self.UserCred, true)
 	self.SetStageComplete(ctx, nil)
 }

--- a/pkg/compute/tasks/natsentry_delete_task.go
+++ b/pkg/compute/tasks/natsentry_delete_task.go
@@ -16,8 +16,10 @@ package tasks
 
 import (
 	"context"
+	"time"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/pkg/errors"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
@@ -44,19 +46,38 @@ func (self *SNatSEntryDeleteTask) taskFailed(ctx context.Context, snatEntry *mod
 
 func (self *SNatSEntryDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
 	snatEntry := obj.(*models.SNatSEntry)
-	snatEntry.SetStatus(self.UserCred, api.NAT_STATUS_ALLOCATE, "")
+	snatEntry.SetStatus(self.UserCred, api.NAT_STATUS_DELETING, "")
 	cloudNatGateway, err := snatEntry.GetINatGateway()
 	if err != nil {
 		self.taskFailed(ctx, snatEntry, errors.Wrap(err, "Get NatGateway failed"))
 		return
 	}
-	cloudNatDEntry, err := cloudNatGateway.GetINatSEntryByID(snatEntry.ExternalId)
+	cloudNatSEntry, err := cloudNatGateway.GetINatSEntryByID(snatEntry.ExternalId)
 	if err != nil {
 		self.taskFailed(ctx, snatEntry, errors.Wrapf(err, "Get SNat Entry by ID '%s' failed", snatEntry.ExternalId))
+		return
 	}
-	err = cloudNatDEntry.Delete()
+	if cloudNatSEntry == nil {
+		err = snatEntry.Purge(ctx, self.UserCred)
+		if err != nil {
+			self.taskFailed(ctx, snatEntry, err)
+			return
+		}
+		logclient.AddActionLogWithStartable(self, snatEntry, logclient.ACT_DELETE, nil, self.UserCred, true)
+		self.SetStageComplete(ctx, nil)
+		return
+	}
+
+	err = cloudNatSEntry.Delete()
 	if err != nil {
 		self.taskFailed(ctx, snatEntry, errors.Wrapf(err, "Delete SNat Entry '%s' failed", snatEntry.ExternalId))
+		return
+	}
+
+	err = cloudprovider.WaitDeleted(cloudNatSEntry, 10*time.Second, 300*time.Second)
+	if err != nil {
+		self.taskFailed(ctx, snatEntry, err)
+		return
 	}
 
 	err = snatEntry.Purge(ctx, self.UserCred)
@@ -65,6 +86,7 @@ func (self *SNatSEntryDeleteTask) OnInit(ctx context.Context, obj db.IStandalone
 		return
 	}
 
+	db.OpsLog.LogEvent(snatEntry, db.ACT_DELETE, snatEntry.GetShortDesc(ctx), self.UserCred)
 	logclient.AddActionLogWithStartable(self, snatEntry, logclient.ACT_DELETE, nil, self.UserCred, true)
 	self.SetStageComplete(ctx, nil)
 }

--- a/pkg/mcclient/options/natgateways.go
+++ b/pkg/mcclient/options/natgateways.go
@@ -62,5 +62,6 @@ type NatSCreateOptions struct {
 	NATGATEWAYID string `help:"The nat gateway'id to which SNat belongs"`
 	IP           string `help:"External IP"`
 	EXTERNALIPID string `help:"External IP ID, can be empty except huawei Cloud"`
-	SOURCECIDR   string `help:"Source CIDR"`
+	SourceCIDR   string `help:"Source CIDR"`
+	NetworkID    string `help:"Network id"`
 }

--- a/pkg/multicloud/aliyun/natdtable.go
+++ b/pkg/multicloud/aliyun/natdtable.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"
@@ -170,4 +172,12 @@ func (region *SRegion) CreateForwardTableEntry(rule cloudprovider.SNatDRule, tab
 
 	entryID, _ := body.GetString("ForwardEntryId")
 	return entryID, nil
+}
+
+func (dtable *SForwardTableEntry) Refresh() error {
+	new, err := dtable.nat.vpc.region.GetForwardTableEntry(dtable.ForwardEntryId, dtable.ForwardTableId)
+	if err != nil {
+		return err
+	}
+	return jsonutils.Update(dtable, new)
 }

--- a/pkg/multicloud/huawei/natdtable.go
+++ b/pkg/multicloud/huawei/natdtable.go
@@ -15,6 +15,7 @@
 package huawei
 
 import (
+	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/multicloud"
@@ -118,4 +119,12 @@ func (region *SRegion) DeleteNatDEntry(entryID string) error {
 		return errors.Wrapf(err, `delete dnat rule %q failed`, entryID)
 	}
 	return nil
+}
+
+func (nat *SNatDEntry) Refresh() error {
+	new, err := nat.gateway.region.GetNatDEntryByID(nat.ID)
+	if err != nil {
+		return err
+	}
+	return jsonutils.Update(nat, new)
 }

--- a/pkg/multicloud/huawei/natgateway.go
+++ b/pkg/multicloud/huawei/natgateway.go
@@ -55,18 +55,7 @@ func (gateway *SNatGateway) GetStatus() string {
 }
 
 func (gateway *SNatGateway) GetNatSpec() string {
-	switch gateway.Spec {
-	case "1":
-		return "small"
-	case "2":
-		return "middle"
-	case "3":
-		return "large"
-	case "4":
-		return "xlarge"
-	}
-	// can't arrive
-	return ""
+	return gateway.Spec
 }
 
 func (gateway *SNatGateway) GetDescription() string {
@@ -237,7 +226,12 @@ func (region *SRegion) CreateNatDEntry(rule cloudprovider.SNatDRule, gatewayID s
 func (region *SRegion) CreateNatSEntry(rule cloudprovider.SNatSRule, gatewayID string) (SNatSEntry, error) {
 	params := make(map[string]interface{})
 	params["nat_gateway_id"] = gatewayID
-	params["cidr"] = rule.SourceCIDR
+	if len(rule.NetworkID) != 0 {
+		params["network_id"] = rule.NetworkID
+	}
+	if len(rule.SourceCIDR) != 0 {
+		params["cidr"] = rule.SourceCIDR
+	}
 	params["floating_ip_id"] = rule.ExternalIPID
 
 	packParams := map[string]map[string]interface{}{

--- a/pkg/multicloud/huawei/natstable.go
+++ b/pkg/multicloud/huawei/natstable.go
@@ -15,6 +15,7 @@
 package huawei
 
 import (
+	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/multicloud"
@@ -108,4 +109,12 @@ func (region *SRegion) DeleteNatSEntry(entryID string) error {
 		return errors.Wrapf(err, `delete snat rule %q failed`, entryID)
 	}
 	return nil
+}
+
+func (nat *SNatSEntry) Refresh() error {
+	new, err := nat.gateway.region.GetNatSEntryByID(nat.ID)
+	if err != nil {
+		return err
+	}
+	return jsonutils.Update(nat, new)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1.natgateway的规格展示暂时用各个云的driver来控制

2.snat和dnat创建的时候，增加了参数检验，包括cide，ip格式的检验，以及eip，network可用性的检验，snat和dnat的eip不能共用

3.阿里云创建nat需要nat先绑定eip，华为云则不需要，在nat create增加了bindIP的stage，用driver进行区分。

**是否需要 backport 到之前的 release 分支**:
- release/2.11

/cc @swordqiu @zexi @ioito 
/area region
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
