### PR TITLE
Automated cherry pick of #3374: lb: 创建时校验不通过返回httperrors

### DIFF
--- a/pkg/cloudcommon/db/virtualresource.go
+++ b/pkg/cloudcommon/db/virtualresource.go
@@ -62,7 +62,7 @@ type SVirtualResourceBase struct {
 	IsSystem bool `nullable:"true" default:"false" list:"admin" create:"optional"`
 
 	PendingDeletedAt time.Time ``
-	PendingDeleted   bool      `nullable:"false" default:"false" index:"true" get:"admin"`
+	PendingDeleted   bool      `nullable:"false" default:"false" index:"true" get:"user"`
 }
 
 func (model *SVirtualResourceBase) IsOwner(userCred mcclient.TokenCredential) bool {


### PR DESCRIPTION
Cherry pick of #3374 on release/2.10.0.

#3374: lb: 创建时校验不通过返回httperrors