### PR TITLE
fix: guest create eip quota check use owner quota

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -2531,7 +2531,8 @@ func (self *SGuest) PerformCreateEip(ctx context.Context, userCred mcclient.Toke
 	quotaPlatform := self.GetQuotaPlatformID()
 
 	eipPendingUsage := &SQuota{Eip: 1}
-	err = QuotaManager.CheckSetPendingQuota(ctx, userCred, rbacutils.ScopeProject, userCred, quotaPlatform, eipPendingUsage)
+	ownerCred := self.GetOwnerId()
+	err = QuotaManager.CheckSetPendingQuota(ctx, userCred, rbacutils.ScopeProject, ownerCred, quotaPlatform, eipPendingUsage)
 	if err != nil {
 		return nil, httperrors.NewOutOfQuotaError("Out of eip quota: %s", err)
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：主机新建EIP时没有用主机所在项目的配额

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12

/area region