### PR TITLE
fix: 创建相同配置时返回正确的eip信息

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4505,6 +4505,8 @@ func (self *SGuest) ToCreateInput(userCred mcclient.TokenCredential) *api.Server
 	userInput.IsSystem = genInput.IsSystem
 	userInput.SecgroupId = genInput.SecgroupId
 	userInput.KeypairId = genInput.KeypairId
+	userInput.EipBw = genInput.EipBw
+	userInput.EipChargeType = genInput.EipChargeType
 	userInput.Project = genInput.Project
 	if genInput.ResourceType != "" {
 		userInput.ResourceType = genInput.ResourceType
@@ -4557,6 +4559,10 @@ func (self *SGuest) toCreateInput() *api.ServerCreateInput {
 	}
 	if host := self.GetHost(); host != nil {
 		r.ResourceType = host.ResourceType
+	}
+	if eip, _ := self.GetEip(); eip != nil && eip.Mode == api.EIP_MODE_STANDALONE_EIP {
+		r.EipBw = eip.Bandwidth
+		r.EipChargeType = eip.ChargeType
 	}
 	if zone := self.getZone(); zone != nil {
 		r.PreferRegion = zone.GetRegion().GetId()


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
创建相同配置时返回正确的eip信息

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @swordqiu @yousong 
