### PR TITLE
fix: skip esxi vm with nil config

### DIFF
--- a/pkg/multicloud/esxi/datacenter.go
+++ b/pkg/multicloud/esxi/datacenter.go
@@ -148,7 +148,10 @@ func (dc *SDatacenter) fetchVms(vmRefs []types.ManagedObjectReference, all bool)
 	retVms := make([]cloudprovider.ICloudVM, 0)
 	for i := 0; i < len(vms); i += 1 {
 		if all || !strings.HasPrefix(vms[i].Entity().Name, api.ESXI_IMAGE_CACHE_TMP_PREFIX) {
-			retVms = append(retVms, NewVirtualMachine(dc.manager, &vms[i], dc))
+			vmObj := NewVirtualMachine(dc.manager, &vms[i], dc)
+			if vmObj != nil {
+				retVms = append(retVms, vmObj)
+			}
 		}
 	}
 	return retVms, nil

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -68,7 +68,10 @@ func (d byDiskType) Less(i, j int) bool {
 
 func NewVirtualMachine(manager *SESXiClient, vm *mo.VirtualMachine, dc *SDatacenter) *SVirtualMachine {
 	svm := &SVirtualMachine{SManagedObject: newManagedObject(manager, vm, dc)}
-	svm.fetchHardwareInfo()
+	err := svm.fetchHardwareInfo()
+	if err != nil {
+		return nil
+	}
 	return svm
 }
 
@@ -652,7 +655,7 @@ func (self *SVirtualMachine) UpdateUserData(userData string) error {
 	return nil
 }
 
-func (self *SVirtualMachine) fetchHardwareInfo() {
+func (self *SVirtualMachine) fetchHardwareInfo() error {
 	self.vnics = make([]SVirtualNIC, 0)
 	self.vdisks = make([]SVirtualDisk, 0)
 	self.cdroms = make([]SVirtualCdrom, 0)
@@ -666,7 +669,7 @@ func (self *SVirtualMachine) fetchHardwareInfo() {
 	}
 
 	if moVM == nil || moVM.Config == nil || moVM.Config.Hardware.Device == nil {
-		return
+		return errors.Error("invalid vm config")
 	}
 
 	for i := 0; i < len(moVM.Config.Hardware.Device); i += 1 {
@@ -690,6 +693,7 @@ func (self *SVirtualMachine) fetchHardwareInfo() {
 		vdev := NewVirtualDevice(self, dev, 0)
 		self.devs[vdev.getKey()] = vdev
 	}
+	return nil
 }
 
 func (self *SVirtualMachine) getVdev(key int32) SVirtualDevice {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：忽略Config为nil的ESXI虚拟机

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12

/area region

/cc @yousong @zexi 