### PR TITLE
Automated cherry pick of #3363: fix: 避免虚拟机正常磁盘在回收站

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -2606,6 +2606,12 @@ func (self *SGuest) SyncVMDisks(ctx context.Context, userCred mcclient.TokenCred
 			result.Error(err)
 			return result
 		}
+		if disk.PendingDeleted != self.PendingDeleted { //避免主机正常,磁盘在回收站的情况
+			db.Update(disk, func() error {
+				disk.PendingDeleted = self.PendingDeleted
+				return nil
+			})
+		}
 		newdisks = append(newdisks, sSyncDiskPair{disk: disk, vdisk: vdisks[i]})
 	}
 


### PR DESCRIPTION
Cherry pick of #3363 on release/2.11.

#3363: fix: 避免虚拟机正常磁盘在回收站