### PR TITLE
fix: 避免解绑EIP后释放EIP任务失败

### DIFF
--- a/pkg/multicloud/qcloud/qcloud.go
+++ b/pkg/multicloud/qcloud/qcloud.go
@@ -343,10 +343,16 @@ func _baseJsonRequest(client *common.Client, req tchttp.Request, resp qcloudResp
 			break
 		}
 		needRetry := false
-		for _, msg := range []string{"EOF", "TLS handshake timeout", "Code=InternalError", "try later", "Code=MutexOperation.TaskRunning", "Code=InvalidInstance.NotSupported", "i/o timeout"} {
-			// Code=InvalidInstance.NotSupported, Message=The request does not support the instances `ins-bg54517v` which are in operation or in a special state., RequestId=79d02048-a8c9-4b59-b442-3c6f01fb728e
-			// Code=DesOperation.MutexTaskRunning, Message=Mutex task is running, please try later, RequestId=4529e365-b466-4239-ab56-ad36da70d982
-			// 重装系统后立即关机有可能会引发 Code=InvalidInstance.NotSupported 错误, 重试可以避免任务失败
+		for _, msg := range []string{
+			"EOF",
+			"TLS handshake timeout",
+			"Code=InternalError",
+			"try later",
+			"Code=MutexOperation.TaskRunning",   // Code=DesOperation.MutexTaskRunning, Message=Mutex task is running, please try later
+			"Code=InvalidInstance.NotSupported", // Code=InvalidInstance.NotSupported, Message=The request does not support the instances `ins-bg54517v` which are in operation or in a special state., 重装系统后立即关机有可能会引发 Code=InvalidInstance.NotSupported 错误, 重试可以避免任务失败
+			"i/o timeout",
+			"Code=InvalidAddressId.StatusNotPermit", // Code=InvalidAddressId.StatusNotPermit, Message=The status `"UNBINDING"` for AddressId `"eip-m3kix9kx"` is not permit to do this operation., EIP删除需要重试
+		} {
 			if strings.Contains(err.Error(), msg) {
 				needRetry = true
 				break


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免解绑EIP后释放EIP任务失败

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @swordqiu @yousong 
