### PR TITLE
fix: normalize baremetal sysinfo manufacture

### DIFF
--- a/pkg/baremetal/manager.go
+++ b/pkg/baremetal/manager.go
@@ -1210,7 +1210,7 @@ func (b *SBaremetalInstance) GetIPMIConfig() *types.SIPMIInfo {
 		return nil
 	}
 	if conf.Username == "" {
-		sysInfo := types.SIPMISystemInfo{}
+		sysInfo := types.SSystemInfo{}
 		err := b.desc.Unmarshal(&sysInfo, "sys_info")
 		if err != nil {
 			log.Errorf("Unmarshal get sys_info error: %v", err)

--- a/pkg/baremetal/profiles/profiles.go
+++ b/pkg/baremetal/profiles/profiles.go
@@ -15,8 +15,6 @@
 package profiles
 
 import (
-	"strings"
-
 	"yunion.io/x/onecloud/pkg/cloudcommon/types"
 )
 
@@ -97,26 +95,26 @@ var (
 	}
 )
 
-func GetProfile(sysinfo *types.SIPMISystemInfo) IPMIProfile {
-	profile, ok := PROFILES[strings.ToLower(sysinfo.Manufacture)]
+func GetProfile(sysinfo *types.SSystemInfo) IPMIProfile {
+	profile, ok := PROFILES[sysinfo.OemName]
 	if ok {
 		return profile
 	}
 	return DefaultProfile()
 }
 
-func GetLanChannel(sysinfo *types.SIPMISystemInfo) []int {
+func GetLanChannel(sysinfo *types.SSystemInfo) []int {
 	return GetProfile(sysinfo).LanChannel
 }
 
-func GetRootId(sysinfo *types.SIPMISystemInfo) int {
+func GetRootId(sysinfo *types.SSystemInfo) int {
 	return GetProfile(sysinfo).RootId
 }
 
-func GetRootName(sysinfo *types.SIPMISystemInfo) string {
+func GetRootName(sysinfo *types.SSystemInfo) string {
 	return GetProfile(sysinfo).RootName
 }
 
-func IsStrongPass(sysinfo *types.SIPMISystemInfo) bool {
+func IsStrongPass(sysinfo *types.SSystemInfo) bool {
 	return GetProfile(sysinfo).StrongPass
 }

--- a/pkg/baremetal/tasks/ipmiprobe.go
+++ b/pkg/baremetal/tasks/ipmiprobe.go
@@ -104,10 +104,11 @@ func (self *SBaremetalIpmiProbeTask) doRedfishIpmiProbe(ctx context.Context, drv
 	updateInfo["mem_size"] = sysInfo.MemoryGB * 1024
 	updateInfo["sn"] = sysInfo.SerialNumber
 	updateInfo["uuid"] = sysInfo.UUID
-	dmiSysInfo := &types.SDMISystemInfo{
+	dmiSysInfo := &types.SSystemInfo{
 		Manufacture: sysInfo.Manufacturer,
 		Model:       sysInfo.Model,
 		SN:          sysInfo.SerialNumber,
+		OemName:     types.ManufactureOemName(sysInfo.Manufacturer),
 	}
 	updateInfo["sys_info"] = dmiSysInfo
 	updateInfo["is_baremetal"] = true
@@ -200,11 +201,12 @@ func (self *SBaremetalIpmiProbeTask) doRawIpmiProbe(ctx context.Context, cli ipm
 	updateInfo := make(map[string]interface{})
 	if len(sysInfo.SN) > 0 {
 		updateInfo["sn"] = sysInfo.SN
-		dmiSysInfo := &types.SDMISystemInfo{
+		dmiSysInfo := &types.SSystemInfo{
 			Manufacture: sysInfo.Manufacture,
 			Model:       sysInfo.Model,
 			Version:     sysInfo.Version,
 			SN:          sysInfo.SN,
+			OemName:     types.ManufactureOemName(sysInfo.Manufacture),
 		}
 		updateInfo["sys_info"] = dmiSysInfo
 	}

--- a/pkg/baremetal/utils/ipmitool/ipmitool.go
+++ b/pkg/baremetal/utils/ipmitool/ipmitool.go
@@ -155,7 +155,7 @@ func GetSysGuid(exector IPMIExecutor) string {
 	return ""
 }
 
-func GetSysInfo(exector IPMIExecutor) (*types.SIPMISystemInfo, error) {
+func GetSysInfo(exector IPMIExecutor) (*types.SSystemInfo, error) {
 	// TODO: do cache
 	args := []string{"fru", "print", "0"}
 	lines, err := exector.ExecuteCommand(args...)
@@ -190,20 +190,21 @@ func GetSysInfo(exector IPMIExecutor) (*types.SIPMISystemInfo, error) {
 		// no product serial
 		ret["sn"] = bsn
 	}
-	info := types.SIPMISystemInfo{}
+	info := types.SSystemInfo{}
 	err = sysutils.DumpMapToObject(ret, &info)
+	info.OemName = types.ManufactureOemName(info.Manufacture)
 	return &info, err
 }
 
-func GetLanChannels(sysinfo *types.SIPMISystemInfo) []int {
+func GetLanChannels(sysinfo *types.SSystemInfo) []int {
 	return profiles.GetLanChannel(sysinfo)
 }
 
-func GetDefaultLanChannel(sysinfo *types.SIPMISystemInfo) int {
+func GetDefaultLanChannel(sysinfo *types.SSystemInfo) int {
 	return GetLanChannels(sysinfo)[0]
 }
 
-func GetRootId(sysinfo *types.SIPMISystemInfo) int {
+func GetRootId(sysinfo *types.SSystemInfo) int {
 	return profiles.GetRootId(sysinfo)
 }
 

--- a/pkg/baremetal/utils/ipmitool/ipmitool_test.go
+++ b/pkg/baremetal/utils/ipmitool/ipmitool_test.go
@@ -28,7 +28,7 @@ func TestGetSysInfo(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    *types.SIPMISystemInfo
+		want    *types.SSystemInfo
 		wantErr bool
 	}{
 		// TODO: Add test cases.

--- a/pkg/cloudcommon/types/types.go
+++ b/pkg/cloudcommon/types/types.go
@@ -14,7 +14,10 @@
 
 package types
 
-import "net"
+import (
+	"net"
+	"strings"
+)
 
 type SSHConfig struct {
 	Username string `json:"username,omitempty"`
@@ -22,20 +25,50 @@ type SSHConfig struct {
 	Password string `json:"password"`
 }
 
-type SDMISystemInfo struct {
-	Manufacture string `json:"manufacture"`
-	Model       string `json:"model"`
-	Version     string `json:"version,omitempty"`
-	SN          string `json:"sn"`
+const (
+	OEM_NAME_DELL       = "dell"
+	OEM_NAME_HPE        = "hpe"
+	OEM_NAME_HP         = "hp"
+	OEM_NAME_HUAWEI     = "huawei"
+	OEM_NAME_INSPUR     = "inspur"
+	OEM_NAME_LENOVO     = "lenovo"
+	OEM_NAME_FOXCONN    = "foxconn"
+	OEM_NAME_QEMU       = "qemu"
+	OEM_NAME_SUPERMICRO = "supermicro"
+)
+
+var (
+	OEM_NAMES = []string{
+		OEM_NAME_DELL,
+		OEM_NAME_HPE,
+		OEM_NAME_HP,
+		OEM_NAME_HUAWEI,
+		OEM_NAME_INSPUR,
+		OEM_NAME_LENOVO,
+		OEM_NAME_FOXCONN,
+		OEM_NAME_QEMU,
+		OEM_NAME_SUPERMICRO,
+	}
+)
+
+func ManufactureOemName(manufacture string) string {
+	manufacture = strings.ToLower(strings.TrimSpace(manufacture))
+	for _, oem := range OEM_NAMES {
+		if strings.Contains(manufacture, oem) {
+			return oem
+		}
+	}
+	return manufacture
 }
 
-func (info *SDMISystemInfo) ToIPMISystemInfo() *SIPMISystemInfo {
-	return &SIPMISystemInfo{
-		Manufacture: info.Manufacture,
-		Model:       info.Model,
-		Version:     info.Version,
-		SN:          info.SN,
-	}
+type SSystemInfo struct {
+	Manufacture string `json:"manufacture"`
+	Model       string `json:"model"`
+	SN          string `json:"sn"`
+	Version     string `json:"version,omitempty"`
+	BSN         string `json:"bsn"`
+
+	OemName string `json:"oem_name"`
 }
 
 type SCPUInfo struct {
@@ -77,14 +110,6 @@ type SDiskInfo struct {
 	Kernel     string `json:"kernel"`
 	PCIClass   string `json:"pci_class"`
 	Driver     string `json:"driver"`
-}
-
-type SIPMISystemInfo struct {
-	Manufacture string `json:"manufacture"`
-	Model       string `json:"model"`
-	SN          string `json:"sn"`
-	Version     string `json:"version"`
-	BSN         string `json:"bsn"`
 }
 
 type SIPMILanConfig struct {

--- a/pkg/compute/tasks/baremetal_ipmi_probe_task.go
+++ b/pkg/compute/tasks/baremetal_ipmi_probe_task.go
@@ -24,6 +24,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/compute/models"
+	"yunion.io/x/onecloud/pkg/util/logclient"
 )
 
 type BaremetalIpmiProbeTask struct {
@@ -47,12 +48,13 @@ func (self *BaremetalIpmiProbeTask) OnInit(ctx context.Context, obj db.IStandalo
 }
 
 func (self *BaremetalIpmiProbeTask) OnFailure(ctx context.Context, baremetal *models.SHost, reason string) {
+	logclient.AddActionLogWithStartable(self, baremetal, logclient.ACT_PROBE, reason, self.UserCred, false)
 	baremetal.SetStatus(self.UserCred, api.BAREMETAL_PROBE_FAIL, reason)
 	self.SetStageFailed(ctx, reason)
 }
 
 func (self *BaremetalIpmiProbeTask) OnSyncConfigComplete(ctx context.Context, baremetal *models.SHost, body jsonutils.JSONObject) {
-	// baremetal.ClearSchedDescCache()
+	logclient.AddActionLogWithStartable(self, baremetal, logclient.ACT_PROBE, baremetal.GetShortDesc(ctx), self.UserCred, true)
 	self.SetStageComplete(ctx, nil)
 }
 

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -258,7 +258,7 @@ func (h *SHostInfo) detectHostInfo() error {
 	if err != nil {
 		return err
 	}
-	h.sysinfo.SDMISystemInfo = sysinfo
+	h.sysinfo.SSystemInfo = sysinfo
 
 	h.detectKvmModuleSupport()
 	h.detectNestSupport()
@@ -452,7 +452,7 @@ func (h *SHostInfo) detectiveKernelVersion() {
 	if err != nil {
 		log.Errorln(err)
 	}
-	h.sysinfo.KernelVersion = string(out)
+	h.sysinfo.KernelVersion = strings.TrimSpace(string(out))
 }
 
 func (h *SHostInfo) detectiveSyssoftwareInfo() error {

--- a/pkg/hostman/hostinfo/hostinfohelper.go
+++ b/pkg/hostman/hostinfo/hostinfohelper.go
@@ -311,7 +311,7 @@ func NewNIC(desc string) (*SNIC, error) {
 }
 
 type SSysInfo struct {
-	*types.SDMISystemInfo
+	*types.SSystemInfo
 
 	Nest           string `json:"nest,omitempty"`
 	OsDistribution string `json:"os_distribution"`

--- a/pkg/util/logclient/consts.go
+++ b/pkg/util/logclient/consts.go
@@ -173,6 +173,7 @@ const (
 	ACT_SUBIMAGE_UPDATE = "更新子镜像"
 
 	ACT_PREPARE = "同步硬件配置"
+	ACT_PROBE   = "检测配置"
 
 	ACT_INSTANCE_GROUP_BIND   = "绑定主机组"
 	ACT_INSTANCE_GROUP_UNBIND = "解绑主机组"

--- a/pkg/util/sysutils/sysutils.go
+++ b/pkg/util/sysutils/sysutils.go
@@ -45,7 +45,7 @@ func DumpMapToObject(data map[string]string, obj interface{}) error {
 	return jsonutils.Marshal(data).Unmarshal(obj)
 }
 
-func ParseDMISysinfo(lines []string) (*types.SDMISystemInfo, error) {
+func ParseDMISysinfo(lines []string) (*types.SSystemInfo, error) {
 	if len(lines) == 0 {
 		return nil, fmt.Errorf("Empty input")
 	}
@@ -64,7 +64,7 @@ func ParseDMISysinfo(lines []string) (*types.SDMISystemInfo, error) {
 			}
 		}
 	}
-	info := types.SDMISystemInfo{}
+	info := types.SSystemInfo{}
 	err := DumpMapToObject(ret, &info)
 	if err != nil {
 		return nil, err
@@ -72,6 +72,7 @@ func ParseDMISysinfo(lines []string) (*types.SDMISystemInfo, error) {
 	if strings.ToLower(info.Version) == "none" {
 		info.Version = ""
 	}
+	info.OemName = types.ManufactureOemName(info.Manufacture)
 	return &info, nil
 }
 

--- a/pkg/util/sysutils/sysutils_test.go
+++ b/pkg/util/sysutils/sysutils_test.go
@@ -73,7 +73,7 @@ func TestParseDMISysinfo(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    *types.SDMISystemInfo
+		want    *types.SSystemInfo
 		wantErr bool
 	}{
 		{
@@ -94,11 +94,12 @@ func TestParseDMISysinfo(t *testing.T) {
 				"        UUID: bca177cc-2bce-11b2-a85c-e98996f19d2f",
 				"        SKU Number: LENOVO_MT_20J6_BU_Think_FM_ThinkPad T470p",
 			}},
-			want: &types.SDMISystemInfo{
+			want: &types.SSystemInfo{
 				Manufacture: "LENOVO",
 				Model:       "20J6CTO1WW",
 				Version:     "ThinkPad T470p",
 				SN:          "PF112JKK",
+				OemName:     "lenovo",
 			},
 			wantErr: false,
 		},
@@ -109,7 +110,7 @@ func TestParseDMISysinfo(t *testing.T) {
 				"        Version: None",
 				"        Serial Number: PF112JKK",
 			}},
-			want: &types.SDMISystemInfo{
+			want: &types.SSystemInfo{
 				Model:   "20J6CTO1WW",
 				Version: "",
 				SN:      "PF112JKK",


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：统一物理机sysinfo的manufacture字段为oem_name

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area baremetal

/cc @zexi @wanyaoqi 
