### PR TITLE
fix: 避免因backup删除失败导致删除rds无限失败

### DIFF
--- a/cmd/climc/shell/dbinstances.go
+++ b/cmd/climc/shell/dbinstances.go
@@ -231,8 +231,17 @@ func init() {
 		return nil
 	})
 
-	R(&DBInstanceIdOptions{}, "dbinstance-delete", "Delete DB instance", func(s *mcclient.ClientSession, opts *DBInstanceIdOptions) error {
-		result, err := modules.DBInstance.Delete(s, opts.ID, nil)
+	type DBInstanceDeleteOptions struct {
+		ID         string `help:"DBInstance Id or name"`
+		KeepBackup bool   `help:"Keep dbinstance manual backup after delete dbinstance"`
+	}
+
+	R(&DBInstanceDeleteOptions{}, "dbinstance-delete", "Delete DB instance", func(s *mcclient.ClientSession, opts *DBInstanceDeleteOptions) error {
+		params := jsonutils.NewDict()
+		if opts.KeepBackup {
+			params.Add(jsonutils.JSONTrue, "keep_backup")
+		}
+		result, err := modules.DBInstance.Delete(s, opts.ID, params)
 		if err != nil {
 			return err
 		}

--- a/docs/dbinstance/dbinstance.yaml
+++ b/docs/dbinstance/dbinstance.yaml
@@ -14,6 +14,7 @@ delete:
   summary: 删除指定RDS实例
   parameters:
     - $ref: '../parameters/dbinstance.yaml#/dbinstanceId'
+    - $ref: '../parameters/dbinstance.yaml#/keep_backup'
   responses:
     200:
       description: 被删除RDS实例的信息

--- a/docs/parameters/dbinstance.yaml
+++ b/docs/parameters/dbinstance.yaml
@@ -40,3 +40,10 @@ dbinstance:
   in: query
   type: string
   description: 根据RDS实例名称或ID过滤资源
+
+keep_backup:
+  name: keep_backup
+  in: body
+  type: boolean
+  default: false
+  description: 删除RDS实例时保留手动备份

--- a/pkg/compute/models/purge.go
+++ b/pkg/compute/models/purge.go
@@ -1354,17 +1354,15 @@ func (instance *SDBInstance) purgeNetwork(ctx context.Context, userCred mcclient
 	return nil
 }
 
-func (instance *SDBInstance) purgeBackups(ctx context.Context, userCred mcclient.TokenCredential) error {
-	backups, err := instance.GetDBInstanceBackups()
+func (instance *SDBInstance) PurgeBackups(ctx context.Context, userCred mcclient.TokenCredential, mode string) error {
+	backups, err := instance.GetDBInstanceBackupByMode(mode)
 	if err != nil {
 		return errors.Wrap(err, "instance.GetDBInstanceBackups")
 	}
 	for _, backup := range backups {
-		if backup.BackupMode == api.BACKUP_MODE_AUTOMATED {
-			err = backup.purge(ctx, userCred)
-			if err != nil {
-				return errors.Wrapf(err, "backup.purge %s(%s)", backup.Name, backup.Id)
-			}
+		err = backup.purge(ctx, userCred)
+		if err != nil {
+			return errors.Wrapf(err, "backup.purge %s(%s)", backup.Name, backup.Id)
 		}
 	}
 	return nil
@@ -1394,7 +1392,7 @@ func (instance *SDBInstance) Purge(ctx context.Context, userCred mcclient.TokenC
 		return err
 	}
 
-	err = instance.purgeBackups(ctx, userCred)
+	err = instance.PurgeBackups(ctx, userCred, api.BACKUP_MODE_AUTOMATED)
 	if err != nil {
 		return errors.Wrap(err, "instance.purgeBackups")
 	}

--- a/pkg/compute/regiondrivers/huawei.go
+++ b/pkg/compute/regiondrivers/huawei.go
@@ -2225,7 +2225,7 @@ func (self *SHuaWeiRegionDriver) ValidateDBInstanceAccountPrivilege(ctx context.
 	if account == "root" {
 		return httperrors.NewInputParameterError("No need to grant or revoke privilege for admin account")
 	}
-	if utils.IsInStringArray(privilege, []string{api.DATABASE_PRIVILEGE_RW, api.DATABASE_PRIVILEGE_R}) {
+	if !utils.IsInStringArray(privilege, []string{api.DATABASE_PRIVILEGE_RW, api.DATABASE_PRIVILEGE_R}) {
 		return httperrors.NewInputParameterError("Unknown privilege %s", privilege)
 	}
 	return nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免因backup删除失败导致删除rds无限失败

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu @yousong 
