### PR TITLE
Bugfix: Guest Image

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -252,6 +252,9 @@ func (self *SGuest) PerformSaveGuestImage(ctx context.Context, userCred mcclient
 		return nil, fmt.Errorf("create subimage of guest image error")
 	}
 	taskParams := jsonutils.NewDict()
+	if restart, _ := kwargs.Bool("auto_start"); restart {
+		taskParams.Add(jsonutils.JSONTrue, "auto_start")
+	}
 	taskParams.Add(imageIds, "image_ids")
 	return nil, self.StartGuestSaveGuestImage(ctx, userCred, taskParams, "")
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

'auto_start' 参数被PerformSaveGuestImage拦截了，没有传递给GuestSaveGuestImageTask。

**是否需要 backport 到之前的 release 分支**:
-release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
