### PR TITLE
fix: guest get host nil pointer panic

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -686,7 +686,9 @@ func (guest *SGuest) CustomizeCreate(ctx context.Context, userCred mcclient.Toke
 func (guest *SGuest) GetHost() *SHost {
 	if len(guest.HostId) > 0 && regutils.MatchUUID(guest.HostId) {
 		host, _ := HostManager.FetchById(guest.HostId)
-		return host.(*SHost)
+		if host != nil {
+			return host.(*SHost)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：gues.GetHost nil pointer panic

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12