### PR TITLE
Bugfix: nat

### DIFF
--- a/pkg/compute/models/purge.go
+++ b/pkg/compute/models/purge.go
@@ -1002,9 +1002,6 @@ func (vpc *SVpc) Purge(ctx context.Context, userCred mcclient.TokenCredential) e
 }
 
 func (dn *SNatDEntry) Purge(ctx context.Context, userCred mcclient.TokenCredential) error {
-	lockman.LockObject(ctx, dn)
-	defer lockman.ReleaseObject(ctx, dn)
-
 	err := dn.ValidateDeleteCondition(ctx)
 	if err != nil {
 		return err
@@ -1013,9 +1010,6 @@ func (dn *SNatDEntry) Purge(ctx context.Context, userCred mcclient.TokenCredenti
 }
 
 func (sn *SNatSEntry) Purge(ctx context.Context, userCred mcclient.TokenCredential) error {
-	lockman.LockObject(ctx, sn)
-	defer lockman.ReleaseObject(ctx, sn)
-
 	err := sn.ValidateDeleteCondition(ctx)
 	if err != nil {
 		return err

--- a/pkg/compute/regiondrivers/aliyun.go
+++ b/pkg/compute/regiondrivers/aliyun.go
@@ -865,7 +865,7 @@ func (self *SAliyunRegionDriver) RequestBindIPToNatgateway(ctx context.Context, 
 			return nil, errors.Wrap(err, "bind eip to natgateway")
 		}
 
-		cloudprovider.WaitStatus(ieip, api.EIP_STATUS_READY, 10*time.Second, 300*time.Second)
+		err = cloudprovider.WaitStatus(ieip, api.EIP_STATUS_ASSOCIATE, 10*time.Second, 300*time.Second)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/multicloud/aliyun/natdtable.go
+++ b/pkg/multicloud/aliyun/natdtable.go
@@ -144,6 +144,9 @@ func (region *SRegion) GetForwardTableEntry(tableID, forwardEntryID string) (SFo
 	if err != nil {
 		return SForwardTableEntry{}, err
 	}
+	if len(dtables) == 0 {
+		return SForwardTableEntry{}, cloudprovider.ErrNotFound
+	}
 	return dtables[0], nil
 }
 
@@ -175,7 +178,7 @@ func (region *SRegion) CreateForwardTableEntry(rule cloudprovider.SNatDRule, tab
 }
 
 func (dtable *SForwardTableEntry) Refresh() error {
-	new, err := dtable.nat.vpc.region.GetForwardTableEntry(dtable.ForwardEntryId, dtable.ForwardTableId)
+	new, err := dtable.nat.vpc.region.GetForwardTableEntry(dtable.ForwardTableId, dtable.ForwardEntryId)
 	if err != nil {
 		return err
 	}

--- a/pkg/multicloud/aliyun/natstable.go
+++ b/pkg/multicloud/aliyun/natstable.go
@@ -130,6 +130,9 @@ func (self *SRegion) GetSNATEntry(tableID, SNATEntryID string) (SSNATTableEntry,
 		log.Errorf("Unmarshal entries fail %s", err)
 		return SSNATTableEntry{}, err
 	}
+	if len(entries) == 0 {
+		return SSNATTableEntry{}, cloudprovider.ErrNotFound
+	}
 	return entries[0], nil
 
 }
@@ -209,7 +212,7 @@ func (nat *SNatGetway) dissociateWithVswitch(vswitchId string) error {
 }
 
 func (stable *SSNATTableEntry) Refresh() error {
-	new, err := stable.nat.vpc.region.GetForwardTableEntry(stable.SnatEntryId, stable.SnatTableId)
+	new, err := stable.nat.vpc.region.GetSNATEntry(stable.SnatTableId, stable.SnatEntryId)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
添加了OnBindIPCompleteFailed 以应对 异步请求失败的情况，
修复了aliyun snat dnat refresh 函数

**是否需要 backport 到之前的 release 分支**:

- release/2.11
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
