### PR TITLE
fix: adjust default process timeout to 1 minute (previously 15 seconds)

### DIFF
--- a/pkg/appsrv/appsrv.go
+++ b/pkg/appsrv/appsrv.go
@@ -71,7 +71,8 @@ const (
 	DEFAULT_READ_TIMEOUT        = 0
 	DEFAULT_READ_HEADER_TIMEOUT = 10 * time.Second
 	DEFAULT_WRITE_TIMEOUT       = 0
-	DEFAULT_PROCESS_TIMEOUT     = 15 * time.Second
+	// set default process timeout to 60 seconds
+	DEFAULT_PROCESS_TIMEOUT = 60 * time.Second
 )
 
 var quitHandlerRegisted bool


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：调整缺少请求超时时间从15秒为60秒（1分钟）

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12

/area util