### PR TITLE
fix: reduce policy sync worker queue size

### DIFF
--- a/pkg/appsrv/workers.go
+++ b/pkg/appsrv/workers.go
@@ -144,9 +144,15 @@ type SWorkerManager struct {
 	workerLock     *sync.Mutex
 	workerId       uint64
 	dbWorker       bool
+
+	ignoreOverflow bool
 }
 
 func NewWorkerManager(name string, workerCount int, backlog int, dbWorker bool) *SWorkerManager {
+	return NewWorkerManagerIgnoreOverflow(name, workerCount, backlog, dbWorker, false)
+}
+
+func NewWorkerManagerIgnoreOverflow(name string, workerCount int, backlog int, dbWorker bool, ignoreOverflow bool) *SWorkerManager {
 	manager := SWorkerManager{name: name,
 		queue:          NewRing(workerCount * backlog),
 		workerCount:    workerCount,
@@ -156,6 +162,8 @@ func NewWorkerManager(name string, workerCount int, backlog int, dbWorker bool) 
 		workerLock:     &sync.Mutex{},
 		workerId:       0,
 		dbWorker:       dbWorker,
+
+		ignoreOverflow: ignoreOverflow,
 	}
 
 	workerManagers = append(workerManagers, &manager)
@@ -176,8 +184,8 @@ func (wm *SWorkerManager) Run(task func(), worker chan *SWorker, onErr func(erro
 	ret := wm.queue.Push(&sWorkerTask{task: task, worker: worker, onError: onErr})
 	if ret {
 		wm.schedule()
-	} else {
-		log.Warningf("queue full, task dropped")
+	} else if !wm.ignoreOverflow {
+		log.Warningf("[%s] queue full, task dropped", wm)
 	}
 	return ret
 }

--- a/pkg/cloudcommon/policy/policy.go
+++ b/pkg/cloudcommon/policy/policy.go
@@ -62,7 +62,8 @@ func init() {
 	}
 	DefaultPolicyFetcher = remotePolicyFetcher
 
-	syncWorkerManager = appsrv.NewWorkerManager("sync_policy_worker", 1, 1000, false)
+	// no need to queue many sync tasks
+	syncWorkerManager = appsrv.NewWorkerManagerIgnoreOverflow("sync_policy_worker", 1, 2, true, true)
 }
 
 type SPolicyManager struct {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：减少policy_sync_worker队列长度，避免异常情况下缓存太多同步任务导致无谓的同步

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12

/area keystone
/area region