### PR TITLE
Automated cherry pick of #3380: fix: local snapshot's ownerId should be same with its disk even if extsnapshot's project has corresponding cloud project

### DIFF
--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -713,14 +713,12 @@ func (self *SSnapshot) SyncWithCloudSnapshot(ctx context.Context, userCred mccli
 
 	// bugfix for now:
 	disk, err := self.GetDisk()
-	if err == sql.ErrNoRows {
-		syncOwnerId = self.GetOwnerId()
-	} else if err != nil {
+	if err != nil && err != sql.ErrNoRows {
 		return errors.Wrapf(err, "get disk of snapshot %s error", self.Id)
-	} else {
-		syncOwnerId = disk.GetOwnerId()
 	}
-	SyncCloudProject(userCred, self, syncOwnerId, ext, self.ManagerId)
+	if err == nil {
+		self.SyncCloudProjectId(userCred, disk.GetOwnerId())
+	}
 
 	return nil
 }
@@ -760,9 +758,10 @@ func (manager *SSnapshotManager) newFromCloudSnapshot(ctx context.Context, userC
 
 	// bugfix for now:
 	if localDisk != nil {
-		syncOwnerId = localDisk.GetOwnerId()
+		snapshot.SyncCloudProjectId(userCred, localDisk.GetOwnerId())
+	} else {
+		SyncCloudProject(userCred, &snapshot, syncOwnerId, extSnapshot, snapshot.ManagerId)
 	}
-	SyncCloudProject(userCred, &snapshot, syncOwnerId, extSnapshot, snapshot.ManagerId)
 
 	db.OpsLog.LogEvent(&snapshot, db.ACT_CREATE, snapshot.GetShortDesc(ctx), userCred)
 


### PR DESCRIPTION
Cherry pick of #3380 on release/2.12.

#3380: fix: local snapshot's ownerId should be same with its disk even if extsnapshot's project has corresponding cloud project