### PR TITLE
Automated cherry pick of #3317: Bugfix: add parameter deepsync to command 'cloud-provider-sync' and 'cloud-account-sync'; fix the bug when syncing eip.

### DIFF
--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -507,6 +507,9 @@ func (self *SCloudprovider) PerformSync(ctx context.Context, userCred mcclient.T
 	if err != nil {
 		return nil, httperrors.NewInputParameterError("invalid input %s", err)
 	}
+	if syncRange.FullSync || len(syncRange.Region) > 0 || len(syncRange.Zone) > 0 || len(syncRange.Host) > 0 {
+		syncRange.DeepSync = true
+	}
 	if self.CanSync() || syncRange.Force {
 		err = self.StartSyncCloudProviderInfoTask(ctx, userCred, &syncRange, "")
 	}


### PR DESCRIPTION
Cherry pick of #3317 on release/2.12.

#3317: Bugfix: add parameter deepsync to command 'cloud-provider-sync' and 'cloud-account-sync'; fix the bug when syncing eip.