### PR TITLE
Automated cherry pick of #2569: fix: 宿主机下线时，需要将宿主机底下的虚拟机状态设为unknown

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -1369,6 +1369,13 @@ func (self *SHost) syncRemoveCloudHost(ctx context.Context, userCred mcclient.To
 		if err == nil {
 			_, err = self.PerformDisable(ctx, userCred, nil, nil)
 		}
+		guests := self.GetGuests()
+		for _, guest := range guests {
+			err = guest.SetStatus(userCred, api.VM_UNKNOWN, "sync to delete")
+			if err != nil {
+				return err
+			}
+		}
 	} else {
 		err = self.RealDelete(ctx, userCred)
 	}


### PR DESCRIPTION
Cherry pick of #2569 on release/2.10.0.

#2569: fix: 宿主机下线时，需要将宿主机底下的虚拟机状态设为unknown