### PR TITLE
fix: azure create bucket failure due to empty storageClass

### DIFF
--- a/pkg/multicloud/azure/azure.go
+++ b/pkg/multicloud/azure/azure.go
@@ -906,9 +906,15 @@ func (self *SAzureClient) GetIProjects() ([]cloudprovider.ICloudProject, error) 
 }
 
 func (self *SAzureClient) GetStorageClasses(regionExtId string) ([]string, error) {
-	iRegion, err := self.GetIRegionById(regionExtId)
+	var iRegion cloudprovider.ICloudRegion
+	var err error
+	if regionExtId == "" {
+		iRegion, err = self.getDefaultRegion()
+	} else {
+		iRegion, err = self.GetIRegionById(regionExtId)
+	}
 	if err != nil {
-		return nil, errors.Wrap(err, "self.GetIRegionById")
+		return nil, errors.Wrapf(err, "self.GetIRegionById %s", regionExtId)
 	}
 	skus, err := iRegion.(*SRegion).GetStorageAccountSkus()
 	if err != nil {

--- a/pkg/multicloud/azure/classic_storage.go
+++ b/pkg/multicloud/azure/classic_storage.go
@@ -27,7 +27,7 @@ type ClassicStorageProperties struct {
 	ProvisioningState       string
 	Status                  string
 	Endpoints               []string
-	AccountType             string
+	AccountType             string `json:"accountType"`
 	GeoPrimaryRegion        string
 	StatusOfPrimaryRegion   string
 	GeoSecondaryRegion      string

--- a/pkg/multicloud/azure/provider/provider.go
+++ b/pkg/multicloud/azure/provider/provider.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 
 	"yunion.io/x/jsonutils"
-
 	"yunion.io/x/log"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/httperrors"
@@ -175,7 +175,7 @@ func (self *SAzureProvider) GetIProjects() ([]cloudprovider.ICloudProject, error
 func (self *SAzureProvider) GetStorageClasses(regionId string) []string {
 	sc, err := self.client.GetStorageClasses(regionId)
 	if err != nil {
-		log.Errorf("Fail to find storage classes")
+		log.Errorf("Fail to find storage classes: %s", err)
 		return nil
 	}
 	return sc

--- a/pkg/multicloud/azure/region.go
+++ b/pkg/multicloud/azure/region.go
@@ -632,7 +632,7 @@ func (region *SRegion) GetIBuckets() ([]cloudprovider.ICloudBucket, error) {
 func (region *SRegion) CreateIBucket(name string, storageClassStr string, acl string) error {
 	_, err := region.createStorageAccount(name, storageClassStr)
 	if err != nil {
-		return errors.Wrap(err, "region.createStorageAccount")
+		return errors.Wrapf(err, "region.createStorageAccount name=%s storageClass=%s acl=%s", name, storageClassStr, acl)
 	}
 	return nil
 }

--- a/pkg/multicloud/objectstore/shell.go
+++ b/pkg/multicloud/objectstore/shell.go
@@ -43,7 +43,7 @@ func S3Shell() {
 	type BucketCreateOptions struct {
 		NAME         string `help:"name of bucket to create"`
 		Acl          string `help:"ACL string" choices:"private|public-read|public-read-write"`
-		StorageClass string `help:"StorageClass" choices:"STANDARD|IA|ARCHIVE"`
+		StorageClass string `help:"StorageClass"`
 	}
 	shellutils.R(&BucketCreateOptions{}, "bucket-create", "Create bucket", func(cli cloudprovider.ICloudRegion, args *BucketCreateOptions) error {
 		err := cli.CreateIBucket(args.NAME, args.StorageClass, args.Acl)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：azure创建bucket时，如果缺少storageClass，则默认用Standard_GRS类型

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12

/area region