### PR TITLE
bugfix: fix init listen interface

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -139,11 +139,6 @@ func (h *SHostInfo) parseConfig() error {
 	if h.GetMemory() < 64 { // MB
 		return fmt.Errorf("Not enough memory!")
 	}
-	if len(options.HostOptions.ListenInterface) > 0 {
-		h.MasterNic = netutils2.NewNetInterface(options.HostOptions.ListenInterface)
-	} else {
-		h.MasterNic = nil
-	}
 	for _, n := range options.HostOptions.Networks {
 		nic, err := NewNIC(n)
 		if err != nil {
@@ -155,6 +150,14 @@ func (h *SHostInfo) parseConfig() error {
 		if err := h.Nics[i].SetupDhcpRelay(); err != nil {
 			return err
 		}
+	}
+	if len(options.HostOptions.ListenInterface) > 0 {
+		h.MasterNic = netutils2.NewNetInterface(options.HostOptions.ListenInterface)
+		if len(h.MasterNic.Addr) == 0 {
+			return fmt.Errorf("Listen interface %s master not have IP", options.HostOptions.ListenInterface)
+		}
+	} else {
+		h.MasterNic = nil
 	}
 
 	if man, err := isolated_device.NewManager(h); err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复初始化listen interface的顺序
**是否需要 backport 到之前的 release 分支**:
release/2.10.0
/cc @swordqiu @zexi 
/area host
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
