### PR TITLE
fix: nil pointer panic when auth decode body failed

### DIFF
--- a/pkg/keystone/tokens/handlers.go
+++ b/pkg/keystone/tokens/handlers.go
@@ -73,6 +73,10 @@ func authenticateTokensV2(ctx context.Context, w http.ResponseWriter, r *http.Re
 
 func authenticateTokensV3(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	_, _, body := appsrv.FetchEnv(ctx, w, r)
+	if body == nil {
+		httperrors.InvalidInputError(w, "fail to decode request body")
+		return
+	}
 	input := mcclient.SAuthenticationInputV3{}
 	err := body.Unmarshal(&input)
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：keystone auth nil pointer panic when auth body decode failed

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12

/area keystone

/cc @yousong @zexi 