### PR TITLE
Automated cherry pick of #3154: ansibleserver: enable tenant/user cache manager

### DIFF
--- a/pkg/ansibleserver/service/handlers.go
+++ b/pkg/ansibleserver/service/handlers.go
@@ -39,6 +39,8 @@ func InitHandlers(app *appsrv.Application) {
 	db.InitAllManagers()
 
 	db.RegisterModelManager(db.OpsLog)
+	db.RegisterModelManager(db.UserCacheManager)
+	db.RegisterModelManager(db.TenantCacheManager)
 	for _, manager := range []db.IModelManager{
 		models.AnsiblePlaybookManager,
 	} {


### PR DESCRIPTION
Cherry pick of #3154 on release/2.10.0.

#3154: ansibleserver: enable tenant/user cache manager