### PR TITLE
Automated cherry pick of #3162: fix: show delele fail reason if cannot delete a resource

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -670,15 +670,16 @@ func getModelExtraDetails(item IModel, ctx context.Context, extra *jsonutils.JSO
 	err := item.ValidateDeleteCondition(ctx)
 	if err != nil {
 		extra.Add(jsonutils.JSONFalse, "can_delete")
+		extra.Add(jsonutils.NewString(err.Error()), "delete_fail_reason")
 	} else {
 		extra.Add(jsonutils.JSONTrue, "can_delete")
 	}
-	err = item.ValidateUpdateCondition(ctx)
+	/* err = item.ValidateUpdateCondition(ctx)
 	if err != nil {
 		extra.Add(jsonutils.JSONFalse, "can_update")
 	} else {
 		extra.Add(jsonutils.JSONTrue, "can_update")
-	}
+	}*/
 	return extra
 }
 


### PR DESCRIPTION
Cherry pick of #3162 on release/2.12.

#3162: fix: show delele fail reason if cannot delete a resource