### PR TITLE
bugfix: vnc connect

### DIFF
--- a/pkg/compute/guestdrivers/kvm.go
+++ b/pkg/compute/guestdrivers/kvm.go
@@ -122,10 +122,15 @@ func findVNCPort(results string) int {
 
 func findVNCPort2(results string) int {
 	vncInfo := strings.Split(results, "\n")
-	addrParts := strings.Split(vncInfo[3], ":")
-	v := addrParts[len(addrParts)-1]
-	port, _ := strconv.Atoi(v[0 : len(v)-7])
-	return port
+	for i := 0; i < len(vncInfo); i++ {
+		if strings.HasSuffix(vncInfo[i], "(ipv4)") {
+			addrParts := strings.Split(vncInfo[3], ":")
+			v := addrParts[len(addrParts)-1]
+			port, _ := strconv.Atoi(v[0 : len(v)-7])
+			return port
+		}
+	}
+	return -1
 }
 
 func (self *SKVMGuestDriver) GetGuestVncInfo(ctx context.Context, userCred mcclient.TokenCredential, guest *models.SGuest, host *models.SHost) (*jsonutils.JSONDict, error) {
@@ -152,15 +157,17 @@ func (self *SKVMGuestDriver) GetGuestVncInfo(ctx context.Context, userCred mccli
 	// info_vnc = result['results'].split('\n')
 	// port = int(info_vnc[1].split(':')[-1].split()[0])
 
-	/*													QEMU 2.9.1
-	info spice			QEMU 2.12.1 monitor				Server:
+	/*													$ QEMU 2.9.1
+	info spice			$ QEMU 2.12.1 monitor			Server:
 	Server:				(qemu) info vnc					address: 0.0.0.0:5901
 	address: *:5921		info vnc						auth: none
 	migrated: false		default:						Client: none
-	auth: spice			Server: :::5902 (ipv6)
-	compiled: 0.13.3	Auth: none (Sub: none)
-	mouse-mode: server	Server: 0.0.0.0:5902 (ipv4)
-	Channels: none		Auth: none (Sub: none)
+	auth: spice			Server: :::5902 (ipv6)			$ QEMU 2.12.1 monitor without ipv6
+	compiled: 0.13.3	Auth: none (Sub: none)			(qemu) info vnc
+	mouse-mode: server	Server: 0.0.0.0:5902 (ipv4)		info vnc
+	Channels: none		Auth: none (Sub: none)			default:
+														Server: 0.0.0.0:5902 (ipv4)
+														Auth: none (Sub: none)
 	*/
 	var port int
 	if guest.CheckQemuVersion(guest.GetMetadata("__qemu_version", userCred), "2.12.1") && strings.HasSuffix(cmd, "vnc") {

--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -39,6 +39,7 @@ const (
 	OS_NAME_MACOS   = "macOS"
 	OS_NAME_ANDROID = "Android"
 	OS_NAME_VMWARE  = "VMWare"
+	OS_NAME_CIRROS  = "Cirros"
 
 	MODE_READLINE = "readline"
 	MODE_CONTROL  = "control"
@@ -69,14 +70,16 @@ func (s *SKVMGuestInstance) getMonitorDesc(idstr string, port int, mode string) 
 }
 
 func (s *SKVMGuestInstance) getOsname() string {
-	if s.Desc.Contains("metadata") {
-		metadata, _ := s.Desc.Get("metadata")
-		if metadata.Contains("os_name") {
-			osname, _ := metadata.GetString("os_name")
-			return osname
-		}
+	osName, err := s.Desc.GetString("metadata", "os_name")
+	if err != nil {
+		return OS_NAME_LINUX
 	}
-	return OS_NAME_LINUX
+	return osName
+}
+
+func (s *SKVMGuestInstance) getOsDistribution() string {
+	osDis, _ := s.Desc.GetString("metadata", "os_distribution")
+	return osDis
 }
 
 func (s *SKVMGuestInstance) getMachine() string {
@@ -468,7 +471,9 @@ func (s *SKVMGuestInstance) generateStartScript(data *jsonutils.JSONDict) (strin
 
 	cmd += " -device virtio-serial"
 	cmd += " -usb"
-	// cmd += " -device usb-kbd"
+	if s.getOsDistribution() != OS_NAME_CIRROS {
+		cmd += " -device usb-kbd"
+	}
 	// # if osname == self.OS_NAME_ANDROID:
 	// #     cmd += " -device usb-mouse"
 	// # else:


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
- fix guest vnc connect failed on host unsupport ipv6
- fix cirros qemu args conflict with windows

**是否需要 backport 到之前的 release 分支**:
release/2.10.0
/cc @swordqiu @zexi 
/area region
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
