### PR TITLE
Automated cherry pick of #3189: fix: openstack上传镜像时也指定os_type及额外信息

### DIFF
--- a/pkg/multicloud/openstack/shell/image.go
+++ b/pkg/multicloud/openstack/shell/image.go
@@ -52,11 +52,15 @@ func init() {
 	})
 
 	type ImageCreateOptions struct {
-		NAME string
+		NAME          string
+		OsType        string `help:"os type" default:"linux" choices:"linux|windows"`
+		OsDistro      string
+		MinDiskSizeGB int
+		MinRamMb      int
 	}
 
 	shellutils.R(&ImageCreateOptions{}, "image-create", "Create image", func(cli *openstack.SRegion, args *ImageCreateOptions) error {
-		image, err := cli.CreateImage(args.NAME)
+		image, err := cli.CreateImage(args.NAME, args.OsType, args.OsDistro, args.MinDiskSizeGB, args.MinRamMb)
 		if err != nil {
 			return err
 		}

--- a/pkg/multicloud/openstack/storagecache.go
+++ b/pkg/multicloud/openstack/storagecache.go
@@ -142,7 +142,16 @@ func (cache *SStoragecache) uploadImage(ctx context.Context, userCred mcclient.T
 		nameIdx++
 	}
 
-	img, err := cache.region.CreateImage(imageName)
+	minDiskSizeMb, _ := meta.Int("min_disk")
+	minRamMb, _ := meta.Int("min_ram")
+	osType, _ := meta.GetString("properties", "os_type")
+	osDist, _ := meta.GetString("properties", "os_distribution")
+	minDiskSizeGB := minDiskSizeMb / 1024
+	if minDiskSizeMb%1024 > 0 {
+		minDiskSizeGB += 1
+	}
+
+	img, err := cache.region.CreateImage(imageName, osType, osDist, int(minDiskSizeGB), int(minRamMb))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Cherry pick of #3189 on release/2.11.

#3189: fix: openstack上传镜像时也指定os_type及额外信息