### PR TITLE
Automated cherry pick of #3075: 新增 devtool cron manager，用来管理Ansibleserver 的定时任务

### DIFF
--- a/build/devtool/vars
+++ b/build/devtool/vars
@@ -1,0 +1,1 @@
+DESCRIPTION="Yunion DevTools Server"

--- a/cmd/climc/shell/devtool_cronjobs.go
+++ b/cmd/climc/shell/devtool_cronjobs.go
@@ -1,0 +1,221 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shell
+
+import (
+	"fmt"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
+	"yunion.io/x/onecloud/pkg/mcclient/modules"
+	"yunion.io/x/onecloud/pkg/mcclient/options"
+)
+
+func paramValidator(param jsonutils.JSONObject) (bool, error) {
+	// TODO 移到 server 端
+	log.Infof("paramValidator: param: %+v", param)
+	interval, err := param.Int("interval")
+	if err != nil {
+		return true, nil
+	}
+	day, err := param.Int("day")
+	if err != nil {
+		return true, nil
+	}
+	if interval == 0 && day == 0 {
+		return false, fmt.Errorf("interval and day can not be 0 at the same time")
+	}
+	return true, nil
+}
+
+func init() {
+	type CronjobListOptions struct {
+		options.BaseListOptions
+		Name string `help:"cloud region ID or Name" json:"-"`
+	}
+
+	R(&CronjobListOptions{}, "devtool-cronjob-list", "List Devtool Cronjobs", func(s *mcclient.ClientSession, args *CronjobListOptions) error {
+		params, err := options.ListStructToParams(args)
+		if err != nil {
+			return err
+		}
+		var result *modulebase.ListResult
+		result, err = modules.DevToolCronjobs.List(s, params)
+		printList(result, modules.DevToolCronjobs.GetColumns(s))
+		return nil
+	})
+
+	type CronjobCreateOptions struct {
+		NAME     string `help:"Ansible Playbook ID or Name" json:"-"`
+		Day      int    `help:"Cronjob runs at given day" default:"0"`
+		Hour     int    `help:"Cronjob runs at given hour" default:"0"`
+		Min      int    `help:"Cronjob runs at given min" default:"0"`
+		Sec      int    `help:"Cronjob runs at given sec" default:"0"`
+		Interval int64  `help:"Cronjob runs at given interval" default:"0"`
+		Start    bool   `help:"start job when created" default:"false"`
+		Enabled  bool   `help:"Set job status enabled" default:"false"`
+	}
+	R(
+		&CronjobCreateOptions{},
+		"devtool-cronjob-create",
+		"Create a cronjob repo component",
+		func(s *mcclient.ClientSession, args *CronjobCreateOptions) error {
+			result, err := modules.AnsiblePlaybooks.Get(s, args.NAME, nil)
+			if err != nil {
+				return err
+			}
+			ansiblePlaybookName, err := result.GetString("name")
+			if err != nil {
+				return err
+			}
+
+			ansiblePlaybookID, err := result.GetString("id")
+			if err != nil {
+				return err
+			}
+
+			params := jsonutils.NewDict()
+			params.Add(jsonutils.NewString(ansiblePlaybookName), "name")
+
+			params.Add(jsonutils.NewString(ansiblePlaybookID), "ansible_playbook_id")
+
+			if args.Start {
+				params.Add(jsonutils.JSONTrue, "start")
+
+			}
+			if args.Enabled {
+				params.Add(jsonutils.JSONTrue, "enabled")
+			} else if args.Interval > 0 {
+				params.Add(jsonutils.NewInt(int64(args.Interval)), "interval")
+			} else {
+				params.Add(jsonutils.NewInt(int64(0)), "interval")
+				params.Add(jsonutils.NewInt(int64(args.Day)), "day")
+				params.Add(jsonutils.NewInt(int64(args.Hour)), "hour")
+				params.Add(jsonutils.NewInt(int64(args.Min)), "min")
+				params.Add(jsonutils.NewInt(int64(args.Sec)), "sec")
+			}
+			ok, err := paramValidator(params)
+			if err != nil || !ok {
+				log.Infof("paramValidator error %s", err)
+				return err
+			}
+			cronjob, err := modules.DevToolCronjobs.Create(s, params)
+			if err != nil {
+				log.Infof("modules.DevToolCronjobs.Create error %s", err)
+				return err
+			}
+			printObject(cronjob)
+			return nil
+		},
+	)
+
+	type DevToolCronjobShowOptions struct {
+		ID string `help:"ID or Name of the DevToolCronjob to show"`
+	}
+	R(&DevToolCronjobShowOptions{}, "devtool-cronjob-show", "Show cronjob details", func(s *mcclient.ClientSession, args *DevToolCronjobShowOptions) error {
+		result, err := modules.DevToolCronjobs.Get(s, args.ID, nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
+	type DevToolCronjobUpdateOptions struct {
+		ID       string `help:"ID or Name of DevToolCronjob to update"`
+		Day      int    `help:"Cronjob runs at given day" json:"-" default:"-1"`
+		Hour     int    `help:"Cronjob runs at given hour" json:"-" default:"-1"`
+		Min      int    `help:"Cronjob runs at given min" default:"-1"`
+		Sec      int    `help:"Cronjob runs at given sec" default:"-1"`
+		Interval int    `help:"Cronjob runs at given interval" default:"-1"`
+		Start    bool   `help:"start job when created"`
+		Stop     bool   `help:"start job when created"`
+		Enable   bool   `help:"Set job status enabled"`
+		Disable  bool   `help:"Set job status enabled"`
+	}
+	R(&DevToolCronjobUpdateOptions{}, "devtool-cronjob-update", "Update DevToolCronjob", func(s *mcclient.ClientSession, args *DevToolCronjobUpdateOptions) error {
+		result, err := modules.DevToolCronjobs.Get(s, args.ID, nil)
+		if err != nil {
+			return err
+		}
+
+		params := jsonutils.NewDict()
+		interval, _ := result.Int("interval")
+		day, _ := result.Int("day")
+		params.Add(jsonutils.NewString(args.ID), "id")
+		params.Add(jsonutils.NewInt(int64(interval)), "interval")
+		params.Add(jsonutils.NewInt(int64(day)), "day")
+
+		log.Infof("DevToolCronjobUpdateOptions args: %+v", args)
+		if args.Interval >= 0 {
+			params.Add(jsonutils.NewInt(int64(args.Interval)), "interval")
+			if args.Interval > 0 {
+				params.Add(jsonutils.NewInt(0), "day")
+			}
+		} else if args.Day >= 0 {
+			params.Add(jsonutils.NewInt(int64(args.Day)), "day")
+			if args.Day > 0 {
+				params.Add(jsonutils.NewInt(0), "interval")
+			}
+		}
+		if args.Hour >= 0 {
+			params.Add(jsonutils.NewInt(int64(args.Hour)), "hour")
+		}
+		if args.Min >= 0 {
+			params.Add(jsonutils.NewInt(int64(args.Min)), "min")
+		}
+		if args.Sec >= 0 {
+			params.Add(jsonutils.NewInt(int64(args.Sec)), "sec")
+		}
+
+		ok, err := paramValidator(params)
+		if err != nil || !ok {
+			return err
+		}
+
+		if args.Start && args.Stop {
+			return fmt.Errorf("can not set job start and stop at the same time")
+		} else if args.Start {
+			params.Add(jsonutils.JSONTrue, "start")
+		} else if args.Stop {
+			params.Add(jsonutils.JSONFalse, "start")
+		}
+		if args.Enable && args.Disable {
+			return fmt.Errorf("can not set job enabled and disabled at the same time")
+		} else if args.Enable {
+			params.Add(jsonutils.JSONTrue, "enabled")
+		} else if args.Disable {
+			params.Add(jsonutils.JSONFalse, "enabled")
+		}
+
+		result, err = modules.DevToolCronjobs.Update(s, args.ID, params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
+	R(&DevToolCronjobShowOptions{}, "devtool-cronjob-delete", "Delete DevToolCronjob", func(s *mcclient.ClientSession, args *DevToolCronjobShowOptions) error {
+		result, err := modules.DevToolCronjobs.Delete(s, args.ID, nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+}

--- a/cmd/climc/shell/zones.go
+++ b/cmd/climc/shell/zones.go
@@ -16,7 +16,6 @@ package shell
 
 import (
 	"yunion.io/x/jsonutils"
-
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"

--- a/cmd/devtool/main.go
+++ b/cmd/devtool/main.go
@@ -1,0 +1,26 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"yunion.io/x/onecloud/pkg/devtool/service"
+	"yunion.io/x/onecloud/pkg/util/atexit"
+)
+
+func main() {
+	defer atexit.Handle()
+
+	service.StartService()
+}

--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -1017,7 +1017,6 @@ func _doCreateItem(
 	if err != nil {
 		return nil, httperrors.NewGeneralError(err)
 	}
-
 	// run name validation after validate create data
 	name, _ := dataDict.GetString("name")
 	if len(name) > 0 {

--- a/pkg/devtool/models/cronjob.go
+++ b/pkg/devtool/models/cronjob.go
@@ -1,0 +1,121 @@
+package models
+
+import (
+	"context"
+	"time"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
+	"yunion.io/x/onecloud/pkg/cloudcommon/cronman"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/mcclient/modules"
+)
+
+type SCronjob struct {
+	Day               int    `json:"day" nullable:"true" create:"optional" list:"user" update:"user" default:"0"`
+	Hour              int    `nullable:"true" create:"optional" list:"user" update:"user" default:"0"`
+	Min               int    `nullable:"true" create:"optional" list:"user" update:"user" default:"0"`
+	Sec               int    `nullable:"true" create:"optional" list:"user" update:"user" default:"0"`
+	Interval          int64  `nullable:"true" create:"optional" list:"user" update:"user" default:"0"`
+	Start             bool   `nullable:"true" create:"optional" list:"user" update:"user" default:"false"`
+	Enabled           bool   `nullable:"true" create:"optional" list:"user" update:"user" default:"false"`
+	AnsiblePlaybookID string `nullable:"false" create:"required" list:"user" update:"user"`
+	db.SStandaloneResourceBase
+}
+
+type SCronjobManager struct {
+	db.SStandaloneResourceBaseManager
+}
+
+var (
+	CronjobManager     *SCronjobManager
+	DevToolCronManager *cronman.SCronJobManager
+	Session            *mcclient.ClientSession
+)
+
+func init() {
+	CronjobManager = &SCronjobManager{
+		SStandaloneResourceBaseManager: db.NewStandaloneResourceBaseManager(
+			SCronjob{},
+			"devtool_cronjobs",
+			"devtool_cronjob",
+			"devtool_cronjobs",
+		),
+	}
+	CronjobManager.SetVirtualObject(CronjobManager)
+	db.RegisterModelManager(CronjobManager)
+	DevToolCronManager = cronman.InitCronJobManager(true, 8)
+}
+
+func RunAnsibleCronjob(name string, s *mcclient.ClientSession) cronman.TCronJobFunction {
+	return func(ctx context.Context, userCred mcclient.TokenCredential, isStart bool) {
+		log.Debugf("[RunAnsibleCronjob] perform ansible cronjob run: %s", name)
+		ret, err := modules.AnsiblePlaybooks.PerformAction(s, name, "run", nil)
+		if err != nil {
+			log.Errorf("AnsiblePlaybooks.PerformAction error: %s", err)
+		}
+		log.Debugf("AnsiblePlaybooks.PerformAction ret: %+v", ret)
+	}
+}
+
+func AddOneCronjob(item *SCronjob, s *mcclient.ClientSession) error {
+
+	if !item.Enabled {
+		log.Debugf("ansible cronjob %s (devtool item.Id: %s) is not enabled", item.Name, item.Id)
+		return nil
+	}
+	if item.Interval > 0 {
+		err := DevToolCronManager.AddJobAtIntervalsWithStartRun(item.Id, time.Duration(item.Interval)*time.Second, RunAnsibleCronjob(item.Id, s), item.Start)
+		if err != nil {
+			log.Errorf("ansible cronjob %s (devtool item.Id: %s) error! %s", item.Name, item.Id, err)
+			return err
+		}
+		log.Infof("ansible cronjob %s (devtool item.Id: %s) registered at item.Interval: %ds", item.Name, item.Id, item.Interval)
+	} else {
+		err := DevToolCronManager.AddJobEveryFewDays(item.Id, int(item.Day), int(item.Hour), int(item.Min), int(item.Sec), RunAnsibleCronjob(item.Id, s), item.Start)
+		if err != nil {
+			log.Errorf("ansible cronjob %s (devtool item.Id: %s) registered at item.Interval: item.Day(%d) item.Hour(%d) item.Min(%d) item.Sec(%d) error: %s", item.Name, item.Id, int(item.Day), int(item.Hour), int(item.Min), int(item.Sec), err)
+			return err
+		}
+		log.Infof("ansible cronjob %s (devtool item.Id: %s) registered at item.Interval: item.Day(%d) item.Hour(%d) item.Min(%d) item.Sec(%d)", item.Name, item.Id, int(item.Day), int(item.Hour), int(item.Min), int(item.Sec))
+	}
+	return nil
+}
+
+func (man *SCronjobManager) InitializeData() error {
+	if Session == nil {
+		Session = auth.GetAdminSession(nil, "", "")
+	}
+
+	go func() {
+		items := make([]SCronjob, 0)
+		q := CronjobManager.Query().Equals("enabled", true)
+		err := q.All(&items)
+		if err != nil {
+			log.Errorf("query error: %s", err)
+		}
+		for _, item := range items {
+			AddOneCronjob(&item, Session)
+		}
+		DevToolCronManager.Start()
+	}()
+
+	return nil
+}
+
+func (job *SCronjob) PostCreate(ctx context.Context, userCred mcclient.TokenCredential, ownerID mcclient.IIdentityProvider, query jsonutils.JSONObject, data jsonutils.JSONObject) {
+	job.SStandaloneResourceBase.PostCreate(ctx, userCred, nil, query, data)
+	AddOneCronjob(job, Session)
+}
+
+func (job *SCronjob) PostDelete(ctx context.Context, userCred mcclient.TokenCredential) {
+	DevToolCronManager.Remove(job.Id)
+}
+
+func (job *SCronjob) PostUpdate(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) {
+	job.SStandaloneResourceBase.PostUpdate(ctx, userCred, query, data)
+	DevToolCronManager.Remove(job.Id)
+	AddOneCronjob(job, Session)
+}

--- a/pkg/devtool/models/doc.go
+++ b/pkg/devtool/models/doc.go
@@ -1,0 +1,1 @@
+package models // import "yunion.io/x/onecloud/pkg/devtool/models"

--- a/pkg/devtool/models/initdb.go
+++ b/pkg/devtool/models/initdb.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"yunion.io/x/log"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+)
+
+func InitDB() error {
+	for _, manager := range []db.IModelManager{
+		CronjobManager,
+	} {
+		err := manager.InitializeData()
+		if err != nil {
+			log.Errorf("Manager %s initializeData fail %s", manager.Keyword(), err)
+			return err
+		} else {
+			log.Infof("Manager %s initializeData PASS!", manager.Keyword())
+		}
+	}
+	return nil
+}

--- a/pkg/devtool/options/doc.go
+++ b/pkg/devtool/options/doc.go
@@ -1,0 +1,1 @@
+package options // import "yunion.io/x/onecloud/pkg/devtool/options"

--- a/pkg/devtool/options/option.go
+++ b/pkg/devtool/options/option.go
@@ -1,0 +1,26 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
+
+type DevToolOptions struct {
+	common_options.CommonOptions
+	common_options.DBOptions
+}
+
+var (
+	Options DevToolOptions
+)

--- a/pkg/devtool/service/doc.go
+++ b/pkg/devtool/service/doc.go
@@ -1,0 +1,1 @@
+package service // import "yunion.io/x/onecloud/pkg/devtool/service"

--- a/pkg/devtool/service/handler.go
+++ b/pkg/devtool/service/handler.go
@@ -1,0 +1,40 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"yunion.io/x/onecloud/pkg/appsrv"
+	"yunion.io/x/onecloud/pkg/appsrv/dispatcher"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/devtool/models"
+)
+
+func InitHandlers(app *appsrv.Application) {
+	db.InitAllManagers()
+
+	for _, manager := range []db.IModelManager{
+		db.TenantCacheManager,
+	} {
+		db.RegisterModelManager(manager)
+	}
+
+	for _, manager := range []db.IModelManager{
+		models.CronjobManager,
+	} {
+		db.RegisterModelManager(manager)
+		handler := db.NewModelHandler(manager)
+		dispatcher.AddModelDispatcher("", app, handler)
+	}
+}

--- a/pkg/devtool/service/service.go
+++ b/pkg/devtool/service/service.go
@@ -1,0 +1,50 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"os"
+
+	_ "github.com/go-sql-driver/mysql"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+
+	"yunion.io/x/log"
+	"yunion.io/x/onecloud/pkg/cloudcommon"
+	app_common "yunion.io/x/onecloud/pkg/cloudcommon/app"
+	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
+	"yunion.io/x/onecloud/pkg/devtool/models"
+	"yunion.io/x/onecloud/pkg/devtool/options"
+)
+
+func StartService() {
+	opts := &options.Options
+	commonOpts := &opts.CommonOptions
+	dbOpts := &options.Options.DBOptions
+	baseOpts := &opts.BaseOptions
+	common_options.ParseOptions(opts, os.Args, "devtool.conf", "devtool")
+
+	app_common.InitAuth(commonOpts, func() {
+		log.Infof("Auth complete!!")
+	})
+
+	app := app_common.InitApp(&opts.BaseOptions, false)
+
+	db.EnsureAppInitSyncDB(app, dbOpts, models.InitDB)
+
+	InitHandlers(app)
+	app_common.ServeForeverWithCleanup(app, baseOpts, func() {
+		cloudcommon.CloseDB()
+	})
+}

--- a/pkg/mcclient/modules/managers.go
+++ b/pkg/mcclient/modules/managers.go
@@ -154,3 +154,9 @@ func NewAnsibleManager(keyword, keywordPlural string, columns, adminColumns []st
 		BaseManager: *modulebase.NewBaseManager("ansible", "", "", columns, adminColumns),
 		Keyword:     keyword, KeywordPlural: keywordPlural}
 }
+
+func NewDevtoolManager(keyword, keywordPlural string, columns, adminColumns []string) modulebase.ResourceManager {
+	return modulebase.ResourceManager{
+		BaseManager: *modulebase.NewBaseManager("devtool", "", "", columns, adminColumns),
+		Keyword:     keyword, KeywordPlural: keywordPlural}
+}

--- a/pkg/mcclient/modules/mod_devtools.go
+++ b/pkg/mcclient/modules/mod_devtools.go
@@ -1,0 +1,34 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modules
+
+import (
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
+)
+
+var (
+	DevToolCronjobs modulebase.ResourceManager
+)
+
+func init() {
+
+	DevToolCronjobs = NewDevtoolManager(
+		"devtool_cronjob",
+		"devtool_cronjobs",
+		[]string{"id", "ansible_playbook_id", "name", "day", "hour", "min", "sec", "interval", "start", "enabled", "created_at"},
+		[]string{},
+	)
+	registerCompute(&DevToolCronjobs)
+}


### PR DESCRIPTION
Cherry pick of #3075 on release/2.12.

#3075: 新增 devtool cron manager，用来管理Ansibleserver 的定时任务