### PR TITLE
Automated cherry pick of #2932: lbagents: deploy: check existence of pbId before create/update

### DIFF
--- a/pkg/ansibleserver/models/ansibleplaybooks.go
+++ b/pkg/ansibleserver/models/ansibleplaybooks.go
@@ -271,6 +271,15 @@ func (apb *SAnsiblePlaybook) stopPlaybook(ctx context.Context, userCred mcclient
 	man.sessionsMux.Lock()
 	defer man.sessionsMux.Unlock()
 	if !man.sessions.Has(apb.Id) {
+		if apb.Status == AnsiblePlaybookStatusRunning {
+			_, err := db.Update(apb, func() error {
+				apb.Status = AnsiblePlaybookStatusUnknown
+				return nil
+			})
+			if err != nil {
+				log.Errorf("updating ansible playbook status to unknown failed: %v", err)
+			}
+		}
 		return fmt.Errorf("playbook is not running")
 	}
 	// the playbook will be removed from session map in runPlaybook() on return from run

--- a/pkg/compute/models/loadbalanceragents_deploy.go
+++ b/pkg/compute/models/loadbalanceragents_deploy.go
@@ -313,6 +313,17 @@ func (lbagent *SLoadbalancerAgent) updateOrCreatePbModel(ctx context.Context,
 	pb *ansible.Playbook,
 ) (*mcclient_models.AnsiblePlaybook, error) {
 	cliSess := auth.GetSession(ctx, userCred, "", "")
+
+	if pbId == "" {
+		pbJson, err := mcclient_modules.AnsiblePlaybooks.Get(cliSess, pbName, nil)
+		if err == nil {
+			pbModel := &mcclient_models.AnsiblePlaybook{}
+			if err := pbJson.Unmarshal(pbModel); err == nil {
+				pbId = pbModel.Id
+			}
+		}
+	}
+
 	var pbJson jsonutils.JSONObject
 	if pbId != "" {
 		var err error


### PR DESCRIPTION
Cherry pick of #2932 on release/2.11.

#2932: lbagents: deploy: check existence of pbId before create/update