### PR TITLE
Bugfix: instance_group

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -3171,17 +3171,6 @@ func (self *SGuest) Delete(ctx context.Context, userCred mcclient.TokenCredentia
 }
 
 func (self *SGuest) RealDelete(ctx context.Context, userCred mcclient.TokenCredential) error {
-	// delete group
-	joints, err := GroupguestManager.FetchByGuestId(self.Id)
-	if err != nil {
-		return err
-	}
-	for i := range joints {
-		err = joints[i].Detach(ctx, userCred)
-		if err != nil {
-			return err
-		}
-	}
 	return self.SVirtualResourceBase.Delete(ctx, userCred)
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
guest 删除的时候离开group的操作不应该放在RealDelete函数里面

**是否需要 backport 到之前的 release 分支**:
 - release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
