### PR TITLE
hostman: ovs: implement PersistentMAC()

### DIFF
--- a/pkg/hostman/hostinfo/hostbridge/ovs.go
+++ b/pkg/hostman/hostinfo/hostbridge/ovs.go
@@ -95,6 +95,18 @@ func (o *SOVSBridgeDriver) SetupBridgeDev() error {
 	return nil
 }
 
+func (d *SOVSBridgeDriver) PersistentMac() error {
+	args := []string{
+		"ovs-vsctl", "set", "Bridge", d.bridge.String(),
+		"other-config:hwaddr=" + d.inter.Mac,
+	}
+	output, err := procutils.NewCommand(args[0], args[1:]...).Run()
+	if err != nil {
+		return fmt.Errorf("Ovs bridge set mac address failed %s %s", output, err)
+	}
+	return nil
+}
+
 func (o *SOVSBridgeDriver) GenerateIfdownScripts(scriptPath string, nic jsonutils.JSONObject) error {
 	return o.generateIfdownScripts(o, scriptPath, nic)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

This is required if phy port was not added as first member or macaddr of
phy port is "locally managed"

More importantly, it needs to be fixed

**是否需要 backport 到之前的 release 分支**:

- release/2.10.0