### PR TITLE
baremetal: add cdrom boot schedule

### DIFF
--- a/pkg/apis/scheduler/api.go
+++ b/pkg/apis/scheduler/api.go
@@ -51,6 +51,7 @@ type ServerConfig struct {
 	Ncpu        int    `json:"vcpu_count"`
 	Name        string `json:"name"`
 	GuestStatus string `json:"guest_status"`
+	Cdrom       string `json:"cdrom"`
 
 	// DEPRECATED
 	Metadata       map[string]string `json:"__meta__"`

--- a/pkg/mcclient/options/schedulers.go
+++ b/pkg/mcclient/options/schedulers.go
@@ -22,10 +22,11 @@ import (
 type SchedulerTestBaseOptions struct {
 	ServerConfigs
 
-	Mem  int    `help:"Memory size (MB), default 512" metavar:"MEMORY" default:"512"`
-	Ncpu int    `help:"#CPU cores of VM server, default 1" default:"1" metavar:"<SERVER_CPU_COUNT>"`
-	Sku  string `help:"Server SKU instance type"`
-	Log  bool   `help:"Record to schedule history"`
+	Mem   int    `help:"Memory size (MB), default 512" metavar:"MEMORY" default:"512"`
+	Ncpu  int    `help:"#CPU cores of VM server, default 1" default:"1" metavar:"<SERVER_CPU_COUNT>"`
+	Sku   string `help:"Server SKU instance type"`
+	Log   bool   `help:"Record to schedule history"`
+	Cdrom string `help:"ISO image ID" metavar:"IMAGE_ID"`
 }
 
 func (o SchedulerTestBaseOptions) data(s *mcclient.ClientSession) (*scheduler.ServerConfig, error) {
@@ -45,6 +46,9 @@ func (o SchedulerTestBaseOptions) data(s *mcclient.ClientSession) (*scheduler.Se
 	}
 	if o.Sku != "" {
 		data.InstanceType = o.Sku
+	}
+	if o.Cdrom != "" {
+		data.Cdrom = o.Cdrom
 	}
 	return data, nil
 }

--- a/pkg/scheduler/algorithm/predicates/baremetal/cdrom_boot_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/baremetal/cdrom_boot_predicate.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package baremetal
+
+import (
+	"fmt"
+
+	"yunion.io/x/onecloud/pkg/scheduler/algorithm/predicates"
+	"yunion.io/x/onecloud/pkg/scheduler/core"
+)
+
+type CdromBootPredicate struct {
+	BasePredicate
+}
+
+func (p *CdromBootPredicate) Name() string {
+	return "cdrom_boot"
+}
+
+func (p *CdromBootPredicate) Clone() core.FitPredicate {
+	return &CdromBootPredicate{}
+}
+
+func (p *CdromBootPredicate) PreExecute(u *core.Unit, _ []core.Candidater) (bool, error) {
+	cdrom := u.SchedData().Cdrom
+	if len(cdrom) == 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (p *CdromBootPredicate) Execute(u *core.Unit, c core.Candidater) (bool, []core.PredicateFailureReason, error) {
+	h := predicates.NewPredicateHelper(p, u, c)
+	info := c.Getter().GetIpmiInfo()
+	if !info.CdromBoot {
+		h.Exclude(fmt.Sprintf("ipmi not support cdrom boot"))
+	}
+	return h.GetResult()
+}

--- a/pkg/scheduler/algorithmprovider/baremetal.go
+++ b/pkg/scheduler/algorithmprovider/baremetal.go
@@ -39,5 +39,6 @@ func baremetalPredicates() sets.String {
 		factory.RegisterFitPredicate("h-DiskschedtagFilter", &predicates.DiskSchedtagPredicate{}),
 		factory.RegisterFitPredicate("i-NetschedtagFilter", &predicates.NetworkSchedtagPredicate{}),
 		factory.RegisterFitPredicate("k-NetBondingFilter", &predicatebm.NetBondingPredicate{}),
+		factory.RegisterFitPredicate("l-CdromFilter", &predicatebm.CdromBootPredicate{}),
 	)
 }

--- a/pkg/scheduler/core/types.go
+++ b/pkg/scheduler/core/types.go
@@ -18,6 +18,7 @@ import (
 	"yunion.io/x/jsonutils"
 
 	schedapi "yunion.io/x/onecloud/pkg/apis/scheduler"
+	"yunion.io/x/onecloud/pkg/cloudcommon/types"
 	"yunion.io/x/onecloud/pkg/compute/baremetal"
 	computemodels "yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/scheduler/api"
@@ -89,6 +90,8 @@ type CandidatePropertyGetter interface {
 
 	InstanceGroups() map[string]*api.CandidateGroup
 	GetFreeGroupCount(groupId string) (int, error)
+
+	GetIpmiInfo() types.SIPMIInfo
 }
 
 // Candidater replace host Candidate resource info


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

baremetal support cdrom schedule

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- 2.12
/cc @swordqiu 
/area scheduler region