### PR TITLE
Automated cherry pick of #3381: .circleci: yunionio/onecloud-ci: bump golang version to 1.13.3

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -13,9 +13,9 @@ RUN true \
 
 WORKDIR /opt
 RUN true \
-	&& wget https://dl.google.com/go/go1.12.6.linux-amd64.tar.gz \
-	&& tar xzf go1.12.6.linux-amd64.tar.gz \
-	&& rm -vf  go1.12.6.linux-amd64.tar.gz \
+	&& wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz \
+	&& tar xzf go1.13.3.linux-amd64.tar.gz \
+	&& rm -vf  go1.13.3.linux-amd64.tar.gz \
 	&& true
 ENV GOROOT="/opt/go"
 ENV PATH="/opt/go/bin:${PATH}"

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -24,6 +24,7 @@ RUN useradd -c "OneCloud Builder" --create-home --home-dir /home/build --shell /
 USER build
 ENV HOME /home/build
 WORKDIR /home/build
+USER build
 
 ENV GOPATH="/home/build/go"
 ENV PATH="${GOPATH}/bin:${PATH}"

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -28,3 +28,12 @@ USER build
 
 ENV GOPATH="/home/build/go"
 ENV PATH="${GOPATH}/bin:${PATH}"
+
+RUN true \
+	&& mkdir -p "$GOPATH" \
+	&& d="$GOPATH/src/golang.org/x/tools" \
+	&& mkdir -p "$d" \
+	&& git clone --branch yun --depth 8 https://github.com/yousong/tools "$d" \
+	&& cd "$d" \
+	&& go install ./cmd/goimports \
+	&& true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   check:
     docker:
-      - image: yunionio/onecloud-ci:v1.0.2
+      - image: yunionio/onecloud-ci:v1.0.3
         environment:
           ONECLOUD_CI_BUILD: "1"
     working_directory: /home/build/go/src/yunion.io/x/onecloud

--- a/Makefile
+++ b/Makefile
@@ -137,8 +137,20 @@ gendocgo-check: gendocgo
 	fi
 .PHONY: gendocgo adddocgo gendocgo-check
 
+goimports-check:
+	@goimports -w -local "yunion.io/x/:yunion.io/x/onecloud" pkg cmd; \
+	if git status --short | grep -E '^.M .*/[^.]+.go'; then \
+		echo "$@: working tree modified (possibly by goimports)" >&2 ; \
+		echo "$@: " >&2 ; \
+		echo "$@: import spec should be grouped in order: std, 3rd-party, yunion.io/x, yunion.io/x/onecloud" >&2 ; \
+		echo "$@: see \"yun\" branch at https://github.com/yousong/tools" >&2 ; \
+		false ; \
+	fi
+.PHONY: goimports-check
+
 check: fmt-check
 check: gendocgo-check
+check: goimports-check
 .PHONY: check
 
 

--- a/cmd/climc/shell/copyright.go
+++ b/cmd/climc/shell/copyright.go
@@ -16,6 +16,7 @@ package shell
 
 import (
 	"fmt"
+
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/pkg/mcclient"

--- a/cmd/climc/shell/identityproviders.go
+++ b/cmd/climc/shell/identityproviders.go
@@ -17,12 +17,12 @@ package shell
 import (
 	"fmt"
 
+	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/mcclient/options"
-
-	"yunion.io/x/jsonutils"
 )
 
 func init() {

--- a/cmd/climc/shell/k8s/raw.go
+++ b/cmd/climc/shell/k8s/raw.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 
 	"github.com/ghodss/yaml"
+
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/pkg/mcclient"

--- a/cmd/climc/shell/servers.go
+++ b/cmd/climc/shell/servers.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	yaml "gopkg.in/yaml.v2"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/cmd/climc/shell/snapshot_policy.go
+++ b/cmd/climc/shell/snapshot_policy.go
@@ -16,6 +16,7 @@ package shell
 
 import (
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/mcclient/options"

--- a/cmd/cryptool/main.go
+++ b/cmd/cryptool/main.go
@@ -21,9 +21,8 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/structarg"
 
-	"yunion.io/x/onecloud/pkg/util/shellutils"
-
 	_ "yunion.io/x/onecloud/cmd/cryptool/shell"
+	"yunion.io/x/onecloud/pkg/util/shellutils"
 )
 
 type BaseOptions struct {

--- a/cmd/ucloudcli/main.go
+++ b/cmd/ucloudcli/main.go
@@ -17,12 +17,12 @@ package main
 import (
 	"fmt"
 	"os"
-	"yunion.io/x/onecloud/pkg/util/ucloud"
 
 	"yunion.io/x/log"
 	"yunion.io/x/structarg"
 
 	"yunion.io/x/onecloud/pkg/util/shellutils"
+	"yunion.io/x/onecloud/pkg/util/ucloud"
 	_ "yunion.io/x/onecloud/pkg/util/ucloud/shell"
 )
 

--- a/pkg/appsrv/dispatcher/dispatcher.go
+++ b/pkg/appsrv/dispatcher/dispatcher.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/utils"
 
-	"strings"
 	"yunion.io/x/onecloud/pkg/appctx"
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/httperrors"

--- a/pkg/baremetal/utils/disktool/disktool.go
+++ b/pkg/baremetal/utils/disktool/disktool.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/utils"
 

--- a/pkg/baremetal/utils/raid/drivers/drivers.go
+++ b/pkg/baremetal/utils/raid/drivers/drivers.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/pkg/baremetal/utils/raid/megactl/megactl.go
+++ b/pkg/baremetal/utils/raid/megactl/megactl.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/pkg/util/stringutils"

--- a/pkg/baremetal/utils/raid/raid.go
+++ b/pkg/baremetal/utils/raid/raid.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/tristate"
 

--- a/pkg/cloudcommon/cmdline/helper_test.go
+++ b/pkg/cloudcommon/cmdline/helper_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/apis/compute"
 )
 

--- a/pkg/cloudcommon/cmdline/parser_test.go
+++ b/pkg/cloudcommon/cmdline/parser_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/apis/compute"
 )
 

--- a/pkg/cloudcommon/db/fieldtags.go
+++ b/pkg/cloudcommon/db/fieldtags.go
@@ -16,6 +16,7 @@ package db
 
 import (
 	"sort"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
 	"yunion.io/x/onecloud/pkg/util/stringutils2"

--- a/pkg/cloudcommon/db/quotas/quotas.go
+++ b/pkg/cloudcommon/db/quotas/quotas.go
@@ -16,11 +16,11 @@ package quotas
 
 import (
 	"context"
+	"database/sql"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 
-	"database/sql"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
 	"yunion.io/x/onecloud/pkg/mcclient"

--- a/pkg/cloudcommon/db/sharedresource.go
+++ b/pkg/cloudcommon/db/sharedresource.go
@@ -17,9 +17,10 @@ package db
 import (
 	"context"
 
+	"yunion.io/x/sqlchemy"
+
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/sqlchemy"
 )
 
 // sharing resoure between project

--- a/pkg/cloudcommon/db/tenantcache.go
+++ b/pkg/cloudcommon/db/tenantcache.go
@@ -21,10 +21,9 @@ import (
 	"runtime/debug"
 	"time"
 
-	"yunion.io/x/jsonutils"
-
 	"github.com/pkg/errors"
 
+	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/sqlchemy"
 

--- a/pkg/cloudcommon/service/services.go
+++ b/pkg/cloudcommon/service/services.go
@@ -22,12 +22,12 @@ import (
 	"syscall"
 
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/util/signalutils"
+	"yunion.io/x/pkg/utils"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/options"
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
 	"yunion.io/x/onecloud/pkg/util/procutils"
-	"yunion.io/x/pkg/util/signalutils"
-	"yunion.io/x/pkg/utils"
 )
 
 type IService interface {

--- a/pkg/cloudcommon/validators/misc.go
+++ b/pkg/cloudcommon/validators/misc.go
@@ -16,8 +16,9 @@ package validators
 
 import (
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/sqlchemy"
+
+	"yunion.io/x/onecloud/pkg/mcclient"
 )
 
 type ModelFilterOptions struct {

--- a/pkg/cloudcommon/validators/validators.go
+++ b/pkg/cloudcommon/validators/validators.go
@@ -27,10 +27,9 @@ import (
 	"regexp"
 	"strings"
 
-	"yunion.io/x/pkg/util/netutils"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/gotypes"
+	"yunion.io/x/pkg/util/netutils"
 	"yunion.io/x/pkg/util/regutils"
 	"yunion.io/x/sqlchemy"
 

--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -21,8 +21,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"yunion.io/x/onecloud/pkg/util/cloudinit"
-	"yunion.io/x/onecloud/pkg/util/seclib2"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
@@ -37,6 +35,8 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/billing"
+	"yunion.io/x/onecloud/pkg/util/cloudinit"
+	"yunion.io/x/onecloud/pkg/util/seclib2"
 )
 
 type SManagedVirtualizedGuestDriver struct {

--- a/pkg/compute/guestdrivers/openstack.go
+++ b/pkg/compute/guestdrivers/openstack.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/utils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/models"
@@ -26,7 +28,6 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/billing"
-	"yunion.io/x/pkg/utils"
 )
 
 type SOpenStackGuestDriver struct {

--- a/pkg/compute/hostdrivers/managedvirtual.go
+++ b/pkg/compute/hostdrivers/managedvirtual.go
@@ -21,10 +21,10 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"yunion.io/x/pkg/utils"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/utils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"

--- a/pkg/compute/models/cloudregionresource.go
+++ b/pkg/compute/models/cloudregionresource.go
@@ -19,6 +19,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 

--- a/pkg/compute/models/external_projects.go
+++ b/pkg/compute/models/external_projects.go
@@ -21,6 +21,7 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/compare"
+	"yunion.io/x/sqlchemy"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
@@ -28,7 +29,6 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/logclient"
-	"yunion.io/x/sqlchemy"
 )
 
 type SExternalProjectManager struct {

--- a/pkg/compute/models/host_recycle.go
+++ b/pkg/compute/models/host_recycle.go
@@ -16,9 +16,7 @@ package models
 
 import (
 	"context"
-	"fmt"
-
-	// "strings"
+	"fmt" // "strings"
 	"time"
 
 	"github.com/golang-plus/errors"

--- a/pkg/compute/models/networkschedtags.go
+++ b/pkg/compute/models/networkschedtags.go
@@ -16,6 +16,7 @@ package models
 
 import (
 	"context"
+
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"

--- a/pkg/compute/models/storageschedtags.go
+++ b/pkg/compute/models/storageschedtags.go
@@ -16,6 +16,7 @@ package models
 
 import (
 	"context"
+
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"

--- a/pkg/compute/models/zoneresource.go
+++ b/pkg/compute/models/zoneresource.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 

--- a/pkg/compute/regiondrivers/aws.go
+++ b/pkg/compute/regiondrivers/aws.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/httperrors"

--- a/pkg/compute/regiondrivers/azure.go
+++ b/pkg/compute/regiondrivers/azure.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/httperrors"

--- a/pkg/compute/regiondrivers/huawei.go
+++ b/pkg/compute/regiondrivers/huawei.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/httperrors"

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"yunion.io/x/onecloud/pkg/httperrors"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/utils"
@@ -29,6 +27,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/models"
+	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 

--- a/pkg/compute/regiondrivers/openstack.go
+++ b/pkg/compute/regiondrivers/openstack.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
 	"yunion.io/x/onecloud/pkg/compute/models"

--- a/pkg/compute/regiondrivers/qcloud.go
+++ b/pkg/compute/regiondrivers/qcloud.go
@@ -18,13 +18,12 @@ import (
 	"context"
 	"fmt"
 
-	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
-
 	"yunion.io/x/jsonutils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
+	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/httperrors"

--- a/pkg/compute/regiondrivers/ucloud.go
+++ b/pkg/compute/regiondrivers/ucloud.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/httperrors"

--- a/pkg/compute/regiondrivers/zstack.go
+++ b/pkg/compute/regiondrivers/zstack.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
 	"yunion.io/x/onecloud/pkg/compute/models"

--- a/pkg/compute/storagedrivers/gpfs.go
+++ b/pkg/compute/storagedrivers/gpfs.go
@@ -20,12 +20,13 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/util/timeutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/compute/options"
 	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/pkg/util/timeutils"
 )
 
 type SGpfsStorageDriver struct {

--- a/pkg/compute/storagedrivers/rbd.go
+++ b/pkg/compute/storagedrivers/rbd.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/pkg/compute/tasks/snapshot_policy_delete_task.go
+++ b/pkg/compute/tasks/snapshot_policy_delete_task.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"

--- a/pkg/hostman/guestfs/core.go
+++ b/pkg/hostman/guestfs/core.go
@@ -19,6 +19,7 @@ import (
 	"math/rand"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/netutils"

--- a/pkg/hostman/guestfs/sshpart/sshpart.go
+++ b/pkg/hostman/guestfs/sshpart/sshpart.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/utils"
 

--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/regutils"

--- a/pkg/hostman/guestman/qemu-kvmhelper.go
+++ b/pkg/hostman/guestman/qemu-kvmhelper.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/mdlayher/arp"
 	"github.com/mdlayher/ethernet"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/utils"

--- a/pkg/hostman/hostdeployer/apis/utils.go
+++ b/pkg/hostman/hostdeployer/apis/utils.go
@@ -19,6 +19,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	"yunion.io/x/onecloud/pkg/cloudcommon/types"
 )
 

--- a/pkg/hostman/hostdeployer/deployserver/deployserver.go
+++ b/pkg/hostman/hostdeployer/deployserver/deployserver.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"google.golang.org/grpc"
+
 	"yunion.io/x/log"
 
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"

--- a/pkg/hostman/hostinfo/hostbridge/linux_bridge.go
+++ b/pkg/hostman/hostinfo/hostbridge/linux_bridge.go
@@ -22,9 +22,10 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/utils"
+
 	"yunion.io/x/onecloud/pkg/hostman/options"
 	"yunion.io/x/onecloud/pkg/util/procutils"
-	"yunion.io/x/pkg/utils"
 )
 
 func NewLinuxBridgeDeriver(bridge, inter, ip string) (*SLinuxBridgeDriver, error) {

--- a/pkg/hostman/storageman/disk_base.go
+++ b/pkg/hostman/storageman/disk_base.go
@@ -20,6 +20,7 @@ import (
 	"path"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/pkg/hostman/storageman/disk_nas.go
+++ b/pkg/hostman/storageman/disk_nas.go
@@ -20,6 +20,7 @@ import (
 	"path"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/pkg/hostman/storageman/storage_local.go
+++ b/pkg/hostman/storageman/storage_local.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/timeutils"

--- a/pkg/keystone/service/service.go
+++ b/pkg/keystone/service/service.go
@@ -27,20 +27,16 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/cronman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
-	"yunion.io/x/onecloud/pkg/cloudcommon/policy"
-
-	// "yunion.io/x/onecloud/pkg/keystone/keys"
+	"yunion.io/x/onecloud/pkg/cloudcommon/policy" // "yunion.io/x/onecloud/pkg/keystone/keys"
 	"yunion.io/x/onecloud/pkg/keystone/cronjobs"
-	"yunion.io/x/onecloud/pkg/keystone/models"
-	"yunion.io/x/onecloud/pkg/keystone/options"
-	"yunion.io/x/onecloud/pkg/keystone/tokens"
-
-	"yunion.io/x/onecloud/pkg/mcclient/auth"
-	"yunion.io/x/onecloud/pkg/util/logclient"
-
 	_ "yunion.io/x/onecloud/pkg/keystone/driver/ldap"
 	_ "yunion.io/x/onecloud/pkg/keystone/driver/sql"
+	"yunion.io/x/onecloud/pkg/keystone/models"
+	"yunion.io/x/onecloud/pkg/keystone/options"
 	_ "yunion.io/x/onecloud/pkg/keystone/tasks"
+	"yunion.io/x/onecloud/pkg/keystone/tokens"
+	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/util/logclient"
 )
 
 func keystoneUUIDGenerator() string {

--- a/pkg/keystone/tokens/payloads.go
+++ b/pkg/keystone/tokens/payloads.go
@@ -24,8 +24,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/vmihailenco/msgpack"
 
-	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/pkg/util/netutils"
+
+	"yunion.io/x/onecloud/pkg/mcclient"
 )
 
 type TScopedPayloadVersion byte

--- a/pkg/lbagent/hastate.go
+++ b/pkg/lbagent/hastate.go
@@ -29,6 +29,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 
 	"yunion.io/x/log"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	agentutils "yunion.io/x/onecloud/pkg/lbagent/utils"
 )

--- a/pkg/mcclient/modules/joint.go
+++ b/pkg/mcclient/modules/joint.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 

--- a/pkg/mcclient/modules/mod_itsm_tasks.go
+++ b/pkg/mcclient/modules/mod_itsm_tasks.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 

--- a/pkg/mcclient/modules/mod_scheduler.go
+++ b/pkg/mcclient/modules/mod_scheduler.go
@@ -20,10 +20,9 @@ import (
 
 	"yunion.io/x/jsonutils"
 
+	api "yunion.io/x/onecloud/pkg/apis/scheduler"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
-
-	api "yunion.io/x/onecloud/pkg/apis/scheduler"
 )
 
 var (

--- a/pkg/mcclient/modules/mod_workers.go
+++ b/pkg/mcclient/modules/mod_workers.go
@@ -16,6 +16,7 @@ package modules
 
 import (
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 

--- a/pkg/scheduler/algorithm/predicates/k8s/network_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/k8s/network_predicate.go
@@ -24,7 +24,6 @@ import (
 	"yunion.io/x/pkg/util/netutils"
 
 	"yunion.io/x/onecloud/pkg/compute/models"
-
 	"yunion.io/x/onecloud/pkg/scheduler/api"
 	"yunion.io/x/onecloud/pkg/scheduler/cache/candidate"
 )

--- a/pkg/scheduler/api/sched.go
+++ b/pkg/scheduler/api/sched.go
@@ -15,9 +15,8 @@
 package api
 
 import (
-	"net/http"
+	"net/http" //"yunion.io/x/jsonutils"
 
-	//"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 
 	computeapi "yunion.io/x/onecloud/pkg/apis/compute"

--- a/pkg/scheduler/cache/candidate/base.go
+++ b/pkg/scheduler/cache/candidate/base.go
@@ -22,11 +22,10 @@ import (
 	"yunion.io/x/pkg/utils"
 	"yunion.io/x/sqlchemy"
 
-	"yunion.io/x/onecloud/pkg/scheduler/api"
-
 	computeapi "yunion.io/x/onecloud/pkg/apis/compute"
 	computedb "yunion.io/x/onecloud/pkg/cloudcommon/db"
 	computemodels "yunion.io/x/onecloud/pkg/compute/models"
+	"yunion.io/x/onecloud/pkg/scheduler/api"
 	schedmodels "yunion.io/x/onecloud/pkg/scheduler/models"
 )
 

--- a/pkg/scheduler/core/context.go
+++ b/pkg/scheduler/core/context.go
@@ -19,12 +19,12 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"yunion.io/x/onecloud/pkg/apis/compute"
-	"yunion.io/x/onecloud/pkg/compute/models"
-	"yunion.io/x/pkg/tristate"
 
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/tristate"
 
+	"yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/scheduler/api"
 	"yunion.io/x/onecloud/pkg/scheduler/core/score"
 )

--- a/pkg/scheduler/handler/forecast_helper.go
+++ b/pkg/scheduler/handler/forecast_helper.go
@@ -16,6 +16,7 @@ package handler
 
 import (
 	"fmt"
+
 	"yunion.io/x/log"
 
 	schedapi "yunion.io/x/onecloud/pkg/apis/scheduler"

--- a/pkg/scheduler/manager/task_history.go
+++ b/pkg/scheduler/manager/task_history.go
@@ -23,9 +23,8 @@ import (
 	"yunion.io/x/pkg/util/wait"
 	u "yunion.io/x/pkg/utils"
 
-	o "yunion.io/x/onecloud/pkg/scheduler/options"
-
 	"yunion.io/x/onecloud/pkg/scheduler/models"
+	o "yunion.io/x/onecloud/pkg/scheduler/options"
 )
 
 type HistoryItem struct {

--- a/pkg/scheduler/service/service.go
+++ b/pkg/scheduler/service/service.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	_ "github.com/go-sql-driver/mysql"
 
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/prometheus"
@@ -30,17 +31,15 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon"
 	app_common "yunion.io/x/onecloud/pkg/cloudcommon/app"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	_ "yunion.io/x/onecloud/pkg/compute/guestdrivers"
+	_ "yunion.io/x/onecloud/pkg/compute/hostdrivers"
 	computemodels "yunion.io/x/onecloud/pkg/compute/models"
+	_ "yunion.io/x/onecloud/pkg/scheduler/algorithmprovider"
 	skuman "yunion.io/x/onecloud/pkg/scheduler/data_manager/sku"
 	schedhandler "yunion.io/x/onecloud/pkg/scheduler/handler"
 	schedman "yunion.io/x/onecloud/pkg/scheduler/manager"
 	o "yunion.io/x/onecloud/pkg/scheduler/options"
 	"yunion.io/x/onecloud/pkg/util/gin/middleware"
-
-	_ "github.com/go-sql-driver/mysql"
-	_ "yunion.io/x/onecloud/pkg/compute/guestdrivers"
-	_ "yunion.io/x/onecloud/pkg/compute/hostdrivers"
-	_ "yunion.io/x/onecloud/pkg/scheduler/algorithmprovider"
 )
 
 func StartService() error {

--- a/pkg/util/aliyun/business.go
+++ b/pkg/util/aliyun/business.go
@@ -18,10 +18,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 func (self *SAliyunClient) businessRequest(apiName string, params map[string]string) (jsonutils.JSONObject, error) {

--- a/pkg/util/aliyun/host.go
+++ b/pkg/util/aliyun/host.go
@@ -19,10 +19,10 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/multicloud"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 	"yunion.io/x/onecloud/pkg/util/billing"
 )
 

--- a/pkg/util/aliyun/loadbalancer.go
+++ b/pkg/util/aliyun/loadbalancer.go
@@ -19,14 +19,13 @@ import (
 	"strings"
 	"time"
 
-	"yunion.io/x/onecloud/pkg/multicloud"
-	"yunion.io/x/pkg/errors"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 )
 
 type ListenerProtocol string

--- a/pkg/util/aliyun/loadbalancermasterslavebackend.go
+++ b/pkg/util/aliyun/loadbalancermasterslavebackend.go
@@ -18,11 +18,10 @@ import (
 	"fmt"
 	"strings"
 
-	"yunion.io/x/onecloud/pkg/cloudprovider"
-
 	"yunion.io/x/jsonutils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 type SLoadbalancerMasterSlaveBackend struct {

--- a/pkg/util/ansible/serializable.go
+++ b/pkg/util/ansible/serializable.go
@@ -16,6 +16,7 @@ package ansible
 
 import (
 	"reflect"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/gotypes"
 )

--- a/pkg/util/aws/instance.go
+++ b/pkg/util/aws/instance.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"yunion.io/x/onecloud/pkg/multicloud"
-
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	"yunion.io/x/jsonutils"
@@ -33,6 +31,7 @@ import (
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 	"yunion.io/x/onecloud/pkg/util/billing"
 	"yunion.io/x/onecloud/pkg/util/cloudinit"
 )

--- a/pkg/util/aws/latitude_and_longitude.go
+++ b/pkg/util/aws/latitude_and_longitude.go
@@ -15,9 +15,8 @@
 package aws
 
 import (
-	"yunion.io/x/onecloud/pkg/cloudprovider"
-
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 // https://docs.aws.amazon.com/general/latest/gr/rande.html

--- a/pkg/util/aws/securitygroup.go
+++ b/pkg/util/aws/securitygroup.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/secrules"

--- a/pkg/util/aws/shell/s3.go
+++ b/pkg/util/aws/shell/s3.go
@@ -16,8 +16,10 @@ package shell
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"os"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+
 	"yunion.io/x/onecloud/pkg/util/aws"
 	"yunion.io/x/onecloud/pkg/util/shellutils"
 	"yunion.io/x/onecloud/pkg/util/streamutils"

--- a/pkg/util/aws/utils.go
+++ b/pkg/util/aws/utils.go
@@ -26,8 +26,9 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/pkg/util/secrules"
+
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 type portRange struct {

--- a/pkg/util/azure/host.go
+++ b/pkg/util/azure/host.go
@@ -19,11 +19,10 @@ import (
 	"strings"
 	"time"
 
-	"yunion.io/x/pkg/util/osprofile"
-	"yunion.io/x/pkg/utils"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/util/osprofile"
+	"yunion.io/x/pkg/utils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"

--- a/pkg/util/azure/resourcegroup.go
+++ b/pkg/util/azure/resourcegroup.go
@@ -16,6 +16,7 @@ package azure
 
 import (
 	"fmt"
+
 	"yunion.io/x/jsonutils"
 )
 

--- a/pkg/util/azure/storagecache.go
+++ b/pkg/util/azure/storagecache.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 

--- a/pkg/util/dhcp/server.go
+++ b/pkg/util/dhcp/server.go
@@ -20,6 +20,7 @@ import (
 	"runtime/debug"
 
 	"golang.org/x/net/bpf"
+
 	"yunion.io/x/log"
 )
 

--- a/pkg/util/fernetool/fernet.go
+++ b/pkg/util/fernetool/fernet.go
@@ -15,17 +15,17 @@
 package fernetool
 
 import (
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"time"
 
 	"github.com/fernet/fernet-go"
-
-	"crypto/sha1"
-	"encoding/base64"
-	"encoding/hex"
 	"github.com/pkg/errors"
+
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
 )
 

--- a/pkg/util/huawei/instance.go
+++ b/pkg/util/huawei/instance.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/osprofile"

--- a/pkg/util/huawei/region.go
+++ b/pkg/util/huawei/region.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/secrules"

--- a/pkg/util/ldaputils/ldaputils.go
+++ b/pkg/util/ldaputils/ldaputils.go
@@ -19,9 +19,8 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/ldap.v3"
-
 	"github.com/pkg/errors"
+	"gopkg.in/ldap.v3"
 
 	"yunion.io/x/log"
 )

--- a/pkg/util/openstack/eip.go
+++ b/pkg/util/openstack/eip.go
@@ -21,10 +21,10 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/pkg/errors"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 type SPortDetail struct {

--- a/pkg/util/openstack/image.go
+++ b/pkg/util/openstack/image.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/util/osprofile"
 	"yunion.io/x/pkg/utils"

--- a/pkg/util/openstack/instance.go
+++ b/pkg/util/openstack/instance.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"yunion.io/x/onecloud/pkg/multicloud"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
@@ -29,6 +27,7 @@ import (
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 	"yunion.io/x/onecloud/pkg/util/billing"
 )
 

--- a/pkg/util/openstack/network.go
+++ b/pkg/util/openstack/network.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/netutils"

--- a/pkg/util/qcloud/network.go
+++ b/pkg/util/qcloud/network.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/netutils"

--- a/pkg/util/rbacutils/rbac_test.go
+++ b/pkg/util/rbacutils/rbac_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"yunion.io/x/jsonutils"
-
 	"yunion.io/x/pkg/util/netutils"
 )
 

--- a/pkg/util/sysutils/sysutils_test.go
+++ b/pkg/util/sysutils/sysutils_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/types"
 )

--- a/pkg/util/ucloud/eip.go
+++ b/pkg/util/ucloud/eip.go
@@ -19,9 +19,8 @@ import (
 	"strings"
 	"time"
 
-	"yunion.io/x/log"
-
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
 
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"
 	api "yunion.io/x/onecloud/pkg/apis/compute"

--- a/pkg/util/ucloud/host.go
+++ b/pkg/util/ucloud/host.go
@@ -20,14 +20,13 @@ import (
 	"strconv"
 	"strings"
 
-	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/util/billing"
-
 	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"
+	"yunion.io/x/onecloud/pkg/util/billing"
 )
 
 type SHost struct {

--- a/pkg/util/ucloud/instance.go
+++ b/pkg/util/ucloud/instance.go
@@ -21,12 +21,11 @@ import (
 	"strings"
 	"time"
 
-	"yunion.io/x/pkg/errors"
-	"yunion.io/x/pkg/utils"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/osprofile"
+	"yunion.io/x/pkg/utils"
 
 	billing_api "yunion.io/x/onecloud/pkg/apis/billing"
 	api "yunion.io/x/onecloud/pkg/apis/compute"

--- a/pkg/util/ucloud/network.go
+++ b/pkg/util/ucloud/network.go
@@ -16,6 +16,7 @@ package ucloud
 
 import (
 	"fmt"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/netutils"

--- a/pkg/util/ucloud/ufile.go
+++ b/pkg/util/ucloud/ufile.go
@@ -19,12 +19,14 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
-	"github.com/coredns/coredns/plugin/pkg/log"
 	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/coredns/coredns/plugin/pkg/log"
+
 	"yunion.io/x/onecloud/pkg/util/httputils"
 )
 

--- a/pkg/util/ucloud/vpc.go
+++ b/pkg/util/ucloud/vpc.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"yunion.io/x/jsonutils"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )

--- a/pkg/util/ucloud/wire.go
+++ b/pkg/util/ucloud/wire.go
@@ -16,7 +16,9 @@ package ucloud
 
 import (
 	"fmt"
+
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 

--- a/pkg/util/zstack/eip.go
+++ b/pkg/util/zstack/eip.go
@@ -19,9 +19,9 @@ import (
 	"time"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 type SEipAddress struct {

--- a/pkg/util/zstack/host.go
+++ b/pkg/util/zstack/host.go
@@ -19,12 +19,13 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
-	"yunion.io/x/onecloud/pkg/multicloud"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 )
 
 type SHost struct {

--- a/pkg/util/zstack/image.go
+++ b/pkg/util/zstack/image.go
@@ -23,15 +23,15 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"yunion.io/x/onecloud/pkg/util/imagetools"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
-	"yunion.io/x/onecloud/pkg/util/httputils"
-	"yunion.io/x/onecloud/pkg/util/multipart"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/util/httputils"
+	"yunion.io/x/onecloud/pkg/util/imagetools"
+	"yunion.io/x/onecloud/pkg/util/multipart"
 )
 
 type SBackupStorageRef struct {

--- a/pkg/util/zstack/instance.go
+++ b/pkg/util/zstack/instance.go
@@ -23,12 +23,12 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
-	"yunion.io/x/onecloud/pkg/util/billing"
 	"yunion.io/x/pkg/util/osprofile"
 	"yunion.io/x/pkg/utils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/util/billing"
 )
 
 type SInstanceCdrome struct {

--- a/pkg/util/zstack/instancenic.go
+++ b/pkg/util/zstack/instancenic.go
@@ -16,8 +16,8 @@ package zstack
 
 import (
 	"yunion.io/x/jsonutils"
-
 	"yunion.io/x/log"
+
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 

--- a/pkg/util/zstack/network.go
+++ b/pkg/util/zstack/network.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/pkg/util/netutils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
 )
 

--- a/pkg/util/zstack/provider/provider.go
+++ b/pkg/util/zstack/provider/provider.go
@@ -17,12 +17,11 @@ package provider
 import (
 	"context"
 
-	"yunion.io/x/onecloud/pkg/httperrors"
-
 	"yunion.io/x/jsonutils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/zstack"
 )

--- a/pkg/util/zstack/securitygroup.go
+++ b/pkg/util/zstack/securitygroup.go
@@ -21,8 +21,9 @@ import (
 	"strings"
 
 	"yunion.io/x/jsonutils"
-	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/pkg/util/secrules"
+
+	api "yunion.io/x/onecloud/pkg/apis/compute"
 )
 
 type SSecurityGroupRule struct {

--- a/pkg/util/zstack/storage.go
+++ b/pkg/util/zstack/storage.go
@@ -20,6 +20,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )

--- a/pkg/util/zstack/storage_local.go
+++ b/pkg/util/zstack/storage_local.go
@@ -20,6 +20,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )

--- a/pkg/util/zstack/storagecache.go
+++ b/pkg/util/zstack/storagecache.go
@@ -21,6 +21,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/options"

--- a/pkg/util/zstack/vpc.go
+++ b/pkg/util/zstack/vpc.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 type SVpc struct {

--- a/pkg/util/zstack/wire.go
+++ b/pkg/util/zstack/wire.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 

--- a/pkg/util/zstack/zone.go
+++ b/pkg/util/zstack/zone.go
@@ -16,9 +16,9 @@ package zstack
 
 import (
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/onecloud/pkg/cloudprovider"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
 type SZone struct {

--- a/pkg/util/zstack/zstack.go
+++ b/pkg/util/zstack/zstack.go
@@ -27,8 +27,10 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/util/httputils"

--- a/pkg/yunionconf/models/parameters.go
+++ b/pkg/yunionconf/models/parameters.go
@@ -20,8 +20,7 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/timeutils"
-	"yunion.io/x/sqlchemy"
-	// "yunion.io/x/pkg/utils"
+	"yunion.io/x/sqlchemy" // "yunion.io/x/pkg/utils"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
@@ -31,7 +30,6 @@ import (
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
-
 	"yunion.io/x/onecloud/pkg/yunionconf/options"
 )
 


### PR DESCRIPTION
Cherry pick of #3381 on release/2.10.0.

#3381: .circleci: yunionio/onecloud-ci: bump golang version to 1.13.3