### PR TITLE
Automated cherry pick of #3009: ansibleserver: 避免数据库故障引起内部状态不一致

### DIFF
--- a/pkg/ansibleserver/models/ansibleplaybooks.go
+++ b/pkg/ansibleserver/models/ansibleplaybooks.go
@@ -225,8 +225,6 @@ func (apb *SAnsiblePlaybook) runPlaybook(ctx context.Context, userCred mcclient.
 	}
 	pb.OutputWriter(&ansiblePlaybookOutputRecorder{apb})
 
-	man.sessions.Add(apb.Id, pb)
-
 	_, err := db.Update(apb, func() error {
 		apb.StartTime = time.Now()
 		apb.EndTime = time.Time{}
@@ -237,7 +235,8 @@ func (apb *SAnsiblePlaybook) runPlaybook(ctx context.Context, userCred mcclient.
 	if err != nil {
 		log.Errorf("run playbook: update db failed before run: %v", err)
 	}
-	// NOTE host state check? run only on online hosts and running guests, skip others
+
+	man.sessions.Add(apb.Id, pb)
 	go func() {
 		defer func() {
 			man.sessionsMux.Lock()


### PR DESCRIPTION
Cherry pick of #3009 on release/2.10.0.

#3009: ansibleserver: 避免数据库故障引起内部状态不一致