### PR TITLE
Automated cherry pick of #2662: fix: qcloud fail to set object acl

### DIFF
--- a/pkg/multicloud/qcloud/object.go
+++ b/pkg/multicloud/qcloud/object.go
@@ -55,7 +55,9 @@ func (o *SObject) SetAcl(aclStr cloudprovider.TBucketACLType) error {
 	if err != nil {
 		return errors.Wrap(err, "o.bucket.region.GetCosClient")
 	}
-	opts := &cos.ObjectPutACLOptions{}
+	opts := &cos.ObjectPutACLOptions{
+		Header: &cos.ACLHeaderOptions{},
+	}
 	opts.Header.XCosACL = string(aclStr)
 	_, err = coscli.Object.PutACL(context.Background(), o.Key, opts)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #2662 on release/2.12.

#2662: fix: qcloud fail to set object acl