### PR TITLE
Feature & Fix: Guest Image 

### DIFF
--- a/cmd/climc/shell/imageguest.go
+++ b/cmd/climc/shell/imageguest.go
@@ -104,7 +104,52 @@ func init() {
 				printObject(image)
 			}
 			return nil
-		})
+		},
+	)
+
+	type GuestImageUpdateOptions struct {
+		ID             string `help:"id of guest image"`
+		Name           string `help:"new name of guest image"`
+		Protected      string `help:"delete protection" choices:"enable|disable"`
+		OsType         string `help:"os type"`
+		OsDistribution string `help:"os distribution"`
+		DiskDriver     string `help:"disk driver"`
+		NetDriver      string `help:"net driver"`
+	}
+	R(&GuestImageUpdateOptions{}, "guest-image-update", "update guest image", func(s *mcclient.ClientSession,
+		args *GuestImageUpdateOptions) error {
+
+		params := jsonutils.NewDict()
+		if len(args.Name) > 0 {
+			params.Add(jsonutils.NewString(args.Name), "name")
+		}
+		if len(args.Protected) > 0 {
+			if args.Protected == "enable" {
+				params.Add(jsonutils.JSONTrue, "protected")
+			} else {
+				params.Add(jsonutils.JSONFalse, "protected")
+			}
+		}
+		properties := jsonutils.NewDict()
+		if len(args.OsType) > 0 {
+			properties.Add(jsonutils.NewString(args.OsType), "os_type")
+		}
+		if len(args.OsDistribution) > 0 {
+			properties.Add(jsonutils.NewString(args.OsDistribution), "os_distribution")
+		}
+		if len(args.DiskDriver) > 0 {
+			properties.Add(jsonutils.NewString(args.DiskDriver), "disk_driver")
+		}
+		if len(args.NetDriver) > 0 {
+			properties.Add(jsonutils.NewString(args.NetDriver), "net_driver")
+		}
+		params.Add(properties, "properties")
+		_, err := modules.GuestImages.Update(s, args.ID, params)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
 
 	type GuestImageOptions struct {
 		ID string `help:"Guest Image id or name"`

--- a/pkg/cloudcommon/db/opslog.go
+++ b/pkg/cloudcommon/db/opslog.go
@@ -247,6 +247,8 @@ const (
 	ACT_RESTORE          = "restore"
 	ACT_CHANGE_CONFIG    = "change_config"
 	ACT_RESET_PASSWORD   = "reset_password"
+
+	ACT_SUBIMAGE_UPDATE_FAIL = "guest_image_subimages_update_fail"
 )
 
 type SOpsLogManager struct {

--- a/pkg/cloudcommon/policy/defaults.go
+++ b/pkg/cloudcommon/policy/defaults.go
@@ -333,6 +333,18 @@ var (
 					Result:   rbacutils.Allow,
 				},
 				{
+					Service:  "image",
+					Resource: "guestimages",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  "image",
+					Resource: "guestimages",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
 					Service:  "log",
 					Resource: "actions",
 					Action:   PolicyActionList,

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4725,7 +4725,11 @@ func (self *SGuest) GetDiskSnapshotsNotInInstanceSnapshots() ([]SSnapshot, error
 }
 
 func (self *SGuestManager) checkGuestImage(ctx context.Context, input *api.ServerCreateInput) error {
-	// that data disks has image id show that these image is part of guest image.
+	// There is no need to check the availability of guest imag if input.Disks is empty
+	if len(input.Disks) == 0 {
+		return nil
+	}
+	// That data disks has image id show that these image is part of guest image
 	for _, config := range input.Disks[1:] {
 		if len(config.ImageId) != 0 && len(input.GuestImageID) == 0 {
 			return httperrors.NewMissingParameterError("guest_image_id")

--- a/pkg/image/tasks/guest_image_update_task.go
+++ b/pkg/image/tasks/guest_image_update_task.go
@@ -1,0 +1,85 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"context"
+	"fmt"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/sqlchemy"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
+	"yunion.io/x/onecloud/pkg/image/models"
+	"yunion.io/x/onecloud/pkg/util/logclient"
+)
+
+type GuestImageUpdateTask struct {
+	taskman.STask
+}
+
+func init() {
+	taskman.RegisterTask(GuestImageUpdateTask{})
+}
+
+func (self *GuestImageUpdateTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
+	guestImage := obj.(*models.SGuestImage)
+	subImages, err := models.GuestImageJointManager.GetImagesByFilter(guestImage.GetId(), func(q *sqlchemy.SQuery) *sqlchemy.SQuery {
+		return q.Asc("name")
+	})
+	if err != nil {
+		self.taskFailed(ctx, guestImage, err.Error())
+	}
+	if self.Params.Contains("name") {
+		name, _ := self.Params.GetString("name")
+		for i := range subImages[:len(subImages)-1] {
+			sub := &subImages[i]
+			_, err := db.Update(sub, func() error {
+				sub.Name = fmt.Sprintf("%s-%s-%d", name, "data", i)
+				return nil
+			})
+			if err != nil {
+				self.taskFailed(ctx, guestImage, fmt.Sprintf("modify subimage's name failed: %s", err.Error()))
+				return
+			}
+		}
+		root := &subImages[len(subImages)-1]
+		_, err := db.Update(root, func() error {
+			root.Name = fmt.Sprintf("%s-%s", name, "root")
+			return nil
+		})
+		if err != nil {
+			self.taskFailed(ctx, guestImage, fmt.Sprintf("modify subimage's name failed: %s", err.Error()))
+			return
+		}
+	}
+	if self.Params.Contains("properties") {
+		rootImageId := subImages[len(subImages)-1].GetId()
+		props, _ := self.Params.Get("properties")
+		err := models.ImagePropertyManager.SaveProperties(ctx, self.UserCred, rootImageId, props)
+		if err != nil {
+			self.taskFailed(ctx, guestImage, fmt.Sprintf("save properties error: %s", err.Error()))
+			return
+		}
+	}
+	self.SetStageComplete(ctx, nil)
+}
+
+func (self *GuestImageUpdateTask) taskFailed(ctx context.Context, guestImage *models.SGuestImage, reason string) {
+	db.OpsLog.LogEvent(guestImage, db.ACT_SUBIMAGE_UPDATE_FAIL, reason, self.UserCred)
+	logclient.AddActionLogWithContext(ctx, guestImage, logclient.ACT_SUBIMAGE_UPDATE, reason, self.UserCred, false)
+	self.SetStageFailed(ctx, reason)
+}

--- a/pkg/util/logclient/consts.go
+++ b/pkg/util/logclient/consts.go
@@ -169,4 +169,6 @@ const (
 	ACT_VM_DISSOCIATE           = "解绑虚拟机"
 	ACT_NATGATEWAY_DISSOCIATE   = "解绑NAT网关"
 	ACT_LOADBALANCER_DISSOCIATE = "解绑负载均衡"
+
+	ACT_SUBIMAGE_UPDATE = "更新子镜像"
 )


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

feature:  guest image 添加了更新的接口，增加了一些返回参数；为guest image增加默认的policy，可以list和get。

fix: 在创建guest的时候，如果输入的disk列表为空，会触发panic。

**是否需要 backport 到之前的 release 分支**:
 - release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
