### PR TITLE
bugfix: fix host image memory leak and optimize open blk device

### DIFF
--- a/pkg/mcclient/mcclient.go
+++ b/pkg/mcclient/mcclient.go
@@ -80,6 +80,10 @@ func NewClient(authUrl string, timeout int, debug bool, insecure bool, certFile,
 	return &client
 }
 
+func (this *Client) HttpClient() *http.Client {
+	return this.httpconn
+}
+
 func (this *Client) SetDebug(debug bool) {
 	this.debug = debug
 }

--- a/pkg/mcclient/modules/pprof.go
+++ b/pkg/mcclient/modules/pprof.go
@@ -15,12 +15,24 @@
 package modules
 
 import (
+	"context"
+	"fmt"
 	"io"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
+	"yunion.io/x/onecloud/pkg/util/httputils"
 )
 
 func GetPProfByType(s *mcclient.ClientSession, serviceType string, profileType string, seconds int) (io.Reader, error) {
 	return modulebase.GetPProfByType(s, serviceType, profileType, seconds)
+}
+
+func GetNamedAddressPProfByType(s *mcclient.ClientSession, address string, profileType string, seconds int) (io.Reader, error) {
+	urlStr := fmt.Sprintf("%s%s", address, fmt.Sprintf("/debug/pprof/%s?seconds=%d", profileType, seconds))
+	resp, err := httputils.Request(s.GetClient().HttpClient(), context.Background(), "GET", urlStr, s.Header, nil, false)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复host-image 内存泄漏问题，优化get接口

**是否需要 backport 到之前的 release 分支**:
NONE
/area host-image
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
