### PR TITLE
fix github action lib missing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,7 @@ jobs:
 
     - name: Build
       run: |
+        sudo apt-get install librados-dev librbd-dev
         make cmd/apigateway cmd/baremetal-agent cmd/climc cmd/keystone
         make cmd/logger cmd/region cmd/scheduler cmd/webconsole
         make cmd/yunionconf cmd/glance cmd/torrent cmd/s3gateway


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
NONE
/area util