### PR TITLE
fix: 修复2.10.0 ucloud安全组同步问题

### DIFF
--- a/pkg/util/ucloud/region.go
+++ b/pkg/util/ucloud/region.go
@@ -198,7 +198,7 @@ func (self *SRegion) DeleteSecurityGroup(vpcId, secgroupId string) error {
 func (self *SRegion) SyncSecurityGroup(secgroupId string, vpcId string, name string, desc string, rules []secrules.SecurityRule) (string, error) {
 	if len(secgroupId) > 0 {
 		_, err := self.GetSecurityGroupById(secgroupId)
-		if err == cloudprovider.ErrNotSupported {
+		if err == cloudprovider.ErrNotFound {
 			secgroupId = ""
 		} else if err != nil {
 			return "", err


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复2.10.0 ucloud安全组同步问题

**是否需要 backport 到之前的 release 分支**:
None

/area region
/cc @swordqiu @yousong @tb365 
