### PR TITLE
auth: add session-endpoint-type to common options

### DIFF
--- a/pkg/cloudcommon/app/auth.go
+++ b/pkg/cloudcommon/app/auth.go
@@ -20,6 +20,9 @@ import (
 	"os"
 	"time"
 
+	"yunion.io/x/log"
+	"yunion.io/x/pkg/utils"
+
 	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/cloudcommon/notifyclient"
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
@@ -59,6 +62,14 @@ func InitAuth(options *common_options.CommonOptions, authComplete auth.AuthCompl
 	)
 
 	// debug := options.LogLevel == "debug"
+
+	if options.SessionEndpointType != "" {
+		if !utils.IsInStringArray(options.SessionEndpointType,
+			[]string{auth.PublicEndpointType, auth.InternalEndpointType}) {
+			log.Fatalf("Invalid session endpoint type %s", options.SessionEndpointType)
+		}
+		auth.SetEndpointType(options.SessionEndpointType)
+	}
 
 	auth.Init(a, options.DebugClient, true, options.SslCertfile, options.SslKeyfile) // , authComplete)
 

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -83,6 +83,8 @@ type CommonOptions struct {
 
 	TenantCacheExpireSeconds int `help:"expire seconds of cached tenant/domain info. defailt 15 minutes" default:"900"`
 
+	SessionEndpointType string `help:"Client session end point type"`
+
 	BaseOptions
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

服务选项支持设置 `--session-endpoint-type` 参数设置通过 auth 获取默认 mcclient.Session 的 endpoint 类型

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
 NONE

/cc @wanyaoqi 
/area util