### PR TITLE
fix: 避免解绑eip更新状态不及时导致再次同步出现public ip问题

### DIFF
--- a/pkg/multicloud/qcloud/instance.go
+++ b/pkg/multicloud/qcloud/instance.go
@@ -795,6 +795,7 @@ func (self *SInstance) GetIEIP() (cloudprovider.ICloudEIP, error) {
 	if total == 1 {
 		return &eip[0], nil
 	}
+	self.Refresh()
 	for _, address := range self.PublicIpAddresses {
 		eip := SEipAddress{region: self.host.zone.region}
 		eip.AddressIp = address


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免刚使用remoteVM.GetIEip时，eip刚解除完成，instance未刷新及时，导致出现public ip情况

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @swordqiu @yousong 
