### PR TITLE
Automated cherry pick of #2940: fix: fail to delete disconnected cloudaccount

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -161,7 +161,7 @@ func (self *SCloudaccount) ValidateDeleteCondition(ctx context.Context) error {
 	if self.Enabled {
 		return httperrors.NewInvalidStatusError("account is enabled")
 	}
-	if self.getSyncStatus2() != api.CLOUD_PROVIDER_SYNC_STATUS_IDLE {
+	if self.Status == api.CLOUD_PROVIDER_CONNECTED && self.getSyncStatus2() != api.CLOUD_PROVIDER_SYNC_STATUS_IDLE {
 		return httperrors.NewInvalidStatusError("account is not idle")
 	}
 	cloudproviders := self.GetCloudproviders()


### PR DESCRIPTION
Cherry pick of #2940 on release/2.12.

#2940: fix: fail to delete disconnected cloudaccount