### PR TITLE
Automated cherry pick of #2881: fix: 1. specifically baremetal use access ip to manage and listen ip to serve baremetal 2. hot net interface might be attached to multiple wire 2. hack fix: baremetal cannot access glance on management network

### DIFF
--- a/pkg/baremetal/agent.go
+++ b/pkg/baremetal/agent.go
@@ -94,6 +94,12 @@ func (agent *SBaremetalAgent) GetDHCPServerListenIP() (net.IP, error) {
 }
 
 func (agent *SBaremetalAgent) GetAccessIP() (net.IP, error) {
+	if o.Options.AccessAddress != "" && o.Options.AccessAddress != "0.0.0.0" {
+		return net.ParseIP(o.Options.AccessAddress), nil
+	}
+	if o.Options.Address != "" && o.Options.Address != "0.0.0.0" {
+		return net.ParseIP(o.Options.Address), nil
+	}
 	return agent.FindAccessIP(o.Options.AccessAddress)
 }
 

--- a/pkg/baremetal/manager_test.go
+++ b/pkg/baremetal/manager_test.go
@@ -1,0 +1,30 @@
+package baremetal
+
+import (
+	"testing"
+)
+
+func TestReplaceHostAddr(t *testing.T) {
+	cases := []struct {
+		In   string
+		Addr string
+		Want string
+	}{
+		{
+			In:   "https://www.sina.com.cn",
+			Addr: "118.187.65.237",
+			Want: "https://118.187.65.237",
+		},
+		{
+			In:   "https://192.168.223.22:9292/v1/images",
+			Addr: "10.168.24.23",
+			Want: "https://10.168.24.23:9292/v1/images",
+		},
+	}
+	for _, c := range cases {
+		got := replaceHostAddr(c.In, c.Addr)
+		if got != c.Want {
+			t.Errorf("In: %s Addr: %s Got: %s Want: %s", c.In, c.Addr, got, c.Want)
+		}
+	}
+}

--- a/pkg/baremetal/utils/raid/hpssactl/hpssactl.go
+++ b/pkg/baremetal/utils/raid/hpssactl/hpssactl.go
@@ -207,10 +207,11 @@ func (adapter *HPSARaidAdaptor) conf2Params(conf *api.BaremetalDiskConfig) []str
 
 func (adapter *HPSARaidAdaptor) getLastArray() (string, error) {
 	cmd := GetCommand("controller", fmt.Sprintf("slot=%d", adapter.index), "logicaldrive", "all", "show")
-	ret, err := adapter.raid.term.Run(cmd)
-	if err != nil {
-		return "", err
-	}
+	ret, _ := adapter.raid.term.Run(cmd)
+	// ignore errors
+	// if err != nil {
+	// 	return "", err
+	// }
 	var lastArray string
 	for _, line := range ret {
 		m := regutils2.SubGroupMatch(`array\s+(?P<idx>\w+)`, line)
@@ -299,10 +300,11 @@ func (adapter *HPSARaidAdaptor) removeLogicVolume(idx int) error {
 
 func (adapter *HPSARaidAdaptor) GetLogicVolumes() ([]*raid.RaidLogicalVolume, error) {
 	cmd := GetCommand("controller", fmt.Sprintf("slot=%d", adapter.index), "logicaldrive", "all", "show")
-	ret, err := adapter.raid.term.Run(cmd)
-	if err != nil {
-		return nil, err
-	}
+	ret, _ := adapter.raid.term.Run(cmd)
+	// ignore error
+	// if err != nil {
+	// 	return nil, err
+	// }
 	return adapter.parseLogicalVolumes(ret)
 }
 

--- a/pkg/cloudcommon/agent/agent.go
+++ b/pkg/cloudcommon/agent/agent.go
@@ -295,6 +295,15 @@ func (agent *SBaseAgent) GetManagerUri() string {
 	return fmt.Sprintf("%s://%s:%d", proto, accessIP, agent.IAgent().GetPort())
 }
 
+func (agent *SBaseAgent) GetListenUri() string {
+	listenIP, _ := agent.IAgent().GetListenIP()
+	proto := "http"
+	if agent.IAgent().GetEnableSsl() {
+		proto = "https"
+	}
+	return fmt.Sprintf("%s://%s:%d", proto, listenIP, agent.IAgent().GetPort())
+}
+
 func (agent *SBaseAgent) getCreateUpdateInfo() (jsonutils.JSONObject, error) {
 	accessIP, err := agent.IAgent().GetAccessIP()
 	if err != nil {

--- a/pkg/compute/models/hostwires.go
+++ b/pkg/compute/models/hostwires.go
@@ -156,12 +156,15 @@ func (manager *SHostwireManager) FilterByParams(q *sqlchemy.SQuery, params jsonu
 	return q
 }
 
-func (manager *SHostwireManager) FetchByIdsAndMac(hostId string, wireId string, mac string) (*SHostwire, error) {
-	query := jsonutils.NewDict()
-	query.Add(jsonutils.NewString(mac), "mac_addr")
-	ihw, err := db.FetchJointByIds(manager, hostId, wireId, query)
+func (manager *SHostwireManager) FetchByHostIdAndMac(hostId string, mac string) (*SHostwire, error) {
+	hw, err := db.NewModelObject(manager)
 	if err != nil {
 		return nil, err
 	}
-	return ihw.(*SHostwire), nil
+	q := manager.Query().Equals("host_id", hostId).Equals("mac_addr", mac)
+	err = q.First(hw)
+	if err != nil {
+		return nil, err
+	}
+	return hw.(*SHostwire), nil
 }


### PR DESCRIPTION
Cherry pick of #2881 on release/2.10.0.

#2881: fix: 1. specifically baremetal use access ip to manage and listen ip to serve baremetal 2. hot net interface might be attached to multiple wire 2. hack fix: baremetal cannot access glance on management network