### PR TITLE
Automated cherry pick of #3325: fix: 避免解绑eip更新状态不及时导致再次同步出现public ip问题

### DIFF
--- a/pkg/multicloud/qcloud/instance.go
+++ b/pkg/multicloud/qcloud/instance.go
@@ -795,6 +795,7 @@ func (self *SInstance) GetIEIP() (cloudprovider.ICloudEIP, error) {
 	if total == 1 {
 		return &eip[0], nil
 	}
+	self.Refresh()
 	for _, address := range self.PublicIpAddresses {
 		eip := SEipAddress{region: self.host.zone.region}
 		eip.AddressIp = address


### PR DESCRIPTION
Cherry pick of #3325 on release/2.11.

#3325: fix: 避免解绑eip更新状态不及时导致再次同步出现public ip问题