### PR TITLE
Bugfux: snapshotpolicy for qcloud

### DIFF
--- a/pkg/compute/models/snapshotpolicy.go
+++ b/pkg/compute/models/snapshotpolicy.go
@@ -50,7 +50,7 @@ type SSnapshotPolicy struct {
 
 	RetentionDays int `nullable:"false" list:"user" get:"user" create:"required"`
 
-	// 0~6, 0 is Monday
+	// 1~7, 1 is Monday
 	RepeatWeekdays uint8 `charset:"utf8" create:"required"`
 	// 0~23
 	TimePoints  uint32            `charset:"utf8" create:"required"`

--- a/pkg/multicloud/qcloud/snapshot_policy.go
+++ b/pkg/multicloud/qcloud/snapshot_policy.go
@@ -209,8 +209,8 @@ func (self *SRegion) CreateSnapshotPolicy(input *cloudprovider.SnapshotPolicyInp
 	}
 	dayOfWeekPrefix, hourPrefix := "Policy.0.DayOfWeek.", "Policy.0.Hour."
 	for index, day := range input.RepeatWeekdays {
-		if day == 0 {
-			day = 7
+		if day == 7 {
+			day = 0
 		}
 		params[dayOfWeekPrefix+strconv.Itoa(index)] = strconv.Itoa(day)
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 创建腾讯的snapshotpolicy，周天是0

**是否需要 backport 到之前的 release 分支**:
 - release/2.11
 - release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
