### PR TITLE
Fix: Keystone Policy

### DIFF
--- a/pkg/util/rbacutils/rbac.go
+++ b/pkg/util/rbacutils/rbac.go
@@ -359,7 +359,7 @@ func (policy *SRbacPolicy) Decode(policyJson jsonutils.JSONObject) error {
 		return ErrEmptyPolicy
 	}
 
-	policy.Rules = CompactRules(rules)
+	policy.Rules = rules
 
 	return nil
 }

--- a/pkg/util/rbacutils/reduce.go
+++ b/pkg/util/rbacutils/reduce.go
@@ -177,6 +177,9 @@ func (n *sRbacNode) reduce() {
 	for k := range n.downStream {
 		n.downStream[k].reduce()
 	}
+	if n.level == levelService || n.level == levelResource {
+		return
+	}
 	n.reduceDownstream()
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

问题：在升级的时候，对于新功能的权限，会因为其他服务的权限而产生不确定的行为。
修复：在合并 keystone policy 时，取消对 service 层和 resource 层的合并。 
其他：创建 policy 的时候，CompactRules 重复了 json2Rules 中的行为。

**是否需要 backport 到之前的 release 分支**:
 - release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
