### PR TITLE
Automated cherry pick of #2780: snapshotpolicy and disk should have same domain and project in snapshotpolicydisks

### DIFF
--- a/docs/schemas/snapshotpolicy.yaml
+++ b/docs/schemas/snapshotpolicy.yaml
@@ -155,6 +155,8 @@ SnapshotPolicyDisk:
       type: string
       example: f7749379-34b1-4219-8835-257615cf34f6
       description: 磁盘ID
+    disk:
+      $ref: 'disk.yaml#/Disk'
 
 SnapshotPolicyDiskResponse:
   type: object

--- a/pkg/compute/regiondrivers/base.go
+++ b/pkg/compute/regiondrivers/base.go
@@ -17,8 +17,10 @@ package regiondrivers
 import (
 	"context"
 	"fmt"
+
 	"yunion.io/x/jsonutils"
 
+	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/models"
@@ -166,6 +168,13 @@ func (self *SBaseRegionDriver) OnDiskReset(ctx context.Context, userCred mcclien
 
 func (self *SBaseRegionDriver) ValidateCreateSnapshopolicyDiskData(ctx context.Context,
 	userCred mcclient.TokenCredential, disk *models.SDisk, snapshotPolicy *models.SSnapshotPolicy) error {
+
+	if disk.DomainId != snapshotPolicy.DomainId {
+		return httperrors.NewBadRequestError("disk and snapshotpolicy should have same domain")
+	}
+	if disk.ProjectId != snapshotPolicy.ProjectId {
+		return httperrors.NewBadRequestError("disk and snapshotpolicy should have same project")
+	}
 	return nil
 }
 

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -785,6 +785,11 @@ func (self *SKVMRegionDriver) RequestUpdateSnapshotPolicy(ctx context.Context,
 func (self *SKVMRegionDriver) ValidateCreateSnapshopolicyDiskData(ctx context.Context,
 	userCred mcclient.TokenCredential, disk *models.SDisk, snapshotPolicy *models.SSnapshotPolicy) error {
 
+	err := self.SBaseRegionDriver.ValidateCreateSnapshopolicyDiskData(ctx, userCred, disk, snapshotPolicy)
+	if err != nil {
+		return err
+	}
+
 	if snapshotPolicy.RetentionDays < -1 || snapshotPolicy.RetentionDays == 0 || snapshotPolicy.RetentionDays > options.Options.RetentionDaysLimit {
 		return httperrors.NewInputParameterError("Retention days must in 1~%d or -1", options.Options.RetentionDaysLimit)
 	}

--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -1211,6 +1211,12 @@ func (self *SManagedVirtualizationRegionDriver) OnDiskReset(ctx context.Context,
 
 func (self *SManagedVirtualizationRegionDriver) ValidateCreateSnapshopolicyDiskData(ctx context.Context,
 	userCred mcclient.TokenCredential, disk *models.SDisk, snapshotPolicy *models.SSnapshotPolicy) error {
+
+	err := self.SBaseRegionDriver.ValidateCreateSnapshopolicyDiskData(ctx, userCred, disk, snapshotPolicy)
+	if err != nil {
+		return err
+	}
+
 	if snapshotPolicy.RetentionDays < -1 || snapshotPolicy.RetentionDays == 0 || snapshotPolicy.RetentionDays > 65535 {
 		return httperrors.NewInputParameterError("Retention days must in 1~65535 or -1")
 	}

--- a/pkg/compute/service/handlers.go
+++ b/pkg/compute/service/handlers.go
@@ -57,6 +57,8 @@ func InitHandlers(app *appsrv.Application) {
 
 		models.QuotaManager,
 		models.QuotaUsageManager,
+
+		models.SnapshotPolicyCacheManager,
 	} {
 		db.RegisterModelManager(manager)
 	}
@@ -94,7 +96,6 @@ func InitHandlers(app *appsrv.Application) {
 		models.NatSEntryManager,
 		models.SnapshotManager,
 		models.SnapshotPolicyManager,
-		models.SnapshotPolicyCacheManager,
 		models.BaremetalagentManager,
 		models.LoadbalancerManager,
 		models.LoadbalancerListenerManager,


### PR DESCRIPTION
Cherry pick of #2780 on release/2.11.

#2780: snapshotpolicy and disk should have same domain and project in snapshotpolicydisks