### PR TITLE
fix: simplify object delete-fail-reason message

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -670,14 +670,14 @@ func getModelExtraDetails(item IModel, ctx context.Context, extra *jsonutils.JSO
 	err := item.ValidateDeleteCondition(ctx)
 	if err != nil {
 		extra.Add(jsonutils.JSONFalse, "can_delete")
-		extra.Add(jsonutils.NewString(err.Error()), "delete_fail_reason")
+		extra.Add(jsonutils.NewString(httputils.ErrorMsg(err)), "delete_fail_reason")
 	} else {
 		extra.Add(jsonutils.JSONTrue, "can_delete")
 	}
 	err = item.ValidateUpdateCondition(ctx)
 	if err != nil {
 		extra.Add(jsonutils.JSONFalse, "can_update")
-		extra.Add(jsonutils.NewString(err.Error()), "update_fail_reason")
+		extra.Add(jsonutils.NewString(httputils.ErrorMsg(err)), "update_fail_reason")
 	} else {
 		extra.Add(jsonutils.JSONTrue, "can_update")
 	}

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -2338,7 +2338,7 @@ func (self *SHost) getMoreDetails(ctx context.Context, extra *jsonutils.JSONDict
 			extra.Add(jsonutils.JSONTrue, "can_prepare")
 		} else {
 			extra.Add(jsonutils.JSONFalse, "can_prepare")
-			extra.Add(jsonutils.NewString(err.Error()), "prepare_fail_reason")
+			extra.Add(jsonutils.NewString(httputils.ErrorMsg(err)), "prepare_fail_reason")
 		}
 	}
 

--- a/pkg/util/httputils/httputils.go
+++ b/pkg/util/httputils/httputils.go
@@ -92,6 +92,17 @@ func ErrorCode(err error) int {
 	return -1
 }
 
+func ErrorMsg(err error) string {
+	if err == nil {
+		return ""
+	}
+	switch je := err.(type) {
+	case *JSONClientError:
+		return je.Details
+	}
+	return err.Error()
+}
+
 func GetAddrPort(urlStr string) (string, int, error) {
 	parts, err := url.Parse(urlStr)
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：简化object的delete_fail_reason消息

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12

/area region

/cc @zexi @yousong 