### PR TITLE
fix: Table 'yunionlogger.users_cache_tbl' doesn't exist

### DIFF
--- a/pkg/logger/service/handlers.go
+++ b/pkg/logger/service/handlers.go
@@ -25,7 +25,7 @@ func initHandlers(app *appsrv.Application) {
 	db.InitAllManagers()
 
 	for _, manager := range []db.IModelManager{
-		// db.UserCacheManager,
+		db.UserCacheManager,
 		db.TenantCacheManager,
 	} {
 		db.RegisterModelManager(manager)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：Table 'yunionlogger.users_cache_tbl' doesn't exist”

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12

/area log