### PR TITLE
bugfix: snapshot policy

### DIFF
--- a/pkg/compute/models/snapshotpolicycache.go
+++ b/pkg/compute/models/snapshotpolicycache.go
@@ -395,6 +395,16 @@ func (spc *SSnapshotPolicyCache) DeleteCloudSnapshotPolicy() error {
 		if err != nil {
 			return err
 		}
+		cloudSp, err := iregion.GetISnapshotPolicyById(spc.ExternalId)
+		if err == cloudprovider.ErrNotFound {
+			return nil
+		}
+		if err != nil {
+			return errors.Wrap(err, "fetch snapshotpolicy from cloud before deleting failed")
+		}
+		if cloudSp == nil {
+			return nil
+		}
 		return iregion.DeleteSnapshotPolicy(spc.ExternalId)
 	}
 	return nil

--- a/pkg/compute/models/snapshotpolicydisks.go
+++ b/pkg/compute/models/snapshotpolicydisks.go
@@ -110,9 +110,15 @@ func (self *SSnapshotPolicyDisk) GetExtraDetails(ctx context.Context, userCred m
 func (self *SSnapshotPolicyDisk) getMoreDetails(ctx context.Context, userCred mcclient.TokenCredential,
 	query jsonutils.JSONObject) (*jsonutils.JSONDict, error) {
 
-	disk := DiskManager.FetchDiskById(self.DiskId)
 	ret := jsonutils.NewDict()
-	ret.Add(jsonutils.Marshal(disk), "disk")
+	disk := DiskManager.FetchDiskById(self.DiskId)
+	extraDict, err := disk.GetExtraDetails(ctx, userCred, query)
+	if err != nil {
+		return ret, nil
+	}
+	dict := jsonutils.Marshal(disk).(*jsonutils.JSONDict)
+	dict.Update(extraDict)
+	ret.Add(dict, "disk")
 	return ret, nil
 }
 

--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -1100,12 +1100,15 @@ func (self *SManagedVirtualizationRegionDriver) RequestCancelSnapshotPolicy(ctx 
 		if err != nil {
 			return nil, err
 		}
+		data := jsonutils.NewDict()
+		data.Add(jsonutils.NewString(sp.GetId()), "snapshotpolicy_id")
 		err = iRegion.CancelSnapshotPolicyToDisks(spcache.GetExternalId(), disk.GetExternalId())
+		if err == cloudprovider.ErrNotFound {
+			return data, nil
+		}
 		if err != nil {
 			return nil, err
 		}
-		data := jsonutils.NewDict()
-		data.Add(jsonutils.NewString(sp.GetId()), "snapshotpolicy_id")
 		return data, nil
 	})
 	return nil

--- a/pkg/compute/tasks/snapshotpolicy_disk_task.go
+++ b/pkg/compute/tasks/snapshotpolicy_disk_task.go
@@ -58,7 +58,7 @@ func (self *SnapshotPolicyApplyTask) taskFail(ctx context.Context, disk *models.
 func (self *SnapshotPolicyApplyTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
 	disk := obj.(*models.SDisk)
 	spd := models.SSnapshotPolicyDisk{}
-	data.Unmarshal(&spd, "snapshotPolicy")
+	data.Unmarshal(&spd, "snapshotPolicyDisk")
 
 	var snapshotPolicy *models.SSnapshotPolicy
 	if data.Contains("need_detach") {
@@ -70,7 +70,7 @@ func (self *SnapshotPolicyApplyTask) OnInit(ctx context.Context, obj db.IStandal
 		}
 		snapshotPolicy = model.(*models.SSnapshotPolicy)
 	}
-	self.Params.Add(jsonutils.NewString(spd.GetId()), "snapshotpolicy_id")
+	self.Params.Add(jsonutils.NewString(spd.SnapshotpolicyId), "snapshotpolicy_id")
 
 	self.SetStage("OnPreSnapshotPolicyApplyComplete", nil)
 	// pass data to next Stage without inserting database through this way

--- a/pkg/multicloud/qcloud/snapshot_policy.go
+++ b/pkg/multicloud/qcloud/snapshot_policy.go
@@ -100,7 +100,13 @@ func (self *SSnapshotPolicy) GetRepeatWeekdays() ([]int, error) {
 	if len(self.Policy) == 0 {
 		return nil, errors.Error("Policy Set Empty")
 	}
-	return self.Policy[0].DayOfWeek, nil
+	repeatWeekdays := self.Policy[0].DayOfWeek
+	if len(repeatWeekdays) > 0 {
+		if repeatWeekdays[0] == 0 {
+			repeatWeekdays = append(repeatWeekdays, 7)[1:]
+		}
+	}
+	return repeatWeekdays, nil
 }
 
 func (self *SSnapshotPolicy) GetTimePoints() ([]int, error) {


### PR DESCRIPTION
disk diskplay

**这个 PR 实现什么功能/修复什么问题**:

1. snapshotpolicydisk 展示添加disk的详细信息
2. 修复了qcloud 周日显示的问题
3. snapshotpolicy 云上没有会直接删除

**是否需要 backport 到之前的 release 分支**:

- release/2.11


<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
