### PR TITLE
scheduler: set random network filter default scope domain

### DIFF
--- a/pkg/scheduler/algorithm/predicates/network_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/network_predicate.go
@@ -203,7 +203,7 @@ func (p *NetworkPredicate) Execute(u *core.Unit, c core.Candidater) (bool, []cor
 
 	filterByRandomNetwork := func() {
 		counters := core.NewCounters()
-		if errMsg := isRandomNetworkAvailable("", "", false, false, "", counters); len(errMsg) != 0 {
+		if errMsg := isRandomNetworkAvailable("", string(rbacutils.ScopeDomain), false, false, "", counters); len(errMsg) != 0 {
 			h.ExcludeByErrors(errMsg)
 		}
 		h.SetCapacityCounter(counters)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复调度器 network filter 过滤 random 网络时忘记设置默认 public_scope 为 domain

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- 2.10

/cc @swordqiu 
/area scheduler