### PR TITLE
Automated cherry pick of #2747: fix: networkinterfaces belong system resource

### DIFF
--- a/pkg/cloudcommon/policy/resources.go
+++ b/pkg/cloudcommon/policy/resources.go
@@ -36,6 +36,7 @@ var (
 		"metadatas",
 		"loadbalancerclusters",
 		"loadbalanceragents",
+		"netowkinterfaces",
 	}
 	computeDomainResources = []string{
 		"cloudaccounts",


### PR DESCRIPTION
Cherry pick of #2747 on release/2.11.

#2747: fix: networkinterfaces belong system resource