### PR TITLE
fix: fail to search opslog by obj_name

### DIFF
--- a/pkg/cloudcommon/db/opslog.go
+++ b/pkg/cloudcommon/db/opslog.go
@@ -457,9 +457,9 @@ func (manager *SOpsLogManager) ListItemFilter(ctx context.Context, q *sqlchemy.S
 	objNames := jsonutils.GetQueryStringArray(query, "obj_name")
 	if len(objNames) > 0 {
 		if len(objNames) == 1 {
-			q = q.Filter(sqlchemy.Equals(q.Field("obj_id"), objNames[0]))
+			q = q.Filter(sqlchemy.Equals(q.Field("obj_name"), objNames[0]))
 		} else {
-			q = q.Filter(sqlchemy.In(q.Field("obj_id"), objNames))
+			q = q.Filter(sqlchemy.In(q.Field("obj_name"), objNames))
 		}
 	}
 	queryDict := query.(*jsonutils.JSONDict)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：通过obj_name搜索opslog失败

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12

/area region