### PR TITLE
fix: session.GetServiceURL: No such service compute

### DIFF
--- a/pkg/mcclient/modules/managers.go
+++ b/pkg/mcclient/modules/managers.go
@@ -32,7 +32,7 @@ func NewResourceManager(serviceType string, keyword, keywordPlural string,
 
 func NewComputeManager(keyword, keywordPlural string, columns, adminColumns []string) modulebase.ResourceManager {
 	return modulebase.ResourceManager{
-		BaseManager: *modulebase.NewBaseManager("compute", "", "", columns, adminColumns),
+		BaseManager: *modulebase.NewBaseManager("compute_v2", "", "", columns, adminColumns),
 		Keyword:     keyword, KeywordPlural: keywordPlural}
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
目前compute service已经更名为compute_v2, 使用modulebase.GetModule(session *mcclient.ClientSession, name string) 会出现 No such service compute错误。
**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @yunionio/maintainer 
