### PR TITLE
Automated cherry pick of #2823: fix: 修复安全组关联数量校验不正确问题

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -936,7 +936,7 @@ func (self *SGuest) PerformAddSecgroup(ctx context.Context, userCred mcclient.To
 	}
 
 	originSecgroups := self.GetSecgroups()
-	if len(originSecgroups)+len(secgrpJsonArray) >= maxCount {
+	if len(originSecgroups)+len(secgrpJsonArray) > maxCount {
 		return nil, httperrors.NewUnsupportOperationError("guest %s band to up to %d security groups", self.Name, maxCount)
 	}
 


### PR DESCRIPTION
Cherry pick of #2823 on release/2.10.0.

#2823: fix: 修复安全组关联数量校验不正确问题