### PR TITLE
Bugfix: Nat Purge

### DIFF
--- a/pkg/compute/models/natdtable.go
+++ b/pkg/compute/models/natdtable.go
@@ -268,7 +268,7 @@ func (self *SNatDEntry) getMoreDetails(ctx context.Context, userCred mcclient.To
 		return query
 	}
 	query.Add(jsonutils.NewString(natgateway.Name), "natgateway")
-	query.Add(jsonutils.NewString(NatGatewayManager.NatNameToReal(self.Name, natgateway.GetId())))
+	query.Add(jsonutils.NewString(NatGatewayManager.NatNameToReal(self.Name, natgateway.GetId())), "real_name")
 	return query
 }
 

--- a/pkg/compute/models/natgateways.go
+++ b/pkg/compute/models/natgateways.go
@@ -333,7 +333,7 @@ func (self *SNatGateway) syncRemoveCloudNatGateway(ctx context.Context, userCred
 	if err != nil { // cannot delete
 		return self.SetStatus(userCred, api.VPC_STATUS_UNKNOWN, "sync to delete")
 	}
-	return self.Delete(ctx, userCred)
+	return self.purge(ctx, userCred)
 }
 
 func (self *SNatGateway) SyncWithCloudNatGateway(ctx context.Context, userCred mcclient.TokenCredential, provider *SCloudprovider, extNat cloudprovider.ICloudNatGateway) error {

--- a/pkg/compute/models/natstable.go
+++ b/pkg/compute/models/natstable.go
@@ -332,7 +332,7 @@ func (self *SNatSEntry) getMoreDetails(ctx context.Context, userCred mcclient.To
 		return query
 	}
 	query.Add(jsonutils.NewString(natgateway.Name), "natgateway")
-	query.Add(jsonutils.NewString(NatGatewayManager.NatNameToReal(self.Name, natgateway.GetId())))
+	query.Add(jsonutils.NewString(NatGatewayManager.NatNameToReal(self.Name, natgateway.GetId())), "real_name")
 	return query
 }
 

--- a/pkg/compute/models/purge.go
+++ b/pkg/compute/models/purge.go
@@ -1112,7 +1112,7 @@ func (table *SNatSEntry) purge(ctx context.Context, userCred mcclient.TokenCrede
 		return err
 	}
 
-	return table.Delete(ctx, userCred)
+	return table.RealDelete(ctx, userCred)
 }
 
 func (nat *SNatGateway) purgeSTables(ctx context.Context, userCred mcclient.TokenCredential) error {
@@ -1139,7 +1139,7 @@ func (table *SNatDEntry) purge(ctx context.Context, userCred mcclient.TokenCrede
 		return err
 	}
 
-	return table.Delete(ctx, userCred)
+	return table.RealDelete(ctx, userCred)
 }
 
 func (nat *SNatGateway) purgeDTables(ctx context.Context, userCred mcclient.TokenCredential) error {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 同步NAT网关，sync remove 阶段应该要 purge nat table。
2. nat rule 返回添加 'real_name'。 

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
