### PR TITLE
Automated cherry pick of #3224: fix: Should not leave groups in SGuest.RealDelete; SGuest.LeaveAllGroups will be call in purge and guest_delete_task.

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -3171,17 +3171,6 @@ func (self *SGuest) Delete(ctx context.Context, userCred mcclient.TokenCredentia
 }
 
 func (self *SGuest) RealDelete(ctx context.Context, userCred mcclient.TokenCredential) error {
-	// delete group
-	joints, err := GroupguestManager.FetchByGuestId(self.Id)
-	if err != nil {
-		return err
-	}
-	for i := range joints {
-		err = joints[i].Detach(ctx, userCred)
-		if err != nil {
-			return err
-		}
-	}
 	return self.SVirtualResourceBase.Delete(ctx, userCred)
 }
 


### PR DESCRIPTION
Cherry pick of #3224 on release/2.12.

#3224: fix: Should not leave groups in SGuest.RealDelete; SGuest.LeaveAllGroups will be call in purge and guest_delete_task.