### PR TITLE
fix: realdelete secgroupcache

### DIFF
--- a/pkg/compute/models/secgroupcache.go
+++ b/pkg/compute/models/secgroupcache.go
@@ -248,7 +248,7 @@ func (manager *SSecurityGroupCacheManager) SyncSecurityGroupCaches(ctx context.C
 	}
 
 	for i := 0; i < len(removed); i++ {
-		err = removed[i].Delete(ctx, userCred)
+		err = removed[i].RealDelete(ctx, userCred)
 		if err != nil {
 			syncResult.DeleteError(err)
 		} else {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
同步删除安全组缓存

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu @yousong 
