### PR TITLE
Bugfix and feature add: nat

### DIFF
--- a/cmd/climc/shell/natgateways.go
+++ b/cmd/climc/shell/natgateways.go
@@ -43,4 +43,30 @@ func init() {
 		printObject(results)
 		return nil
 	})
+
+	type NatGatewayListEipOptions struct {
+		ID string `help:"ID"`
+	}
+
+	R(&NatGatewayListEipOptions{}, "natgateway-dnat-resources", "list resources in dnats of natgateway",
+		func(s *mcclient.ClientSession, opts *NatGatewayListEipOptions) error {
+
+		ret, err := modules.NatGateways.PerformAction(s, opts.ID, "dnat-resources", nil)
+		if err != nil {
+			return err
+		}
+		printObject(ret)
+		return nil
+	})
+
+	R(&NatGatewayListEipOptions{}, "natgateway-snat-resources", "list resources in snats of natgateway",
+		func(s *mcclient.ClientSession, opts *NatGatewayListEipOptions) error {
+
+			ret, err := modules.NatGateways.PerformAction(s, opts.ID, "snat-resources", nil)
+			if err != nil {
+				return err
+			}
+			printObject(ret)
+			return nil
+		})
 }

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -245,6 +245,10 @@ paths:
     $ref: "./natgateway/natgateways.yaml"
   /natgateways/{natgatewayId}:
     $ref: "./natgateway/natgateway.yaml"
+  /natgateways/{natgatewayId}/dnat-eips:
+    $ref: "./natgateway/dnat-eips.yaml"
+  /natgateways/{natgatewayId}/snat-eips:
+    $ref: "./natgateway/snat-eips.yaml"
   /natdentries:
     $ref: "./natgateway/dnatentries.yaml"
   /natdentries/{dnatentryId}:

--- a/docs/natgateway/dnat-eips.yaml
+++ b/docs/natgateway/dnat-eips.yaml
@@ -1,0 +1,13 @@
+post:
+  summary: NAT网关下DNAT规则EIP的集合
+  parameters:
+    - $ref: "../parameters/natgateway.yaml#/natgatewayId"
+  responses:
+    200:
+      description: DNAT规则EIP集合
+      schema:
+        - $ref: "../schemas/natgateway.yaml#/EIPAddrs"
+  tags:
+    - natgateway
+
+

--- a/docs/natgateway/snat-eips.yaml
+++ b/docs/natgateway/snat-eips.yaml
@@ -1,0 +1,11 @@
+post:
+  summary: NAT网关下SNAT规则EIP的集合
+  parameters:
+    - $ref: "../parameters/natgateway.yaml#/natgatewayId"
+  responses:
+    200:
+      description: SNAT规则EIP集合
+      schema:
+        - $ref: "../schemas/natgateway.yaml#/EIPAddrs"
+  tags:
+    - natgateway

--- a/docs/schemas/natgateway.yaml
+++ b/docs/schemas/natgateway.yaml
@@ -225,9 +225,7 @@ SNatEntry:
       example: 4daf9886-ebe6-4a8a-8082-3bd623d1c857
       description: 所属NAT网关ID
     network:
-      type: string
-      example: test-network
-      description: 所属子网名称
+      $ref: 'network.yaml#/Network'
     network_id:
       type: string
       example: 7caf732e-93fc-42c0-89d2-86aac2970c38
@@ -348,3 +346,12 @@ SNatEntryCreate:
           type: string
           example: 192.168.1.0/24
           description: 映射到公网IP的内网网段(和network_id互斥，只需要传入一个）
+
+EIPAddrs:
+  type: object
+  properties:
+    eips:
+      type: array
+      items:
+        type: string
+      example: [34.23.125.45, 23.45.123.56]

--- a/pkg/cloudcommon/policy/resources.go
+++ b/pkg/cloudcommon/policy/resources.go
@@ -37,6 +37,9 @@ var (
 		"loadbalancerclusters",
 		"loadbalanceragents",
 		"netowkinterfaces",
+		"natgateways",
+		"natsentries",
+		"natdentries",
 	}
 	computeDomainResources = []string{
 		"cloudaccounts",


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
接口修改：添加了 获取snat的dnat已经使用的资源 的接口，snat查询返回值中增加了network的详细信息
参数检测：创建snat时，检查sourceCIDR是否合法，是否在所属的vpc内部
权限控制：添加natgateways，natsentries，natdentries到 compute system resources

**是否需要 backport 到之前的 release 分支**:
 - release/2.11
 - release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
