### PR TITLE
Automated cherry pick of #3492: fix: 避免version输出不正确

### DIFF
--- a/pkg/util/imagetools/image_test.go
+++ b/pkg/util/imagetools/image_test.go
@@ -17,12 +17,49 @@ package imagetools
 import "testing"
 
 func TestNormalizeImageInfo(t *testing.T) {
-	info := NormalizeImageInfo("rhel67_20180816.qcow2", "", "", "", "")
-	t.Logf("%#v", info)
+	images := []struct {
+		Name      string
+		OsDistro  string
+		OsType    string
+		OsVersion string
+	}{
+		{
+			Name:      "rhel67_20180816.qcow2",
+			OsDistro:  "RHEL",
+			OsType:    "linux",
+			OsVersion: "-",
+		},
+		{
+			Name:      "Ubuntu_16.04.3_amd64_qingcloud_20180817.qcow2",
+			OsDistro:  "Ubuntu",
+			OsType:    "linux",
+			OsVersion: "16",
+		},
+		{
+			Name:      "windows-server-2008-dc-cn-20180717",
+			OsDistro:  "Windows Server 2008",
+			OsType:    "windows",
+			OsVersion: "-",
+		},
+		{
+			Name:      "Ubuntu  14.04 32位",
+			OsDistro:  "Ubuntu",
+			OsType:    "linux",
+			OsVersion: "14",
+		},
+	}
 
-	info = NormalizeImageInfo("Ubuntu_16.04.3_amd64_qingcloud_20180817.qcow2", "", "", "", "")
-	t.Logf("%#v", info)
+	for _, image := range images {
+		info := NormalizeImageInfo(image.Name, "", "", "", "")
+		if info.OsType != image.OsType {
+			t.Errorf("%s osType should be %s", image.Name, image.OsType)
+		}
+		if info.OsDistro != image.OsDistro {
+			t.Errorf("%s osDistro should be %s, but is %s", image.Name, image.OsDistro, info.OsDistro)
+		}
+		if info.OsVersion != image.OsVersion {
+			t.Errorf("%s osVersion should be %s, but is %s", image.Name, image.OsVersion, info.OsVersion)
+		}
+	}
 
-	info = NormalizeImageInfo("windows-server-2008-dc-cn-20180717", "", "", "", "")
-	t.Logf("%#v", info)
 }

--- a/pkg/util/imagetools/imagetools.go
+++ b/pkg/util/imagetools/imagetools.go
@@ -91,7 +91,7 @@ var imageVersions = map[string][]string{
 	"CentOS":   {"5", "6", "7"},
 	"RHEL":     {"5", "6", "7"},
 	"FreeBSD":  {"10"},
-	"Ubuntu":   {"10", "12", "14", "16"},
+	"Ubuntu":   {"10", "12", "14", "16", "18"},
 	"OpenSUSE": {"11", "12"},
 	"SUSE":     {"10", "11", "12", "13"},
 	"Debian":   {"6", "7", "8", "9"},
@@ -102,12 +102,15 @@ var imageVersions = map[string][]string{
 func normalizeOsVersion(imageName string, osDist string, osVersion string) string {
 	if versions, ok := imageVersions[osDist]; ok {
 		for _, version := range versions {
-			if strings.HasPrefix(osVersion, version) {
-				return version
+			if len(osVersion) > 0 {
+				if strings.HasPrefix(osVersion, version) {
+					return version
+				}
+			} else {
+				if strings.Contains(imageName, " "+version) || strings.Contains(imageName, "_"+version) {
+					return version
+				}
 			}
-		}
-		if len(versions) > 0 {
-			return versions[0]
 		}
 	}
 	return "-"


### PR DESCRIPTION
Cherry pick of #3492 on release/2.10.0.

#3492: fix: 避免version输出不正确