### PR TITLE
Automated cherry pick of #3370: fix: host-wire-update param rename

### DIFF
--- a/cmd/climc/shell/hostwires.go
+++ b/cmd/climc/shell/hostwires.go
@@ -71,15 +71,15 @@ func init() {
 	type HostWireUpdateOptions struct {
 		HOST      string `help:"ID or Name of Host"`
 		WIRE      string `help:"ID or Name of Wire"`
-		Mac       string `help:"Mac address"`
+		MacAddr   string `help:"Mac address"`
 		Interface string `help:"Interface"`
 		Bridge    string `help:"Bridge"`
 		IsMaster  string `help:"Master interface" choices:"true|false"`
 	}
 	R(&HostWireUpdateOptions{}, "host-wire-update", "Update host wire information", func(s *mcclient.ClientSession, args *HostWireUpdateOptions) error {
 		params := jsonutils.NewDict()
-		if len(args.Mac) > 0 {
-			params.Add(jsonutils.NewString(args.Mac), "mac_addr")
+		if len(args.MacAddr) > 0 {
+			params.Add(jsonutils.NewString(args.MacAddr), "mac_addr")
 		}
 		if len(args.Interface) > 0 {
 			params.Add(jsonutils.NewString(args.Interface), "interface")

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -946,7 +946,7 @@ func (h *SHostInfo) doSyncNicInfo(nic *SNIC) {
 	query := jsonutils.NewDict()
 	query.Set("mac_addr", jsonutils.NewString(nic.BridgeDev.GetMac()))
 	_, err := modules.Hostwires.Update(h.GetSession(),
-		h.HostId, nic.Network, query, content)
+		h.HostId, nic.WireId, query, content)
 	if err != nil {
 		log.Errorln(err)
 		h.onFail()


### PR DESCRIPTION
Cherry pick of #3370 on release/2.12.

#3370: fix: host-wire-update param rename