### PR TITLE
region: fix create params cdrom missing

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4392,6 +4392,7 @@ func (self *SGuest) ToCreateInput(userCred mcclient.TokenCredential) *api.Server
 	userInput.Vga = genInput.Vga
 	userInput.Vdi = genInput.Vdi
 	userInput.Bios = genInput.Bios
+	userInput.Cdrom = genInput.Cdrom
 	userInput.Description = genInput.Description
 	userInput.BootOrder = genInput.BootOrder
 	userInput.DisableDelete = genInput.DisableDelete


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
创建相同配置 cdrom 信息缺失
**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- 2.10

/area region
/cc @wanyaoqi 