### PR TITLE
fix: 赋予rds账号权限失败后进行重试

### DIFF
--- a/pkg/multicloud/aliyun/aliyun.go
+++ b/pkg/multicloud/aliyun/aliyun.go
@@ -100,7 +100,13 @@ func jsonRequest(client *sdk.Client, domain, apiVersion, apiName string, params 
 					return nil, cloudprovider.ErrNotFound
 				}
 			}
-			for _, code := range []string{"SignatureNonceUsed", "InvalidInstance.NotSupported", "try later", "BackendServer.configuring"} {
+			for _, code := range []string{
+				"SignatureNonceUsed",
+				"InvalidInstance.NotSupported",
+				"try later",
+				"BackendServer.configuring",
+				"Another operation is being performed", //Another operation is being performed on the DB instance or the DB instance is faulty(赋予RDS账号权限)
+			} {
 				if strings.Contains(err.Error(), code) {
 					retry = true
 					break


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
赋予rds账号权限失败后进行重试

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu @yousong 
