### PR TITLE
host: use public endpoint

### DIFF
--- a/pkg/hostman/hostutils/hostutils.go
+++ b/pkg/hostman/hostutils/hostutils.go
@@ -52,15 +52,15 @@ type IHost interface {
 }
 
 func GetComputeSession(ctx context.Context) *mcclient.ClientSession {
-	return auth.GetAdminSession(ctx, options.HostOptions.Region, "v2")
+	return auth.GetAdminSessionWithPublic(ctx, options.HostOptions.Region, "v2")
 }
 
 func GetK8sSession(ctx context.Context) *mcclient.ClientSession {
-	return auth.GetAdminSession(ctx, options.HostOptions.Region, "")
+	return auth.GetAdminSessionWithPublic(ctx, options.HostOptions.Region, "")
 }
 
 func GetImageSession(ctx context.Context, zone string) *mcclient.ClientSession {
-	return auth.AdminSession(ctx, options.HostOptions.Region, zone, "internal", "v1")
+	return auth.AdminSessionWithPublic(ctx, options.HostOptions.Region, zone, "v1")
 }
 
 func TaskFailed(ctx context.Context, reason string) {

--- a/pkg/hostman/storageman/imagecache_local.go
+++ b/pkg/hostman/storageman/imagecache_local.go
@@ -171,7 +171,7 @@ func (l *SLocalImageCache) prepare(ctx context.Context, zone, srcUrl, format str
 		l.consumerCount++
 		return true, true
 	}
-	url, err := auth.GetServiceURL("image", "", zone, "internal")
+	url, err := auth.GetServiceURL("image", "", zone, "public")
 	if err != nil {
 		log.Errorf("Failed to acquire image %s", err)
 		return false, true

--- a/pkg/mcclient/auth/auth.go
+++ b/pkg/mcclient/auth/auth.go
@@ -279,6 +279,14 @@ func AdminSession(ctx context.Context, region, zone, endpointType, apiVersion st
 	return cli.NewSession(ctx, region, zone, endpointType, AdminCredential(), apiVersion)
 }
 
+func AdminSessionWithInternal(ctx context.Context, region, zone, apiVersion string) *mcclient.ClientSession {
+	return AdminSession(ctx, region, zone, "internal", apiVersion)
+}
+
+func AdminSessionWithPublic(ctx context.Context, region, zone, apiVersion string) *mcclient.ClientSession {
+	return AdminSession(ctx, region, zone, "public", apiVersion)
+}
+
 type AuthCompletedCallback func()
 
 func (callback *AuthCompletedCallback) Run() {
@@ -317,8 +325,25 @@ func GetAdminSession(ctx context.Context, region string,
 	return GetSession(ctx, manager.adminCredential, region, apiVersion)
 }
 
+func GetAdminSessionWithPublic(ctx context.Context, region string,
+	apiVersion string) *mcclient.ClientSession {
+	return GetSessionWithPublic(ctx, manager.adminCredential, region, apiVersion)
+}
+
 func GetSession(ctx context.Context, token mcclient.TokenCredential, region string, apiVersion string) *mcclient.ClientSession {
-	return manager.client.NewSession(ctx, region, "", "internal", token, apiVersion)
+	return GetSessionWithInternal(ctx, token, region, apiVersion)
+}
+
+func GetSessionWithInternal(ctx context.Context, token mcclient.TokenCredential, region string, apiVersion string) *mcclient.ClientSession {
+	return getSessionByType(ctx, token, region, apiVersion, "internal")
+}
+
+func GetSessionWithPublic(ctx context.Context, token mcclient.TokenCredential, region string, apiVersion string) *mcclient.ClientSession {
+	return getSessionByType(ctx, token, region, apiVersion, "public")
+}
+
+func getSessionByType(ctx context.Context, token mcclient.TokenCredential, region string, apiVersion string, epType string) *mcclient.ClientSession {
+	return manager.client.NewSession(ctx, region, "", epType, token, apiVersion)
 }
 
 // use for climc test only


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

为了支持 k8s 部署，host 使用 public 类型的 endpoint 避免 dns 域名解析

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
NONE
/cc @swordqiu @wanyaoqi 
/area host