### PR TITLE
fix: aliyun bucket sync cancel local limit

### DIFF
--- a/pkg/cloudprovider/objectstore.go
+++ b/pkg/cloudprovider/objectstore.go
@@ -133,6 +133,7 @@ type ICloudBucket interface {
 	GetStats() SBucketStats
 	GetLimit() SBucketStats
 	SetLimit(limit SBucketStats) error
+	LimitSupport() SBucketStats
 
 	SetAcl(acl TBucketACLType) error
 

--- a/pkg/compute/models/buckets.go
+++ b/pkg/compute/models/buckets.go
@@ -196,8 +196,13 @@ func (manager *SBucketManager) newFromCloudBucket(
 	bucket.ObjectCnt = stats.ObjectCount
 
 	limit := extBucket.GetLimit()
-	bucket.SizeBytesLimit = limit.SizeBytes
-	bucket.ObjectCntLimit = limit.ObjectCount
+	limitSupport := extBucket.LimitSupport()
+	if limitSupport.SizeBytes > 0 {
+		bucket.SizeBytesLimit = limit.SizeBytes
+	}
+	if limitSupport.ObjectCount > 0 {
+		bucket.ObjectCntLimit = limit.ObjectCount
+	}
 
 	bucket.AccessUrls = jsonutils.Marshal(extBucket.GetAccessUrls())
 
@@ -251,8 +256,13 @@ func (bucket *SBucket) syncWithCloudBucket(
 
 		if !statsOnly {
 			limit := extBucket.GetLimit()
-			bucket.SizeBytesLimit = limit.SizeBytes
-			bucket.ObjectCntLimit = limit.ObjectCount
+			limitSupport := extBucket.LimitSupport()
+			if limitSupport.SizeBytes > 0 {
+				bucket.SizeBytesLimit = limit.SizeBytes
+			}
+			if limitSupport.ObjectCount > 0 {
+				bucket.ObjectCntLimit = limit.ObjectCount
+			}
 
 			bucket.Acl = string(extBucket.GetAcl())
 			bucket.Location = extBucket.GetLocation()

--- a/pkg/multicloud/bucket_base.go
+++ b/pkg/multicloud/bucket_base.go
@@ -57,6 +57,13 @@ func (b *SBaseBucket) GetMetadata() *jsonutils.JSONDict {
 	return nil
 }
 
+func (b *SBaseBucket) LimitSupport() cloudprovider.SBucketStats {
+	return cloudprovider.SBucketStats{
+		SizeBytes:   -1,
+		ObjectCount: -1,
+	}
+}
+
 func (b *SBaseBucket) GetLimit() cloudprovider.SBucketStats {
 	return cloudprovider.SBucketStats{}
 }

--- a/pkg/multicloud/huawei/bucket.go
+++ b/pkg/multicloud/huawei/bucket.go
@@ -391,6 +391,13 @@ func (b *SBucket) GetTempUrl(method string, key string, expire time.Duration) (s
 	return output.SignedUrl, nil
 }
 
+func (b *SBucket) LimitSupport() cloudprovider.SBucketStats {
+	return cloudprovider.SBucketStats{
+		SizeBytes:   1,
+		ObjectCount: -1,
+	}
+}
+
 func (b *SBucket) GetLimit() cloudprovider.SBucketStats {
 	stats := cloudprovider.SBucketStats{}
 	obscli, err := b.region.getOBSClient()

--- a/pkg/multicloud/objectstore/xsky/bucket.go
+++ b/pkg/multicloud/objectstore/xsky/bucket.go
@@ -47,6 +47,13 @@ func (b *SXskyBucket) GetStats() cloudprovider.SBucketStats {
 	return b.SBucket.GetStats()
 }
 
+func (b *SXskyBucket) LimitSupport() cloudprovider.SBucketStats {
+	return cloudprovider.SBucketStats{
+		SizeBytes:   1,
+		ObjectCount: 1,
+	}
+}
+
 func (b *SXskyBucket) GetLimit() cloudprovider.SBucketStats {
 	limit := cloudprovider.SBucketStats{}
 	bucket, err := b.client.adminApi.getBucketByName(context.Background(), b.Name)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：阿里云bucket同步后会重置本地设置的bucket限制

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12

/area region