### PR TITLE
Automated cherry pick of #3507: fix(region): Pass 'auto_start' parameter to GuestSaveGuestImageTask if have

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -252,6 +252,9 @@ func (self *SGuest) PerformSaveGuestImage(ctx context.Context, userCred mcclient
 		return nil, fmt.Errorf("create subimage of guest image error")
 	}
 	taskParams := jsonutils.NewDict()
+	if restart, _ := kwargs.Bool("auto_start"); restart {
+		taskParams.Add(jsonutils.JSONTrue, "auto_start")
+	}
 	taskParams.Add(imageIds, "image_ids")
 	return nil, self.StartGuestSaveGuestImage(ctx, userCred, taskParams, "")
 }


### PR DESCRIPTION
Cherry pick of #3507 on release/2.12.

#3507: fix(region): Pass 'auto_start' parameter to GuestSaveGuestImageTask if have