### PR TITLE
fix: system account user fail to login apigateway

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -669,6 +669,7 @@ func getUserInfo(ctx context.Context, s *mcclient.ClientSession, token mcclient.
 	query := jsonutils.NewDict()
 	query.Add(jsonutils.JSONNull, "effective")
 	query.Add(jsonutils.JSONNull, "include_names")
+	query.Add(jsonutils.JSONNull, "include_system")
 	query.Add(jsonutils.NewInt(0), "limit")
 	query.Add(jsonutils.NewString(token.GetUserId()), "user", "id")
 	roleAssigns, err := modules.RoleAssignments.List(s, query)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：系统账户的用户无法登录apigateway

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12

/area apigateway