### PR TITLE
fix: keystone panic on invalid auth token

### DIFF
--- a/pkg/keystone/tokens/handlers.go
+++ b/pkg/keystone/tokens/handlers.go
@@ -179,7 +179,7 @@ func verifyTokensV3(ctx context.Context, w http.ResponseWriter, r *http.Request)
 
 func verifyCommon(ctx context.Context, w http.ResponseWriter, tokenStr string) (*SAuthToken, error) {
 	adminToken := policy.FetchUserCredential(ctx)
-	if !adminToken.IsAllow(rbacutils.ScopeSystem, api.SERVICE_TYPE, "tokens", "perform", "auth") {
+	if adminToken == nil || !adminToken.IsAllow(rbacutils.ScopeSystem, api.SERVICE_TYPE, "tokens", "perform", "auth") {
 		return nil, httperrors.NewForbiddenError("not allow to auth")
 	}
 	token := SAuthToken{}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：验证keystone token的管理token无效时报nil pointer panic

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12

/area keystone