### PR TITLE
region: support list wire by host

### DIFF
--- a/cmd/climc/shell/wires.go
+++ b/cmd/climc/shell/wires.go
@@ -27,9 +27,10 @@ func init() {
 	type WireListOptions struct {
 		options.BaseListOptions
 
-		Region string `help:"List hosts in region"`
+		Region string `help:"List wires in region"`
 		Zone   string `help:"list wires in zone" json:"-"`
 		Vpc    string `help:"List wires in vpc"`
+		Host   string `help:"List wires attached to a host"`
 	}
 	R(&WireListOptions{}, "wire-list", "List wires", func(s *mcclient.ClientSession, opts *WireListOptions) error {
 		params, err := options.ListStructToParams(opts)

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -792,6 +792,16 @@ func (manager *SWireManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQu
 		q = q.In("vpc_id", sq.SubQuery())
 	}
 
+	hostStr, _ := query.GetString("host")
+	if len(hostStr) > 0 {
+		hostObj, err := HostManager.FetchByIdOrName(userCred, hostStr)
+		if err != nil {
+			return nil, httperrors.NewResourceNotFoundError2(HostManager.Keyword(), hostStr)
+		}
+		sq := HostwireManager.Query("wire_id").Equals("host_id", hostObj.GetId())
+		q = q.Filter(sqlchemy.In(q.Field("id"), sq.SubQuery()))
+	}
+
 	/*managerStr := jsonutils.GetAnyString(query, []string{"manager", "cloudprovider", "cloudprovider_id", "manager_id"})
 	if len(managerStr) > 0 {
 		provider, err := CloudproviderManager.FetchByIdOrName(nil, managerStr)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

wire 支持根据 host 过滤

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- 2.12
/area region