### PR TITLE
Automated cherry pick of #2723: region: fix create params cdrom missing

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4392,6 +4392,7 @@ func (self *SGuest) ToCreateInput(userCred mcclient.TokenCredential) *api.Server
 	userInput.Vga = genInput.Vga
 	userInput.Vdi = genInput.Vdi
 	userInput.Bios = genInput.Bios
+	userInput.Cdrom = genInput.Cdrom
 	userInput.Description = genInput.Description
 	userInput.BootOrder = genInput.BootOrder
 	userInput.DisableDelete = genInput.DisableDelete


### PR DESCRIPTION
Cherry pick of #2723 on release/2.10.0.

#2723: region: fix create params cdrom missing