### PR TITLE
Automated cherry pick of #2952: fix: Table 'yunionlogger.users_cache_tbl' doesn't exist

### DIFF
--- a/pkg/logger/service/handlers.go
+++ b/pkg/logger/service/handlers.go
@@ -25,7 +25,7 @@ func initHandlers(app *appsrv.Application) {
 	db.InitAllManagers()
 
 	for _, manager := range []db.IModelManager{
-		// db.UserCacheManager,
+		db.UserCacheManager,
 		db.TenantCacheManager,
 	} {
 		db.RegisterModelManager(manager)


### PR DESCRIPTION
Cherry pick of #2952 on release/2.11.

#2952: fix: Table 'yunionlogger.users_cache_tbl' doesn't exist