### PR TITLE
Bugfix: Guest Image

### DIFF
--- a/cmd/climc/shell/servers.go
+++ b/cmd/climc/shell/servers.go
@@ -556,9 +556,9 @@ func init() {
 		return nil
 	})
 
-	R(&options.ServerSaveImageOptions{}, "server-save-guest-image",
+	R(&options.ServerSaveGuestImageOptions{}, "server-save-guest-image",
 		"save root disk and data disks to new images and upload to glance.", func(s *mcclient.ClientSession,
-			opts *options.ServerSaveImageOptions) error {
+			opts *options.ServerSaveGuestImageOptions) error {
 
 			params, err := options.StructToParams(opts)
 			if err != nil {

--- a/pkg/apis/image/consts.go
+++ b/pkg/apis/image/consts.go
@@ -47,6 +47,8 @@ const (
 	IMAGE_IS_READONLY         = "is_readonly"
 	IMAGE_PARTITION_TYPE      = "partition_type"
 	IMAGE_INSTALLED_CLOUDINIT = "installed_cloud_init"
+
+	IMAGE_STATUS_UPDATING = "updating"
 )
 
 var (

--- a/pkg/compute/guestdrivers/virtualization.go
+++ b/pkg/compute/guestdrivers/virtualization.go
@@ -300,7 +300,7 @@ func (self *SVirtualizedGuestDriver) StartGuestSaveImage(ctx context.Context, us
 
 func (self *SVirtualizedGuestDriver) StartGuestSaveGuestImage(ctx context.Context, userCred mcclient.TokenCredential,
 	guest *models.SGuest, params *jsonutils.JSONDict, parentTaskId string) error {
-
+	guest.SetStatus(userCred, api.VM_START_SAVE_DISK, "")
 	if task, err := taskman.TaskManager.NewTask(ctx, "GuestSaveGuestImageTask", guest, userCred, params, parentTaskId,
 		"", nil); err != nil {
 		return err

--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -1511,7 +1511,12 @@ func parseIsoInfo(ctx context.Context, userCred mcclient.TokenCredential, imageI
 func (self *SDisk) fetchDiskInfo(diskConfig *api.DiskConfig) {
 	if len(diskConfig.ImageId) > 0 {
 		self.TemplateId = diskConfig.ImageId
-		self.DiskType = api.DISK_TYPE_SYS
+		// support for create vm from guest image
+		if len(diskConfig.DiskType) == 0 {
+			self.DiskType = api.DISK_TYPE_SYS
+		} else {
+			self.DiskType = diskConfig.DiskType
+		}
 	} else if len(diskConfig.SnapshotId) > 0 {
 		self.SnapshotId = diskConfig.SnapshotId
 		self.DiskType = diskConfig.DiskType

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -198,7 +198,7 @@ func (self *SGuest) PerformSaveGuestImage(ctx context.Context, userCred mcclient
 	if !utils.IsInStringArray(self.Status, []string{api.VM_READY}) {
 		return nil, httperrors.NewBadRequestError("Cannot save image in status %s", self.Status)
 	}
-	if !data.Contains("name") {
+	if !data.Contains("name") && !data.Contains("generate_name") {
 		return nil, httperrors.NewMissingParameterError("Image name is required")
 	}
 	if self.Hypervisor != api.HYPERVISOR_KVM {
@@ -237,7 +237,7 @@ func (self *SGuest) PerformSaveGuestImage(ctx context.Context, userCred mcclient
 
 	kwargs.Add(images, "images")
 
-	s := auth.GetAdminSession(ctx, options.Options.Region, "")
+	s := auth.GetSession(ctx, userCred, options.Options.Region, "")
 	ret, err := modules.GuestImages.Create(s, kwargs)
 	if err != nil {
 		return nil, err

--- a/pkg/compute/tasks/guest_save_instance_image_task.go
+++ b/pkg/compute/tasks/guest_save_instance_image_task.go
@@ -66,10 +66,11 @@ func (self *GuestSaveGuestImageTask) OnSaveRootImageComplete(ctx context.Context
 		self.taskFailed(ctx, guest, "subtask failed")
 	}
 
-	if restart, _ := self.GetParams().Bool("restart"); restart {
+	if restart, _ := self.GetParams().Bool("auto_start"); restart {
 		self.SetStage("on_start_server_complete", nil)
 		guest.StartGueststartTask(ctx, self.GetUserCred(), nil, self.GetTaskId())
 	} else {
+		guest.SetStatus(self.UserCred, api.VM_READY, "")
 		self.taskSuc(ctx, guest)
 	}
 }

--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -554,7 +554,7 @@ func (self *SImage) ImageProbeAndCustomization(
 
 func (self *SImage) ValidateUpdateData(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
 	if self.Status != api.IMAGE_STATUS_QUEUED {
-		if self.IsGuestImage.IsTrue() && !self.CanUpdate(data) {
+		if !self.CanUpdate(data) {
 			return nil, httperrors.NewForbiddenError("image is the part of guest imgae")
 		}
 		appParams := appsrv.AppContextGetParams(ctx)
@@ -1263,8 +1263,6 @@ func (self *SImage) PerformUpdateTorrentStatus(ctx context.Context, userCred mcc
 
 func (self *SImage) CanUpdate(data jsonutils.JSONObject) bool {
 	dict := data.(*jsonutils.JSONDict)
-	if dict.Length() == 1 && !dict.Contains("description") {
-		return false
-	}
-	return true
+	// Only allow update description for now when Image is part of guest image
+	return self.IsGuestImage.IsFalse() || (dict.Length() == 1 && dict.Contains("description"))
 }

--- a/pkg/mcclient/options/servers.go
+++ b/pkg/mcclient/options/servers.go
@@ -538,6 +538,12 @@ type ServerSaveImageOptions struct {
 	AutoStart *bool  `help:"Auto start server after image saved"`
 }
 
+type ServerSaveGuestImageOptions struct {
+	ID        string `help:"ID or name of server" json:"-"`
+	IMAGE     string `help:"Image name" json:"name"`
+	AutoStart *bool  `help:"Auto start server after image saved"`
+}
+
 type ServerRebuildRootOptions struct {
 	ID            string `help:"Server to rebuild root" json:"-"`
 	ImageId       string `help:"New root Image template ID" json:"image_id" token:"image"`


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. guest image 支持 generate_name 创建
2. 解决一个bug：使用主机镜像创建主机时，所有盘的类型都会变成系统盘
3. 子镜像只允许改备注
4. 修复主机做完主机镜像后不能自动启动
5. 修复主机镜像的项目不对
6. 添加主机镜像更新的状态，防止主机镜像更新完子镜像还没有更新完就被前端拉取展示了

**是否需要 backport 到之前的 release 分支**:
- release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
