### PR TITLE
Bugfix: Eip

### DIFF
--- a/pkg/compute/models/natgateways.go
+++ b/pkg/compute/models/natgateways.go
@@ -230,6 +230,18 @@ func (self *SNatGateway) GetSTable() ([]SNatSEntry, error) {
 	return tables, nil
 }
 
+func (self *SNatGateway) GetSTableSize(filter func(q *sqlchemy.SQuery) *sqlchemy.SQuery) (int, error) {
+	q := NatSEntryManager.Query().Equals("natgateway_id", self.Id)
+	q = filter(q)
+	return q.CountWithError()
+}
+
+func (self *SNatGateway) GetDTableSize(filter func(q *sqlchemy.SQuery) *sqlchemy.SQuery) (int, error) {
+	q := NatDEntryManager.Query().Equals("natgateway_id", self.Id)
+	q = filter(q)
+	return q.CountWithError()
+}
+
 func (self *SNatGateway) GetExtraDetails(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (*jsonutils.JSONDict, error) {
 	extra, err := self.SStatusStandaloneResourceBase.GetExtraDetails(ctx, userCred, query)
 	if err != nil {

--- a/pkg/compute/tasks/eip_associate_task.go
+++ b/pkg/compute/tasks/eip_associate_task.go
@@ -43,6 +43,7 @@ func (self *EipAssociateTask) TaskFail(ctx context.Context, eip *models.SElastic
 		db.OpsLog.LogEvent(vm, db.ACT_EIP_ATTACH, msg, self.GetUserCred())
 		logclient.AddActionLogWithStartable(self, vm, logclient.ACT_EIP_ASSOCIATE, msg, self.UserCred, false)
 	}
+	logclient.AddActionLogWithStartable(self, eip, logclient.ACT_VM_ASSOCIATE, msg, self.UserCred, false)
 }
 
 func (self *EipAssociateTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
@@ -86,6 +87,7 @@ func (self *EipAssociateTask) OnInit(ctx context.Context, obj db.IStandaloneMode
 
 	server.StartSyncstatus(ctx, self.UserCred, "")
 	logclient.AddActionLogWithStartable(self, server, logclient.ACT_EIP_ASSOCIATE, nil, self.UserCred, true)
+	logclient.AddActionLogWithStartable(self, eip, logclient.ACT_VM_ASSOCIATE, nil, self.UserCred, true)
 
 	self.SetStageComplete(ctx, nil)
 }

--- a/pkg/util/logclient/consts.go
+++ b/pkg/util/logclient/consts.go
@@ -164,4 +164,9 @@ const (
 	ACT_SET_PRIVILEGES   = "设置权限"
 	ACT_RESTORE          = "备份恢复"
 	ACT_RESET_PASSWORD   = "重置密码"
+
+	ACT_VM_ASSOCIATE            = "绑定虚拟机"
+	ACT_VM_DISSOCIATE           = "解绑虚拟机"
+	ACT_NATGATEWAY_DISSOCIATE   = "解绑NAT网关"
+	ACT_LOADBALANCER_DISSOCIATE = "解绑负载均衡"
 )


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 修复eip 绑定的资源不是虚拟机的时候，list 不返回 associate_name
2. eip 绑定和解绑资源的时候，也会添加日志到eip里
3. eip解绑nat网关的时候，会检查nat网关是否还有其他绑定了该eip的nat规则。

**是否需要 backport 到之前的 release 分支**:
 - release/2.11
 - release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
