### PR TITLE
Automated cherry pick of #2866: fix: system account user fail to login apigateway

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -669,6 +669,7 @@ func getUserInfo(ctx context.Context, s *mcclient.ClientSession, token mcclient.
 	query := jsonutils.NewDict()
 	query.Add(jsonutils.JSONNull, "effective")
 	query.Add(jsonutils.JSONNull, "include_names")
+	query.Add(jsonutils.JSONNull, "include_system")
 	query.Add(jsonutils.NewInt(0), "limit")
 	query.Add(jsonutils.NewString(token.GetUserId()), "user", "id")
 	roleAssigns, err := modules.RoleAssignments.List(s, query)


### PR DESCRIPTION
Cherry pick of #2866 on release/2.12.

#2866: fix: system account user fail to login apigateway