### PR TITLE
fix: 避免虚拟机正常磁盘在回收站

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -2651,6 +2651,12 @@ func (self *SGuest) SyncVMDisks(ctx context.Context, userCred mcclient.TokenCred
 			result.Error(err)
 			return result
 		}
+		if disk.PendingDeleted != self.PendingDeleted { //避免主机正常,磁盘在回收站的情况
+			db.Update(disk, func() error {
+				disk.PendingDeleted = self.PendingDeleted
+				return nil
+			})
+		}
 		newdisks = append(newdisks, sSyncDiskPair{disk: disk, vdisk: vdisks[i]})
 	}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免虚拟机正常磁盘在回收站

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @swordqiu @yousong 
