### PR TITLE
Automated cherry pick of #2615: fix: avoid rbd image exist when rebuild-root

### DIFF
--- a/pkg/hostman/storageman/disk_rbd.go
+++ b/pkg/hostman/storageman/disk_rbd.go
@@ -172,6 +172,7 @@ func (d *SRBDDisk) createFromTemplate(ctx context.Context, imageId, format strin
 	defer imageCacheManager.ReleaseImage(imageId)
 	storage := d.Storage.(*SRbdStorage)
 	destPool, _ := storage.StorageConf.GetString("pool")
+	storage.deleteImage(destPool, d.Id) //重装系统时，需要删除以前的系统盘
 	if err := storage.cloneImage(imageCacheManager.GetPath(), imageCache.GetName(), destPool, d.Id); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry pick of #2615 on release/2.10.0.

#2615: fix: avoid rbd image exist when rebuild-root