### PR TITLE
fix: compatible with minio s3

### DIFF
--- a/pkg/compute/models/buckets.go
+++ b/pkg/compute/models/buckets.go
@@ -68,7 +68,7 @@ type SBucket struct {
 
 	SManagedResourceBase
 
-	CloudregionId string `width:"36" charset:"ascii" nullable:"false" list:"user" create:"admin_required"`
+	CloudregionId string `width:"36" charset:"ascii" nullable:"false" list:"user" create:"required"`
 
 	StorageClass string `width:"36" charset:"ascii" nullable:"false" list:"user"`
 	Location     string `width:"36" charset:"ascii" nullable:"false" list:"user"`

--- a/pkg/multicloud/objectstore/buckets.go
+++ b/pkg/multicloud/objectstore/buckets.go
@@ -168,10 +168,10 @@ func (bucket *SBucket) PutObject(ctx context.Context, key string, input io.Reade
 	}
 	obj, err := cloudprovider.GetIObject(bucket, key)
 	if err != nil {
-		return errors.Wrap(err, "GetIObject")
+		return errors.Wrap(err, "cloudprovider.GetIObject")
 	}
 	err = obj.SetAcl(cannedAcl)
-	if err != nil {
+	if err != nil && errors.Cause(err) != cloudprovider.ErrNotImplemented {
 		return errors.Wrap(err, "obj.SetAcl")
 	}
 	return nil

--- a/pkg/multicloud/objectstore/object.go
+++ b/pkg/multicloud/objectstore/object.go
@@ -15,9 +15,11 @@
 package objectstore
 
 import (
-	"github.com/pkg/errors"
+	"strings"
+
 	"yunion.io/x/log"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/pkg/errors"
 )
 
 type SObject struct {
@@ -42,7 +44,11 @@ func (o *SObject) GetAcl() cloudprovider.TBucketACLType {
 func (o *SObject) SetAcl(aclStr cloudprovider.TBucketACLType) error {
 	err := o.bucket.client.SetObjectAcl(o.bucket.Name, o.Key, aclStr)
 	if err != nil {
-		return errors.Wrap(err, "o.bucket.client.SetObjectAcl")
+		if strings.Contains(err.Error(), "not implemented") {
+			return cloudprovider.ErrNotImplemented
+		} else {
+			return errors.Wrap(err, "o.bucket.client.SetObjectAcl")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：
1. minio后端无法设置acl以及忽略目录文件导致创建对象出错的问题
2. 域管理员新建bucket无region信息的问题

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12

/area region