### PR TITLE
bugfix:  guest manager servers use sync.Map

### DIFF
--- a/pkg/hostman/guestman/guesthandlers/guesthandler.go
+++ b/pkg/hostman/guestman/guesthandlers/guesthandler.go
@@ -244,7 +244,7 @@ func guestSuspend(ctx context.Context, sid string, body jsonutils.JSONObject) (i
 }
 
 func guestIoThrottle(ctx context.Context, sid string, body jsonutils.JSONObject) (interface{}, error) {
-	guest, ok := guestman.GetGuestManager().Servers[sid]
+	guest, ok := guestman.GetGuestManager().GetServer(sid)
 	if !ok {
 		return nil, httperrors.NewNotFoundError("Guest %s not found", sid)
 	}
@@ -449,16 +449,16 @@ func guestCreateFromLibvirt(ctx context.Context, sid string, body jsonutils.JSON
 }
 
 func guestReloadDiskSnapshot(ctx context.Context, sid string, body jsonutils.JSONObject) (interface{}, error) {
-	if !guestman.GetGuestManager().IsGuestExist(sid) {
-		return nil, httperrors.NewNotFoundError("Guest %s not found", sid)
-	}
 	diskId, err := body.GetString("disk_id")
 	if err != nil {
 		return nil, httperrors.NewMissingParameterError("disk_id")
 	}
+	guest, ok := guestman.GetGuestManager().GetServer(sid)
+	if !ok {
+		return nil, httperrors.NewNotFoundError("guest %s not found", sid)
+	}
 
 	var disk storageman.IDisk
-	guest := guestman.GetGuestManager().Servers[sid]
 	disks, _ := guest.Desc.GetArray("disks")
 	for _, d := range disks {
 		id, _ := d.GetString("disk_id")
@@ -477,9 +477,6 @@ func guestReloadDiskSnapshot(ctx context.Context, sid string, body jsonutils.JSO
 }
 
 func guestSnapshot(ctx context.Context, sid string, body jsonutils.JSONObject) (interface{}, error) {
-	if !guestman.GetGuestManager().IsGuestExist(sid) {
-		return nil, httperrors.NewNotFoundError("Guest %s not found", sid)
-	}
 	snapshotId, err := body.GetString("snapshot_id")
 	if err != nil {
 		return nil, httperrors.NewMissingParameterError("snapshot_id")
@@ -488,9 +485,12 @@ func guestSnapshot(ctx context.Context, sid string, body jsonutils.JSONObject) (
 	if err != nil {
 		return nil, httperrors.NewMissingParameterError("disk_id")
 	}
+	guest, ok := guestman.GetGuestManager().GetServer(sid)
+	if !ok {
+		return nil, httperrors.NewNotFoundError("guest %s not found", sid)
+	}
 
 	var disk storageman.IDisk
-	guest := guestman.GetGuestManager().Servers[sid]
 	disks, _ := guest.Desc.GetArray("disks")
 	for _, d := range disks {
 		id, _ := d.GetString("disk_id")
@@ -517,9 +517,12 @@ func guestDeleteSnapshot(ctx context.Context, sid string, body jsonutils.JSONObj
 	if err != nil {
 		return nil, httperrors.NewMissingParameterError("disk_id")
 	}
+	guest, ok := guestman.GetGuestManager().GetServer(sid)
+	if !ok {
+		return nil, httperrors.NewNotFoundError("guest %s not found", sid)
+	}
 
 	var disk storageman.IDisk
-	guest := guestman.GetGuestManager().Servers[sid]
 	disks, _ := guest.Desc.GetArray("disks")
 	for _, d := range disks {
 		id, _ := d.GetString("disk_id")

--- a/pkg/hostman/guestman/libvirt.go
+++ b/pkg/hostman/guestman/libvirt.go
@@ -70,7 +70,7 @@ func (m *SGuestManager) GuestCreateFromLibvirt(
 		}
 		disksPath.Set(diskId, jsonutils.NewString(iDisk.GetPath()))
 	}
-	guest := m.Servers[createConfig.Sid]
+	guest, _ := m.GetServer(createConfig.Sid)
 	if err = guest.SaveDesc(createConfig.GuestDesc); err != nil {
 		return nil, err
 	}

--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -305,7 +305,7 @@ func (s *SKVMGuestInstance) GetStopScriptPath() string {
 }
 
 func (s *SKVMGuestInstance) ImportServer(pendingDelete bool) {
-	s.manager.Servers[s.Id] = s
+	s.manager.SaveServer(s.Id, s)
 	s.manager.RemoveCandidateServer(s)
 
 	if s.IsDirtyShotdown() && !pendingDelete {

--- a/pkg/hostman/hostmetrics/hostmetrics.go
+++ b/pkg/hostman/hostmetrics/hostmetrics.go
@@ -164,8 +164,9 @@ func NewGuestMonitorCollector() *SGuestMonitorCollector {
 func (s *SGuestMonitorCollector) GetGuests() map[string]*SGuestMonitor {
 	var err error
 	gms := make(map[string]*SGuestMonitor, 0)
-	guetmananger := guestman.GetGuestManager()
-	for _, guest := range guetmananger.Servers {
+	guestmanager := guestman.GetGuestManager()
+	guestmanager.Servers.Range(func(k, v interface{}) bool {
+		guest := v.(*guestman.SKVMGuestInstance)
 		pid := guest.GetPid()
 		if pid > 0 {
 			guestName, _ := guest.Desc.GetString("name")
@@ -185,12 +186,13 @@ func (s *SGuestMonitorCollector) GetGuests() map[string]*SGuestMonitor {
 				gm, err = NewGuestMonitor(guestName, guestId, pid, nics, int(vcpuCount))
 				if err != nil {
 					log.Errorln(err)
-					continue
+					return true
 				}
 			}
 			gms[guestId] = gm
 		}
-	}
+		return true
+	})
 	s.monitors = gms
 	return gms
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
servers 使用sync.Map防止并发读写导致panic
**是否需要 backport 到之前的 release 分支**:
release/2.11
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/area host
/cc @swordqiu 