### PR TITLE
baremetal: auto prepare when pxe boot

### DIFF
--- a/pkg/baremetal/handler/handlers.go
+++ b/pkg/baremetal/handler/handlers.go
@@ -24,6 +24,8 @@ import (
 
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/baremetal"
+	baremetalstatus "yunion.io/x/onecloud/pkg/baremetal/status"
+	"yunion.io/x/onecloud/pkg/baremetal/tasks"
 	baremetaltypes "yunion.io/x/onecloud/pkg/baremetal/types"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
@@ -97,9 +99,12 @@ func handleBaremetalNotify(ctx *Context, bm *baremetal.SBaremetalInstance) {
 
 	// execute BaremetalServerPrepareTask
 	task := bm.GetTask()
-	if task != nil {
-		task.SSHExecute(task, remoteAddr, key, nil)
+	if task == nil {
+		task = tasks.NewBaremetalServerPrepareTask(bm)
+		bm.SyncStatus(baremetalstatus.PREPARE, "")
 	}
+	log.Infof("Get notify from pxe rom os, start exec task: %s", task.GetName())
+	task.SSHExecute(task, remoteAddr, key, nil)
 	ctx.ResponseOk()
 }
 

--- a/pkg/compute/tasks/baremetal_unconvert_hypervisor_task.go
+++ b/pkg/compute/tasks/baremetal_unconvert_hypervisor_task.go
@@ -74,6 +74,7 @@ func (self *BaremetalUnconvertHypervisorTask) OnGuestDeleteCompleteFailed(ctx co
 func (self *BaremetalUnconvertHypervisorTask) OnPrepareComplete(ctx context.Context, baremetal *models.SHost, body jsonutils.JSONObject) {
 	self.SetStageComplete(ctx, nil)
 }
+
 func (self *BaremetalUnconvertHypervisorTask) OnFailSyncstatusComplete(ctx context.Context, baremetal *models.SHost, body jsonutils.JSONObject) {
 	self.SetStageFailed(ctx, "Delete server failed")
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

物理机 pxe 启动并没有其它 task 的情况下自动 prepare

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.10

/cc @swordqiu 
/area baremetal