### PR TITLE
Bugfix: Snapshot Sync

### DIFF
--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -713,14 +713,12 @@ func (self *SSnapshot) SyncWithCloudSnapshot(ctx context.Context, userCred mccli
 
 	// bugfix for now:
 	disk, err := self.GetDisk()
-	if err == sql.ErrNoRows {
-		syncOwnerId = self.GetOwnerId()
-	} else if err != nil {
+	if err != nil && err != sql.ErrNoRows {
 		return errors.Wrapf(err, "get disk of snapshot %s error", self.Id)
-	} else {
-		syncOwnerId = disk.GetOwnerId()
 	}
-	SyncCloudProject(userCred, self, syncOwnerId, ext, self.ManagerId)
+	if err == nil {
+		self.SyncCloudProjectId(userCred, disk.GetOwnerId())
+	}
 
 	return nil
 }
@@ -760,9 +758,10 @@ func (manager *SSnapshotManager) newFromCloudSnapshot(ctx context.Context, userC
 
 	// bugfix for now:
 	if localDisk != nil {
-		syncOwnerId = localDisk.GetOwnerId()
+		snapshot.SyncCloudProjectId(userCred, localDisk.GetOwnerId())
+	} else {
+		SyncCloudProject(userCred, &snapshot, syncOwnerId, extSnapshot, snapshot.ManagerId)
 	}
-	SyncCloudProject(userCred, &snapshot, syncOwnerId, extSnapshot, snapshot.ManagerId)
 
 	db.OpsLog.LogEvent(&snapshot, db.ACT_CREATE, snapshot.GetShortDesc(ctx), userCred)
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复的问题：如果云上 snapshot 的 project 和本地的 project 有关联关系的话，snapshot 同步的时候会选择此 project，而正确的是优先和 snapshot 关联的 disk 一样

**是否需要 backport 到之前的 release 分支**:
 - release/2.11
 - release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
