### PR TITLE
Automated cherry pick of #3414: fix: avoid create dbinstance without secgroup

### DIFF
--- a/pkg/compute/models/dbinstance_skus.go
+++ b/pkg/compute/models/dbinstance_skus.go
@@ -56,7 +56,10 @@ type SDBInstanceSku struct {
 	MaxDiskSizeGb int    `list:"user" create:"optional"`
 	MinDiskSizeGb int    `list:"user" create:"optional"`
 
-	IOPS int `list:"user" create:"optional"`
+	IOPS           int `list:"user" create:"optional"`
+	TPS            int `list:"user" create:"optional"`
+	QPS            int `list:"user" create:"optional"`
+	MaxConnections int `list:"user" create:"optional"`
 
 	VcpuCount  int `nullable:"false" default:"1" list:"user" create:"optional"`
 	VmemSizeMb int `nullable:"false" list:"user" create:"required"`
@@ -146,6 +149,8 @@ func (manager *SDBInstanceSkuManager) GetPropertyInstanceSpecs(ctx context.Conte
 		"engine":         input.Engine,
 		"engine_version": input.EngineVersion,
 		"iops":           input.IOPS,
+		"qps":            input.QPS,
+		"tps":            input.TPS,
 		"vcpu_count":     input.VcpuCount,
 		"vmem_size_mb":   input.VmemSizeMb,
 	} {
@@ -415,6 +420,9 @@ func (sku SDBInstanceSku) GetGlobalId() string {
 func (sku *SDBInstanceSku) syncWithCloudSku(ctx context.Context, userCred mcclient.TokenCredential, isku SDBInstanceSku) error {
 	_, err := db.Update(sku, func() error {
 		sku.Status = isku.Status
+		sku.TPS = isku.TPS
+		sku.QPS = isku.QPS
+		sku.MaxConnections = isku.MaxConnections
 		return nil
 	})
 	return err

--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -1502,7 +1502,7 @@ func (self *SManagedVirtualizationRegionDriver) RequestCreateDBInstance(ctx cont
 		secgroup, _ := dbinstance.GetSecgroup()
 		if secgroup != nil {
 			vpcId := region.GetDriver().GetSecurityGroupVpcId(ctx, userCred, region, nil, vpc, false)
-			_, err = region.GetDriver().RequestSyncSecurityGroup(ctx, userCred, vpcId, vpc, secgroup)
+			desc.SecgroupId, err = region.GetDriver().RequestSyncSecurityGroup(ctx, userCred, vpcId, vpc, secgroup)
 			if err != nil {
 				return nil, errors.Wrap(err, "SyncSecurityGroup")
 			}


### PR DESCRIPTION
Cherry pick of #3414 on release/2.12.

#3414: fix: avoid create dbinstance without secgroup