### PR TITLE
feature: 支持预cache secgroup到云上

### DIFF
--- a/cmd/climc/shell/secgroupcaches.go
+++ b/cmd/climc/shell/secgroupcaches.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shell
+
+import (
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modules"
+	"yunion.io/x/onecloud/pkg/mcclient/options"
+)
+
+func init() {
+	type SecGroupCacheListOptions struct {
+		options.BaseListOptions
+		Secgroup string `help:"Secgroup ID or Name"`
+	}
+
+	R(&SecGroupCacheListOptions{}, "secgroup-cache-list", "List security group caches", func(s *mcclient.ClientSession, args *SecGroupCacheListOptions) error {
+		params, err := options.ListStructToParams(args)
+		if err != nil {
+			return err
+		}
+		result, err := modules.SecGroupCaches.List(s, params)
+		if err != nil {
+			return err
+		}
+		printList(result, modules.SecGroupCaches.GetColumns(s))
+		return nil
+	})
+	type SecGroupCacheIdOptions struct {
+		ID string `help:"ID or Name or secgroup cache"`
+	}
+	R(&SecGroupCacheIdOptions{}, "secgroup-cache-show", "Show security group cache", func(s *mcclient.ClientSession, args *SecGroupCacheIdOptions) error {
+		result, err := modules.SecGroupCaches.Get(s, args.ID, nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
+	R(&SecGroupCacheIdOptions{}, "secgroup-cache-delete", "Delete security group cache", func(s *mcclient.ClientSession, args *SecGroupCacheIdOptions) error {
+		result, err := modules.SecGroupCaches.Delete(s, args.ID, nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
+}

--- a/cmd/climc/shell/secgroups.go
+++ b/cmd/climc/shell/secgroups.go
@@ -176,4 +176,37 @@ func init() {
 		printObject(secgroups)
 		return nil
 	})
+
+	type SecurityGroupCacheSecurityGroup struct {
+		ID      string `help:"ID or Name of security group"`
+		VPC     string `help:"ID or Name of vpc"`
+		Classic *bool  `help:"Is classic vpc"`
+	}
+
+	R(&SecurityGroupCacheSecurityGroup{}, "secgroup-cache-secgroup", "Cache security group for special vpc", func(s *mcclient.ClientSession, args *SecurityGroupCacheSecurityGroup) error {
+		params, err := options.StructToParams(args)
+		secgroups, err := modules.SecGroups.PerformAction(s, args.ID, "cache-secgroup", params)
+		if err != nil {
+			return err
+		}
+		printObject(secgroups)
+		return nil
+	})
+
+	type SecurityGroupUncacheSecurityGroup struct {
+		ID    string `help:"ID or Name of security group"`
+		CACHE string `help:"ID of secgroup cache"`
+	}
+
+	R(&SecurityGroupUncacheSecurityGroup{}, "secgroup-uncache-secgroup", "Unache special secgroup cache", func(s *mcclient.ClientSession, args *SecurityGroupUncacheSecurityGroup) error {
+		params := jsonutils.NewDict()
+		params.Add(jsonutils.NewString(args.CACHE), "secgroupcache")
+		secgroups, err := modules.SecGroups.PerformAction(s, args.ID, "uncache-secgroup", params)
+		if err != nil {
+			return err
+		}
+		printObject(secgroups)
+		return nil
+	})
+
 }

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -446,6 +446,18 @@ paths:
     $ref: "./secgroup/public.yaml"
   /secgroups/{secgroupId}/private:
     $ref: "./secgroup/private.yaml"
+  /secgroups/{secgroupId}/cache-secgroup:
+    $ref: "./secgroup/cache-secgroup.yaml"
+  /secgroups/{secgroupId}/uncache-secgroup:
+    $ref: "./secgroup/uncache-secgroup.yaml"
+
+
+  /secgroupcaches:
+    $ref: "./secgroupcache/secgroupcaches.yaml"
+  /secgroupcaches/{cacheId}:
+    $ref: "./secgroupcache/secgroupcache.yaml"
+
+
   /secgrouprules:
     $ref: "./secgrouprule/secgrouprules.yaml"
   /secgrouprules/{secgroupruleId}:

--- a/docs/parameters/secgroupcache.yaml
+++ b/docs/parameters/secgroupcache.yaml
@@ -1,0 +1,13 @@
+cacheId:
+  name: cacheId
+  required: true
+  in: path
+  type: string
+  description: 安全组缓存ID
+
+
+secgroup:
+  name: secgroup
+  in: query 
+  type: string 
+  description: 安全组ID,仅过滤此安全组底下的缓存

--- a/docs/schemas/secgroup.yaml
+++ b/docs/schemas/secgroup.yaml
@@ -156,3 +156,26 @@ SecgroupAddRule:
       type: string
       example: test-rule
       description: 规则描述
+
+SecgroupCache:
+  type: object
+  properties:
+    vpc:
+      type: string
+      example: test-vpc
+      required: true
+      description: vpc名称或ID,建议使用ID
+    classic:
+      type: boolean
+      default: false
+      example: false
+      description: 仅针对支持经典网络的情况,目前仅Azure支持此参数
+
+SecgroupUncache:
+  type: object
+  properties:
+    secgroupcache:
+      type: string
+      example: 2e974625-d7e2-481b-8471-1c46fa9a65b0
+      required: true
+      description: 安全组缓存ID

--- a/docs/schemas/secgroupcache.yaml
+++ b/docs/schemas/secgroupcache.yaml
@@ -1,0 +1,67 @@
+SecgroupCacheResponse:
+  type: object
+  properties:
+    secgroupcache:
+      type: object
+      $ref: '#/SecgroupCache'
+
+SecgroupCache:
+  allOf:
+    - $ref: "./common.yaml#/StatusStandaloneResponse"
+    - type: object
+      properties:
+        vpc_id:
+          type: string
+          example: normal
+          description: 云上的vpc_id,若返回normal一般是指此安全组是region级别的
+        secgroup_id:
+          type: string 
+          example: a9ee32d4-66f3-4d2d-89b7-b1dea778484c 
+          desciption: 本地安全组ID
+        account:
+          type: string
+          example: openstack
+          description: 资源所属的云账号名称
+        account_id:
+          type: string 
+          example: a9ee32d4-66f3-4d2d-89b7-b1dea778484c
+          desciption: 源所属的云账号ID
+        account_domain:
+          type: string 
+          example: Default 
+          description: 资源账号所属的域
+        account_domain_id:
+          type: string 
+          example: default 
+          description: 资源账号所属的域ID
+        external_id:
+          type: string 
+          example: a359d7d6-54b7-4853-b200-9e4a9cfc5f42
+          description: 安全组对应云上的ID
+        manager:
+          type: string 
+          example: openstack
+          desciption: 安全组所属的子账号ID
+        provider:
+          type: string 
+          example: OpenStack
+          description: 所属云平台
+        region:
+          type: string 
+          example: openstack-RegionOne
+          desciption: 所在区域
+
+
+SecgroupCacheListResponse:
+  type: object
+  properties:
+    limit: 
+      type: integer
+      example: 20
+    secgroupcaches:
+      type: array
+      items:
+        $ref: '#/SecgroupCache'
+    total:
+      type: integer
+      example: 124

--- a/docs/secgroup/cache-secgroup.yaml
+++ b/docs/secgroup/cache-secgroup.yaml
@@ -1,0 +1,16 @@
+post:
+  summary: 预创建安全组到云上
+  parameters: 
+    - $ref: '../parameters/secgroup.yaml#/secgroupId'
+    - in: body
+      name: secgroup
+      required: true
+      schema:
+        $ref: '../schemas/secgroup.yaml#/SecgroupCache' 
+  responses:
+    200:
+      description: 安全组信息
+      schema:
+        $ref: '../schemas/secgroup.yaml#/SecgroupResponse'
+  tags:
+    - secgroups

--- a/docs/secgroup/uncache-secgroup.yaml
+++ b/docs/secgroup/uncache-secgroup.yaml
@@ -1,0 +1,16 @@
+post:
+  summary: 删除云上的某个安全组
+  parameters: 
+    - $ref: '../parameters/secgroup.yaml#/secgroupId'
+    - in: body
+      name: secgroup
+      required: true
+      schema:
+        $ref: '../schemas/secgroup.yaml#/SecgroupUncache' 
+  responses:
+    200:
+      description: 安全组信息
+      schema:
+        $ref: '../schemas/secgroup.yaml#/SecgroupResponse'
+  tags:
+    - secgroups

--- a/docs/secgroupcache/secgroupcache.yaml
+++ b/docs/secgroupcache/secgroupcache.yaml
@@ -1,0 +1,22 @@
+get:
+  summary: 获取指定安全组缓存详情信息
+  parameters:
+    - $ref: '../parameters/secgroupcache.yaml#/cacheId'
+  responses:
+    200:
+      description: 安全组信息
+      schema:
+        $ref: '../schemas/secgroupcache.yaml#/SecgroupCacheResponse'
+  tags:
+    - secgroupcaches
+
+delete:
+  summary: 删除指定安全组缓存
+  parameters:
+    - $ref: '../parameters/secgroupcache.yaml#/cacheId'
+  responses:
+    200:
+      schema:
+        $ref: '../schemas/secgroupcache.yaml#/SecgroupCacheResponse'
+  tags:
+    - secgroupcaches

--- a/docs/secgroupcache/secgroupcaches.yaml
+++ b/docs/secgroupcache/secgroupcaches.yaml
@@ -1,0 +1,13 @@
+get:
+  summary: 按指定条件列出安全组缓存列表
+  parameters:
+    - $ref: '../parameters/common.yaml#/limit'
+    - $ref: '../parameters/common.yaml#/offset'
+    - $ref: '../parameters/secgroupcache.yaml#/secgroup'
+  responses:
+    200:
+      description: 安全组缓存列表信息
+      schema:
+        $ref: '../schemas/secgroupcache.yaml#/SecgroupCacheListResponse'
+  tags:
+    - secgroupcaches

--- a/pkg/apis/compute/secgroup.go
+++ b/pkg/apis/compute/secgroup.go
@@ -57,6 +57,7 @@ type SSecgroupCreateInput struct {
 	apis.Meta
 
 	Name        string
+	Status      string
 	Description string
 	Rules       []SSecgroupRuleCreateInput
 }

--- a/pkg/apis/compute/secgroup_const.go
+++ b/pkg/apis/compute/secgroup_const.go
@@ -1,0 +1,20 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compute
+
+const (
+	SECGROUP_STATUS_READY    = "ready"
+	SECGROUP_STATUS_DELETING = "deleting"
+)

--- a/pkg/apis/compute/secgroupcache_const.go
+++ b/pkg/apis/compute/secgroupcache_const.go
@@ -1,0 +1,22 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compute
+
+const (
+	SECGROUP_CACHE_STATUS_READY         = "ready"
+	SECGROUP_CACHE_STATUS_DELETING      = "deleting"
+	SECGROUP_CACHE_STATUS_CACHING       = "caching"
+	SECGROUP_CACHE_STATUS_DELETE_FAILED = "delete_failed"
+)

--- a/pkg/cloudprovider/fakeregion.go
+++ b/pkg/cloudprovider/fakeregion.go
@@ -16,7 +16,6 @@ package cloudprovider
 
 import (
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/pkg/util/secrules"
 )
 
 type SFakeOnPremiseRegion struct {
@@ -90,12 +89,12 @@ func (region *SFakeOnPremiseRegion) CreateEIP(eip *SEip) (ICloudEIP, error) {
 	return nil, ErrNotSupported
 }
 
-func (region *SFakeOnPremiseRegion) DeleteSecurityGroup(vpcId, secgroupId string) error {
-	return ErrNotSupported
+func (region *SFakeOnPremiseRegion) GetISecurityGroupById(id string) (ICloudSecurityGroup, error) {
+	return nil, ErrNotSupported
 }
 
-func (region *SFakeOnPremiseRegion) SyncSecurityGroup(secgroupId string, vpcId string, name string, desc string, rules []secrules.SecurityRule) (string, error) {
-	return "", ErrNotSupported
+func (region *SFakeOnPremiseRegion) CreateISecurityGroup(conf *SecurityGroupCreateInput) (ICloudSecurityGroup, error) {
+	return nil, ErrNotSupported
 }
 
 func (region *SFakeOnPremiseRegion) GetILoadBalancers() ([]ICloudLoadbalancer, error) {

--- a/pkg/cloudprovider/resources.go
+++ b/pkg/cloudprovider/resources.go
@@ -69,8 +69,8 @@ type ICloudRegion interface {
 	GetIVMById(id string) (ICloudVM, error)
 	GetIDiskById(id string) (ICloudDisk, error)
 
-	DeleteSecurityGroup(vpcId, secgroupId string) error
-	SyncSecurityGroup(secgroupId string, vpcId string, name string, desc string, rules []secrules.SecurityRule) (string, error)
+	GetISecurityGroupById(secgroupId string) (ICloudSecurityGroup, error)
+	CreateISecurityGroup(conf *SecurityGroupCreateInput) (ICloudSecurityGroup, error)
 
 	CreateIVpc(name string, desc string, cidr string) (ICloudVpc, error)
 	CreateEIP(eip *SEip) (ICloudEIP, error)
@@ -327,6 +327,9 @@ type ICloudSecurityGroup interface {
 	GetDescription() string
 	GetRules() ([]secrules.SecurityRule, error)
 	GetVpcId() string
+
+	SyncRules(rules []secrules.SecurityRule) error
+	Delete() error
 }
 
 type ICloudRouteTable interface {

--- a/pkg/cloudprovider/securitygroup.go
+++ b/pkg/cloudprovider/securitygroup.go
@@ -1,0 +1,24 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprovider
+
+import "yunion.io/x/pkg/util/secrules"
+
+type SecurityGroupCreateInput struct {
+	Name  string
+	Desc  string
+	VpcId string
+	Rules []secrules.SecurityRule
+}

--- a/pkg/compute/guestdrivers/azure.go
+++ b/pkg/compute/guestdrivers/azure.go
@@ -17,7 +17,6 @@ package guestdrivers
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/utils"
@@ -139,14 +138,6 @@ func (self *SAzureGuestDriver) GetGuestInitialStateAfterRebuild() string {
 
 func (self *SAzureGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManagedVMCreateConfig) string {
 	return api.VM_AZURE_DEFAULT_LOGIN_USER
-}
-
-func (self *SAzureGuestDriver) GetGuestSecgroupVpcid(guest *models.SGuest) (string, error) {
-	host := guest.GetHost()
-	if host != nil && strings.HasSuffix(host.Name, "-classic") {
-		return "classic", nil
-	}
-	return api.NORMAL_VPC_ID, nil
 }
 
 func (self *SAzureGuestDriver) IsSupportedBillingCycle(bc billing.SBillingCycle) bool {

--- a/pkg/compute/guestdrivers/base.go
+++ b/pkg/compute/guestdrivers/base.go
@@ -299,21 +299,6 @@ func (self *SBaseGuestDriver) RequestSyncSecgroupsOnHost(ctx context.Context, gu
 	return nil // do nothing
 }
 
-func (self *SBaseGuestDriver) GetGuestSecgroupVpcid(guest *models.SGuest) (string, error) {
-	vpcId := ""
-	guestnets, err := guest.GetNetworks("")
-	if err != nil {
-		return "", err
-	}
-	for _, network := range guestnets {
-		if vpc := network.GetNetwork().GetVpc(); vpc != nil {
-			vpcId = vpc.ExternalId
-			break
-		}
-	}
-	return vpcId, nil
-}
-
 func (self *SBaseGuestDriver) CancelExpireTime(
 	ctx context.Context, userCred mcclient.TokenCredential, guest *models.SGuest) error {
 

--- a/pkg/compute/guestdrivers/openstack.go
+++ b/pkg/compute/guestdrivers/openstack.go
@@ -146,10 +146,6 @@ func (self *SOpenStackGuestDriver) GetGuestInitialStateAfterRebuild() string {
 	return api.VM_READY
 }
 
-func (self *SOpenStackGuestDriver) GetGuestSecgroupVpcid(guest *models.SGuest) (string, error) {
-	return api.NORMAL_VPC_ID, nil
-}
-
 func (self *SOpenStackGuestDriver) AllowReconfigGuest() bool {
 	return true
 }

--- a/pkg/compute/guestdrivers/qcloud.go
+++ b/pkg/compute/guestdrivers/qcloud.go
@@ -234,10 +234,6 @@ func (self *SQcloudGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManag
 	return userName
 }
 
-func (self *SQcloudGuestDriver) GetGuestSecgroupVpcid(guest *models.SGuest) (string, error) {
-	return api.NORMAL_VPC_ID, nil
-}
-
 func (self *SQcloudGuestDriver) AllowReconfigGuest() bool {
 	return true
 }

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -1164,6 +1164,7 @@ func (self *SCloudprovider) RealDelete(ctx context.Context, userCred mcclient.To
 		SnapshotPolicyManager,
 		StorageManager,
 		StoragecacheManager,
+		SecurityGroupCacheManager,
 		LoadbalancerManager,
 		LoadbalancerBackendGroupManager,
 		CachedLoadbalancerAclManager,

--- a/pkg/compute/models/cloudsync.go
+++ b/pkg/compute/models/cloudsync.go
@@ -219,7 +219,9 @@ func syncRegionVPCs(ctx context.Context, userCred mcclient.TokenCredential, sync
 			defer lockman.ReleaseObject(ctx, &localVpcs[j])
 
 			syncVpcWires(ctx, userCred, syncResults, provider, &localVpcs[j], remoteVpcs[j], syncRange)
-			syncVpcSecGroup(ctx, userCred, syncResults, provider, &localVpcs[j], remoteVpcs[j], syncRange)
+			if localRegion.GetDriver().IsSecurityGroupBelongVpc() || localRegion.GetDriver().IsSupportClassicSecurityGroup() || j == 0 { //有vpc属性的每次都同步,支持classic的vpc也同步，否则仅同步一次
+				syncVpcSecGroup(ctx, userCred, syncResults, provider, &localVpcs[j], remoteVpcs[j], syncRange)
+			}
 			syncVpcRouteTables(ctx, userCred, syncResults, provider, &localVpcs[j], remoteVpcs[j], syncRange)
 			syncVpcNatgateways(ctx, userCred, syncResults, provider, &localVpcs[j], remoteVpcs[j], syncRange)
 		}()

--- a/pkg/compute/models/guestdrivers.go
+++ b/pkg/compute/models/guestdrivers.go
@@ -100,7 +100,6 @@ type IGuestDriver interface {
 
 	RequestSyncConfigOnHost(ctx context.Context, guest *SGuest, host *SHost, task taskman.ITask) error
 	RequestSyncSecgroupsOnHost(ctx context.Context, guest *SGuest, host *SHost, task taskman.ITask) error
-	GetGuestSecgroupVpcid(guest *SGuest) (string, error)
 
 	RequestSyncstatusOnHost(ctx context.Context, guest *SGuest, host *SHost, userCred mcclient.TokenCredential) (jsonutils.JSONObject, error)
 

--- a/pkg/compute/models/purge.go
+++ b/pkg/compute/models/purge.go
@@ -1580,3 +1580,30 @@ func (manager *SElasticcacheManager) purgeAll(ctx context.Context, userCred mccl
 	}
 	return nil
 }
+
+func (cache *SSecurityGroupCache) purge(ctx context.Context, userCred mcclient.TokenCredential) error {
+	lockman.LockObject(ctx, cache)
+	defer lockman.ReleaseObject(ctx, cache)
+
+	err := cache.ValidateDeleteCondition(ctx)
+	if err != nil {
+		return err
+	}
+
+	return cache.RealDelete(ctx, userCred)
+}
+
+func (manager *SSecurityGroupCacheManager) purgeAll(ctx context.Context, userCred mcclient.TokenCredential, providerId string) error {
+	caches := []SSecurityGroupCache{}
+	err := fetchByManagerId(manager, providerId, &caches)
+	if err != nil {
+		return err
+	}
+	for i := range caches {
+		err := caches[i].purge(ctx, userCred)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/compute/models/regiondrivers.go
+++ b/pkg/compute/models/regiondrivers.go
@@ -102,6 +102,13 @@ type IRegionDriver interface {
 	RequestBindIPToNatgateway(ctx context.Context, task taskman.ITask, natgateway *SNatGateway, eipId string) error
 	RequestUnBindIPFromNatgateway(ctx context.Context, task taskman.ITask, nat INatHelper, natgateway *SNatGateway) error
 	BindIPToNatgatewayRollback(ctx context.Context, eipId string) error
+
+	RequestCacheSecurityGroup(ctx context.Context, userCred mcclient.TokenCredential, region *SCloudregion, vpc *SVpc, secgroup *SSecurityGroup, classic bool, task taskman.ITask) error
+	RequestSyncSecurityGroup(ctx context.Context, userCred mcclient.TokenCredential, vpcId string, vpc *SVpc, secgroup *SSecurityGroup) (string, error)
+	IsSupportClassicSecurityGroup() bool
+	IsSecurityGroupBelongVpc() bool
+	GetDefaultSecurityGroupVpcId() string
+	GetSecurityGroupVpcId(ctx context.Context, userCred mcclient.TokenCredential, region *SCloudregion, host *SHost, vpc *SVpc, classic bool) string
 }
 
 var regionDrivers map[string]IRegionDriver

--- a/pkg/compute/regiondrivers/aliyun.go
+++ b/pkg/compute/regiondrivers/aliyun.go
@@ -957,6 +957,9 @@ func (self *SAliyunRegionDriver) RequestUnBindIPFromNatgateway(ctx context.Conte
 }
 
 func (self *SAliyunRegionDriver) BindIPToNatgatewayRollback(ctx context.Context, eipId string) error {
-
 	return nil
+}
+
+func (self *SAliyunRegionDriver) IsSecurityGroupBelongVpc() bool {
+	return true
 }

--- a/pkg/compute/regiondrivers/aws.go
+++ b/pkg/compute/regiondrivers/aws.go
@@ -1209,3 +1209,7 @@ func (self *SAwsRegionDriver) RequestSyncLoadbalancerListener(ctx context.Contex
 	})
 	return nil
 }
+
+func (self *SAwsRegionDriver) IsSecurityGroupBelongVpc() bool {
+	return true
+}

--- a/pkg/compute/regiondrivers/azure.go
+++ b/pkg/compute/regiondrivers/azure.go
@@ -48,3 +48,7 @@ func (self *SAzureRegionDriver) ValidateCreateLoadbalancerAclData(ctx context.Co
 func (self *SAzureRegionDriver) ValidateCreateLoadbalancerCertificateData(ctx context.Context, userCred mcclient.TokenCredential, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
 	return nil, httperrors.NewNotImplementedError("%s does not currently support creating loadbalancer certificate", self.GetProvider())
 }
+
+func (self *SAzureRegionDriver) IsSupportClassicSecurityGroup() bool {
+	return true
+}

--- a/pkg/compute/regiondrivers/base.go
+++ b/pkg/compute/regiondrivers/base.go
@@ -20,6 +20,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 
+	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/models"
@@ -190,4 +191,28 @@ func (self *SBaseRegionDriver) RequestBingToNatgateway(ctx context.Context, task
 	natgateway *models.SNatGateway, needBind bool, eipID string) error {
 
 	return fmt.Errorf("Not implement RequestBindIPToNatgateway")
+}
+
+func (self *SBaseRegionDriver) RequestCacheSecurityGroup(ctx context.Context, userCred mcclient.TokenCredential, region *models.SCloudregion, vpc *models.SVpc, secgroup *models.SSecurityGroup, classic bool, task taskman.ITask) error {
+	return fmt.Errorf("Not Implemented RequestCacheSecurityGroup")
+}
+
+func (self *SBaseRegionDriver) IsSupportClassicSecurityGroup() bool {
+	return false
+}
+
+func (self *SBaseRegionDriver) IsSecurityGroupBelongVpc() bool {
+	return false
+}
+
+func (self *SBaseRegionDriver) GetDefaultSecurityGroupVpcId() string {
+	return api.NORMAL_VPC_ID
+}
+
+func (self *SBaseRegionDriver) GetSecurityGroupVpcId(ctx context.Context, userCred mcclient.TokenCredential, region *models.SCloudregion, host *models.SHost, vpc *models.SVpc, classic bool) string {
+	return ""
+}
+
+func (self *SBaseRegionDriver) RequestSyncSecurityGroup(ctx context.Context, userCred mcclient.TokenCredential, vpcId string, vpc *models.SVpc, secgroup *models.SSecurityGroup) (string, error) {
+	return "", fmt.Errorf("Not Implemented RequestSyncSecurityGroup")
 }

--- a/pkg/compute/regiondrivers/huawei.go
+++ b/pkg/compute/regiondrivers/huawei.go
@@ -1526,3 +1526,7 @@ func (self *SHuaWeiRegionDriver) DealNatGatewaySpec(spec string) string {
 	//can't arrive
 	return ""
 }
+
+func (self *SHuaWeiRegionDriver) IsSecurityGroupBelongVpc() bool {
+	return true
+}

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -857,3 +857,7 @@ func (self *SKVMRegionDriver) RequestPreSnapshotPolicyApply(ctx context.Context,
 func (self *SKVMRegionDriver) BindIPToNatgatewayRollback(ctx context.Context, eipId string) error {
 	return nil
 }
+
+func (self *SKVMRegionDriver) ValidateCacheSecgroup(ctx context.Context, userCred mcclient.TokenCredential, secgroup *models.SSecurityGroup, vpc *models.SVpc, classic bool) error {
+	return fmt.Errorf("No need to cache secgroup for onecloud region")
+}

--- a/pkg/compute/tasks/secgroup_group_cache_task.go
+++ b/pkg/compute/tasks/secgroup_group_cache_task.go
@@ -1,0 +1,85 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"context"
+	"fmt"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
+	"yunion.io/x/onecloud/pkg/compute/models"
+)
+
+type SecurityGroupCacheTask struct {
+	taskman.STask
+}
+
+func init() {
+	taskman.RegisterTask(SecurityGroupCacheTask{})
+}
+
+func (self *SecurityGroupCacheTask) taskFailed(ctx context.Context, secgroup *models.SSecurityGroup, err error) {
+	self.SetStageFailed(ctx, err.Error())
+}
+
+func (self *SecurityGroupCacheTask) getVpc() (*models.SVpc, error) {
+	vpcId, _ := self.GetParams().GetString("vpc_id")
+	if len(vpcId) == 0 {
+		return nil, fmt.Errorf("Missing vpc_id params")
+	}
+	vpc, err := models.VpcManager.FetchById(vpcId)
+	if err != nil {
+		return nil, errors.Wrap(err, "VpcManager.FetchById")
+	}
+	return vpc.(*models.SVpc), nil
+}
+
+func (self *SecurityGroupCacheTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
+	secgroup := obj.(*models.SSecurityGroup)
+
+	vpc, err := self.getVpc()
+	if err != nil {
+		self.taskFailed(ctx, secgroup, errors.Wrap(err, "self.getVpc()"))
+		return
+	}
+
+	region, err := vpc.GetRegion()
+	if err != nil {
+		self.taskFailed(ctx, secgroup, errors.Wrap(err, "vpc.GetRegion"))
+		return
+	}
+
+	classic, _ := self.GetParams().Bool("classic")
+
+	self.SetStage("OnCacheSecurityGroupComplete", nil)
+
+	err = region.GetDriver().RequestCacheSecurityGroup(ctx, self.UserCred, region, vpc, secgroup, classic, self)
+	if err != nil {
+		self.taskFailed(ctx, secgroup, errors.Wrap(err, "RequestCacheSecgroup"))
+		return
+	}
+}
+
+func (self *SecurityGroupCacheTask) OnCacheSecurityGroupComplete(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
+	self.SetStageComplete(ctx, nil)
+}
+
+func (self *SecurityGroupCacheTask) OnCacheSecurityGroupCompleteFailed(ctx context.Context, obj db.IStandaloneModel, err jsonutils.JSONObject) {
+	self.SetStageFailed(ctx, err.String())
+}

--- a/pkg/compute/tasks/security_group_cache_delete_task.go
+++ b/pkg/compute/tasks/security_group_cache_delete_task.go
@@ -1,0 +1,92 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"context"
+	"database/sql"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/compute/models"
+	"yunion.io/x/onecloud/pkg/util/logclient"
+)
+
+type SecurityGroupCacheDeleteTask struct {
+	taskman.STask
+}
+
+func init() {
+	taskman.RegisterTask(SecurityGroupCacheDeleteTask{})
+}
+
+func (self *SecurityGroupCacheDeleteTask) taskFailed(ctx context.Context, cache *models.SSecurityGroupCache, err error) {
+	cache.SetStatus(self.UserCred, api.SECGROUP_CACHE_STATUS_DELETE_FAILED, err.Error())
+	secgroup, _ := cache.GetSecgroup()
+	if secgroup != nil {
+		logclient.AddActionLogWithStartable(self, secgroup, logclient.ACT_DELETE, err, self.UserCred, false)
+	}
+	self.SetStageFailed(ctx, err.Error())
+}
+
+func (self *SecurityGroupCacheDeleteTask) taskComplete(ctx context.Context, cache *models.SSecurityGroupCache) {
+	cache.RealDelete(ctx, self.UserCred)
+	self.SetStageComplete(ctx, nil)
+}
+
+func (self *SecurityGroupCacheDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
+	cache := obj.(*models.SSecurityGroupCache)
+
+	if len(cache.ExternalId) == 0 {
+		self.taskComplete(ctx, cache)
+		return
+	}
+
+	_, err := models.CloudproviderManager.FetchById(cache.ManagerId)
+	if err == sql.ErrNoRows {
+		self.taskComplete(ctx, cache)
+		return
+	}
+
+	iRegion, err := cache.GetIRegion()
+	if err != nil {
+		if err == cloudprovider.ErrNotFound {
+			self.taskComplete(ctx, cache)
+			return
+		}
+		self.taskFailed(ctx, cache, errors.Wrap(err, "cache.GetIRegion"))
+		return
+	}
+	iSecgroup, err := iRegion.GetISecurityGroupById(cache.ExternalId)
+	if err != nil {
+		if err == cloudprovider.ErrNotFound {
+			self.taskComplete(ctx, cache)
+			return
+		}
+		self.taskFailed(ctx, cache, errors.Wrap(err, "iRegion.GetIStoragecacheById"))
+		return
+	}
+	err = iSecgroup.Delete()
+	if err != nil {
+		self.taskFailed(ctx, cache, err)
+		return
+	}
+	self.taskComplete(ctx, cache)
+}

--- a/pkg/mcclient/modules/mod_secgroupcaches.go
+++ b/pkg/mcclient/modules/mod_secgroupcaches.go
@@ -1,0 +1,31 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modules
+
+import "yunion.io/x/onecloud/pkg/mcclient/modulebase"
+
+var (
+	SecGroupCaches modulebase.ResourceManager
+)
+
+func init() {
+	SecGroupCaches = NewComputeManager("secgroupcache", "secgroupcaches",
+		[]string{"ID", "Name", "Descritpion", "Status",
+			"Vpc_Id", "Vpc", "Region", "Account",
+			"Secgroup_Id"},
+		[]string{""})
+
+	registerCompute(&SecGroupCaches)
+}

--- a/pkg/multicloud/aliyun/securitygroup.go
+++ b/pkg/multicloud/aliyun/securitygroup.go
@@ -546,7 +546,7 @@ func (self *SRegion) leaveSecurityGroup(secgroupId, instanceId string) error {
 	return err
 }
 
-func (self *SRegion) DeleteSecurityGroup(vpcId, secGrpId string) error {
+func (self *SRegion) DeleteSecurityGroup(secGrpId string) error {
 	params := make(map[string]string)
 	params["SecurityGroupId"] = secGrpId
 
@@ -558,6 +558,14 @@ func (self *SRegion) DeleteSecurityGroup(vpcId, secGrpId string) error {
 	return nil
 }
 
+func (self *SSecurityGroup) Delete() error {
+	return self.vpc.region.DeleteSecurityGroup(self.SecurityGroupId)
+}
+
 func (self *SSecurityGroup) GetProjectId() string {
 	return ""
+}
+
+func (self *SSecurityGroup) SyncRules(rules []secrules.SecurityRule) error {
+	return self.vpc.region.syncSecgroupRules(self.SecurityGroupId, rules)
 }

--- a/pkg/multicloud/aliyun/vpc.go
+++ b/pkg/multicloud/aliyun/vpc.go
@@ -240,7 +240,7 @@ func (self *SVpc) Delete() error {
 	}
 	for i := 0; i < len(self.secgroups); i += 1 {
 		secgroup := self.secgroups[i].(*SSecurityGroup)
-		err := self.region.DeleteSecurityGroup(self.VpcId, secgroup.SecurityGroupId)
+		err := self.region.DeleteSecurityGroup(secgroup.SecurityGroupId)
 		if err != nil {
 			log.Errorf("deleteSecurityGroup for VPC delete fail %s", err)
 			return err

--- a/pkg/multicloud/aws/region.go
+++ b/pkg/multicloud/aws/region.go
@@ -1014,3 +1014,25 @@ func (self *SRegion) GetILoadBalancerBackendGroups() ([]cloudprovider.ICloudLoad
 
 	return ret, nil
 }
+
+func (self *SRegion) GetISecurityGroupById(secgroupId string) (cloudprovider.ICloudSecurityGroup, error) {
+	secgroups, total, err := self.GetSecurityGroups("", secgroupId, 0, 1)
+	if err != nil {
+		return nil, err
+	}
+	if total == 0 {
+		return nil, cloudprovider.ErrNotFound
+	}
+	if total > 1 {
+		return nil, cloudprovider.ErrDuplicateId
+	}
+	return &secgroups[0], nil
+}
+
+func (self *SRegion) CreateISecurityGroup(conf *cloudprovider.SecurityGroupCreateInput) (cloudprovider.ICloudSecurityGroup, error) {
+	groupId, err := self.createSecurityGroup(conf.VpcId, conf.Name, "", conf.Desc)
+	if err != nil {
+		return nil, err
+	}
+	return self.GetISecurityGroupById(groupId)
+}

--- a/pkg/multicloud/aws/securitygroup.go
+++ b/pkg/multicloud/aws/securitygroup.go
@@ -495,3 +495,12 @@ func (self *SRegion) GetSecurityGroups(vpcId string, secgroupId string, offset i
 func (self *SSecurityGroup) GetProjectId() string {
 	return ""
 }
+
+func (self *SSecurityGroup) SyncRules(rules []secrules.SecurityRule) error {
+	rules = SecurityRuleSetToAllowSet(rules)
+	return self.vpc.region.syncSecgroupRules(self.SecurityGroupId, rules)
+}
+
+func (self *SSecurityGroup) Delete() error {
+	return self.vpc.region.DeleteSecurityGroup(self.SecurityGroupId)
+}

--- a/pkg/multicloud/aws/vpc.go
+++ b/pkg/multicloud/aws/vpc.go
@@ -291,7 +291,7 @@ func (self *SRegion) assignSecurityGroups(secgroupIds []*string, instanceId stri
 	return nil
 }
 
-func (self *SRegion) DeleteSecurityGroup(vpcId, secGrpId string) error {
+func (self *SRegion) DeleteSecurityGroup(secGrpId string) error {
 	params := &ec2.DeleteSecurityGroupInput{}
 	params.SetGroupId(secGrpId)
 

--- a/pkg/multicloud/huawei/securitygroup.go
+++ b/pkg/multicloud/huawei/securitygroup.go
@@ -170,6 +170,9 @@ func (self *SSecurityGroup) GetMetadata() *jsonutils.JSONDict {
 }
 
 func (self *SSecurityGroup) GetDescription() string {
+	if self.Description == self.VpcID {
+		return ""
+	}
 	return self.Description
 }
 
@@ -331,4 +334,13 @@ func (self *SRegion) GetSecurityGroups(vpcId string) ([]SSecurityGroup, error) {
 
 func (self *SSecurityGroup) GetProjectId() string {
 	return ""
+}
+
+func (self *SSecurityGroup) Delete() error {
+	return self.region.DeleteSecurityGroup(self.ID)
+}
+
+func (self *SSecurityGroup) SyncRules(rules []secrules.SecurityRule) error {
+	rules = SecurityRuleSetToAllowSet(rules)
+	return self.region.syncSecgroupRules(self.ID, rules)
 }

--- a/pkg/multicloud/huawei/shell/secgroup.go
+++ b/pkg/multicloud/huawei/shell/secgroup.go
@@ -43,4 +43,19 @@ func init() {
 		printObject(secgrp)
 		return nil
 	})
+
+	type SecurityGroupCreateOptions struct {
+		NAME string `help:"secgroup name"`
+		VPC  string `help:"ID of VPC"`
+		Desc string `help:"description"`
+	}
+	shellutils.R(&SecurityGroupCreateOptions{}, "security-group-create", "Create security group", func(cli *huawei.SRegion, args *SecurityGroupCreateOptions) error {
+		result, err := cli.CreateSecurityGroup(args.VPC, args.NAME, args.Desc)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
 }

--- a/pkg/multicloud/objectstore/objectstore.go
+++ b/pkg/multicloud/objectstore/objectstore.go
@@ -195,10 +195,6 @@ func (cli *SObjectStoreClient) GetIDiskById(id string) (cloudprovider.ICloudDisk
 	return nil, cloudprovider.ErrNotSupported
 }
 
-func (cli *SObjectStoreClient) DeleteSecurityGroup(vpcId, secgroupId string) error {
-	return cloudprovider.ErrNotSupported
-}
-
 func (cli *SObjectStoreClient) SyncSecurityGroup(secgroupId string, vpcId string, name string, desc string, rules []secrules.SecurityRule) (string, error) {
 	return "", cloudprovider.ErrNotSupported
 }

--- a/pkg/multicloud/openstack/region.go
+++ b/pkg/multicloud/openstack/region.go
@@ -527,3 +527,11 @@ func (region *SRegion) GetIBucketById(name string) (cloudprovider.ICloudBucket, 
 func (region *SRegion) GetIBucketByName(name string) (cloudprovider.ICloudBucket, error) {
 	return nil, cloudprovider.ErrNotImplemented
 }
+
+func (region *SRegion) GetISecurityGroupById(secgroupId string) (cloudprovider.ICloudSecurityGroup, error) {
+	return region.GetSecurityGroup(secgroupId)
+}
+
+func (region *SRegion) CreateISecurityGroup(conf *cloudprovider.SecurityGroupCreateInput) (cloudprovider.ICloudSecurityGroup, error) {
+	return region.CreateSecurityGroup(conf.Name, conf.Desc)
+}

--- a/pkg/multicloud/openstack/vpc.go
+++ b/pkg/multicloud/openstack/vpc.go
@@ -126,7 +126,7 @@ func (vpc *SVpc) GetISecurityGroups() ([]cloudprovider.ICloudSecurityGroup, erro
 	}
 	iSecgroups := []cloudprovider.ICloudSecurityGroup{}
 	for i := 0; i < len(secgroups); i++ {
-		secgroups[i].vpc = vpc
+		secgroups[i].region = vpc.region
 		iSecgroups = append(iSecgroups, &secgroups[i])
 	}
 	return iSecgroups, nil

--- a/pkg/multicloud/qcloud/region.go
+++ b/pkg/multicloud/qcloud/region.go
@@ -796,10 +796,6 @@ func (self *SRegion) instanceOperation(instanceId string, opname string, extra m
 	return err
 }
 
-func (self *SRegion) DeleteSecurityGroup(vpcId string, secgroupId string) error {
-	return self.deleteSecurityGroup(secgroupId)
-}
-
 func (self *SRegion) GetInstanceVNCUrl(instanceId string) (string, error) {
 	params := make(map[string]string)
 	params["InstanceId"] = instanceId
@@ -919,4 +915,12 @@ func (region *SRegion) GetIBucketById(name string) (cloudprovider.ICloudBucket, 
 
 func (region *SRegion) GetIBucketByName(name string) (cloudprovider.ICloudBucket, error) {
 	return region.GetIBucketById(name)
+}
+
+func (self *SRegion) GetISecurityGroupById(secgroupId string) (cloudprovider.ICloudSecurityGroup, error) {
+	return self.GetSecurityGroupDetails(secgroupId)
+}
+
+func (self *SRegion) CreateISecurityGroup(conf *cloudprovider.SecurityGroupCreateInput) (cloudprovider.ICloudSecurityGroup, error) {
+	return self.CreateSecurityGroup(conf.Name, conf.Desc)
 }

--- a/pkg/multicloud/qcloud/shell/securitygroup.go
+++ b/pkg/multicloud/qcloud/shell/securitygroup.go
@@ -46,7 +46,7 @@ func init() {
 	})
 
 	shellutils.R(&SecurityGroupOptions{}, "security-group-delete", "Delete SecurityGroup", func(cli *qcloud.SRegion, args *SecurityGroupOptions) error {
-		return cli.DeleteSecurityGroup("", args.ID)
+		return cli.DeleteSecurityGroup(args.ID)
 	})
 
 	type SecurityGroupCreateOptions struct {

--- a/pkg/multicloud/qcloud/vpc.go
+++ b/pkg/multicloud/qcloud/vpc.go
@@ -97,7 +97,7 @@ func (self *SVpc) GetISecurityGroups() ([]cloudprovider.ICloudSecurityGroup, err
 	}
 	isecgroups := make([]cloudprovider.ICloudSecurityGroup, len(secgroups))
 	for i := 0; i < len(secgroups); i++ {
-		secgroups[i].vpc = self
+		secgroups[i].region = self.region
 		isecgroups[i] = &secgroups[i]
 	}
 	return isecgroups, nil

--- a/pkg/multicloud/ucloud/region.go
+++ b/pkg/multicloud/ucloud/region.go
@@ -192,10 +192,22 @@ func (self *SRegion) GetIEipById(id string) (cloudprovider.ICloudEIP, error) {
 }
 
 // https://docs.ucloud.cn/api/unet-api/delete_firewall
-func (self *SRegion) DeleteSecurityGroup(vpcId, secgroupId string) error {
+func (self *SRegion) DeleteSecurityGroup(secgroupId string) error {
 	params := NewUcloudParams()
 	params.Set("FWId", secgroupId)
 	return self.DoAction("DeleteFirewall", params, nil)
+}
+
+func (self *SRegion) GetISecurityGroupById(secgroupId string) (cloudprovider.ICloudSecurityGroup, error) {
+	return self.GetSecurityGroupById(secgroupId)
+}
+
+func (self *SRegion) CreateISecurityGroup(conf *cloudprovider.SecurityGroupCreateInput) (cloudprovider.ICloudSecurityGroup, error) {
+	externalId, err := self.CreateDefaultSecurityGroup(conf.Name, conf.Desc)
+	if err != nil {
+		return nil, err
+	}
+	return self.GetISecurityGroupById(externalId)
 }
 
 // https://docs.ucloud.cn/api/unet-api/describe_firewall

--- a/pkg/multicloud/ucloud/securitygroup.go
+++ b/pkg/multicloud/ucloud/securitygroup.go
@@ -258,3 +258,26 @@ func (self *SRegion) GetSecurityGroups(secGroupId string, resourceId string) ([]
 
 	return secgroups, nil
 }
+
+func (self *SSecurityGroup) SyncRules(rules []secrules.SecurityRule) error {
+	// 如果是空规则，onecloud。默认拒绝所有流量
+	if len(rules) == 0 {
+		_, IpNet, _ := net.ParseCIDR("0.0.0.0/0")
+		rules = []secrules.SecurityRule{{
+			Priority:    0,
+			Action:      secrules.SecurityRuleDeny,
+			IPNet:       IpNet,
+			Protocol:    secrules.PROTO_ANY,
+			Direction:   secrules.SecurityRuleIngress,
+			PortStart:   0,
+			PortEnd:     0,
+			Ports:       nil,
+			Description: "",
+		}}
+	}
+	return self.region.syncSecgroupRules(self.FWID, rules)
+}
+
+func (self *SSecurityGroup) Delete() error {
+	return self.region.DeleteSecurityGroup(self.FWID)
+}

--- a/pkg/multicloud/ucloud/shell/secgroup.go
+++ b/pkg/multicloud/ucloud/shell/secgroup.go
@@ -15,6 +15,8 @@
 package shell
 
 import (
+	"fmt"
+
 	"yunion.io/x/onecloud/pkg/multicloud/ucloud"
 	"yunion.io/x/onecloud/pkg/util/shellutils"
 )
@@ -31,10 +33,10 @@ func init() {
 		return nil
 	})
 
-	type SecurityGroupShowOptions struct {
+	type SecurityGroupIdOptions struct {
 		ID string `help:"ID or name of security group"`
 	}
-	shellutils.R(&SecurityGroupShowOptions{}, "security-group-show", "Show details of a security group", func(cli *ucloud.SRegion, args *SecurityGroupShowOptions) error {
+	shellutils.R(&SecurityGroupIdOptions{}, "security-group-show", "Show details of a security group", func(cli *ucloud.SRegion, args *SecurityGroupIdOptions) error {
 		secgrp, err := cli.GetSecurityGroupById(args.ID)
 		if err != nil {
 			return err
@@ -42,4 +44,23 @@ func init() {
 		printObject(secgrp)
 		return nil
 	})
+
+	shellutils.R(&SecurityGroupIdOptions{}, "security-group-delete", "Show details of a security group", func(cli *ucloud.SRegion, args *SecurityGroupIdOptions) error {
+		return cli.DeleteSecurityGroup(args.ID)
+	})
+
+	type SecurityGroupCreateOptions struct {
+		NAME string `help:"Name of security group"`
+		Desc string `help:"Description of secgroup"`
+	}
+
+	shellutils.R(&SecurityGroupCreateOptions{}, "security-group-create", "Create security group", func(cli *ucloud.SRegion, args *SecurityGroupCreateOptions) error {
+		secgrpId, err := cli.CreateDefaultSecurityGroup(args.NAME, args.Desc)
+		if err != nil {
+			return err
+		}
+		fmt.Println(secgrpId)
+		return nil
+	})
+
 }

--- a/pkg/multicloud/zstack/region.go
+++ b/pkg/multicloud/zstack/region.go
@@ -290,10 +290,6 @@ func (region *SRegion) CreateILoadBalancerAcl(acl *cloudprovider.SLoadbalancerAc
 	return nil, cloudprovider.ErrNotImplemented
 }
 
-func (region *SRegion) DeleteSecurityGroup(vpcId, secGrpId string) error {
-	return cloudprovider.ErrNotImplemented
-}
-
 func (region *SRegion) GetIEips() ([]cloudprovider.ICloudEIP, error) {
 	eips, err := region.GetEips("", "")
 	if err != nil {
@@ -351,6 +347,14 @@ func (region *SRegion) DeleteISkuByName(name string) error {
 
 func (region *SRegion) GetISkuById(skuId string) (cloudprovider.ICloudSku, error) {
 	return region.GetInstanceOffering(skuId)
+}
+
+func (region *SRegion) GetISecurityGroupById(secgroupId string) (cloudprovider.ICloudSecurityGroup, error) {
+	return region.GetSecurityGroup(secgroupId)
+}
+
+func (region *SRegion) CreateISecurityGroup(conf *cloudprovider.SecurityGroupCreateInput) (cloudprovider.ICloudSecurityGroup, error) {
+	return region.CreateSecurityGroup(conf.Name, conf.Desc)
 }
 
 func (region *SRegion) SyncSecurityGroup(secgroupId string, vpcId string, name string, desc string, rules []secrules.SecurityRule) (string, error) {

--- a/pkg/multicloud/zstack/securitygroup.go
+++ b/pkg/multicloud/zstack/securitygroup.go
@@ -265,7 +265,7 @@ func (region *SRegion) DeleteSecurityGroupRules(ruleIds []string) error {
 }
 
 func (region *SRegion) CreateSecurityGroup(name, desc string) (*SSecurityGroup, error) {
-	secgroup := &SSecurityGroup{}
+	secgroup := &SSecurityGroup{region: region}
 	params := map[string]map[string]string{
 		"params": {
 			"name":        name,
@@ -356,4 +356,12 @@ func (region *SRegion) syncSecgroupRules(secgroupId string, rules []secrules.Sec
 		}
 	}
 	return region.AddSecurityGroupRule(secgroupId, addRules)
+}
+
+func (self *SSecurityGroup) SyncRules(rules []secrules.SecurityRule) error {
+	return self.region.syncSecgroupRules(self.UUID, rules)
+}
+
+func (self *SSecurityGroup) Delete() error {
+	return self.region.client.delete("security-groups", self.UUID, "Permissive")
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 支持预创建安全组，或单个删除云上安全组
2. 优化cache，支持云上删除的安全组，同步时自动清理cache
3. 优化同步安全组功能，避免因使用颗粒度高的同步函数
4. 支持删除账号时同时删除账号对应的安全组缓存
5. 安全组删除时，状态跟随变化

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu @yousong @tb365 
