### PR TITLE
Bugfix: NAT

### DIFF
--- a/docs/schemas/natgateway.yaml
+++ b/docs/schemas/natgateway.yaml
@@ -154,8 +154,8 @@ DNatEntry:
       example: tcp
     name:
       type: string
-      description: DNAT名称
-      example: 111.230.80.43/udp/32
+      description: DNAT名称(处理过的)
+      example: hello-ea27c0ce-5870-49f3-8d57-f53e63f40361
     natgateway:
       type: string
       description: 所属NAT网关名称
@@ -168,6 +168,10 @@ DNatEntry:
       type: string
       description: DNAT状态
       example: available
+    real_name:
+      type: string
+      description: DNAT真实的名称
+      example: hello
 
 DNatEntryListResponse:
   type: object
@@ -215,7 +219,8 @@ SNatEntry:
       description: 公网IP
     name:
       type: string
-      example: snat-2zeqqfcow4t67ahduei7x
+      description: SNAT名称（经过处理的）
+      example: hello-ea27c0ce-5870-49f3-8d57-f53e63f40361
     natgateway:
       type: string
       example: test-nat
@@ -238,6 +243,10 @@ SNatEntry:
       type: string
       example: available
       description: SNAT状态
+    real_name:
+      type: string
+      example: hello
+      description: SNAT真实的名称
 
 SNatEntryListResponse:
   type: object

--- a/pkg/compute/models/regiondrivers.go
+++ b/pkg/compute/models/regiondrivers.go
@@ -99,7 +99,9 @@ type IRegionDriver interface {
 
 	//Nat gateway
 	DealNatGatewaySpec(spec string) string
-	RequestBindIPToNatgateway(ctx context.Context, task taskman.ITask, natgateway *SNatGateway, needBind bool, eipID string) error
+	RequestBindIPToNatgateway(ctx context.Context, task taskman.ITask, natgateway *SNatGateway, eipId string) error
+	RequestUnBindIPFromNatgateway(ctx context.Context, task taskman.ITask, nat INatHelper, natgateway *SNatGateway) error
+	BindIPToNatgatewayRollback(ctx context.Context, eipId string) error
 }
 
 var regionDrivers map[string]IRegionDriver

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -832,8 +832,14 @@ func (self *SKVMRegionDriver) OnSnapshotDelete(ctx context.Context, snapshot *mo
 func (self *SKVMRegionDriver) DealNatGatewaySpec(spec string) string {
 	return spec
 }
-func (self *SKVMRegionDriver) RequestBindIPToNatgateway(ctx context.Context, task taskman.ITask,
-	natgateway *models.SNatGateway, needBind bool, eipID string) error {
+func (self *SKVMRegionDriver) RequestBindIPToNatgateway(ctx context.Context, task taskman.ITask, natgateway *models.SNatGateway,
+	eipId string) error {
+
+	return nil
+}
+
+func (self *SKVMRegionDriver) RequestUnBindIPFromNatgateway(ctx context.Context, task taskman.ITask,
+	nat models.INatHelper, natgateway *models.SNatGateway) error {
 
 	return nil
 }
@@ -845,5 +851,9 @@ func (self *SKVMRegionDriver) RequestPreSnapshotPolicyApply(ctx context.Context,
 
 		return data, nil
 	})
+	return nil
+}
+
+func (self *SKVMRegionDriver) BindIPToNatgatewayRollback(ctx context.Context, eipId string) error {
 	return nil
 }

--- a/pkg/compute/tasks/nat_common.go
+++ b/pkg/compute/tasks/nat_common.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"context"
+
+	"yunion.io/x/pkg/errors"
+
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
+	"yunion.io/x/onecloud/pkg/compute/models"
+)
+
+type iTask interface {
+	taskman.ITask
+	TaskFailed(ctx context.Context, nat models.INatHelper, err error)
+}
+
+func NatToBindIPStage(ctx context.Context, task iTask, nat models.INatHelper) {
+	nat.SetStatus(task.GetUserCred(), api.NAT_STATUS_ALLOCATE, "")
+	natgateway, err := nat.GetNatgateway()
+	if err != nil {
+		task.TaskFailed(ctx, nat, errors.Wrap(err, "fetch natgateway failed"))
+		return
+	}
+	task.SetStage("OnBindIPComplete", nil)
+	if !task.GetParams().Contains("need_bind") {
+		task.ScheduleRun(nil)
+		return
+	}
+
+	eipId, _ := task.GetParams().GetString("eip_id")
+	if err := natgateway.GetRegion().GetDriver().RequestBindIPToNatgateway(ctx, task, natgateway, eipId); err != nil {
+		task.TaskFailed(ctx, nat, err)
+		return
+	}
+}
+
+func CreateINatFailedRollback(ctx context.Context, task iTask, nat models.INatHelper) error {
+	natgateway, err := nat.GetNatgateway()
+	if err != nil {
+		return errors.Wrap(err, "fetch natgateway failed")
+	}
+	eipId, _ := task.GetParams().GetString("eip_id")
+	err = natgateway.GetRegion().GetDriver().BindIPToNatgatewayRollback(ctx, eipId)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/util/logclient/consts.go
+++ b/pkg/util/logclient/consts.go
@@ -147,4 +147,9 @@ const (
 	ACT_MKDIR         = "创建目录"
 	ACT_DELETE_OBJECT = "删除对象"
 	ACT_UPLOAD_OBJECT = "上传对象"
+
+	ACT_NAT_CREATE_SNAT = "创建SNAT规则"
+	ACT_NAT_CREATE_DNAT = "创建DNAT规则"
+	ACT_NAT_DELETE_SNAT = "删除SNAT规则"
+	ACT_NAT_DELETE_DNAT = "删除DNAT规则"
 )


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1.  把SNAT和DNAT的操作日志加到了NAT网关上。
2. 对于阿里云来说，在创建和删除NAT规则的时候，如果需要绑定和解绑EIP，会自动完成这一步。
3. 对于华为云来说，在创建和删除NAT规则的时候，如果需要，会修改EIP本地数据库中绑定信息
4. SNAT和DNAT的名称显示现在使用real_name这个字段，这是因为不同NAT网关下的NAT规则应该是允许重名的。所以显示的时候不用name字段，而用real_name。
5. 华为云的SNAT规则可以一次性绑定多个EIP，现在同步下来展示是正确的。
6. 把SNAT和DNAT的公共的field和function放在了SNatEntry和SNatEntryManager。

**是否需要 backport 到之前的 release 分支**:
 - realease/2.11
 - realease/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
