### PR TITLE
Automated cherry pick of #3035: add: lb vpc info

### DIFF
--- a/pkg/compute/models/loadbalancers.go
+++ b/pkg/compute/models/loadbalancers.go
@@ -517,6 +517,12 @@ func (lb *SLoadbalancer) GetCustomizeColumns(ctx context.Context, userCred mccli
 		extra.Set("eip_mode", jsonutils.NewString(eip.Mode))
 	}
 
+	if len(lb.VpcId) > 0 {
+		if vpc := lb.GetVpc(); vpc != nil {
+			extra.Set("vpc", jsonutils.NewString(vpc.Name))
+		}
+	}
+
 	if lb.BackendGroupId != "" {
 		lbbg, err := LoadbalancerBackendGroupManager.FetchById(lb.BackendGroupId)
 		if err != nil {


### PR DESCRIPTION
Cherry pick of #3035 on release/2.10.0.

#3035: add: lb vpc info