### PR TITLE
fix: 添加vpc usable过滤参数,过滤cloudprovider异常的networks

### DIFF
--- a/cmd/climc/shell/vpcs.go
+++ b/cmd/climc/shell/vpcs.go
@@ -27,6 +27,7 @@ func init() {
 	type VpcListOptions struct {
 		options.BaseListOptions
 
+		Usable *bool  `help:"Filter usable vpcs"`
 		Region string `help:"ID or Name of region" json:"-"`
 	}
 	R(&VpcListOptions{}, "vpc-list", "List VPCs", func(s *mcclient.ClientSession, opts *VpcListOptions) error {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
添加vpc usable过滤参数,过滤cloudprovider异常的networks

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu @yousong 
