### PR TITLE
Automated cherry pick of #3487: fix: nil pointer panic when auth decode body failed

### DIFF
--- a/pkg/keystone/tokens/handlers.go
+++ b/pkg/keystone/tokens/handlers.go
@@ -73,6 +73,10 @@ func authenticateTokensV2(ctx context.Context, w http.ResponseWriter, r *http.Re
 
 func authenticateTokensV3(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	_, _, body := appsrv.FetchEnv(ctx, w, r)
+	if body == nil {
+		httperrors.InvalidInputError(w, "fail to decode request body")
+		return
+	}
 	input := mcclient.SAuthenticationInputV3{}
 	err := body.Unmarshal(&input)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #3487 on release/2.10.0.

#3487: fix: nil pointer panic when auth decode body failed