### PR TITLE
Bugfix: EIP Sync

### DIFF
--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -507,6 +507,9 @@ func (self *SCloudprovider) PerformSync(ctx context.Context, userCred mcclient.T
 	if err != nil {
 		return nil, httperrors.NewInputParameterError("invalid input %s", err)
 	}
+	if syncRange.FullSync || len(syncRange.Region) > 0 || len(syncRange.Zone) > 0 || len(syncRange.Host) > 0 {
+		syncRange.DeepSync = true
+	}
 	if self.CanSync() || syncRange.Force {
 		err = self.StartSyncCloudProviderInfoTask(ctx, userCred, &syncRange, "")
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. cloudprovider的PerformSync中增加对syncRange的处理（参考cloudaccount中的PerformSync）。
2. eip 同步，对于需要删除的本地eip，不需要检测是否满足删除条件，直接删除。这是因为，如果检测删除条件，对于绑定了实例并且对应实例已经被删除的eip，eip的状态会被置为'unkown'，使得eip处于不可解绑且不可删除的状态。再者，如果确认cloud eip已经不存在，本地eip应该是可直接删除的。
3. eip 同步，对于SyncWithCloudEip的情况，应该要同步eip associated instance。
4. eip 同步，对于需要新创建本地eip的情况，直接在newFromCloudEip中调用SyncInstanceWithCloudEip即可同步associated instance，不需要针对VM做特殊处理。

**是否需要 backport 到之前的 release 分支**:
 - release/2.12
 - release/2.11
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
