### PR TITLE
Automated cherry pick of #3358: fix: eip display info will contains 'associate_name' even if associate_type is not vm; eip-dissociate will add log to eip now; eip-dissociate for natgateway will check if natgatway has nat rules with this eip.

### DIFF
--- a/pkg/compute/models/natgateways.go
+++ b/pkg/compute/models/natgateways.go
@@ -230,6 +230,18 @@ func (self *SNatGateway) GetSTable() ([]SNatSEntry, error) {
 	return tables, nil
 }
 
+func (self *SNatGateway) GetSTableSize(filter func(q *sqlchemy.SQuery) *sqlchemy.SQuery) (int, error) {
+	q := NatSEntryManager.Query().Equals("natgateway_id", self.Id)
+	q = filter(q)
+	return q.CountWithError()
+}
+
+func (self *SNatGateway) GetDTableSize(filter func(q *sqlchemy.SQuery) *sqlchemy.SQuery) (int, error) {
+	q := NatDEntryManager.Query().Equals("natgateway_id", self.Id)
+	q = filter(q)
+	return q.CountWithError()
+}
+
 func (self *SNatGateway) GetExtraDetails(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (*jsonutils.JSONDict, error) {
 	extra, err := self.SStatusStandaloneResourceBase.GetExtraDetails(ctx, userCred, query)
 	if err != nil {

--- a/pkg/compute/tasks/eip_associate_task.go
+++ b/pkg/compute/tasks/eip_associate_task.go
@@ -43,6 +43,7 @@ func (self *EipAssociateTask) TaskFail(ctx context.Context, eip *models.SElastic
 		db.OpsLog.LogEvent(vm, db.ACT_EIP_ATTACH, msg, self.GetUserCred())
 		logclient.AddActionLogWithStartable(self, vm, logclient.ACT_EIP_ASSOCIATE, msg, self.UserCred, false)
 	}
+	logclient.AddActionLogWithStartable(self, eip, logclient.ACT_VM_ASSOCIATE, msg, self.UserCred, false)
 }
 
 func (self *EipAssociateTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
@@ -86,6 +87,7 @@ func (self *EipAssociateTask) OnInit(ctx context.Context, obj db.IStandaloneMode
 
 	server.StartSyncstatus(ctx, self.UserCred, "")
 	logclient.AddActionLogWithStartable(self, server, logclient.ACT_EIP_ASSOCIATE, nil, self.UserCred, true)
+	logclient.AddActionLogWithStartable(self, eip, logclient.ACT_VM_ASSOCIATE, nil, self.UserCred, true)
 
 	self.SetStageComplete(ctx, nil)
 }

--- a/pkg/util/logclient/consts.go
+++ b/pkg/util/logclient/consts.go
@@ -164,4 +164,9 @@ const (
 	ACT_SET_PRIVILEGES   = "设置权限"
 	ACT_RESTORE          = "备份恢复"
 	ACT_RESET_PASSWORD   = "重置密码"
+
+	ACT_VM_ASSOCIATE            = "绑定虚拟机"
+	ACT_VM_DISSOCIATE           = "解绑虚拟机"
+	ACT_NATGATEWAY_DISSOCIATE   = "解绑NAT网关"
+	ACT_LOADBALANCER_DISSOCIATE = "解绑负载均衡"
 )


### PR DESCRIPTION
Cherry pick of #3358 on release/2.12.

#3358: fix: eip display info will contains 'associate_name' even if associate_type is not vm; eip-dissociate will add log to eip now; eip-dissociate for natgateway will check if natgatway has nat rules with this eip.