### PR TITLE
bugfix glance save form url save md5

### DIFF
--- a/pkg/image/tasks/image_copy_from_url_task.go
+++ b/pkg/image/tasks/image_copy_from_url_task.go
@@ -55,10 +55,7 @@ func (self *ImageCopyFromUrlTask) OnInit(ctx context.Context, obj db.IStandalone
 		if err != nil {
 			return nil, err
 		}
-		md5 := resp.Header.Get("Content-Md5")
-		if len(md5) == 0 {
-			md5 = resp.Header.Get("x-oss-meta-yunion-os-checksum")
-		}
+		md5 := resp.Header.Get("x-oss-meta-yunion-os-checksum")
 		if len(md5) > 0 {
 			db.Update(image, func() error {
 				image.OssChecksum = md5


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复galnce保存镜像时md5的来源
**是否需要 backport 到之前的 release 分支**:
release/2.10.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
/cc @swordqiu @zexi @tb365 
/area image
