### PR TITLE
Feature: Snapshot Policy Cache

### DIFF
--- a/pkg/apis/compute/snapshot_const.go
+++ b/pkg/apis/compute/snapshot_const.go
@@ -48,4 +48,8 @@ const (
 	INSTANCE_SNAPSHOT_FAILED        = "instance_snapshot_create_failed"
 	INSTANCE_SNAPSHOT_START_DELETE  = "instance_snapshot_start_delete"
 	INSTANCE_SNAPSHOT_DELETE_FAILED = "instance_snapshot_delete_failed"
+
+	SNAPSHOT_POLICY_CACHE_STATUS_READY         = "ready"
+	SNAPSHOT_POLICY_CACHE_STATUS_DELETING      = "deleting"
+	SNAPSHOT_POLICY_CACHE_STATUS_DELETE_FAILED = "delete_failed"
 )

--- a/pkg/compute/service/handlers.go
+++ b/pkg/compute/service/handlers.go
@@ -97,6 +97,7 @@ func InitHandlers(app *appsrv.Application) {
 		models.InstanceSnapshotManager,
 		models.SnapshotManager,
 		models.SnapshotPolicyManager,
+		models.SnapshotPolicyCacheManager,
 		models.BaremetalagentManager,
 		models.LoadbalancerManager,
 		models.LoadbalancerListenerManager,

--- a/pkg/compute/tasks/snapshot_policy_cache_delete_task.go
+++ b/pkg/compute/tasks/snapshot_policy_cache_delete_task.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"context"
+
+	"yunion.io/x/jsonutils"
+
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
+	"yunion.io/x/onecloud/pkg/compute/models"
+)
+
+type SnapshotPolicyCacheDeleteTask struct {
+	taskman.STask
+}
+
+func init() {
+	taskman.RegisterTask(SnapshotPolicyCacheDeleteTask{})
+}
+
+func (self *SnapshotPolicyCacheDeleteTask) taskFailed(ctx context.Context, cache *models.SSnapshotPolicyCache,
+	err error) {
+
+	cache.SetStatus(self.UserCred, api.SNAPSHOT_POLICY_CACHE_STATUS_DELETE_FAILED, err.Error())
+	self.SetStageFailed(ctx, err.Error())
+}
+
+func (self *SnapshotPolicyCacheDeleteTask) taskComplete(ctx context.Context, cache *models.SSnapshotPolicyCache) {
+	cache.RealDetele(ctx, self.UserCred)
+	self.SetStageComplete(ctx, nil)
+}
+
+func (self *SnapshotPolicyCacheDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneModel,
+	data jsonutils.JSONObject) {
+
+	cache := obj.(*models.SSnapshotPolicyCache)
+
+	if len(cache.ExternalId) == 0 {
+		self.taskComplete(ctx, cache)
+		return
+	}
+
+	err := cache.DeleteCloudSnapshotPolicy()
+	if err != nil {
+		self.taskFailed(ctx, cache, err)
+		return
+	}
+	self.taskComplete(ctx, cache)
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 增加了snapshotpolicycache 的 list 和 delete 接口
2. 修改了snapshotpolicycachei的一些字段（字段名未变），由之前的自定义的字段改成了通用的
3. 为 snapshotpolicycache 增加了状态：ready，deleting，delete_failed

**是否需要 backport 到之前的 release 分支**:
- release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
