### PR TITLE
hotfix: avolid auth for yunionmeta dbinstance_skus

### DIFF
--- a/pkg/cloudcommon/policy/defaults.go
+++ b/pkg/cloudcommon/policy/defaults.go
@@ -329,6 +329,25 @@ var (
 			},
 		},
 		{
+			// meta服务 dbinstance_skus列表不需要认证
+			Auth:  false,
+			Scope: rbacutils.ScopeSystem,
+			Rules: []rbacutils.SRbacRule{
+				{
+					Service:  "yunionmeta",
+					Resource: "dbinstance_skus",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  "yunionmeta",
+					Resource: "dbinstance_skus",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+			},
+		},
+		{
 			// for anonymous update torrent status
 			Auth:  false,
 			Scope: rbacutils.ScopeSystem,


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
meta 服务的rds套餐不需要认证

**是否需要 backport 到之前的 release 分支**:
None

/area region
/cc @swordqiu @yousong 
