### PR TITLE
Feature: Unforced Instance Group

### DIFF
--- a/pkg/compute/models/groups.go
+++ b/pkg/compute/models/groups.go
@@ -14,7 +14,11 @@
 
 package models
 
-import "yunion.io/x/onecloud/pkg/cloudcommon/db"
+import (
+	"yunion.io/x/pkg/tristate"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+)
 
 const (
 	REDIS_TYPE = "REDIS"
@@ -44,16 +48,14 @@ func init() {
 type SGroup struct {
 	db.SVirtualResourceBase
 
-	ServiceType string `width:"36" charset:"ascii" nullable:"true" list:"user" update:"user" create:"optional"` // Column(VARCHAR(36, charset='ascii'), nullable=True)
-
-	ParentId string `width:"36" charset:"ascii" nullable:"true" list:"user" update:"user" create:"optional"` // Column(VARCHAR(36, charset='ascii'), nullable=True)
-
-	ZoneId string `width:"36" charset:"ascii" nullable:"true" list:"user" update:"user" create:"required"` // Column(VARCHAR(36, charset='ascii'), nullable=True)
-
+	ServiceType   string `width:"36" charset:"ascii" nullable:"true" list:"user" update:"user" create:"optional"`            // Column(VARCHAR(36, charset='ascii'), nullable=True)
+	ParentId      string `width:"36" charset:"ascii" nullable:"true" list:"user" update:"user" create:"optional"`            // Column(VARCHAR(36, charset='ascii'), nullable=True)
+	ZoneId        string `width:"36" charset:"ascii" nullable:"true" list:"user" update:"user" create:"required"`            // Column(VARCHAR(36, charset='ascii'), nullable=True)
 	SchedStrategy string `width:"16" charset:"ascii" nullable:"true" default:"" list:"user" update:"user" create:"optional"` // Column(VARCHAR(16, charset='ascii'), nullable=True, default='')
 
 	// the upper limit number of guests with this group in a host
-	Granularity int `nullable:"false" list:"user" get:"user" create:"optional" default:"1"`
+	Granularity     int               `nullable:"false" list:"user" get:"user" create:"optional" update:"user" default:"1"`
+	ForceDispersion tristate.TriState `list:"user" get:"user" create:"optional" update:"user" default:"true"`
 }
 
 func (group *SGroup) GetNetworks() ([]SGroupnetwork, error) {

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4378,7 +4378,7 @@ func (self *SGuest) ToSchedDesc() *schedapi.ScheduleInput {
 		ServerConfigs: new(api.ServerConfigs),
 	}
 	desc.Id = self.Id
-	//self.FillGroupSchedDesc(desc)
+	self.FillGroupSchedDesc(config.ServerConfigs)
 	self.FillDiskSchedDesc(config.ServerConfigs)
 	self.FillNetSchedDesc(config.ServerConfigs)
 	if len(self.HostId) > 0 && regutils.MatchUUID(self.HostId) {
@@ -4396,18 +4396,19 @@ func (self *SGuest) ToSchedDesc() *schedapi.ScheduleInput {
 	return desc
 }
 
-/*func (self *SGuest) FillGroupSchedDesc(desc *schedapi.ServerConfig) {
+func (self *SGuest) FillGroupSchedDesc(desc *api.ServerConfigs) {
 	groups := make([]SGroupguest, 0)
 	err := GroupguestManager.Query().Equals("guest_id", self.Id).All(&groups)
 	if err != nil {
 		log.Errorln(err)
 		return
 	}
-	for i := 0; i < len(groups); i++ {
-		desc.Set(fmt.Sprintf("srvtag.%d", i),
-			jsonutils.NewString(fmt.Sprintf("%s:%s", groups[i].SrvtagId, groups[i].Tag)))
+	groupids := make([]string, len(groups))
+	for i := range groups {
+		groupids[i] = groups[i].GroupId
 	}
-}*/
+	desc.InstanceGroupIds = groupids
+}
 
 func (self *SGuest) FillDiskSchedDesc(desc *api.ServerConfigs) {
 	guestDisks := make([]SGuestdisk, 0)

--- a/pkg/mcclient/modules/mod_instance_group.go
+++ b/pkg/mcclient/modules/mod_instance_group.go
@@ -23,7 +23,7 @@ var (
 func init() {
 	InstanceGroup = NewComputeManager("instancegroup", "instancegroups",
 		[]string{"ID", "Name", "Service_Type", "Parent_Id", "Zone_Id", "Sched_Strategy", "Domain_Id", "Project_Id",
-			"Granularity"},
+			"Granularity", "Is_Froced_Sep"},
 		[]string{})
 
 	registerCompute(&InstanceGroup)

--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -165,6 +165,14 @@ func (h *PredicateHelper) SetCapacityCounter(counter core.Counter) {
 	h.Unit.SetCapacity(h.Candidate.IndexKey(), h.predicate.Name(), counter)
 }
 
+func (h *PredicateHelper) SetSelectPriority(sp int) {
+	if sp < 0 {
+		sp = 0
+	}
+
+	h.Unit.SetSelectPriorityWithLock(h.Candidate.IndexKey(), h.predicate.Name(), core.SSelectPriorityValue(sp))
+}
+
 func (h *PredicateHelper) Exclude(reason string) {
 	h.SetCapacity(0)
 	h.AppendPredicateFailMsg(reason)

--- a/pkg/scheduler/algorithmprovider/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults.go
@@ -45,7 +45,8 @@ func defaultPredicates() sets.String {
 		factory.RegisterFitPredicate("m-GuestDiskschedtagFilter", &predicates.DiskSchedtagPredicate{}),
 		factory.RegisterFitPredicate("n-ServerSkuFilter", &predicates.InstanceTypePredicate{}),
 		factory.RegisterFitPredicate("o-GuestNetschedtagFilter", &predicates.NetworkSchedtagPredicate{}),
-		factory.RegisterFitPredicate("p-GuestDispersionFilter", &predicates.InstanceGroupPredicate{}),
+		factory.RegisterFitPredicate("p-GuestForcedDispersionFilter", &predicates.SForcedGroupPredicate{}),
+		factory.RegisterFitPredicate("p-GuestUnForcedDispersionFilter", &predicates.SUnForcedGroupPredicate{}),
 	)
 }
 

--- a/pkg/scheduler/api/sched.go
+++ b/pkg/scheduler/api/sched.go
@@ -143,9 +143,7 @@ func (data *SchedInfo) reviseData() {
 }
 
 func (d *SchedInfo) SkipDirtyMarkHost() bool {
-	skipByHypervisor := d.IsContainer || d.Hypervisor == SchedTypeContainer
-	skipByBackup := d.Backup
-	return skipByHypervisor || skipByBackup
+	return d.IsContainer || d.Hypervisor == SchedTypeContainer
 }
 
 func (d *SchedInfo) GetCandidateHostTypes() []string {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 调度器增加了一个优先级的概念，选择主机的时候，在保证host容量足够的前提下，会优先调度优先级高的host。借此，实现了Group的非强制策略，会优先调度满足互斥条件的主机，但是如果没有也会调度其他资源足够的主机。
2. 添加instanceGroups的信息在SGuest.ToShedDesc中，后者与主机克隆等一系列操作有关。
3. 对于高可用主机中的backup主机，也会占用InstanceGroup的名额，这样展示出来不直观，所以如果Group中有高可用机器的话应该提示用户，会占用两个Group中的名额。

小的修改：
4. 高可用主机调度时，会setpendingusage
5. 去除了SelectHosts时不必要的sort

**是否需要 backport 到之前的 release 分支**:
 - release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
