### PR TITLE
fix: for backward compatility, only check account id consistency for non-empty account id

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -445,7 +445,8 @@ func (self *SCloudaccount) PerformUpdateCredential(ctx context.Context, userCred
 	if err != nil {
 		return nil, httperrors.NewInputParameterError("invalid cloud account info error: %s", err.Error())
 	}
-	if accountId != self.AccountId {
+	// for backward compatibility
+	if len(self.AccountId) > 0 && accountId != self.AccountId {
 		return nil, httperrors.NewConflictError("inconsistent account_id, previous '%s' and now '%s'", self.AccountId, accountId)
 	}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：只有accountId不为空，才在更新云账号信息时检查accountId的一致性

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12

/area region