### PR TITLE
Automated cherry pick of #3381: .circleci: yunionio/onecloud-ci: bump golang version to 1.13.3

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -13,9 +13,9 @@ RUN true \
 
 WORKDIR /opt
 RUN true \
-	&& wget https://dl.google.com/go/go1.12.6.linux-amd64.tar.gz \
-	&& tar xzf go1.12.6.linux-amd64.tar.gz \
-	&& rm -vf  go1.12.6.linux-amd64.tar.gz \
+	&& wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz \
+	&& tar xzf go1.13.3.linux-amd64.tar.gz \
+	&& rm -vf  go1.13.3.linux-amd64.tar.gz \
 	&& true
 ENV GOROOT="/opt/go"
 ENV PATH="/opt/go/bin:${PATH}"

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -24,6 +24,7 @@ RUN useradd -c "OneCloud Builder" --create-home --home-dir /home/build --shell /
 USER build
 ENV HOME /home/build
 WORKDIR /home/build
+USER build
 
 ENV GOPATH="/home/build/go"
 ENV PATH="${GOPATH}/bin:${PATH}"

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -28,3 +28,12 @@ USER build
 
 ENV GOPATH="/home/build/go"
 ENV PATH="${GOPATH}/bin:${PATH}"
+
+RUN true \
+	&& mkdir -p "$GOPATH" \
+	&& d="$GOPATH/src/golang.org/x/tools" \
+	&& mkdir -p "$d" \
+	&& git clone --branch yun --depth 8 https://github.com/yousong/tools "$d" \
+	&& cd "$d" \
+	&& go install ./cmd/goimports \
+	&& true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   check:
     docker:
-      - image: yunionio/onecloud-ci:v1.0.2
+      - image: yunionio/onecloud-ci:v1.0.3
         environment:
           ONECLOUD_CI_BUILD: "1"
     working_directory: /home/build/go/src/yunion.io/x/onecloud

--- a/Makefile
+++ b/Makefile
@@ -143,8 +143,20 @@ gendocgo-check: gendocgo
 	fi
 .PHONY: gendocgo adddocgo gendocgo-check
 
+goimports-check:
+	@goimports -w -local "yunion.io/x/:yunion.io/x/onecloud" pkg cmd; \
+	if git status --short | grep -E '^.M .*/[^.]+.go'; then \
+		echo "$@: working tree modified (possibly by goimports)" >&2 ; \
+		echo "$@: " >&2 ; \
+		echo "$@: import spec should be grouped in order: std, 3rd-party, yunion.io/x, yunion.io/x/onecloud" >&2 ; \
+		echo "$@: see \"yun\" branch at https://github.com/yousong/tools" >&2 ; \
+		false ; \
+	fi
+.PHONY: goimports-check
+
 check: fmt-check
 check: gendocgo-check
+check: goimports-check
 .PHONY: check
 
 

--- a/cmd/climc/shell/copyright.go
+++ b/cmd/climc/shell/copyright.go
@@ -16,6 +16,7 @@ package shell
 
 import (
 	"fmt"
+
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/pkg/mcclient"

--- a/cmd/climc/shell/dbinstance_backups.go
+++ b/cmd/climc/shell/dbinstance_backups.go
@@ -16,6 +16,7 @@ package shell
 
 import (
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/mcclient/options"

--- a/cmd/climc/shell/dbinstances.go
+++ b/cmd/climc/shell/dbinstances.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"

--- a/cmd/climc/shell/identityproviders.go
+++ b/cmd/climc/shell/identityproviders.go
@@ -17,12 +17,12 @@ package shell
 import (
 	"fmt"
 
+	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/mcclient/options"
-
-	"yunion.io/x/jsonutils"
 )
 
 func init() {

--- a/cmd/climc/shell/k8s/raw.go
+++ b/cmd/climc/shell/k8s/raw.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 
 	"github.com/ghodss/yaml"
+
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/pkg/mcclient"

--- a/cmd/climc/shell/networkinterfacenetworks.go
+++ b/cmd/climc/shell/networkinterfacenetworks.go
@@ -16,6 +16,7 @@ package shell
 
 import (
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"

--- a/cmd/climc/shell/notify.go
+++ b/cmd/climc/shell/notify.go
@@ -16,6 +16,7 @@ package shell
 
 import (
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 )

--- a/cmd/climc/shell/servers.go
+++ b/cmd/climc/shell/servers.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	"gopkg.in/yaml.v2"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/cmd/cryptool/main.go
+++ b/cmd/cryptool/main.go
@@ -20,9 +20,8 @@ import (
 
 	"yunion.io/x/structarg"
 
-	"yunion.io/x/onecloud/pkg/util/shellutils"
-
 	_ "yunion.io/x/onecloud/cmd/cryptool/shell"
+	"yunion.io/x/onecloud/pkg/util/shellutils"
 )
 
 type BaseOptions struct {

--- a/cmd/redfishcli/main.go
+++ b/cmd/redfishcli/main.go
@@ -21,11 +21,10 @@ import (
 
 	"yunion.io/x/structarg"
 
-	"yunion.io/x/onecloud/pkg/util/redfish"
-	"yunion.io/x/onecloud/pkg/util/shellutils"
-
 	_ "yunion.io/x/onecloud/cmd/redfishcli/shell"
+	"yunion.io/x/onecloud/pkg/util/redfish"
 	_ "yunion.io/x/onecloud/pkg/util/redfish/loader"
+	"yunion.io/x/onecloud/pkg/util/shellutils"
 )
 
 type BaseOptions struct {

--- a/cmd/ucloudcli/main.go
+++ b/cmd/ucloudcli/main.go
@@ -17,10 +17,10 @@ package main
 import (
 	"fmt"
 	"os"
-	"yunion.io/x/onecloud/pkg/multicloud/ucloud"
 
 	"yunion.io/x/structarg"
 
+	"yunion.io/x/onecloud/pkg/multicloud/ucloud"
 	_ "yunion.io/x/onecloud/pkg/multicloud/ucloud/shell"
 	"yunion.io/x/onecloud/pkg/util/shellutils"
 )

--- a/pkg/apigateway/handler/csrfexempt.go
+++ b/pkg/apigateway/handler/csrfexempt.go
@@ -21,7 +21,6 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/pkg/util/sets"
 
 	"yunion.io/x/onecloud/pkg/appctx"
@@ -29,6 +28,7 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 type CSRFResourceHandler struct {

--- a/pkg/apigateway/handler/misc.go
+++ b/pkg/apigateway/handler/misc.go
@@ -30,10 +30,9 @@ import (
 
 	"yunion.io/x/onecloud/pkg/appctx"
 	"yunion.io/x/onecloud/pkg/appsrv"
+	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
-
-	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 )
 

--- a/pkg/apigateway/handler/request.go
+++ b/pkg/apigateway/handler/request.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/utils"
@@ -29,6 +28,7 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 type Request struct {

--- a/pkg/apigateway/handler/resource.go
+++ b/pkg/apigateway/handler/resource.go
@@ -22,11 +22,11 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/onecloud/pkg/util/excelutils"
 )
 

--- a/pkg/apigateway/handler/rpc.go
+++ b/pkg/apigateway/handler/rpc.go
@@ -22,13 +22,13 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/pkg/utils"
 
 	"yunion.io/x/onecloud/pkg/appctx"
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/onecloud/pkg/util/httputils"
 )
 

--- a/pkg/apigateway/service/service.go
+++ b/pkg/apigateway/service/service.go
@@ -21,7 +21,6 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/apigateway/app"
 	"yunion.io/x/onecloud/pkg/apigateway/clientman"
@@ -29,6 +28,7 @@ import (
 	app_common "yunion.io/x/onecloud/pkg/cloudcommon/app"
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 func StartService() {

--- a/pkg/apis/compute/cloudaccount.go
+++ b/pkg/apis/compute/cloudaccount.go
@@ -16,6 +16,7 @@ package compute
 
 import (
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/apis"
 )
 

--- a/pkg/apis/compute/secgroup.go
+++ b/pkg/apis/compute/secgroup.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"yunion.io/x/onecloud/pkg/apis"
+
 	"yunion.io/x/pkg/util/regutils"
 	"yunion.io/x/pkg/util/secrules"
+
+	"yunion.io/x/onecloud/pkg/apis"
 )
 
 type SSecgroupRuleCreateInput struct {

--- a/pkg/appsrv/fetch.go
+++ b/pkg/appsrv/fetch.go
@@ -15,11 +15,12 @@
 package appsrv
 
 import (
+	"encoding/xml"
 	"io/ioutil"
 	"net/http"
 
-	"encoding/xml"
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 )
 

--- a/pkg/appsrv/send.go
+++ b/pkg/appsrv/send.go
@@ -16,12 +16,13 @@ package appsrv
 
 import (
 	"encoding/xml"
+	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 
-	"fmt"
 	"github.com/pkg/errors"
-	"io"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/gotypes"

--- a/pkg/baremetal/service/service.go
+++ b/pkg/baremetal/service/service.go
@@ -29,7 +29,6 @@ import (
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
 	"yunion.io/x/onecloud/pkg/cloudcommon/service"
 	"yunion.io/x/onecloud/pkg/hostman/guestfs/fsdriver"
-
 	_ "yunion.io/x/onecloud/pkg/util/redfish/loader"
 )
 

--- a/pkg/baremetal/utils/disktool/disktool.go
+++ b/pkg/baremetal/utils/disktool/disktool.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/utils"
 

--- a/pkg/baremetal/utils/raid/drivers/drivers.go
+++ b/pkg/baremetal/utils/raid/drivers/drivers.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/pkg/baremetal/utils/raid/megactl/megactl.go
+++ b/pkg/baremetal/utils/raid/megactl/megactl.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/pkg/util/stringutils"

--- a/pkg/baremetal/utils/raid/raid.go
+++ b/pkg/baremetal/utils/raid/raid.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/tristate"
 

--- a/pkg/cloudcommon/cmdline/helper_test.go
+++ b/pkg/cloudcommon/cmdline/helper_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/apis/compute"
 )
 

--- a/pkg/cloudcommon/cmdline/parser_test.go
+++ b/pkg/cloudcommon/cmdline/parser_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/apis/compute"
 )
 

--- a/pkg/cloudcommon/cronman/cronman.go
+++ b/pkg/cloudcommon/cronman/cronman.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/log"
 
 	"yunion.io/x/onecloud/pkg/appctx"

--- a/pkg/cloudcommon/db/db_joint_dispatcher.go
+++ b/pkg/cloudcommon/db/db_joint_dispatcher.go
@@ -21,13 +21,13 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/policy"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 type DBJointModelDispatcher struct {

--- a/pkg/cloudcommon/db/fieldtags.go
+++ b/pkg/cloudcommon/db/fieldtags.go
@@ -16,6 +16,7 @@ package db
 
 import (
 	"sort"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
 	"yunion.io/x/onecloud/pkg/util/stringutils2"

--- a/pkg/cloudcommon/db/quotas/quotas.go
+++ b/pkg/cloudcommon/db/quotas/quotas.go
@@ -16,11 +16,11 @@ package quotas
 
 import (
 	"context"
+	"database/sql"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 
-	"database/sql"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
 	"yunion.io/x/onecloud/pkg/mcclient"

--- a/pkg/cloudcommon/db/sharedresource.go
+++ b/pkg/cloudcommon/db/sharedresource.go
@@ -17,9 +17,10 @@ package db
 import (
 	"context"
 
+	"yunion.io/x/sqlchemy"
+
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/sqlchemy"
 )
 
 // sharing resoure between project

--- a/pkg/cloudcommon/db/tenantcache.go
+++ b/pkg/cloudcommon/db/tenantcache.go
@@ -21,10 +21,9 @@ import (
 	"runtime/debug"
 	"time"
 
-	"yunion.io/x/jsonutils"
-
 	"github.com/pkg/errors"
 
+	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/sqlchemy"
 

--- a/pkg/cloudcommon/etcd/handler/dispatcher.go
+++ b/pkg/cloudcommon/etcd/handler/dispatcher.go
@@ -22,7 +22,6 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/pkg/gotypes"
 	"yunion.io/x/pkg/utils"
 
@@ -33,6 +32,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/policy"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 func NewEtcdModelHandler(manger base.IEtcdModelManager) *SEtcdModelHandler {

--- a/pkg/cloudcommon/notifyclient/notify.go
+++ b/pkg/cloudcommon/notifyclient/notify.go
@@ -26,12 +26,12 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/mcclient/modules/notify"
 )

--- a/pkg/cloudcommon/service/services.go
+++ b/pkg/cloudcommon/service/services.go
@@ -22,12 +22,12 @@ import (
 	"syscall"
 
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/util/signalutils"
+	"yunion.io/x/pkg/utils"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/options"
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
 	"yunion.io/x/onecloud/pkg/util/procutils"
-	"yunion.io/x/pkg/util/signalutils"
-	"yunion.io/x/pkg/utils"
 )
 
 type IService interface {

--- a/pkg/cloudcommon/validators/misc.go
+++ b/pkg/cloudcommon/validators/misc.go
@@ -16,8 +16,9 @@ package validators
 
 import (
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/sqlchemy"
+
+	"yunion.io/x/onecloud/pkg/mcclient"
 )
 
 type ModelFilterOptions struct {

--- a/pkg/cloudcommon/validators/validators.go
+++ b/pkg/cloudcommon/validators/validators.go
@@ -28,10 +28,9 @@ import (
 	"regexp"
 	"strings"
 
-	"yunion.io/x/pkg/util/netutils"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/gotypes"
+	"yunion.io/x/pkg/util/netutils"
 	"yunion.io/x/pkg/util/regutils"
 	"yunion.io/x/sqlchemy"
 

--- a/pkg/cloudnet/models/ifaces.go
+++ b/pkg/cloudnet/models/ifaces.go
@@ -25,13 +25,13 @@ import (
 
 	"yunion.io/x/jsonutils"
 	yerrors "yunion.io/x/pkg/util/errors"
+	"yunion.io/x/pkg/util/netutils"
 	"yunion.io/x/sqlchemy"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
 	cnutils "yunion.io/x/onecloud/pkg/cloudnet/utils"
 	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/pkg/util/netutils"
 )
 
 var regexpIfname = regexp.MustCompile(`[A-Za-z][A-Za-z0-9]{0,14}`)

--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -21,8 +21,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"yunion.io/x/onecloud/pkg/util/cloudinit"
-	"yunion.io/x/onecloud/pkg/util/seclib2"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
@@ -37,6 +35,8 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/billing"
+	"yunion.io/x/onecloud/pkg/util/cloudinit"
+	"yunion.io/x/onecloud/pkg/util/seclib2"
 )
 
 type SManagedVirtualizedGuestDriver struct {

--- a/pkg/compute/guestdrivers/openstack.go
+++ b/pkg/compute/guestdrivers/openstack.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/utils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/models"
@@ -26,7 +28,6 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/billing"
-	"yunion.io/x/pkg/utils"
 )
 
 type SOpenStackGuestDriver struct {

--- a/pkg/compute/hostdrivers/managedvirtual.go
+++ b/pkg/compute/hostdrivers/managedvirtual.go
@@ -21,10 +21,10 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"yunion.io/x/pkg/utils"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/utils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"

--- a/pkg/compute/models/cloudregionresource.go
+++ b/pkg/compute/models/cloudregionresource.go
@@ -19,6 +19,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 

--- a/pkg/compute/models/cloudsyncelasticcache.go
+++ b/pkg/compute/models/cloudsyncelasticcache.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 
 	"yunion.io/x/log"
+
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
-
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/mcclient"
 )

--- a/pkg/compute/models/dbinstance_accounts.go
+++ b/pkg/compute/models/dbinstance_accounts.go
@@ -20,6 +20,11 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/compare"
+	"yunion.io/x/pkg/utils"
+	"yunion.io/x/sqlchemy"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
@@ -29,10 +34,6 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/seclib2"
-	"yunion.io/x/pkg/errors"
-	"yunion.io/x/pkg/util/compare"
-	"yunion.io/x/pkg/utils"
-	"yunion.io/x/sqlchemy"
 )
 
 type SDBInstanceAccountManager struct {

--- a/pkg/compute/models/dbinstance_backups.go
+++ b/pkg/compute/models/dbinstance_backups.go
@@ -23,6 +23,10 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/compare"
+	"yunion.io/x/sqlchemy"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
@@ -31,9 +35,6 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/pkg/errors"
-	"yunion.io/x/pkg/util/compare"
-	"yunion.io/x/sqlchemy"
 )
 
 type SDBInstanceBackupManager struct {

--- a/pkg/compute/models/dbinstance_databases.go
+++ b/pkg/compute/models/dbinstance_databases.go
@@ -19,6 +19,10 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/compare"
+	"yunion.io/x/sqlchemy"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
@@ -27,9 +31,6 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/pkg/errors"
-	"yunion.io/x/pkg/util/compare"
-	"yunion.io/x/sqlchemy"
 )
 
 type SDBInstanceDatabaseManager struct {

--- a/pkg/compute/models/dbinstance_parameters.go
+++ b/pkg/compute/models/dbinstance_parameters.go
@@ -19,15 +19,16 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/compare"
+	"yunion.io/x/sqlchemy"
+
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/pkg/errors"
-	"yunion.io/x/pkg/util/compare"
-	"yunion.io/x/sqlchemy"
 )
 
 type SDBInstanceParameterManager struct {

--- a/pkg/compute/models/dbinstance_privileges.go
+++ b/pkg/compute/models/dbinstance_privileges.go
@@ -18,15 +18,16 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/compare"
+	"yunion.io/x/sqlchemy"
+
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/pkg/errors"
-	"yunion.io/x/pkg/util/compare"
-	"yunion.io/x/sqlchemy"
 )
 
 type SDBInstancePrivilegeManager struct {

--- a/pkg/compute/models/dbinstance_skus.go
+++ b/pkg/compute/models/dbinstance_skus.go
@@ -8,6 +8,11 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/compare"
+	"yunion.io/x/pkg/utils"
+	"yunion.io/x/sqlchemy"
+
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
@@ -16,10 +21,6 @@ import (
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/util/httputils"
-	"yunion.io/x/pkg/errors"
-	"yunion.io/x/pkg/util/compare"
-	"yunion.io/x/pkg/utils"
-	"yunion.io/x/sqlchemy"
 )
 
 type SDBInstanceSkuManager struct {

--- a/pkg/compute/models/dbinstancejoints.go
+++ b/pkg/compute/models/dbinstancejoints.go
@@ -15,8 +15,9 @@
 package models
 
 import (
-	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/pkg/errors"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 )
 
 type SDBInstanceJointsManager struct {

--- a/pkg/compute/models/dbinstancenetworks.go
+++ b/pkg/compute/models/dbinstancenetworks.go
@@ -19,15 +19,15 @@ import (
 	"database/sql"
 	"fmt"
 
-	api "yunion.io/x/onecloud/pkg/apis/compute"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/compare"
 	"yunion.io/x/pkg/util/netutils"
 
-	"yunion.io/x/jsonutils"
+	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 

--- a/pkg/compute/models/dbinstances.go
+++ b/pkg/compute/models/dbinstances.go
@@ -23,6 +23,13 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/tristate"
+	"yunion.io/x/pkg/util/compare"
+	"yunion.io/x/pkg/util/netutils"
+	"yunion.io/x/pkg/utils"
+	"yunion.io/x/sqlchemy"
+
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
@@ -33,12 +40,6 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/billing"
-	"yunion.io/x/pkg/errors"
-	"yunion.io/x/pkg/tristate"
-	"yunion.io/x/pkg/util/compare"
-	"yunion.io/x/pkg/util/netutils"
-	"yunion.io/x/pkg/utils"
-	"yunion.io/x/sqlchemy"
 )
 
 type SDBInstanceManager struct {

--- a/pkg/compute/models/external_projects.go
+++ b/pkg/compute/models/external_projects.go
@@ -21,6 +21,7 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/compare"
+	"yunion.io/x/sqlchemy"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
@@ -28,7 +29,6 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/logclient"
-	"yunion.io/x/sqlchemy"
 )
 
 type SExternalProjectManager struct {

--- a/pkg/compute/models/host_recycle.go
+++ b/pkg/compute/models/host_recycle.go
@@ -16,9 +16,7 @@ package models
 
 import (
 	"context"
-	"fmt"
-
-	// "strings"
+	"fmt" // "strings"
 	"time"
 
 	"github.com/golang-plus/errors"

--- a/pkg/compute/models/loadbalancerbackendgroups.go
+++ b/pkg/compute/models/loadbalancerbackendgroups.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"

--- a/pkg/compute/models/loadbalancercertificates.go
+++ b/pkg/compute/models/loadbalancercertificates.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/sqlchemy"

--- a/pkg/compute/models/networkschedtags.go
+++ b/pkg/compute/models/networkschedtags.go
@@ -16,6 +16,7 @@ package models
 
 import (
 	"context"
+
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"

--- a/pkg/compute/models/skus.go
+++ b/pkg/compute/models/skus.go
@@ -25,14 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"yunion.io/x/onecloud/pkg/compute/options"
-
 	"github.com/pkg/errors"
-	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
-	"yunion.io/x/onecloud/pkg/mcclient/auth"
-	"yunion.io/x/onecloud/pkg/mcclient/modules"
-
-	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
@@ -44,9 +37,14 @@ import (
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
+	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/compute/options"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/util/hashcache"
 	"yunion.io/x/onecloud/pkg/util/logclient"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"

--- a/pkg/compute/models/snapshotpolicydisks.go
+++ b/pkg/compute/models/snapshotpolicydisks.go
@@ -20,11 +20,11 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
-	"yunion.io/x/sqlchemy"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
+	"yunion.io/x/sqlchemy"
 
 	"yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"

--- a/pkg/compute/models/storageschedtags.go
+++ b/pkg/compute/models/storageschedtags.go
@@ -16,6 +16,7 @@ package models
 
 import (
 	"context"
+
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"

--- a/pkg/compute/models/zoneresource.go
+++ b/pkg/compute/models/zoneresource.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 

--- a/pkg/compute/regiondrivers/azure.go
+++ b/pkg/compute/regiondrivers/azure.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/httperrors"

--- a/pkg/compute/regiondrivers/openstack.go
+++ b/pkg/compute/regiondrivers/openstack.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
 	"yunion.io/x/onecloud/pkg/compute/models"

--- a/pkg/compute/regiondrivers/ucloud.go
+++ b/pkg/compute/regiondrivers/ucloud.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/httperrors"

--- a/pkg/compute/regiondrivers/zstack.go
+++ b/pkg/compute/regiondrivers/zstack.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
 	"yunion.io/x/onecloud/pkg/compute/models"

--- a/pkg/compute/service/service.go
+++ b/pkg/compute/service/service.go
@@ -34,7 +34,6 @@ import (
 	_ "yunion.io/x/onecloud/pkg/compute/regiondrivers"
 	_ "yunion.io/x/onecloud/pkg/compute/storagedrivers"
 	_ "yunion.io/x/onecloud/pkg/compute/tasks"
-
 	_ "yunion.io/x/onecloud/pkg/multicloud/loader"
 )
 

--- a/pkg/compute/storagedrivers/gpfs.go
+++ b/pkg/compute/storagedrivers/gpfs.go
@@ -20,12 +20,13 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/util/timeutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/compute/options"
 	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/pkg/util/timeutils"
 )
 
 type SGpfsStorageDriver struct {

--- a/pkg/compute/storagedrivers/rbd.go
+++ b/pkg/compute/storagedrivers/rbd.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/pkg/compute/tasks/dbinstance_account_grant_privilege_task.go
+++ b/pkg/compute/tasks/dbinstance_account_grant_privilege_task.go
@@ -19,13 +19,14 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/util/logclient"
-	"yunion.io/x/pkg/errors"
 )
 
 type DBInstanceAccountGrantPrivilegeTask struct {

--- a/pkg/compute/tasks/dbinstance_account_reset_password_task.go
+++ b/pkg/compute/tasks/dbinstance_account_reset_password_task.go
@@ -18,12 +18,13 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/util/logclient"
-	"yunion.io/x/pkg/errors"
 )
 
 type DBInstanceAccountResetPasswordTask struct {

--- a/pkg/compute/tasks/dbinstance_account_revoke_privilege_task.go
+++ b/pkg/compute/tasks/dbinstance_account_revoke_privilege_task.go
@@ -19,13 +19,14 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/util/logclient"
-	"yunion.io/x/pkg/errors"
 )
 
 type DBInstanceAccountRevokePrivilegeTask struct {

--- a/pkg/compute/tasks/dbinstance_account_set_privileges_task.go
+++ b/pkg/compute/tasks/dbinstance_account_set_privileges_task.go
@@ -20,13 +20,14 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/util/logclient"
-	"yunion.io/x/pkg/errors"
 )
 
 type DBInstanceAccountSetPrivilegesTask struct {

--- a/pkg/compute/tasks/dbinstance_public_connection_task.go
+++ b/pkg/compute/tasks/dbinstance_public_connection_task.go
@@ -19,13 +19,14 @@ import (
 	"time"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/util/logclient"
-	"yunion.io/x/pkg/errors"
 )
 
 type DBInstancePublicConnectionTask struct {

--- a/pkg/compute/tasks/guest_block_io_throttle_task.go
+++ b/pkg/compute/tasks/guest_block_io_throttle_task.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"

--- a/pkg/compute/tasks/loadbalancer_backendgroup_create_task.go
+++ b/pkg/compute/tasks/loadbalancer_backendgroup_create_task.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"

--- a/pkg/compute/tasks/loadbalancer_listener_create_task.go
+++ b/pkg/compute/tasks/loadbalancer_listener_create_task.go
@@ -17,6 +17,7 @@ package tasks
 import (
 	"context"
 	"fmt"
+
 	"yunion.io/x/jsonutils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"

--- a/pkg/compute/tasks/loadbalancer_listener_rule_create_task.go
+++ b/pkg/compute/tasks/loadbalancer_listener_rule_create_task.go
@@ -17,6 +17,7 @@ package tasks
 import (
 	"context"
 	"fmt"
+
 	"yunion.io/x/jsonutils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"

--- a/pkg/compute/tasks/server_sku_delete_task.go
+++ b/pkg/compute/tasks/server_sku_delete_task.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/pkg/hostman/guestfs/core.go
+++ b/pkg/hostman/guestfs/core.go
@@ -19,6 +19,7 @@ import (
 	"math/rand"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/netutils"

--- a/pkg/hostman/guestfs/sshpart/sshpart.go
+++ b/pkg/hostman/guestfs/sshpart/sshpart.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/utils"
 

--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/regutils"

--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/mdlayher/arp"
 	"github.com/mdlayher/ethernet"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/utils"

--- a/pkg/hostman/hostdeployer/apis/utils.go
+++ b/pkg/hostman/hostdeployer/apis/utils.go
@@ -19,6 +19,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	"yunion.io/x/onecloud/pkg/cloudcommon/types"
 )
 

--- a/pkg/hostman/hostdeployer/deployserver/deployserver.go
+++ b/pkg/hostman/hostdeployer/deployserver/deployserver.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"google.golang.org/grpc"
+
 	"yunion.io/x/log"
 
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"

--- a/pkg/hostman/hostinfo/hostbridge/linux_bridge.go
+++ b/pkg/hostman/hostinfo/hostbridge/linux_bridge.go
@@ -22,9 +22,10 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/utils"
+
 	"yunion.io/x/onecloud/pkg/hostman/options"
 	"yunion.io/x/onecloud/pkg/util/procutils"
-	"yunion.io/x/pkg/utils"
 )
 
 func NewLinuxBridgeDeriver(bridge, inter, ip string) (*SLinuxBridgeDriver, error) {

--- a/pkg/hostman/storageman/disk_base.go
+++ b/pkg/hostman/storageman/disk_base.go
@@ -20,6 +20,7 @@ import (
 	"path"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/pkg/hostman/storageman/disk_nas.go
+++ b/pkg/hostman/storageman/disk_nas.go
@@ -20,6 +20,7 @@ import (
 	"path"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/pkg/hostman/storageman/storage_local.go
+++ b/pkg/hostman/storageman/storage_local.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/timeutils"

--- a/pkg/image/models/image_guest_joint.go
+++ b/pkg/image/models/image_guest_joint.go
@@ -17,9 +17,10 @@ package models
 import (
 	"context"
 
+	"yunion.io/x/pkg/errors"
+
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/pkg/errors"
 )
 
 type SGuestImageJointManager struct {

--- a/pkg/keystone/service/service.go
+++ b/pkg/keystone/service/service.go
@@ -27,21 +27,17 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/cronman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
-	"yunion.io/x/onecloud/pkg/cloudcommon/policy"
-
-	// "yunion.io/x/onecloud/pkg/keystone/keys"
+	"yunion.io/x/onecloud/pkg/cloudcommon/policy" // "yunion.io/x/onecloud/pkg/keystone/keys"
 	"yunion.io/x/onecloud/pkg/keystone/cronjobs"
-	"yunion.io/x/onecloud/pkg/keystone/models"
-	"yunion.io/x/onecloud/pkg/keystone/options"
-	"yunion.io/x/onecloud/pkg/keystone/tokens"
-
-	"yunion.io/x/onecloud/pkg/mcclient/auth"
-	"yunion.io/x/onecloud/pkg/util/logclient"
-
 	_ "yunion.io/x/onecloud/pkg/keystone/driver/cas"
 	_ "yunion.io/x/onecloud/pkg/keystone/driver/ldap"
 	_ "yunion.io/x/onecloud/pkg/keystone/driver/sql"
+	"yunion.io/x/onecloud/pkg/keystone/models"
+	"yunion.io/x/onecloud/pkg/keystone/options"
 	_ "yunion.io/x/onecloud/pkg/keystone/tasks"
+	"yunion.io/x/onecloud/pkg/keystone/tokens"
+	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/util/logclient"
 )
 
 func keystoneUUIDGenerator() string {

--- a/pkg/keystone/tokens/payloads.go
+++ b/pkg/keystone/tokens/payloads.go
@@ -24,8 +24,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/vmihailenco/msgpack"
 
-	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/pkg/util/netutils"
+
+	"yunion.io/x/onecloud/pkg/mcclient"
 )
 
 type TScopedPayloadVersion byte

--- a/pkg/lbagent/hastate.go
+++ b/pkg/lbagent/hastate.go
@@ -29,6 +29,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 
 	"yunion.io/x/log"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	agentutils "yunion.io/x/onecloud/pkg/lbagent/utils"
 )

--- a/pkg/lbagent/models/modelset.go
+++ b/pkg/lbagent/models/modelset.go
@@ -18,9 +18,9 @@ import (
 	"sort"
 
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/mcclient/models"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 )
 

--- a/pkg/lbagent/models/reflect.go
+++ b/pkg/lbagent/models/reflect.go
@@ -21,13 +21,13 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/pkg/util/timeutils"
 	"yunion.io/x/pkg/utils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/models"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/onecloud/pkg/mcclient/options"
 )
 

--- a/pkg/mcclient/aksk.go
+++ b/pkg/mcclient/aksk.go
@@ -16,13 +16,13 @@ package mcclient
 
 import (
 	"context"
+	"io"
 	"net/http"
+	"strings"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
 
-	"io"
-	"strings"
 	api "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/util/netutils2"
 	"yunion.io/x/onecloud/pkg/util/s3auth"

--- a/pkg/mcclient/auth/aksk.go
+++ b/pkg/mcclient/auth/aksk.go
@@ -16,10 +16,12 @@ package auth
 
 import (
 	"net/http"
-	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/onecloud/pkg/util/s3auth"
+
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/cache"
+
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/util/s3auth"
 )
 
 type sAccessKeyCache struct {

--- a/pkg/mcclient/auth/auth.go
+++ b/pkg/mcclient/auth/auth.go
@@ -17,13 +17,13 @@ package auth
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/cache"
 
-	"net/http"
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 

--- a/pkg/mcclient/example/server.go
+++ b/pkg/mcclient/example/server.go
@@ -17,12 +17,12 @@ package example
 import (
 	"context"
 
-	"yunion.io/x/onecloud/pkg/mcclient/options"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
+	"yunion.io/x/onecloud/pkg/mcclient/options"
 )
 
 const (

--- a/pkg/mcclient/modulebase/filter.go
+++ b/pkg/mcclient/modulebase/filter.go
@@ -17,6 +17,7 @@ package modulebase
 import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 

--- a/pkg/mcclient/modulebase/joint.go
+++ b/pkg/mcclient/modulebase/joint.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 

--- a/pkg/mcclient/modulebase/projectresources.go
+++ b/pkg/mcclient/modulebase/projectresources.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 

--- a/pkg/mcclient/modulebase/resource.go
+++ b/pkg/mcclient/modulebase/resource.go
@@ -21,6 +21,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/httputils"

--- a/pkg/mcclient/modulebase/utils.go
+++ b/pkg/mcclient/modulebase/utils.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/httputils"
 )

--- a/pkg/mcclient/modules/cache.go
+++ b/pkg/mcclient/modules/cache.go
@@ -20,9 +20,9 @@ import (
 	"time"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 const (

--- a/pkg/mcclient/modules/mod_buckets.go
+++ b/pkg/mcclient/modules/mod_buckets.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modulebase"

--- a/pkg/mcclient/modules/mod_credentials.go
+++ b/pkg/mcclient/modules/mod_credentials.go
@@ -19,14 +19,15 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/pkg/util/seclib"
 
-	"github.com/pkg/errors"
 	api "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 type SCredentialManager struct {

--- a/pkg/mcclient/modules/mod_dbinstanceaccounts.go
+++ b/pkg/mcclient/modules/mod_dbinstanceaccounts.go
@@ -18,10 +18,12 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/utils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
-	"yunion.io/x/pkg/utils"
 )
 
 var (

--- a/pkg/mcclient/modules/mod_hosts.go
+++ b/pkg/mcclient/modules/mod_hosts.go
@@ -21,11 +21,11 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/pkg/utils"
 
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/onecloud/pkg/util/httputils"
 )
 

--- a/pkg/mcclient/modules/mod_identity.go
+++ b/pkg/mcclient/modules/mod_identity.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 type SIdentityUsageManager struct {

--- a/pkg/mcclient/modules/mod_itsm_process_instances.go
+++ b/pkg/mcclient/modules/mod_itsm_process_instances.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )

--- a/pkg/mcclient/modules/mod_itsm_tasks.go
+++ b/pkg/mcclient/modules/mod_itsm_tasks.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )

--- a/pkg/mcclient/modules/mod_license.go
+++ b/pkg/mcclient/modules/mod_license.go
@@ -20,9 +20,9 @@ import (
 	"net/http"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 type LicenseManager struct {

--- a/pkg/mcclient/modules/mod_parameters.go
+++ b/pkg/mcclient/modules/mod_parameters.go
@@ -18,11 +18,11 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 type ParametersManager struct {

--- a/pkg/mcclient/modules/mod_performances.go
+++ b/pkg/mcclient/modules/mod_performances.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 type PerformanceManager struct {

--- a/pkg/mcclient/modules/mod_quotas.go
+++ b/pkg/mcclient/modules/mod_quotas.go
@@ -19,9 +19,9 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 type QuotaManager struct {

--- a/pkg/mcclient/modules/mod_reservedips.go
+++ b/pkg/mcclient/modules/mod_reservedips.go
@@ -19,9 +19,9 @@ import (
 	"sync"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 type ReservedIPManager struct {

--- a/pkg/mcclient/modules/mod_scheduler.go
+++ b/pkg/mcclient/modules/mod_scheduler.go
@@ -19,12 +19,11 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
-
-	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/onecloud/pkg/mcclient/auth"
 
 	api "yunion.io/x/onecloud/pkg/apis/scheduler"
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 var (

--- a/pkg/mcclient/modules/mod_servers.go
+++ b/pkg/mcclient/modules/mod_servers.go
@@ -19,11 +19,11 @@ import (
 	"strings"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/pkg/gotypes"
 	"yunion.io/x/pkg/utils"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/onecloud/pkg/util/seclib2"
 )
 

--- a/pkg/mcclient/modules/mod_stastics.go
+++ b/pkg/mcclient/modules/mod_stastics.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 type StatisticsManager struct {

--- a/pkg/mcclient/modules/mod_users.go
+++ b/pkg/mcclient/modules/mod_users.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 type UserManager struct {

--- a/pkg/mcclient/modules/notify/mod_notification.go
+++ b/pkg/mcclient/modules/notify/mod_notification.go
@@ -16,9 +16,9 @@ package notify
 
 import (
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 )
 

--- a/pkg/multicloud/aliyun/aliyun.go
+++ b/pkg/multicloud/aliyun/aliyun.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/pkg/errors"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	v "yunion.io/x/pkg/util/version"
 	"yunion.io/x/pkg/utils"
 
-	"github.com/aliyun/aliyun-oss-go-sdk/oss"
-	"github.com/pkg/errors"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )

--- a/pkg/multicloud/aliyun/business.go
+++ b/pkg/multicloud/aliyun/business.go
@@ -17,11 +17,11 @@ package aliyun
 import (
 	"time"
 
-	"yunion.io/x/onecloud/pkg/cloudprovider"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
+
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 func (self *SAliyunClient) businessRequest(apiName string, params map[string]string) (jsonutils.JSONObject, error) {

--- a/pkg/multicloud/aliyun/dbinstance.go
+++ b/pkg/multicloud/aliyun/dbinstance.go
@@ -21,16 +21,15 @@ import (
 	"time"
 
 	"yunion.io/x/jsonutils"
-
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/utils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"
 	"yunion.io/x/onecloud/pkg/util/billing"
 	"yunion.io/x/onecloud/pkg/util/rand"
-
-	"yunion.io/x/pkg/errors"
-	"yunion.io/x/pkg/utils"
 )
 
 type SReadOnlyDBInstanceIds struct {

--- a/pkg/multicloud/aliyun/dbinstance_account.go
+++ b/pkg/multicloud/aliyun/dbinstance_account.go
@@ -17,11 +17,11 @@ package aliyun
 import (
 	"fmt"
 
+	"yunion.io/x/pkg/errors"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"
-
-	"yunion.io/x/pkg/errors"
 )
 
 type SDatabasePrivileges struct {

--- a/pkg/multicloud/aliyun/dbinstance_backup.go
+++ b/pkg/multicloud/aliyun/dbinstance_backup.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/plugin/pkg/log"
+
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/utils"
 

--- a/pkg/multicloud/aliyun/elasticcache_instance.go
+++ b/pkg/multicloud/aliyun/elasticcache_instance.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/pkg/multicloud/aliyun/host.go
+++ b/pkg/multicloud/aliyun/host.go
@@ -19,10 +19,10 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/multicloud"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 	"yunion.io/x/onecloud/pkg/util/billing"
 )
 

--- a/pkg/multicloud/aliyun/loadbalancer.go
+++ b/pkg/multicloud/aliyun/loadbalancer.go
@@ -19,14 +19,13 @@ import (
 	"strings"
 	"time"
 
-	"yunion.io/x/onecloud/pkg/multicloud"
-	"yunion.io/x/pkg/errors"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 )
 
 type ListenerProtocol string

--- a/pkg/multicloud/aliyun/loadbalancermasterslavebackend.go
+++ b/pkg/multicloud/aliyun/loadbalancermasterslavebackend.go
@@ -18,11 +18,10 @@ import (
 	"fmt"
 	"strings"
 
-	"yunion.io/x/onecloud/pkg/cloudprovider"
-
 	"yunion.io/x/jsonutils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 type SLoadbalancerMasterSlaveBackend struct {

--- a/pkg/multicloud/aliyun/networkinterfaces.go
+++ b/pkg/multicloud/aliyun/networkinterfaces.go
@@ -18,11 +18,10 @@ import (
 	"fmt"
 	"time"
 
-	"yunion.io/x/onecloud/pkg/cloudprovider"
-
 	"yunion.io/x/pkg/errors"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"
 )
 

--- a/pkg/multicloud/aliyun/objects.go
+++ b/pkg/multicloud/aliyun/objects.go
@@ -15,10 +15,11 @@
 package aliyun
 
 import (
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/pkg/errors"
+
 	"yunion.io/x/log"
 
-	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 

--- a/pkg/multicloud/aliyun/vpc.go
+++ b/pkg/multicloud/aliyun/vpc.go
@@ -18,12 +18,11 @@ import (
 	"strings"
 	"time"
 
-	"yunion.io/x/onecloud/pkg/multicloud"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 )
 
 const (

--- a/pkg/multicloud/aws/aws.go
+++ b/pkg/multicloud/aws/aws.go
@@ -21,11 +21,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/s3"
 
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 
-	"github.com/aws/aws-sdk-go/service/s3"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )

--- a/pkg/multicloud/aws/bucket.go
+++ b/pkg/multicloud/aws/bucket.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -27,7 +28,6 @@ import (
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/s3cli"
 
-	"net/url"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"
 	"yunion.io/x/onecloud/pkg/util/fileutils2"

--- a/pkg/multicloud/aws/dbinstance.go
+++ b/pkg/multicloud/aws/dbinstance.go
@@ -20,6 +20,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	billing "yunion.io/x/onecloud/pkg/apis/billing"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"

--- a/pkg/multicloud/aws/dbinstance_database.go
+++ b/pkg/multicloud/aws/dbinstance_database.go
@@ -15,9 +15,8 @@
 package aws
 
 import (
-	"yunion.io/x/onecloud/pkg/multicloud"
-
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/multicloud"
 )
 
 type SDBInstanceDatabase struct {

--- a/pkg/multicloud/aws/dbinstance_snapshot.go
+++ b/pkg/multicloud/aws/dbinstance_snapshot.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"yunion.io/x/log"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"

--- a/pkg/multicloud/aws/instance.go
+++ b/pkg/multicloud/aws/instance.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"yunion.io/x/onecloud/pkg/multicloud"
-
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"yunion.io/x/jsonutils"
@@ -33,6 +31,7 @@ import (
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 	"yunion.io/x/onecloud/pkg/util/billing"
 	"yunion.io/x/onecloud/pkg/util/cloudinit"
 )

--- a/pkg/multicloud/aws/latitude_and_longitude.go
+++ b/pkg/multicloud/aws/latitude_and_longitude.go
@@ -15,9 +15,8 @@
 package aws
 
 import (
-	"yunion.io/x/onecloud/pkg/cloudprovider"
-
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 // https://docs.aws.amazon.com/general/latest/gr/rande.html

--- a/pkg/multicloud/aws/loadbalancer.go
+++ b/pkg/multicloud/aws/loadbalancer.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/elbv2"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/utils"

--- a/pkg/multicloud/aws/loadbalancerbackend.go
+++ b/pkg/multicloud/aws/loadbalancerbackend.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 )
 

--- a/pkg/multicloud/aws/loadbalancerbackendgroup.go
+++ b/pkg/multicloud/aws/loadbalancerbackendgroup.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/elbv2"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/utils"
 

--- a/pkg/multicloud/aws/loadbalancercert.go
+++ b/pkg/multicloud/aws/loadbalancercert.go
@@ -23,8 +23,10 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/iam"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )

--- a/pkg/multicloud/aws/loadbalancerlistener.go
+++ b/pkg/multicloud/aws/loadbalancerlistener.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/pkg/multicloud/aws/region.go
+++ b/pkg/multicloud/aws/region.go
@@ -36,6 +36,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/s3"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"

--- a/pkg/multicloud/aws/securitygroup.go
+++ b/pkg/multicloud/aws/securitygroup.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/secrules"

--- a/pkg/multicloud/aws/utils.go
+++ b/pkg/multicloud/aws/utils.go
@@ -23,11 +23,12 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/secrules"
+
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 type portRange struct {

--- a/pkg/multicloud/azure/azure.go
+++ b/pkg/multicloud/azure/azure.go
@@ -25,11 +25,11 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	azureenv "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/pkg/errors"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 
-	"github.com/pkg/errors"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )

--- a/pkg/multicloud/azure/classic_disk.go
+++ b/pkg/multicloud/azure/classic_disk.go
@@ -19,10 +19,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/storage"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 
-	"github.com/Azure/azure-sdk-for-go/storage"
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"

--- a/pkg/multicloud/azure/host.go
+++ b/pkg/multicloud/azure/host.go
@@ -19,11 +19,10 @@ import (
 	"strings"
 	"time"
 
-	"yunion.io/x/pkg/util/osprofile"
-	"yunion.io/x/pkg/utils"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/util/osprofile"
+	"yunion.io/x/pkg/utils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"

--- a/pkg/multicloud/azure/resourcegroup.go
+++ b/pkg/multicloud/azure/resourcegroup.go
@@ -16,6 +16,7 @@ package azure
 
 import (
 	"fmt"
+
 	"yunion.io/x/jsonutils"
 )
 

--- a/pkg/multicloud/azure/storagecache.go
+++ b/pkg/multicloud/azure/storagecache.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/pkg/multicloud/bucket_base.go
+++ b/pkg/multicloud/bucket_base.go
@@ -16,6 +16,7 @@ package multicloud
 
 import (
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 

--- a/pkg/multicloud/huawei/client/modules/mod_dbinstance.go
+++ b/pkg/multicloud/huawei/client/modules/mod_dbinstance.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud/huawei/client/auth"
 	"yunion.io/x/onecloud/pkg/multicloud/huawei/client/responses"

--- a/pkg/multicloud/huawei/client/modules/mod_dbinstance_job.go
+++ b/pkg/multicloud/huawei/client/modules/mod_dbinstance_job.go
@@ -16,6 +16,7 @@ package modules
 
 import (
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/multicloud/huawei/client/auth"
 )
 

--- a/pkg/multicloud/huawei/client/modules/mod_loadbalancer_backend.go
+++ b/pkg/multicloud/huawei/client/modules/mod_loadbalancer_backend.go
@@ -16,6 +16,7 @@ package modules
 
 import (
 	"fmt"
+
 	"yunion.io/x/onecloud/pkg/multicloud/huawei/client/auth"
 )
 

--- a/pkg/multicloud/huawei/client/modules/mod_loadbalancer_rules.go
+++ b/pkg/multicloud/huawei/client/modules/mod_loadbalancer_rules.go
@@ -16,6 +16,7 @@ package modules
 
 import (
 	"fmt"
+
 	"yunion.io/x/onecloud/pkg/multicloud/huawei/client/auth"
 )
 

--- a/pkg/multicloud/huawei/dbinstance.go
+++ b/pkg/multicloud/huawei/dbinstance.go
@@ -24,6 +24,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"

--- a/pkg/multicloud/huawei/dbinstance_account.go
+++ b/pkg/multicloud/huawei/dbinstance_account.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"

--- a/pkg/multicloud/huawei/dbinstance_backup.go
+++ b/pkg/multicloud/huawei/dbinstance_backup.go
@@ -18,10 +18,11 @@ import (
 	"time"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"
-	"yunion.io/x/pkg/errors"
 )
 
 type SDBInstanceBackup struct {

--- a/pkg/multicloud/huawei/eip.go
+++ b/pkg/multicloud/huawei/eip.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"yunion.io/x/jsonutils"
+
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"

--- a/pkg/multicloud/huawei/elasticcache_instance.go
+++ b/pkg/multicloud/huawei/elasticcache_instance.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/log"
 
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"

--- a/pkg/multicloud/huawei/instance.go
+++ b/pkg/multicloud/huawei/instance.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/osprofile"

--- a/pkg/multicloud/huawei/loadbalancer.go
+++ b/pkg/multicloud/huawei/loadbalancer.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )

--- a/pkg/multicloud/huawei/loadbalancer_acl.go
+++ b/pkg/multicloud/huawei/loadbalancer_acl.go
@@ -16,7 +16,9 @@ package huawei
 
 import (
 	"strings"
+
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )

--- a/pkg/multicloud/huawei/loadbalancer_backend.go
+++ b/pkg/multicloud/huawei/loadbalancer_backend.go
@@ -17,9 +17,10 @@ package huawei
 import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/utils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
-	"yunion.io/x/pkg/utils"
 )
 
 type SElbBackend struct {

--- a/pkg/multicloud/huawei/loadbalancer_backendgroup.go
+++ b/pkg/multicloud/huawei/loadbalancer_backendgroup.go
@@ -17,7 +17,9 @@ package huawei
 import (
 	"fmt"
 	"strings"
+
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )

--- a/pkg/multicloud/huawei/loadbalancer_cert.go
+++ b/pkg/multicloud/huawei/loadbalancer_cert.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 )
 

--- a/pkg/multicloud/huawei/loadbalancer_listener.go
+++ b/pkg/multicloud/huawei/loadbalancer_listener.go
@@ -16,11 +16,12 @@ package huawei
 
 import (
 	"time"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 type InsertHeaders struct {

--- a/pkg/multicloud/huawei/loadbalancer_listener_rule.go
+++ b/pkg/multicloud/huawei/loadbalancer_listener_rule.go
@@ -17,6 +17,7 @@ package huawei
 import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 )
 

--- a/pkg/multicloud/huawei/port.go
+++ b/pkg/multicloud/huawei/port.go
@@ -15,10 +15,11 @@
 package huawei
 
 import (
+	"yunion.io/x/pkg/utils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"
-	"yunion.io/x/pkg/utils"
 )
 
 type SFixedIP struct {

--- a/pkg/multicloud/huawei/routetable.go
+++ b/pkg/multicloud/huawei/routetable.go
@@ -16,9 +16,11 @@ package huawei
 
 import (
 	"fmt"
+
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/pkg/errors"
+
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 // date: 2019.07.15

--- a/pkg/multicloud/loader/loader.go
+++ b/pkg/multicloud/loader/loader.go
@@ -15,27 +15,20 @@
 package loader
 
 import (
-	"yunion.io/x/log"
+	"yunion.io/x/log" // on-premise virtualization technologies
 
-	// on-premise virtualization technologies
-	_ "yunion.io/x/onecloud/pkg/multicloud/esxi/provider"
-
-	// private clouds
-	_ "yunion.io/x/onecloud/pkg/multicloud/openstack/provider"
-	_ "yunion.io/x/onecloud/pkg/multicloud/zstack/provider"
-
-	// public clouds
 	_ "yunion.io/x/onecloud/pkg/multicloud/aliyun/provider"
 	_ "yunion.io/x/onecloud/pkg/multicloud/aws/provider"
 	_ "yunion.io/x/onecloud/pkg/multicloud/azure/provider"
+	_ "yunion.io/x/onecloud/pkg/multicloud/esxi/provider" // private clouds
 	_ "yunion.io/x/onecloud/pkg/multicloud/huawei/provider"
-	_ "yunion.io/x/onecloud/pkg/multicloud/qcloud/provider"
-	_ "yunion.io/x/onecloud/pkg/multicloud/ucloud/provider"
-
-	// object storages
 	_ "yunion.io/x/onecloud/pkg/multicloud/objectstore/ceph/provider"
 	_ "yunion.io/x/onecloud/pkg/multicloud/objectstore/provider"
 	_ "yunion.io/x/onecloud/pkg/multicloud/objectstore/xsky/provider"
+	_ "yunion.io/x/onecloud/pkg/multicloud/openstack/provider"
+	_ "yunion.io/x/onecloud/pkg/multicloud/qcloud/provider"
+	_ "yunion.io/x/onecloud/pkg/multicloud/ucloud/provider" // object storages
+	_ "yunion.io/x/onecloud/pkg/multicloud/zstack/provider" // public clouds
 )
 
 func init() {

--- a/pkg/multicloud/objectstore/object.go
+++ b/pkg/multicloud/objectstore/object.go
@@ -18,8 +18,9 @@ import (
 	"strings"
 
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/pkg/errors"
+
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 type SObject struct {

--- a/pkg/multicloud/objectstore/shell.go
+++ b/pkg/multicloud/objectstore/shell.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/util/printutils"
 	"yunion.io/x/onecloud/pkg/util/shellutils"

--- a/pkg/multicloud/objectstore/shell/minio.go
+++ b/pkg/multicloud/objectstore/shell/minio.go
@@ -16,6 +16,7 @@ package shell
 
 import (
 	"fmt"
+
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud/objectstore"
 	"yunion.io/x/onecloud/pkg/util/shellutils"

--- a/pkg/multicloud/openstack/eip.go
+++ b/pkg/multicloud/openstack/eip.go
@@ -21,10 +21,10 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/pkg/errors"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 type SPortDetail struct {

--- a/pkg/multicloud/openstack/flavor.go
+++ b/pkg/multicloud/openstack/flavor.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"

--- a/pkg/multicloud/openstack/image.go
+++ b/pkg/multicloud/openstack/image.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/util/osprofile"
 	"yunion.io/x/pkg/utils"

--- a/pkg/multicloud/openstack/instance.go
+++ b/pkg/multicloud/openstack/instance.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"yunion.io/x/onecloud/pkg/multicloud"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
@@ -29,6 +27,7 @@ import (
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 	"yunion.io/x/onecloud/pkg/util/billing"
 )
 

--- a/pkg/multicloud/openstack/network.go
+++ b/pkg/multicloud/openstack/network.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/netutils"

--- a/pkg/multicloud/openstack/port.go
+++ b/pkg/multicloud/openstack/port.go
@@ -19,11 +19,11 @@ import (
 	"net/url"
 	"time"
 
-	"yunion.io/x/onecloud/pkg/multicloud"
 	"yunion.io/x/pkg/errors"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 )
 
 type DnsAssignment struct {

--- a/pkg/multicloud/openstack/region.go
+++ b/pkg/multicloud/openstack/region.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/pkg/multicloud/qcloud/loadbalancer_acl.go
+++ b/pkg/multicloud/qcloud/loadbalancer_acl.go
@@ -16,9 +16,9 @@ package qcloud
 
 import (
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 // 腾讯云没有LB ACL

--- a/pkg/multicloud/qcloud/network.go
+++ b/pkg/multicloud/qcloud/network.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/netutils"

--- a/pkg/multicloud/qcloud/networkinterface.go
+++ b/pkg/multicloud/qcloud/networkinterface.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 	"time"
 
-	api "yunion.io/x/onecloud/pkg/apis/compute"
-	"yunion.io/x/onecloud/pkg/multicloud"
-
 	"github.com/pkg/errors"
+
+	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 )
 
 type SPrivateIpAddress struct {

--- a/pkg/multicloud/ucloud/eip.go
+++ b/pkg/multicloud/ucloud/eip.go
@@ -19,9 +19,8 @@ import (
 	"strings"
 	"time"
 
-	"yunion.io/x/log"
-
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
 
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"
 	api "yunion.io/x/onecloud/pkg/apis/compute"

--- a/pkg/multicloud/ucloud/host.go
+++ b/pkg/multicloud/ucloud/host.go
@@ -20,14 +20,13 @@ import (
 	"strconv"
 	"strings"
 
-	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/util/billing"
-
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"
+	"yunion.io/x/onecloud/pkg/util/billing"
 )
 
 type SHost struct {

--- a/pkg/multicloud/ucloud/instance.go
+++ b/pkg/multicloud/ucloud/instance.go
@@ -21,12 +21,11 @@ import (
 	"strings"
 	"time"
 
-	"yunion.io/x/pkg/errors"
-	"yunion.io/x/pkg/utils"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/osprofile"
+	"yunion.io/x/pkg/utils"
 
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"
 	api "yunion.io/x/onecloud/pkg/apis/compute"

--- a/pkg/multicloud/ucloud/network.go
+++ b/pkg/multicloud/ucloud/network.go
@@ -16,6 +16,7 @@ package ucloud
 
 import (
 	"fmt"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/netutils"

--- a/pkg/multicloud/ucloud/vip.go
+++ b/pkg/multicloud/ucloud/vip.go
@@ -15,11 +15,12 @@
 package ucloud
 
 import (
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/netutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"
-	"yunion.io/x/pkg/errors"
-	"yunion.io/x/pkg/util/netutils"
 )
 
 type SVipAddr struct {

--- a/pkg/multicloud/ucloud/vpc.go
+++ b/pkg/multicloud/ucloud/vpc.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"

--- a/pkg/multicloud/ucloud/wire.go
+++ b/pkg/multicloud/ucloud/wire.go
@@ -16,7 +16,9 @@ package ucloud
 
 import (
 	"fmt"
+
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 

--- a/pkg/multicloud/zstack/eip.go
+++ b/pkg/multicloud/zstack/eip.go
@@ -19,9 +19,9 @@ import (
 	"time"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 type SEipAddress struct {

--- a/pkg/multicloud/zstack/host.go
+++ b/pkg/multicloud/zstack/host.go
@@ -19,12 +19,13 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
-	"yunion.io/x/onecloud/pkg/multicloud"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 )
 
 type SHost struct {

--- a/pkg/multicloud/zstack/image.go
+++ b/pkg/multicloud/zstack/image.go
@@ -23,15 +23,15 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"yunion.io/x/onecloud/pkg/util/imagetools"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
-	"yunion.io/x/onecloud/pkg/util/httputils"
-	"yunion.io/x/onecloud/pkg/util/multipart"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/util/httputils"
+	"yunion.io/x/onecloud/pkg/util/imagetools"
+	"yunion.io/x/onecloud/pkg/util/multipart"
 )
 
 type SBackupStorageRef struct {

--- a/pkg/multicloud/zstack/instance.go
+++ b/pkg/multicloud/zstack/instance.go
@@ -23,12 +23,12 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
-	"yunion.io/x/onecloud/pkg/util/billing"
 	"yunion.io/x/pkg/util/osprofile"
 	"yunion.io/x/pkg/utils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/util/billing"
 )
 
 type SInstanceCdrome struct {

--- a/pkg/multicloud/zstack/instancenic.go
+++ b/pkg/multicloud/zstack/instancenic.go
@@ -16,8 +16,8 @@ package zstack
 
 import (
 	"yunion.io/x/jsonutils"
-
 	"yunion.io/x/log"
+
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 

--- a/pkg/multicloud/zstack/network.go
+++ b/pkg/multicloud/zstack/network.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/pkg/util/netutils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
 )
 

--- a/pkg/multicloud/zstack/offering.go
+++ b/pkg/multicloud/zstack/offering.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"

--- a/pkg/multicloud/zstack/provider/provider.go
+++ b/pkg/multicloud/zstack/provider/provider.go
@@ -17,12 +17,11 @@ package provider
 import (
 	"context"
 
-	"yunion.io/x/onecloud/pkg/httperrors"
-
 	"yunion.io/x/jsonutils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/multicloud/zstack"
 )

--- a/pkg/multicloud/zstack/region.go
+++ b/pkg/multicloud/zstack/region.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/secrules"

--- a/pkg/multicloud/zstack/securitygroup.go
+++ b/pkg/multicloud/zstack/securitygroup.go
@@ -21,8 +21,9 @@ import (
 	"strings"
 
 	"yunion.io/x/jsonutils"
-	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/pkg/util/secrules"
+
+	api "yunion.io/x/onecloud/pkg/apis/compute"
 )
 
 type SSecurityGroupRule struct {

--- a/pkg/multicloud/zstack/storage.go
+++ b/pkg/multicloud/zstack/storage.go
@@ -20,6 +20,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )

--- a/pkg/multicloud/zstack/storage_local.go
+++ b/pkg/multicloud/zstack/storage_local.go
@@ -20,6 +20,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )

--- a/pkg/multicloud/zstack/storagecache.go
+++ b/pkg/multicloud/zstack/storagecache.go
@@ -21,6 +21,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/options"

--- a/pkg/multicloud/zstack/vip.go
+++ b/pkg/multicloud/zstack/vip.go
@@ -17,13 +17,14 @@ package zstack
 import (
 	"fmt"
 
-	"yunion.io/x/onecloud/pkg/multicloud"
-
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/util/netutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
-	"yunion.io/x/pkg/util/netutils"
+	"yunion.io/x/onecloud/pkg/multicloud"
 )
 
 type SVirtualIP struct {

--- a/pkg/multicloud/zstack/vpc.go
+++ b/pkg/multicloud/zstack/vpc.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
-	"yunion.io/x/onecloud/pkg/multicloud"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 )
 
 type SVpc struct {

--- a/pkg/multicloud/zstack/wire.go
+++ b/pkg/multicloud/zstack/wire.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 

--- a/pkg/multicloud/zstack/zone.go
+++ b/pkg/multicloud/zstack/zone.go
@@ -16,9 +16,9 @@ package zstack
 
 import (
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 type SZone struct {

--- a/pkg/multicloud/zstack/zstack.go
+++ b/pkg/multicloud/zstack/zstack.go
@@ -27,8 +27,10 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/util/httputils"

--- a/pkg/notify/models/mod_contact.go
+++ b/pkg/notify/models/mod_contact.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/sqlchemy"

--- a/pkg/notify/rpc/apis/send_server.pb.go
+++ b/pkg/notify/rpc/apis/send_server.pb.go
@@ -20,11 +20,12 @@ package apis
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/pkg/notify/rpc/send.go
+++ b/pkg/notify/rpc/send.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+
 	"yunion.io/x/log"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon"

--- a/pkg/s3gateway/handlers/errors.go
+++ b/pkg/s3gateway/handlers/errors.go
@@ -17,12 +17,12 @@ package handlers
 import (
 	"context"
 	"net/http"
+	"runtime/debug"
 
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/s3cli"
 
-	"runtime/debug"
 	"yunion.io/x/onecloud/pkg/appctx"
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/httperrors"

--- a/pkg/s3gateway/handlers/middelware.go
+++ b/pkg/s3gateway/handlers/middelware.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"net/http"
 
+	"yunion.io/x/log"
 	"yunion.io/x/pkg/gotypes"
 
-	"yunion.io/x/log"
 	"yunion.io/x/onecloud/pkg/appctx"
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"

--- a/pkg/s3gateway/models/buckets.go
+++ b/pkg/s3gateway/models/buckets.go
@@ -16,17 +16,20 @@ package models
 
 import (
 	"context"
-	"github.com/pkg/errors"
 	"time"
+
+	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/gotypes"
+	"yunion.io/x/s3cli"
+
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/s3gateway/session"
 	"yunion.io/x/onecloud/pkg/util/hashcache"
-	"yunion.io/x/pkg/gotypes"
-	"yunion.io/x/s3cli"
 )
 
 type SBucketManagerDelegate struct {

--- a/pkg/s3gateway/models/cloudproviders.go
+++ b/pkg/s3gateway/models/cloudproviders.go
@@ -20,13 +20,13 @@ import (
 
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/gotypes"
+	"yunion.io/x/pkg/utils"
 
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/s3gateway/session"
 	"yunion.io/x/onecloud/pkg/util/hashcache"
-	"yunion.io/x/pkg/utils"
 )
 
 type SCloudproviderManagerDelegate struct {

--- a/pkg/s3gateway/service/service.go
+++ b/pkg/s3gateway/service/service.go
@@ -23,10 +23,9 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon"
 	app_common "yunion.io/x/onecloud/pkg/cloudcommon/app"
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
+	_ "yunion.io/x/onecloud/pkg/multicloud/loader"
 	"yunion.io/x/onecloud/pkg/s3gateway/handlers"
 	"yunion.io/x/onecloud/pkg/s3gateway/options"
-
-	_ "yunion.io/x/onecloud/pkg/multicloud/loader"
 )
 
 func StartService() {

--- a/pkg/s3gateway/session/session.go
+++ b/pkg/s3gateway/session/session.go
@@ -16,6 +16,7 @@ package session
 
 import (
 	"context"
+
 	"yunion.io/x/onecloud/pkg/image/options"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"

--- a/pkg/scheduler/algorithm/predicates/baremetal/storage_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/baremetal/storage_predicate.go
@@ -15,9 +15,8 @@
 package baremetal
 
 import (
-	"fmt"
+	"fmt" // computeapi "yunion.io/x/onecloud/pkg/apis/compute"
 
-	// computeapi "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/compute/baremetal"
 	"yunion.io/x/onecloud/pkg/scheduler/algorithm/predicates"
 	"yunion.io/x/onecloud/pkg/scheduler/core"

--- a/pkg/scheduler/algorithm/predicates/k8s/network_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/k8s/network_predicate.go
@@ -24,7 +24,6 @@ import (
 	"yunion.io/x/pkg/util/netutils"
 
 	"yunion.io/x/onecloud/pkg/compute/models"
-
 	"yunion.io/x/onecloud/pkg/scheduler/api"
 	"yunion.io/x/onecloud/pkg/scheduler/cache/candidate"
 )

--- a/pkg/scheduler/api/sched.go
+++ b/pkg/scheduler/api/sched.go
@@ -15,9 +15,8 @@
 package api
 
 import (
-	"net/http"
+	"net/http" //"yunion.io/x/jsonutils"
 
-	//"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 
 	computeapi "yunion.io/x/onecloud/pkg/apis/compute"

--- a/pkg/scheduler/handler/forecast_helper.go
+++ b/pkg/scheduler/handler/forecast_helper.go
@@ -16,6 +16,7 @@ package handler
 
 import (
 	"fmt"
+
 	"yunion.io/x/log"
 
 	schedapi "yunion.io/x/onecloud/pkg/apis/scheduler"

--- a/pkg/scheduler/manager/task_history.go
+++ b/pkg/scheduler/manager/task_history.go
@@ -23,9 +23,8 @@ import (
 	"yunion.io/x/pkg/util/wait"
 	u "yunion.io/x/pkg/utils"
 
-	o "yunion.io/x/onecloud/pkg/scheduler/options"
-
 	"yunion.io/x/onecloud/pkg/scheduler/models"
+	o "yunion.io/x/onecloud/pkg/scheduler/options"
 )
 
 type HistoryItem struct {

--- a/pkg/scheduler/service/service.go
+++ b/pkg/scheduler/service/service.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	_ "github.com/go-sql-driver/mysql"
 
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/prometheus"
@@ -30,17 +31,15 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon"
 	app_common "yunion.io/x/onecloud/pkg/cloudcommon/app"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	_ "yunion.io/x/onecloud/pkg/compute/guestdrivers"
+	_ "yunion.io/x/onecloud/pkg/compute/hostdrivers"
 	computemodels "yunion.io/x/onecloud/pkg/compute/models"
+	_ "yunion.io/x/onecloud/pkg/scheduler/algorithmprovider"
 	skuman "yunion.io/x/onecloud/pkg/scheduler/data_manager/sku"
 	schedhandler "yunion.io/x/onecloud/pkg/scheduler/handler"
 	schedman "yunion.io/x/onecloud/pkg/scheduler/manager"
 	o "yunion.io/x/onecloud/pkg/scheduler/options"
 	"yunion.io/x/onecloud/pkg/util/gin/middleware"
-
-	_ "github.com/go-sql-driver/mysql"
-	_ "yunion.io/x/onecloud/pkg/compute/guestdrivers"
-	_ "yunion.io/x/onecloud/pkg/compute/hostdrivers"
-	_ "yunion.io/x/onecloud/pkg/scheduler/algorithmprovider"
 )
 
 func StartService() error {

--- a/pkg/util/ansible/serializable.go
+++ b/pkg/util/ansible/serializable.go
@@ -16,6 +16,7 @@ package ansible
 
 import (
 	"reflect"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/gotypes"
 )

--- a/pkg/util/dhcp/server.go
+++ b/pkg/util/dhcp/server.go
@@ -20,6 +20,7 @@ import (
 	"runtime/debug"
 
 	"golang.org/x/net/bpf"
+
 	"yunion.io/x/log"
 )
 

--- a/pkg/util/fernetool/fernet.go
+++ b/pkg/util/fernetool/fernet.go
@@ -15,17 +15,17 @@
 package fernetool
 
 import (
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"time"
 
 	"github.com/fernet/fernet-go"
-
-	"crypto/sha1"
-	"encoding/base64"
-	"encoding/hex"
 	"github.com/pkg/errors"
+
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
 )
 

--- a/pkg/util/httputils/httputils.go
+++ b/pkg/util/httputils/httputils.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"os"
 	"strconv"
@@ -35,7 +36,6 @@ import (
 	"yunion.io/x/pkg/gotypes"
 	"yunion.io/x/pkg/trace"
 
-	"net/http/httputil"
 	"yunion.io/x/onecloud/pkg/appctx"
 )
 

--- a/pkg/util/ldaputils/ldaputils.go
+++ b/pkg/util/ldaputils/ldaputils.go
@@ -19,9 +19,8 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/ldap.v3"
-
 	"github.com/pkg/errors"
+	"gopkg.in/ldap.v3"
 
 	"yunion.io/x/log"
 )

--- a/pkg/util/printutils/printgetter.go
+++ b/pkg/util/printutils/printgetter.go
@@ -20,9 +20,10 @@ import (
 	"strings"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/pkg/gotypes"
 	"yunion.io/x/pkg/utils"
+
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 func getter2json(obj interface{}) jsonutils.JSONObject {

--- a/pkg/util/rbacutils/rbac_test.go
+++ b/pkg/util/rbacutils/rbac_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"yunion.io/x/jsonutils"
-
 	"yunion.io/x/pkg/util/netutils"
 )
 

--- a/pkg/util/redfish/loader/loader.go
+++ b/pkg/util/redfish/loader/loader.go
@@ -16,9 +16,7 @@ package loader
 
 import (
 	"yunion.io/x/log"
-
-	_ "yunion.io/x/onecloud/pkg/util/redfish/generic"
-	// _ "yunion.io/x/onecloud/pkg/util/redfish/hprest"
+	_ "yunion.io/x/onecloud/pkg/util/redfish/generic" // _ "yunion.io/x/onecloud/pkg/util/redfish/hprest"
 	_ "yunion.io/x/onecloud/pkg/util/redfish/idrac"
 	_ "yunion.io/x/onecloud/pkg/util/redfish/ilo"
 )

--- a/pkg/util/s3auth/interface.go
+++ b/pkg/util/s3auth/interface.go
@@ -17,6 +17,7 @@ package s3auth
 import (
 	"net/http"
 	"strings"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
 )

--- a/pkg/util/s3auth/v4.go
+++ b/pkg/util/s3auth/v4.go
@@ -27,9 +27,9 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/timeutils"
 
 	"yunion.io/x/onecloud/pkg/util/streamutils"
-	"yunion.io/x/pkg/util/timeutils"
 )
 
 // Signature and API related constants.

--- a/pkg/util/sysutils/sysutils_test.go
+++ b/pkg/util/sysutils/sysutils_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/types"
 )

--- a/pkg/yunionconf/models/parameters.go
+++ b/pkg/yunionconf/models/parameters.go
@@ -20,8 +20,7 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/timeutils"
-	"yunion.io/x/sqlchemy"
-	// "yunion.io/x/pkg/utils"
+	"yunion.io/x/sqlchemy" // "yunion.io/x/pkg/utils"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
@@ -31,7 +30,6 @@ import (
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
-
 	"yunion.io/x/onecloud/pkg/yunionconf/options"
 )
 


### PR DESCRIPTION
Cherry pick of #3381 on release/2.12.

#3381: .circleci: yunionio/onecloud-ci: bump golang version to 1.13.3