### PR TITLE
lbagent: fix listing filter on manager_id

### DIFF
--- a/pkg/lbagent/models/reflect.go
+++ b/pkg/lbagent/models/reflect.go
@@ -105,7 +105,7 @@ func GetModels(opts *GetModelsOptions) error {
 		Details: options.Bool(true),
 		Filter: []string{
 			minUpdatedAtFilter(minUpdatedAt), // order matters, filter.0
-			"manager_id.isnull()",            // len(manager_id) > 0 is for pubcloud objects
+			"manager_id.isnullorempty()",     // len(manager_id) > 0 is for pubcloud objects
 		},
 		OrderBy: []string{"updated_at", "id"},
 		Order:   "asc",


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

允许manager_id为空串

**是否需要 backport 到之前的 release 分支**:


- release/2.10.0