### PR TITLE
fix: 1. specifically baremetal use access ip to manage and listen ip …

### DIFF
--- a/pkg/baremetal/agent.go
+++ b/pkg/baremetal/agent.go
@@ -94,6 +94,12 @@ func (agent *SBaremetalAgent) GetDHCPServerListenIP() (net.IP, error) {
 }
 
 func (agent *SBaremetalAgent) GetAccessIP() (net.IP, error) {
+	if o.Options.AccessAddress != "" && o.Options.AccessAddress != "0.0.0.0" {
+		return net.ParseIP(o.Options.AccessAddress), nil
+	}
+	if o.Options.Address != "" && o.Options.Address != "0.0.0.0" {
+		return net.ParseIP(o.Options.Address), nil
+	}
 	return agent.FindAccessIP(o.Options.AccessAddress)
 }
 

--- a/pkg/baremetal/manager_test.go
+++ b/pkg/baremetal/manager_test.go
@@ -1,0 +1,30 @@
+package baremetal
+
+import (
+	"testing"
+)
+
+func TestReplaceHostAddr(t *testing.T) {
+	cases := []struct {
+		In   string
+		Addr string
+		Want string
+	}{
+		{
+			In:   "https://www.sina.com.cn",
+			Addr: "118.187.65.237",
+			Want: "https://118.187.65.237",
+		},
+		{
+			In:   "https://192.168.223.22:9292/v1/images",
+			Addr: "10.168.24.23",
+			Want: "https://10.168.24.23:9292/v1/images",
+		},
+	}
+	for _, c := range cases {
+		got := replaceHostAddr(c.In, c.Addr)
+		if got != c.Want {
+			t.Errorf("In: %s Addr: %s Got: %s Want: %s", c.In, c.Addr, got, c.Want)
+		}
+	}
+}

--- a/pkg/baremetal/utils/raid/hpssactl/hpssactl.go
+++ b/pkg/baremetal/utils/raid/hpssactl/hpssactl.go
@@ -207,10 +207,11 @@ func (adapter *HPSARaidAdaptor) conf2Params(conf *api.BaremetalDiskConfig) []str
 
 func (adapter *HPSARaidAdaptor) getLastArray() (string, error) {
 	cmd := GetCommand("controller", fmt.Sprintf("slot=%d", adapter.index), "logicaldrive", "all", "show")
-	ret, err := adapter.raid.term.Run(cmd)
-	if err != nil {
-		return "", err
-	}
+	ret, _ := adapter.raid.term.Run(cmd)
+	// ignore errors
+	// if err != nil {
+	// 	return "", err
+	// }
 	var lastArray string
 	for _, line := range ret {
 		m := regutils2.SubGroupMatch(`array\s+(?P<idx>\w+)`, line)
@@ -299,10 +300,11 @@ func (adapter *HPSARaidAdaptor) removeLogicVolume(idx int) error {
 
 func (adapter *HPSARaidAdaptor) GetLogicVolumes() ([]*raid.RaidLogicalVolume, error) {
 	cmd := GetCommand("controller", fmt.Sprintf("slot=%d", adapter.index), "logicaldrive", "all", "show")
-	ret, err := adapter.raid.term.Run(cmd)
-	if err != nil {
-		return nil, err
-	}
+	ret, _ := adapter.raid.term.Run(cmd)
+	// ignore error
+	// if err != nil {
+	// 	return nil, err
+	// }
 	return adapter.parseLogicalVolumes(ret)
 }
 

--- a/pkg/cloudcommon/agent/agent.go
+++ b/pkg/cloudcommon/agent/agent.go
@@ -287,6 +287,15 @@ func (agent *SBaseAgent) GetManagerUri() string {
 	return fmt.Sprintf("%s://%s:%d", proto, accessIP, agent.IAgent().GetPort())
 }
 
+func (agent *SBaseAgent) GetListenUri() string {
+	listenIP, _ := agent.IAgent().GetListenIP()
+	proto := "http"
+	if agent.IAgent().GetEnableSsl() {
+		proto = "https"
+	}
+	return fmt.Sprintf("%s://%s:%d", proto, listenIP, agent.IAgent().GetPort())
+}
+
 func (agent *SBaseAgent) getCreateUpdateInfo() (jsonutils.JSONObject, error) {
 	accessIP, err := agent.IAgent().GetAccessIP()
 	if err != nil {

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -27,6 +27,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/pkg/util/compare"
 	"yunion.io/x/pkg/util/fileutils"
@@ -3129,6 +3130,10 @@ func (self *SHost) addNetif(ctx context.Context, userCred mcclient.TokenCredenti
 	}
 	netif, err := NetInterfaceManager.FetchByMac(mac)
 	if err != nil {
+		if err != sql.ErrNoRows {
+			return httperrors.NewInternalServerError("fail to fetch netif by mac %s: %s", mac, err)
+		}
+		// else not found
 		netif = &SNetInterface{}
 		netif.Mac = mac
 		netif.BaremetalId = self.Id
@@ -3177,7 +3182,7 @@ func (self *SHost) addNetif(ctx context.Context, userCred mcclient.TokenCredenti
 			return nil
 		})
 		if err != nil {
-			return err
+			return errors.Wrap(err, "db.Update")
 		}
 		if changed || reset {
 			self.DisableNetif(ctx, userCred, netif, false)
@@ -3193,8 +3198,11 @@ func (self *SHost) addNetif(ctx context.Context, userCred mcclient.TokenCredenti
 				bridge = fmt.Sprintf("br%s", sw.GetName())
 			}
 			var isMaster = netif.NicType == api.NIC_TYPE_ADMIN
-			hw, err := HostwireManager.FetchByIdsAndMac(self.Id, sw.Id, mac)
+			hw, err := HostwireManager.FetchByHostIdAndMac(self.Id, mac)
 			if err != nil {
+				if err != sql.ErrNoRows {
+					return httperrors.NewInternalServerError("fail to fetch hostwire by mac %s: %s", mac, err)
+				}
 				hw = &SHostwire{}
 				hw.Bridge = bridge
 				hw.Interface = strInterface
@@ -3211,6 +3219,7 @@ func (self *SHost) addNetif(ctx context.Context, userCred mcclient.TokenCredenti
 					hw.Bridge = bridge
 					hw.Interface = strInterface
 					// hw.MacAddr = mac
+					hw.WireId = sw.Id
 					hw.IsMaster = isMaster
 					return nil
 				})
@@ -3278,8 +3287,11 @@ func (self *SHost) EnableNetif(ctx context.Context, userCred mcclient.TokenCrede
 	if wire == nil {
 		return fmt.Errorf("No wire attached")
 	}
-	hw, err := HostwireManager.FetchByIdsAndMac(self.Id, wire.Id, netif.Mac)
-	if hw == nil {
+	hw, err := HostwireManager.FetchByHostIdAndMac(self.Id, netif.Mac)
+	if err != nil {
+		return err
+	}
+	if hw.WireId != wire.Id {
 		return fmt.Errorf("host not attach to this wire")
 	}
 	if net == nil {
@@ -3404,7 +3416,7 @@ func (self *SHost) RemoveNetif(ctx context.Context, userCred mcclient.TokenCrede
 		log.Infof("Remove wire")
 		others := self.GetNetifsOnWire(wire)
 		if len(others) == 0 {
-			hw, _ := HostwireManager.FetchByIdsAndMac(self.Id, wire.Id, netif.Mac)
+			hw, _ := HostwireManager.FetchByHostIdAndMac(self.Id, netif.Mac)
 			if hw != nil {
 				db.OpsLog.LogDetachEvent(ctx, self, wire, userCred, jsonutils.NewString(fmt.Sprintf("disable netif %s", self.AccessMac)))
 				log.Infof("Detach host wire because of remove netif %s", netif.Mac)

--- a/pkg/compute/models/hostwires.go
+++ b/pkg/compute/models/hostwires.go
@@ -156,12 +156,15 @@ func (manager *SHostwireManager) FilterByParams(q *sqlchemy.SQuery, params jsonu
 	return q
 }
 
-func (manager *SHostwireManager) FetchByIdsAndMac(hostId string, wireId string, mac string) (*SHostwire, error) {
-	query := jsonutils.NewDict()
-	query.Add(jsonutils.NewString(mac), "mac_addr")
-	ihw, err := db.FetchJointByIds(manager, hostId, wireId, query)
+func (manager *SHostwireManager) FetchByHostIdAndMac(hostId string, mac string) (*SHostwire, error) {
+	hw, err := db.NewModelObject(manager)
 	if err != nil {
 		return nil, err
 	}
-	return ihw.(*SHostwire), nil
+	q := manager.Query().Equals("host_id", hostId).Equals("mac_addr", mac)
+	err = q.First(hw)
+	if err != nil {
+		return nil, err
+	}
+	return hw.(*SHostwire), nil
 }


### PR DESCRIPTION
…to serve baremetal

2. hot net interface might be attached to multiple wire
2. hack fix: baremetal cannot access glance on management network

**这个 PR 实现什么功能/修复什么问题**:
1. baremetal用access ip被管理，listen ip服务裸机（裸机网和管理网隔离导致的）
2. 不允许host netinterface和多个wire关联
3. hack：由于裸机无法访问管理网，先临时把glance的URL替换为裸机网络的IP

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12

/area baremetal