### PR TITLE
Automated cherry pick of #3106: fix: server-create allow create server with empty disk

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -893,10 +893,6 @@ func (manager *SGuestManager) validateCreateData(
 			return nil, httperrors.NewBadRequestError("Snapshot error: disk index 0 but disk type is %s", diskConfig.DiskType)
 		}
 
-		if len(diskConfig.ImageId) == 0 && len(diskConfig.SnapshotId) == 0 && !data.Contains("cdrom") {
-			return nil, httperrors.NewBadRequestError("Miss operating system???")
-		}
-
 		// if len(diskConfig.Backend) == 0 {
 		// 	diskConfig.Backend = STORAGE_LOCAL
 		// }
@@ -951,6 +947,10 @@ func (manager *SGuestManager) validateCreateData(
 	input, err = ValidateScheduleCreateData(ctx, userCred, input, hypervisor)
 	if err != nil {
 		return nil, err
+	}
+
+	if input.Hypervisor != api.HYPERVISOR_KVM && len(input.Disks[0].ImageId) == 0 && len(input.Disks[0].SnapshotId) == 0 && input.Cdrom == "" {
+		return nil, httperrors.NewBadRequestError("Miss operating system???")
 	}
 
 	hypervisor = input.Hypervisor

--- a/pkg/mcclient/options/servers.go
+++ b/pkg/mcclient/options/servers.go
@@ -260,6 +260,8 @@ type ServerCreateOptions struct {
 	DryRun           *bool    `help:"Dry run to test scheduler" json:"-"`
 	UserDataFile     string   `help:"user_data file path" json:"-"`
 
+	OsType string `help:"os type, e.g. Linux, Windows, etc."`
+
 	Duration string `help:"valid duration of the server, e.g. 1H, 1D, 1W, 1M, 1Y, ADMIN ONLY option"`
 
 	AutoPrepaidRecycle bool `help:"automatically enable prepaid recycling after server is created successfully" json:"auto_prepaid_recycle,omitfalse"`
@@ -342,6 +344,7 @@ func (opts *ServerCreateOptions) Params() (*computeapi.ServerCreateInput, error)
 		EipChargeType:      opts.EipChargeType,
 		Eip:                opts.Eip,
 		EnableCloudInit:    opts.EnableCloudInit,
+		OsType:             opts.OsType,
 	}
 
 	if opts.GenerateName {


### PR DESCRIPTION
Cherry pick of #3106 on release/2.11.

#3106: fix: server-create allow create server with empty disk