### PR TITLE
Automated cherry pick of #3260: fix: The domain and project info between disk and disk's cloudprovider maybe different and the new snapshot synced from cloud should have same domain and project info with disk. Project of snapshot with undeleted disk should always be same with disk's. Project of snapshot whose disk has been deleted should not change in SyncWithCloudSnapshot.

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -2226,3 +2226,29 @@ func (self *SDisk) GetSnapshotsNotInInstanceSnapshot() ([]SSnapshot, error) {
 	}
 	return snapshots, nil
 }
+
+func (self *SDisk) PerformChangeOwner(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject,
+	data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+
+	_, err := self.SVirtualResourceBase.PerformChangeOwner(ctx, userCred, query, data)
+	if err != nil {
+		return nil, err
+	}
+	snapshotQuery := SnapshotManager.Query().Equals("disk_id", self.Id)
+	snapshots := make([]SSnapshot, 0, 1)
+	err = db.FetchModelObjects(SnapshotManager, snapshotQuery, &snapshots)
+	if err != nil {
+		return nil, errors.Wrapf(err, "fail to fetch snapshots of disk %s", self.Id)
+	}
+	for i := range snapshots {
+		snapshot := snapshots[i]
+		lockman.LockObject(ctx, &snapshot)
+		_, err := snapshot.PerformChangeOwner(ctx, userCred, query, data)
+		if err != nil {
+			lockman.ReleaseObject(ctx, &snapshot)
+			return nil, errors.Wrapf(err, "fail to change owner of this disk(%s)'s snapshot %s", self.Id, snapshot.Id)
+		}
+		lockman.ReleaseObject(ctx, &snapshot)
+	}
+	return nil, nil
+}

--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -711,6 +711,15 @@ func (self *SSnapshot) SyncWithCloudSnapshot(ctx context.Context, userCred mccli
 	}
 	db.OpsLog.LogSyncUpdate(self, diff, userCred)
 
+	// bugfix for now:
+	disk, err := self.GetDisk()
+	if err == sql.ErrNoRows {
+		syncOwnerId = self.GetOwnerId()
+	} else if err != nil {
+		return errors.Wrapf(err, "get disk of snapshot %s error", self.Id)
+	} else {
+		syncOwnerId = disk.GetOwnerId()
+	}
 	SyncCloudProject(userCred, self, syncOwnerId, ext, self.ManagerId)
 
 	return nil
@@ -727,12 +736,14 @@ func (manager *SSnapshotManager) newFromCloudSnapshot(ctx context.Context, userC
 	snapshot.Name = newName
 	snapshot.Status = extSnapshot.GetStatus()
 	snapshot.ExternalId = extSnapshot.GetGlobalId()
+	var localDisk *SDisk
 	if len(extSnapshot.GetDiskId()) > 0 {
 		disk, err := db.FetchByExternalId(DiskManager, extSnapshot.GetDiskId())
 		if err != nil {
 			log.Errorf("snapshot %s missing disk?", snapshot.Name)
 		} else {
 			snapshot.DiskId = disk.GetId()
+			localDisk = disk.(*SDisk)
 		}
 	}
 
@@ -747,6 +758,10 @@ func (manager *SSnapshotManager) newFromCloudSnapshot(ctx context.Context, userC
 		return nil, err
 	}
 
+	// bugfix for now:
+	if localDisk != nil {
+		syncOwnerId = localDisk.GetOwnerId()
+	}
 	SyncCloudProject(userCred, &snapshot, syncOwnerId, extSnapshot, snapshot.ManagerId)
 
 	db.OpsLog.LogEvent(&snapshot, db.ACT_CREATE, snapshot.GetShortDesc(ctx), userCred)


### PR DESCRIPTION
Cherry pick of #3260 on release/2.12.

#3260: fix: The domain and project info between disk and disk's cloudprovider maybe different and the new snapshot synced from cloud should have same domain and project info with disk. Project of snapshot with undeleted disk should always be same with disk's. Project of snapshot whose disk has been deleted should not change in SyncWithCloudSnapshot.