### PR TITLE
fix: show delele fail reason if cannot delete a resource

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -670,15 +670,16 @@ func getModelExtraDetails(item IModel, ctx context.Context, extra *jsonutils.JSO
 	err := item.ValidateDeleteCondition(ctx)
 	if err != nil {
 		extra.Add(jsonutils.JSONFalse, "can_delete")
+		extra.Add(jsonutils.NewString(err.Error()), "delete_fail_reason")
 	} else {
 		extra.Add(jsonutils.JSONTrue, "can_delete")
 	}
-	err = item.ValidateUpdateCondition(ctx)
+	/* err = item.ValidateUpdateCondition(ctx)
 	if err != nil {
 		extra.Add(jsonutils.JSONFalse, "can_update")
 	} else {
 		extra.Add(jsonutils.JSONTrue, "can_update")
-	}
+	}*/
 	return extra
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：当can_delete=false时，delete_fail_reason显示不允许删除的原因

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12

/area region