### PR TITLE
Automated cherry pick of #2736: fix: for backward compatility, only check account id consistency for non-empty account id

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -445,7 +445,8 @@ func (self *SCloudaccount) PerformUpdateCredential(ctx context.Context, userCred
 	if err != nil {
 		return nil, httperrors.NewInputParameterError("invalid cloud account info error: %s", err.Error())
 	}
-	if accountId != self.AccountId {
+	// for backward compatibility
+	if len(self.AccountId) > 0 && accountId != self.AccountId {
 		return nil, httperrors.NewConflictError("inconsistent account_id, previous '%s' and now '%s'", self.AccountId, accountId)
 	}
 


### PR DESCRIPTION
Cherry pick of #2736 on release/2.11.

#2736: fix: for backward compatility, only check account id consistency for non-empty account id