### PR TITLE
Bugfix: Docker Push

### DIFF
--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -21,8 +21,8 @@ readlink_mac() {
   REAL_PATH=$PHYS_DIR/$TARGET_FILE
 }
 
-pushd $(cd "$(dirname "$0")"; pwd)
-readlink_mac $BASH_SOURCE
+pushd $(cd "$(dirname "$0")"; pwd) > /dev/null
+readlink_mac $(basename "$0")
 cd "$(dirname "$REAL_PATH")"
 CUR_DIR=$(pwd)
 SRC_DIR=$(cd .. && pwd)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复 docker_push.sh 的 bug ，在非脚本所在目录不工作

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
