### PR TITLE
fix: avoid create dbinstance without secgroup

### DIFF
--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -1502,7 +1502,7 @@ func (self *SManagedVirtualizationRegionDriver) RequestCreateDBInstance(ctx cont
 		secgroup, _ := dbinstance.GetSecgroup()
 		if secgroup != nil {
 			vpcId := region.GetDriver().GetSecurityGroupVpcId(ctx, userCred, region, nil, vpc, false)
-			_, err = region.GetDriver().RequestSyncSecurityGroup(ctx, userCred, vpcId, vpc, secgroup)
+			desc.SecgroupId, err = region.GetDriver().RequestSyncSecurityGroup(ctx, userCred, vpcId, vpc, secgroup)
 			if err != nil {
 				return nil, errors.Wrap(err, "SyncSecurityGroup")
 			}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复华为云RDS未设置安全组问题

**是否需要 backport 到之前的 release 分支**:
- release/2.12.0

/area region
/cc @swordqiu @yousong 
