### PR TITLE
scheduler: fix disk local backend not select matched storage

### DIFF
--- a/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
@@ -105,7 +105,7 @@ func (p *DiskSchedtagPredicate) IsResourceFitInput(u *core.Unit, c core.Candidat
 	if c.Getter().ResourceType() == computeapi.HostResourceTypePrepaidRecycle {
 		return nil
 	}
-	if !(len(d.Backend) == 0 || d.Backend == computeapi.STORAGE_LOCAL) {
+	if len(d.Backend) != 0 {
 		if storage.StorageType != d.Backend {
 			return &FailReason{
 				fmt.Sprintf("Storage %s backend %s != %s", storage.Name, storage.StorageType, d.Backend),


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

调度其修复本地磁盘和存储不匹配的问题

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- 2.10

/area scheduler
/cc @wanyaoqi 