### PR TITLE
fix: 避免公有云账号统计虚拟的host数量

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -748,7 +748,7 @@ func (self *SCloudaccount) GetProviderCount() (int, error) {
 
 func (self *SCloudaccount) GetHostCount() (int, error) {
 	subq := CloudproviderManager.Query("id").Equals("cloudaccount_id", self.Id).SubQuery()
-	q := HostManager.Query().In("manager_id", subq)
+	q := HostManager.Query().In("manager_id", subq).IsFalse("is_emulated")
 	return q.CountWithError()
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免公有云账号统计虚拟的host数量

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @swordqiu @yousong 
