### PR TITLE
Automated cherry pick of #3046: fix: keystone panic on invalid auth token

### DIFF
--- a/pkg/keystone/tokens/handlers.go
+++ b/pkg/keystone/tokens/handlers.go
@@ -178,7 +178,7 @@ func verifyTokensV3(ctx context.Context, w http.ResponseWriter, r *http.Request)
 
 func verifyCommon(ctx context.Context, w http.ResponseWriter, tokenStr string) (*SAuthToken, error) {
 	adminToken := policy.FetchUserCredential(ctx)
-	if !adminToken.IsAllow(rbacutils.ScopeSystem, api.SERVICE_TYPE, "tokens", "perform", "auth") {
+	if adminToken == nil || !adminToken.IsAllow(rbacutils.ScopeSystem, api.SERVICE_TYPE, "tokens", "perform", "auth") {
 		return nil, httperrors.NewForbiddenError("not allow to auth")
 	}
 	token := SAuthToken{}


### PR DESCRIPTION
Cherry pick of #3046 on release/2.10.0.

#3046: fix: keystone panic on invalid auth token