### PR TITLE
Automated cherry pick of #3241: fix: the input parameters is wrong when create snapshotpolicy with repeatweekday Sunday for qcloud.

### DIFF
--- a/pkg/compute/models/snapshotpolicy.go
+++ b/pkg/compute/models/snapshotpolicy.go
@@ -49,7 +49,7 @@ type SSnapshotPolicy struct {
 
 	RetentionDays int `nullable:"false" list:"user" get:"user" create:"required"`
 
-	// 0~6, 0 is Monday
+	// 1~7, 1 is Monday
 	RepeatWeekdays uint8 `charset:"utf8" create:"required"`
 	// 0~23
 	TimePoints  uint32            `charset:"utf8" create:"required"`

--- a/pkg/multicloud/qcloud/snapshot_policy.go
+++ b/pkg/multicloud/qcloud/snapshot_policy.go
@@ -209,8 +209,8 @@ func (self *SRegion) CreateSnapshotPolicy(input *cloudprovider.SnapshotPolicyInp
 	}
 	dayOfWeekPrefix, hourPrefix := "Policy.0.DayOfWeek.", "Policy.0.Hour."
 	for index, day := range input.RepeatWeekdays {
-		if day == 0 {
-			day = 7
+		if day == 7 {
+			day = 0
 		}
 		params[dayOfWeekPrefix+strconv.Itoa(index)] = strconv.Itoa(day)
 	}


### PR DESCRIPTION
Cherry pick of #3241 on release/2.11.

#3241: fix: the input parameters is wrong when create snapshotpolicy with repeatweekday Sunday for qcloud.