### PR TITLE
Automated cherry pick of #2936: fix: 1. hpssactl blocks on user input 2. host-add-netif reset nic index 3. init baremetal nics with name enX instead of ethX

### DIFF
--- a/cmd/climc/shell/hosts.go
+++ b/cmd/climc/shell/hosts.go
@@ -337,12 +337,14 @@ func init() {
 		MAC    string `help:"Mac address of NIC"`
 		Type   string `help:"Nic type" choices:"admin|ipmi"`
 		IpAddr string `help:"IP address"`
+		Index  int64  `help:"nic index" default:"-1"`
 	}
 	R(&HostAddNetIfOptions{}, "host-add-netif", "Host add a NIC", func(s *mcclient.ClientSession, args *HostAddNetIfOptions) error {
 		params := jsonutils.NewDict()
 		params.Add(jsonutils.NewString(args.WIRE), "wire")
 		params.Add(jsonutils.NewString(args.MAC), "mac")
 		params.Add(jsonutils.JSONTrue, "link_up")
+		params.Add(jsonutils.NewInt(args.Index), "index")
 		if len(args.Type) > 0 {
 			params.Add(jsonutils.NewString(args.Type), "nic_type")
 		}

--- a/pkg/baremetal/agent.go
+++ b/pkg/baremetal/agent.go
@@ -24,6 +24,7 @@ import (
 	o "yunion.io/x/onecloud/pkg/baremetal/options"
 	"yunion.io/x/onecloud/pkg/baremetal/pxe"
 	"yunion.io/x/onecloud/pkg/cloudcommon/agent"
+	"yunion.io/x/onecloud/pkg/hostman/guestfs/fsdriver"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/util/procutils"
@@ -50,6 +51,8 @@ func newBaremetalAgent() (*SBaremetalAgent, error) {
 	if err != nil {
 		return nil, err
 	}
+	// set guest fs NetDevPrefix
+	fsdriver.NetDevPrefix = "en"
 	return agent, nil
 }
 

--- a/pkg/baremetal/manager.go
+++ b/pkg/baremetal/manager.go
@@ -797,7 +797,7 @@ func (b *SBaremetalInstance) SyncServerStatus(status string) {
 	log.Infof("Update server %s to status %s", b.GetServerName(), status)
 }
 
-func (b *SBaremetalInstance) getNics() []types.SNic {
+func (b *SBaremetalInstance) GetNics() []types.SNic {
 	nics := []types.SNic{}
 	err := b.desc.Unmarshal(&nics, "nic_info")
 	if err != nil {
@@ -808,21 +808,20 @@ func (b *SBaremetalInstance) getNics() []types.SNic {
 }
 
 func (b *SBaremetalInstance) getNicByType(nicType string) *types.SNic {
-	nics := b.getNics()
+	nics := b.GetNics()
 	if len(nics) == 0 {
 		return nil
 	}
-	for _, nic := range nics {
-		tmp := nic
-		if tmp.Type == nicType {
-			return &tmp
+	for i := range nics {
+		if nics[i].Type == nicType {
+			return &nics[i]
 		}
 	}
 	return nil
 }
 
 func (b *SBaremetalInstance) GetNicByMac(mac net.HardwareAddr) *types.SNic {
-	nics := b.getNics()
+	nics := b.GetNics()
 	if len(nics) == 0 {
 		return nil
 	}
@@ -836,7 +835,7 @@ func (b *SBaremetalInstance) GetNicByMac(mac net.HardwareAddr) *types.SNic {
 }
 
 func (b *SBaremetalInstance) GetAdminNic() *types.SNic {
-	return b.getNicByType(NIC_TYPE_ADMIN)
+	return b.getNicByType(api.NIC_TYPE_ADMIN)
 }
 
 func (b *SBaremetalInstance) NeedPXEBoot() bool {
@@ -864,7 +863,7 @@ func (b *SBaremetalInstance) GetHostType() string {
 }
 
 func (b *SBaremetalInstance) GetIPMINic(cliMac net.HardwareAddr) *types.SNic {
-	nic := b.getNicByType(types.NIC_TYPE_IPMI)
+	nic := b.getNicByType(api.NIC_TYPE_IPMI)
 	if nic == nil {
 		return nil
 	}
@@ -875,7 +874,7 @@ func (b *SBaremetalInstance) GetIPMINic(cliMac net.HardwareAddr) *types.SNic {
 }
 
 func (b *SBaremetalInstance) GetIPMINicIPAddr() string {
-	nic := b.getNicByType(types.NIC_TYPE_IPMI)
+	nic := b.getNicByType(api.NIC_TYPE_IPMI)
 	if nic == nil {
 		return ""
 	}
@@ -985,7 +984,7 @@ func (b *SBaremetalInstance) InitAdminNetif(
 ) error {
 	// start prepare task
 	// sync status to PREPARE
-	if !isDoImport && nicType == types.NIC_TYPE_ADMIN &&
+	if !isDoImport && nicType == api.NIC_TYPE_ADMIN &&
 		utils.IsInStringArray(b.GetStatus(),
 			[]string{baremetalstatus.INIT,
 				baremetalstatus.PREPARE,
@@ -1039,7 +1038,7 @@ func (b *SBaremetalInstance) attachWire(mac net.HardwareAddr, wireId string, nic
 }
 
 func (b *SBaremetalInstance) postAttachWire(mac net.HardwareAddr, nicType string, netType string, ipAddr string) error {
-	if nicType == types.NIC_TYPE_IPMI {
+	if nicType == api.NIC_TYPE_IPMI {
 		oldIPMIConf := b.GetRawIPMIConfig()
 		if oldIPMIConf != nil && oldIPMIConf.IpAddr != "" {
 			ipAddr = oldIPMIConf.IpAddr
@@ -1062,7 +1061,7 @@ func (b *SBaremetalInstance) enableWire(mac net.HardwareAddr, ipAddr string, nic
 	if ipAddr != "" {
 		params.Add(jsonutils.NewString(ipAddr), "ip_addr")
 	}
-	if nicType == types.NIC_TYPE_IPMI {
+	if nicType == api.NIC_TYPE_IPMI {
 		params.Add(jsonutils.NewString("stepup"), "alloc_dir") // alloc bottom up
 	}
 	if len(netType) > 0 {

--- a/pkg/baremetal/pxe/dhcp.go
+++ b/pkg/baremetal/pxe/dhcp.go
@@ -191,7 +191,7 @@ func (req *dhcpRequest) fetchConfig(session *mcclient.ClientSession) (*dhcp.Resp
 		ipmiNic := req.baremetalInstance.GetIPMINic(req.ClientMac)
 		if ipmiNic != nil && ipmiNic.Mac == req.ClientMac.String() {
 			err = req.baremetalInstance.InitAdminNetif(
-				req.ClientMac, req.netConfig.WireId, types.NIC_TYPE_IPMI, api.NETWORK_TYPE_IPMI, false, "")
+				req.ClientMac, req.netConfig.WireId, api.NIC_TYPE_IPMI, api.NETWORK_TYPE_IPMI, false, "")
 			if err != nil {
 				return nil, err
 			}
@@ -314,7 +314,7 @@ func (req *dhcpRequest) doInitBaremetalAdminNetif(desc jsonutils.JSONObject) err
 		return err
 	}
 	err = req.baremetalInstance.InitAdminNetif(
-		req.ClientMac, req.netConfig.WireId, types.NIC_TYPE_ADMIN, api.NETWORK_TYPE_PXE, false, "")
+		req.ClientMac, req.netConfig.WireId, api.NIC_TYPE_ADMIN, api.NETWORK_TYPE_PXE, false, "")
 	return err
 }
 

--- a/pkg/baremetal/status.go
+++ b/pkg/baremetal/status.go
@@ -34,10 +34,3 @@ const (
 	START_FAIL     = "start_fail"
 	STOP_FAIL      = "stop_fail"
 )
-
-const (
-	NIC_TYPE_IPMI  = "ipmi"
-	NIC_TYPE_ADMIN = "admin"
-)
-
-var NIC_TYPES = []string{NIC_TYPE_ADMIN, NIC_TYPE_IPMI}

--- a/pkg/baremetal/tasks/bm_register.go
+++ b/pkg/baremetal/tasks/bm_register.go
@@ -106,12 +106,12 @@ func (s *sBaremetalRegisterTask) CreateBaremetal() error {
 		return fmt.Errorf("BmManager add baremetal failed: %s", err)
 	}
 	err = pxeBm.InitAdminNetif(
-		s.accessNic.Mac, s.AdminWire, types.NIC_TYPE_ADMIN, api.NETWORK_TYPE_PXE, true, s.RemoteIp)
+		s.accessNic.Mac, s.AdminWire, api.NIC_TYPE_ADMIN, api.NETWORK_TYPE_PXE, true, s.RemoteIp)
 	if err != nil {
 		return fmt.Errorf("BmManager add admin netif failed: %s", err)
 	}
 	err = pxeBm.InitAdminNetif(
-		s.IpmiMac, s.IpmiWire, types.NIC_TYPE_IPMI, api.NETWORK_TYPE_IPMI, true, s.IpmiIpAddr)
+		s.IpmiMac, s.IpmiWire, api.NIC_TYPE_IPMI, api.NETWORK_TYPE_IPMI, true, s.IpmiIpAddr)
 	if err != nil {
 		return fmt.Errorf("BmManager add ipmi netif failed: %s", err)
 	}
@@ -171,7 +171,7 @@ func (s *sBaremetalRegisterTask) updateIpmiInfo(cli *ssh.Client) {
 	} else {
 		nic.Mac = conf.Mac
 	}
-	s.sendNicInfo(nic, -1, types.NIC_TYPE_IPMI, false, "")
+	s.sendNicInfo(nic, -1, api.NIC_TYPE_IPMI, false, "")
 }
 
 func (s *sBaremetalRegisterTask) updateBmInfo(cli *ssh.Client, i *baremetalPrepareInfo) error {

--- a/pkg/baremetal/tasks/interface.go
+++ b/pkg/baremetal/tasks/interface.go
@@ -35,6 +35,7 @@ type IBaremetal interface {
 	GetName() string
 	GetClientSession() *mcclient.ClientSession
 	SaveDesc(desc jsonutils.JSONObject) error
+	GetNics() []types.SNic
 	GetNicByMac(net.HardwareAddr) *types.SNic
 	GetRawIPMIConfig() *types.SIPMIInfo
 	GetIPMINic(mac net.HardwareAddr) *types.SNic

--- a/pkg/baremetal/utils/raid/hpssactl/hpssactl.go
+++ b/pkg/baremetal/utils/raid/hpssactl/hpssactl.go
@@ -239,7 +239,7 @@ func (adapter *HPSARaidAdaptor) buildRaid(level string, devs []*baremetal.Bareme
 	params := adapter.conf2Params(conf)
 	args = append(args, params...)
 	cmd := GetCommand(args...)
-	_, err := adapter.raid.term.Run(cmd)
+	_, err := adapter.raid.term.RunWithInput(strings.NewReader("y\n"), cmd)
 	if err != nil {
 		return err
 	}
@@ -258,7 +258,7 @@ func (adapter *HPSARaidAdaptor) buildRaid(level string, devs []*baremetal.Bareme
 			args = append(args, params...)
 			cmds = append(cmds, GetCommand(args...))
 		}
-		_, err = adapter.raid.term.Run(cmds...)
+		_, err = adapter.raid.term.RunWithInput(strings.NewReader("y\n"), cmds...)
 	}
 	return err
 }

--- a/pkg/cloudcommon/types/nic.go
+++ b/pkg/cloudcommon/types/nic.go
@@ -20,15 +20,6 @@ import (
 	"yunion.io/x/pkg/util/netutils"
 )
 
-const (
-	NIC_TYPE_IPMI  = "ipmi"
-	NIC_TYPE_ADMIN = "admin"
-)
-
-var (
-	NIC_TYPES = []string{NIC_TYPE_IPMI, NIC_TYPE_ADMIN}
-)
-
 type SNic struct {
 	Type    string   `json:"nic_type"`
 	Domain  string   `json:"domain"`

--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -46,6 +46,10 @@ const (
 	YUNIONROOT_USER = "cloudroot"
 )
 
+var (
+	NetDevPrefix = "eth"
+)
+
 type sLinuxRootFs struct {
 	*sGuestRootFsDriver
 }
@@ -256,7 +260,7 @@ func (l *sLinuxRootFs) DeployNetworkingScripts(rootFs IDiskPartition, nics []*ty
 			mac := nic.Mac
 			nicRules += fmt.Sprintf(`ATTR{address}=="%s", ATTR{type}=="1", `, strings.ToLower(mac))
 			idx := nic.Index
-			nicRules += fmt.Sprintf("NAME=\"eth%d\"\n", idx)
+			nicRules += fmt.Sprintf("NAME=\"%s%d\"\n", NetDevPrefix, idx)
 		}
 		if err := rootFs.FilePutContents(path.Join(udevPath, "70-persistent-net.rules"), nicRules, false, false); err != nil {
 			return err
@@ -283,7 +287,7 @@ func (l *sLinuxRootFs) DeployStandbyNetworkingScripts(rootFs IDiskPartition, nic
 			mac := nic.Mac
 			nicRules += fmt.Sprintf(`ATTR{address}=="%s", ATTR{type}=="1", `, strings.ToLower(mac))
 			idx := nic.Index
-			nicRules += fmt.Sprintf(`NAME="eth%d"\n`, idx)
+			nicRules += fmt.Sprintf(`NAME="%s%d"\n`, NetDevPrefix, idx)
 		}
 	}
 	if err := rootFs.FilePutContents(path.Join(udevPath, "70-persistent-net.rules"), nicRules, true, false); err != nil {
@@ -822,7 +826,7 @@ func (r *sRedhatLikeRootFs) Centos5DeployNetworkingScripts(rootFs IDiskPartition
 		for _, nic := range nics {
 			nicRules += `KERNEL=="*", `
 			nicRules += fmt.Sprintf(`SYSFS{address}=="%s", `, strings.ToLower(nic.Mac))
-			nicRules += fmt.Sprintf("NAME=\"eth%d\"\n", nic.Index)
+			nicRules += fmt.Sprintf("NAME=\"%s%d\"\n", NetDevPrefix, nic.Index)
 		}
 		return rootFs.FilePutContents(path.Join(udevPath, "60-net.rules"),
 			nicRules, false, false)
@@ -990,12 +994,12 @@ func (r *sRedhatLikeRootFs) DeployStandbyNetworkingScripts(rootFs IDiskPartition
 	for _, nic := range nicsStandby {
 		var cmds string
 		if len(nic.NicType) == 0 || nic.NicType != "ipmi" {
-			cmds += fmt.Sprintf("DEVICE=eth%d\n", nic.Index)
-			cmds += fmt.Sprintf("NAME=eth%d\n", nic.Index)
+			cmds += fmt.Sprintf("DEVICE=%s%d\n", NetDevPrefix, nic.Index)
+			cmds += fmt.Sprintf("NAME=%s%d\n", NetDevPrefix, nic.Index)
 			cmds += fmt.Sprintf("HWADDR=%s\n", nic.Mac)
 			cmds += fmt.Sprintf("MACADDR=%s\n", nic.Mac)
 			cmds += "ONBOOT=no\n"
-			var fn = fmt.Sprintf("/etc/sysconfig/network-scripts/ifcfg-eth%d", nic.Index)
+			var fn = fmt.Sprintf("/etc/sysconfig/network-scripts/ifcfg-%s%d", NetDevPrefix, nic.Index)
 			if err := rootFs.FilePutContents(fn, cmds, false, false); err != nil {
 				return err
 			}
@@ -1246,14 +1250,14 @@ func (l *SGentooRootFs) DeployNetworkingScripts(rootFs IDiskPartition, nics []*t
 	for _, nic := range nics {
 		nicIndex := nic.Index
 		if nic.Virtual {
-			cmds += fmt.Sprintf(`config_eth%d="`, nicIndex)
+			cmds += fmt.Sprintf(`config_%s%d="`, NetDevPrefix, nicIndex)
 			cmds += fmt.Sprintf("%s netmask 255.255.255.255", netutils2.PSEUDO_VIP)
 			cmds += `"\n`
 		} else {
-			cmds += fmt.Sprintf(`config_eth%d="dhcp"\n`, nicIndex)
+			cmds += fmt.Sprintf(`config_%s%d="dhcp"\n`, NetDevPrefix, nicIndex)
 		}
 		if nic.Mtu > 0 {
-			cmds += fmt.Sprintf(`mtu_eth%d="%d"\n`, nicIndex, nic.Mtu)
+			cmds += fmt.Sprintf(`mtu_%s%d="%d"\n`, NetDevPrefix, nicIndex, nic.Mtu)
 		}
 	}
 	if err := rootFs.FilePutContents(fn, cmds, false, false); err != nil {
@@ -1261,7 +1265,7 @@ func (l *SGentooRootFs) DeployNetworkingScripts(rootFs IDiskPartition, nics []*t
 	}
 	for _, nic := range nics {
 		nicIndex := nic.Index
-		netname := fmt.Sprintf("net.eth%d", nicIndex)
+		netname := fmt.Sprintf("net.%s%d", NetDevPrefix, nicIndex)
 		procutils.NewCommand("ln", "-s", "net.lo",
 			fmt.Sprintf("%s/etc/init.d/%s", rootFs.GetMountPath(), netname)).Run()
 		procutils.NewCommand("chroot",
@@ -1415,7 +1419,7 @@ func (d *SCoreOsRootFs) DeployHosts(rootFs IDiskPartition, hostname, domain stri
 
 func (d *SCoreOsRootFs) DeployNetworkingScripts(rootFs IDiskPartition, nics []*types.SServerNic) error {
 	for _, nic := range nics {
-		name := fmt.Sprintf("eth%d", nic.Index)
+		name := fmt.Sprintf("%s%d", NetDevPrefix, nic.Index)
 		cont := "[Match]\n"
 		cont += "Name=" + name + "\n"
 		cont += "\n[Network]\n"

--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -30,6 +30,7 @@ import (
 	"yunion.io/x/pkg/util/netutils"
 	"yunion.io/x/pkg/utils"
 
+	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/types"
 	deployapi "yunion.io/x/onecloud/pkg/hostman/hostdeployer/apis"
 	"yunion.io/x/onecloud/pkg/util/coreosutils"
@@ -281,7 +282,7 @@ func (l *sLinuxRootFs) DeployStandbyNetworkingScripts(rootFs IDiskPartition, nic
 	var udevPath = "/etc/udev/rules.d/"
 	var nicRules string
 	for _, nic := range nicsStandby {
-		if len(nic.NicType) == 0 || nic.NicType != types.NIC_TYPE_IPMI {
+		if len(nic.NicType) == 0 || nic.NicType != api.NIC_TYPE_IPMI {
 			nicRules += `KERNEL=="*", SUBSYSTEM=="net", ACTION=="add", `
 			nicRules += `DRIVERS=="?*", `
 			mac := nic.Mac

--- a/pkg/hostman/guestfs/fsdriver/nicteaming.go
+++ b/pkg/hostman/guestfs/fsdriver/nicteaming.go
@@ -92,18 +92,18 @@ func convertNicConfigs(nics []*types.SServerNic) ([]*types.SServerNic, []*types.
 		teamNic := findTeamingNic(nics, nics[i].Mac)
 		if teamNic == nil {
 			nnic := nics[i]
-			nnic.Name = fmt.Sprintf("eth%d", nnic.Index)
+			nnic.Name = fmt.Sprintf("%s%d", NetDevPrefix, nnic.Index)
 			allNics = append(allNics, nnic)
 			continue
 		}
 		master := nics[i]
 		nnic := nics[i]
 		tnic := *teamNic
-		nnic.Name = fmt.Sprintf("eth%d", nnic.Index)
+		nnic.Name = fmt.Sprintf("%s%d", NetDevPrefix, nnic.Index)
 		nnic.TeamingMaster = master
 		nnic.Ip = ""
 		nnic.Gateway = ""
-		tnic.Name = fmt.Sprintf("eth%d", tnic.Index)
+		tnic.Name = fmt.Sprintf("%s%d", NetDevPrefix, tnic.Index)
 		tnic.TeamingMaster = master
 		tnic.Ip = ""
 		tnic.Gateway = ""

--- a/pkg/util/printutils/printjson.go
+++ b/pkg/util/printutils/printjson.go
@@ -73,7 +73,7 @@ func PrintJSONList(list *modulebase.ListResult, columns []string) {
 		rows = append(rows, row)
 	}
 	fmt.Print(pt.GetString(rows))
-	var total int64
+	total := int64(list.Total)
 	if list.Total == 0 {
 		total = int64(len(list.Data))
 	}

--- a/pkg/util/ssh/ssh.go
+++ b/pkg/util/ssh/ssh.go
@@ -17,6 +17,7 @@ package ssh
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -110,14 +111,18 @@ func (s *Client) GetConfig() ClientConfig {
 }
 
 func (s *Client) RawRun(cmds ...string) ([]string, error) {
-	return s.run(false, cmds...)
+	return s.run(false, cmds, nil)
 }
 
 func (s *Client) Run(cmds ...string) ([]string, error) {
-	return s.run(true, cmds...)
+	return s.run(true, cmds, nil)
 }
 
-func (s *Client) run(parseOutput bool, cmds ...string) ([]string, error) {
+func (s *Client) RunWithInput(input io.Reader, cmds ...string) ([]string, error) {
+	return s.run(true, cmds, input)
+}
+
+func (s *Client) run(parseOutput bool, cmds []string, input io.Reader) ([]string, error) {
 	ret := []string{}
 	for _, cmd := range cmds {
 		session, err := s.client.NewSession()
@@ -130,6 +135,7 @@ func (s *Client) run(parseOutput bool, cmds ...string) ([]string, error) {
 		var stdErr bytes.Buffer
 		session.Stdout = &stdOut
 		session.Stderr = &stdErr
+		session.Stdin = input
 		err = session.Run(cmd)
 		if err != nil {
 			var outputErr error


### PR DESCRIPTION
Cherry pick of #2936 on release/2.12.

#2936: fix: 1. hpssactl blocks on user input 2. host-add-netif reset nic index 3. init baremetal nics with name enX instead of ethX