### PR TITLE
fix: server-list details report nil pointer panic

### DIFF
--- a/pkg/compute/guestdrivers/baremetals.go
+++ b/pkg/compute/guestdrivers/baremetals.go
@@ -520,6 +520,9 @@ func (self *SBaremetalGuestDriver) IsSupportGuestClone() bool {
 
 func (self *SBaremetalGuestDriver) IsSupportCdrom(guest *models.SGuest) (bool, error) {
 	host := guest.GetHost()
+	if host == nil {
+		return false, errors.Wrap(httperrors.ErrNotFound, "no host")
+	}
 	ipmiInfo, err := host.GetIpmiInfo()
 	if err != nil {
 		return false, errors.Wrap(err, "host.GetIpmiInfo")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：server-list报空指针。sched_failed的主机的host为nil

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region

/cc @zexi 