### PR TITLE
Automated cherry pick of #2998: fix: adjust default process timeout to 1 minute (previously 15 seconds)

### DIFF
--- a/pkg/appsrv/appsrv.go
+++ b/pkg/appsrv/appsrv.go
@@ -71,7 +71,8 @@ const (
 	DEFAULT_READ_TIMEOUT        = 0
 	DEFAULT_READ_HEADER_TIMEOUT = 10 * time.Second
 	DEFAULT_WRITE_TIMEOUT       = 0
-	DEFAULT_PROCESS_TIMEOUT     = 15 * time.Second
+	// set default process timeout to 60 seconds
+	DEFAULT_PROCESS_TIMEOUT = 60 * time.Second
 )
 
 var quitHandlerRegisted bool


### PR DESCRIPTION
Cherry pick of #2998 on release/2.12.

#2998: fix: adjust default process timeout to 1 minute (previously 15 seconds)