### PR TITLE
Automated cherry pick of #3180: fix: 避免公有云账号统计虚拟的host数量

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -748,7 +748,7 @@ func (self *SCloudaccount) GetProviderCount() (int, error) {
 
 func (self *SCloudaccount) GetHostCount() (int, error) {
 	subq := CloudproviderManager.Query("id").Equals("cloudaccount_id", self.Id).SubQuery()
-	q := HostManager.Query().In("manager_id", subq)
+	q := HostManager.Query().In("manager_id", subq).IsFalse("is_emulated")
 	return q.CountWithError()
 }
 


### PR DESCRIPTION
Cherry pick of #3180 on release/2.11.

#3180: fix: 避免公有云账号统计虚拟的host数量