### PR TITLE
feature: keystone v3 auth response carry user's displayname/email/mobile

### DIFF
--- a/docs/schemas/auth.yaml
+++ b/docs/schemas/auth.yaml
@@ -260,7 +260,26 @@ TokenV3:
         $ref: './roleassignments.yaml#/DomainObject'
     user:
       type: object
-      $ref: './roleassignments.yaml#/DomainObject'
+      properties:
+        id:
+          type: string
+          description: 用户ID
+        name:
+          type: string
+          description: 用户名称
+        displayname:  
+          type: string
+          description: 用户显示名称
+        email:
+          type: string
+          description: 用户的电子邮箱
+        mobile:
+          type: string
+          description: 用户的手机号
+        domain:
+          type: object
+          description: 资源归属的域信息
+          $ref: './roleassignments.yaml#/Domain'
     policies:
       type: object
       $ref: './roleassignments.yaml#/PolicyObject'

--- a/pkg/apis/identity/usrext.go
+++ b/pkg/apis/identity/usrext.go
@@ -25,6 +25,10 @@ type SUserExtended struct {
 	LastActiveAt     time.Time
 	DomainId         string
 
+	Displayname string
+	Email       string
+	Mobile      string
+
 	LocalId       int
 	LocalName     string
 	DomainName    string

--- a/pkg/keystone/models/users.go
+++ b/pkg/keystone/models/users.go
@@ -236,6 +236,9 @@ func (manager *SUserManager) FetchUserExtended(userId, userName, domainId, domai
 	q := users.Query(
 		users.Field("id"),
 		users.Field("name"),
+		users.Field("displayname"),
+		users.Field("email"),
+		users.Field("mobile"),
 		users.Field("enabled"),
 		users.Field("default_project_id"),
 		users.Field("created_at"),

--- a/pkg/keystone/tokens/token.go
+++ b/pkg/keystone/tokens/token.go
@@ -255,6 +255,9 @@ func (t *SAuthToken) getTokenV3(
 	token.Token.Methods = []string{t.Method}
 	token.Token.User.Id = user.Id
 	token.Token.User.Name = user.Name
+	token.Token.User.Displayname = user.Displayname
+	token.Token.User.Email = user.Email
+	token.Token.User.Mobile = user.Mobile
 	token.Token.User.Domain.Id = user.DomainId
 	token.Token.User.Domain.Name = user.DomainName
 	token.Token.Context = t.Context

--- a/pkg/mcclient/token3.go
+++ b/pkg/mcclient/token3.go
@@ -60,6 +60,10 @@ type KeystoneUserV3 struct {
 	Name                string
 	Domain              KeystoneDomainV3
 	Password_expires_at time.Time
+
+	Displayname string
+	Email       string
+	Mobile      string
 }
 
 type KeystoneServiceCatalogV3 []KeystoneServiceV3


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：tokenv3验证接口返回用户信息中包含displayname/email/mobile等字段

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12

/area keystone