### PR TITLE
fix: disable cas idp not working

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -133,6 +133,7 @@ func (h *AuthHandlers) GetRegionsResponse(ctx context.Context, w http.ResponseWr
 
 	filters = jsonutils.NewDict()
 	filters.Add(jsonutils.NewStringArray([]string{"cas"}), "driver")
+	filters.Add(jsonutils.JSONTrue, "enabled")
 	filters.Add(jsonutils.NewInt(1000), "limit")
 	idps, err := modules.IdentityProviders.List(s, filters)
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：禁用cas后login应该不显示cas登录

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12

/area apigateway