### PR TITLE
fix: 1. glance/keystone version handler fix 2. allow run glance as normal user

### DIFF
--- a/pkg/image/service/handlers.go
+++ b/pkg/image/service/handlers.go
@@ -31,6 +31,9 @@ const (
 func initHandlers(app *appsrv.Application) {
 	db.InitAllManagers()
 
+	// add version handler with API_VERSION prefix
+	app.AddDefaultHandler("GET", API_VERSION+"/version", appsrv.VersionHandler, "version")
+
 	db.RegistUserCredCacheUpdater()
 
 	db.AddProjectResourceCountHandler(API_VERSION, app)

--- a/pkg/image/service/service.go
+++ b/pkg/image/service/service.go
@@ -35,7 +35,6 @@ import (
 	_ "yunion.io/x/onecloud/pkg/image/tasks"
 	"yunion.io/x/onecloud/pkg/image/torrent"
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
-	"yunion.io/x/onecloud/pkg/util/sysutils"
 )
 
 func StartService() {
@@ -45,10 +44,11 @@ func StartService() {
 	dbOpts := &opts.DBOptions
 	common_options.ParseOptions(opts, os.Args, "glance-api.conf", api.SERVICE_TYPE)
 
-	isRoot := sysutils.IsRootPermission()
-	if !isRoot {
-		log.Fatalf("glance service must running with root permissions")
-	}
+	// no need to run glance as root any more
+	// isRoot := sysutils.IsRootPermission()
+	// if !isRoot {
+	// 	log.Fatalf("glance service must running with root permissions")
+	// }
 
 	if opts.PortV2 > 0 {
 		log.Infof("Port V2 %d is specified, use v2 port", opts.PortV2)

--- a/pkg/keystone/service/handlers.go
+++ b/pkg/keystone/service/handlers.go
@@ -31,6 +31,9 @@ const (
 func initHandlers(app *appsrv.Application) {
 	db.InitAllManagers()
 
+	// add version handler with API_VERSION prefix
+	app.AddDefaultHandler("GET", API_VERSION+"/version", appsrv.VersionHandler, "version")
+
 	// quotas.AddQuotaHandler(models.QuotaManager, API_VERSION, app)
 	usages.AddUsageHandler(API_VERSION, app)
 	taskman.AddTaskHandler(API_VERSION, app)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：1. keystone和glance的version show handler
2. 允许glance以非root用户运行(deployer以root运行)

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12

/area glance
/area keystone