### PR TITLE
Bugfix: Sync snapshot

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -2226,3 +2226,29 @@ func (self *SDisk) GetSnapshotsNotInInstanceSnapshot() ([]SSnapshot, error) {
 	}
 	return snapshots, nil
 }
+
+func (self *SDisk) PerformChangeOwner(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject,
+	data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+
+	_, err := self.SVirtualResourceBase.PerformChangeOwner(ctx, userCred, query, data)
+	if err != nil {
+		return nil, err
+	}
+	snapshotQuery := SnapshotManager.Query().Equals("disk_id", self.Id)
+	snapshots := make([]SSnapshot, 0, 1)
+	err = db.FetchModelObjects(SnapshotManager, snapshotQuery, &snapshots)
+	if err != nil {
+		return nil, errors.Wrapf(err, "fail to fetch snapshots of disk %s", self.Id)
+	}
+	for i := range snapshots {
+		snapshot := snapshots[i]
+		lockman.LockObject(ctx, &snapshot)
+		_, err := snapshot.PerformChangeOwner(ctx, userCred, query, data)
+		if err != nil {
+			lockman.ReleaseObject(ctx, &snapshot)
+			return nil, errors.Wrapf(err, "fail to change owner of this disk(%s)'s snapshot %s", self.Id, snapshot.Id)
+		}
+		lockman.ReleaseObject(ctx, &snapshot)
+	}
+	return nil, nil
+}

--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -711,6 +711,15 @@ func (self *SSnapshot) SyncWithCloudSnapshot(ctx context.Context, userCred mccli
 	}
 	db.OpsLog.LogSyncUpdate(self, diff, userCred)
 
+	// bugfix for now:
+	disk, err := self.GetDisk()
+	if err == sql.ErrNoRows {
+		syncOwnerId = self.GetOwnerId()
+	} else if err != nil {
+		return errors.Wrapf(err, "get disk of snapshot %s error", self.Id)
+	} else {
+		syncOwnerId = disk.GetOwnerId()
+	}
 	SyncCloudProject(userCred, self, syncOwnerId, ext, self.ManagerId)
 
 	return nil
@@ -727,12 +736,14 @@ func (manager *SSnapshotManager) newFromCloudSnapshot(ctx context.Context, userC
 	snapshot.Name = newName
 	snapshot.Status = extSnapshot.GetStatus()
 	snapshot.ExternalId = extSnapshot.GetGlobalId()
+	var localDisk *SDisk
 	if len(extSnapshot.GetDiskId()) > 0 {
 		disk, err := db.FetchByExternalId(DiskManager, extSnapshot.GetDiskId())
 		if err != nil {
 			log.Errorf("snapshot %s missing disk?", snapshot.Name)
 		} else {
 			snapshot.DiskId = disk.GetId()
+			localDisk = disk.(*SDisk)
 		}
 	}
 
@@ -747,6 +758,10 @@ func (manager *SSnapshotManager) newFromCloudSnapshot(ctx context.Context, userC
 		return nil, err
 	}
 
+	// bugfix for now:
+	if localDisk != nil {
+		syncOwnerId = localDisk.GetOwnerId()
+	}
 	SyncCloudProject(userCred, &snapshot, syncOwnerId, extSnapshot, snapshot.ManagerId)
 
 	db.OpsLog.LogEvent(&snapshot, db.ACT_CREATE, snapshot.GetShortDesc(ctx), userCred)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
disk和disk所属的cloudprovider可能会有不同的project和domain信息，在同步snapshot的时候，snapshot的project、domain信息应该和disk保持一致。

**是否需要 backport 到之前的 release 分支**:
 - release/2.12
 - release/2.11
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
