### PR TITLE
Automated cherry pick of #3355: fix: shoule purge snat table and dnat table when sync remove local natgateway; nat rule's 'real_name'.

### DIFF
--- a/pkg/compute/models/natdtable.go
+++ b/pkg/compute/models/natdtable.go
@@ -268,7 +268,7 @@ func (self *SNatDEntry) getMoreDetails(ctx context.Context, userCred mcclient.To
 		return query
 	}
 	query.Add(jsonutils.NewString(natgateway.Name), "natgateway")
-	query.Add(jsonutils.NewString(NatGatewayManager.NatNameToReal(self.Name, natgateway.GetId())))
+	query.Add(jsonutils.NewString(NatGatewayManager.NatNameToReal(self.Name, natgateway.GetId())), "real_name")
 	return query
 }
 

--- a/pkg/compute/models/natgateways.go
+++ b/pkg/compute/models/natgateways.go
@@ -333,7 +333,7 @@ func (self *SNatGateway) syncRemoveCloudNatGateway(ctx context.Context, userCred
 	if err != nil { // cannot delete
 		return self.SetStatus(userCred, api.VPC_STATUS_UNKNOWN, "sync to delete")
 	}
-	return self.Delete(ctx, userCred)
+	return self.purge(ctx, userCred)
 }
 
 func (self *SNatGateway) SyncWithCloudNatGateway(ctx context.Context, userCred mcclient.TokenCredential, provider *SCloudprovider, extNat cloudprovider.ICloudNatGateway) error {

--- a/pkg/compute/models/natstable.go
+++ b/pkg/compute/models/natstable.go
@@ -332,7 +332,7 @@ func (self *SNatSEntry) getMoreDetails(ctx context.Context, userCred mcclient.To
 		return query
 	}
 	query.Add(jsonutils.NewString(natgateway.Name), "natgateway")
-	query.Add(jsonutils.NewString(NatGatewayManager.NatNameToReal(self.Name, natgateway.GetId())))
+	query.Add(jsonutils.NewString(NatGatewayManager.NatNameToReal(self.Name, natgateway.GetId())), "real_name")
 	return query
 }
 

--- a/pkg/compute/models/purge.go
+++ b/pkg/compute/models/purge.go
@@ -1112,7 +1112,7 @@ func (table *SNatSEntry) purge(ctx context.Context, userCred mcclient.TokenCrede
 		return err
 	}
 
-	return table.Delete(ctx, userCred)
+	return table.RealDelete(ctx, userCred)
 }
 
 func (nat *SNatGateway) purgeSTables(ctx context.Context, userCred mcclient.TokenCredential) error {
@@ -1139,7 +1139,7 @@ func (table *SNatDEntry) purge(ctx context.Context, userCred mcclient.TokenCrede
 		return err
 	}
 
-	return table.Delete(ctx, userCred)
+	return table.RealDelete(ctx, userCred)
 }
 
 func (nat *SNatGateway) purgeDTables(ctx context.Context, userCred mcclient.TokenCredential) error {


### PR DESCRIPTION
Cherry pick of #3355 on release/2.12.

#3355: fix: shoule purge snat table and dnat table when sync remove local natgateway; nat rule's 'real_name'.