### PR TITLE
fix: baremetal-prepare report admin ip using ssh client host

### DIFF
--- a/pkg/baremetal/tasks/baseprepare.go
+++ b/pkg/baremetal/tasks/baseprepare.go
@@ -323,6 +323,7 @@ func (task *sBaremetalPrepareTask) DoPrepare(cli *ssh.Client) error {
 }
 
 func (task *sBaremetalPrepareTask) findAdminNic(cli *ssh.Client, nicsInfo []*types.SNicDevInfo) (int, *types.SNicDevInfo, error) {
+	accessIp := cli.GetConfig().Host
 	for idx := range nicsInfo {
 		nic := nicsInfo[idx]
 		output, err := cli.Run("/sbin/ifconfig " + nic.Dev)
@@ -332,7 +333,7 @@ func (task *sBaremetalPrepareTask) findAdminNic(cli *ssh.Client, nicsInfo []*typ
 		}
 		isAdmin := false
 		for _, l := range output {
-			if strings.Contains(l, task.baremetal.GetAccessIp()) {
+			if strings.Contains(l, accessIp) {
 				isAdmin = true
 				break
 			}
@@ -351,7 +352,8 @@ func (task *sBaremetalPrepareTask) updateBmInfo(cli *ssh.Client, i *baremetalPre
 		if err != nil {
 			return errors.Wrap(err, "task.findAdminNic")
 		}
-		err = task.sendNicInfo(adminNicDev, adminIdx, api.NIC_TYPE_ADMIN, false, task.baremetal.GetAccessIp(), true)
+		accessIp := cli.GetConfig().Host
+		err = task.sendNicInfo(adminNicDev, adminIdx, api.NIC_TYPE_ADMIN, false, accessIp, true)
 		if err != nil {
 			return errors.Wrap(err, "send Admin Nic Info")
 		}

--- a/pkg/compute/models/netinterfaces.go
+++ b/pkg/compute/models/netinterfaces.go
@@ -154,10 +154,6 @@ func (self *SNetInterface) networkToJson(ipAddr string, network *SNetwork, desc 
 		desc.Add(jsonutils.NewString(network.Id), "net_id")
 	}
 
-	wire := self.GetWire()
-	if wire != nil {
-		desc.Add(jsonutils.NewString(wire.Name), "wire")
-	}
 	return desc
 }
 
@@ -201,6 +197,10 @@ func (self *SNetInterface) getServerJsonDesc() *jsonutils.JSONDict {
 
 func (self *SNetInterface) getBaremetalJsonDesc() *jsonutils.JSONDict {
 	desc := jsonutils.Marshal(self).(*jsonutils.JSONDict)
+	wire := self.GetWire()
+	if wire != nil {
+		desc.Add(jsonutils.NewString(wire.Name), "wire")
+	}
 	bn := self.GetBaremetalNetwork()
 	if bn != nil {
 		return self.networkToJson(bn.IpAddr, bn.GetNetwork(), desc)

--- a/pkg/util/ssh/ssh.go
+++ b/pkg/util/ssh/ssh.go
@@ -21,10 +21,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 )
 
 type ClientConfig struct {
@@ -143,8 +143,8 @@ func (s *Client) run(parseOutput bool, cmds []string, input io.Reader) ([]string
 			if len(stdOut.String()) != 0 {
 				errMsg = fmt.Sprintf("%s %s", errMsg, stdOut.String())
 			}
-			outputErr = errors.New(errMsg)
-			err = errors.Errorf("%q error: %v, cmd error: %v", cmd, err, outputErr)
+			outputErr = errors.Error(errMsg)
+			err = errors.Wrapf(outputErr, "%q error: %v, cmd error", cmd, err)
 			return nil, err
 		}
 		if parseOutput {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：1. baremetal-prepare时候用ssh client host作为access ip 2. baremetal nic_info包含wire的名称

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/area baremetal

/cc @zexi 