### PR TITLE
Automated cherry pick of #3569: fix: avolid duplicate secgroup name error when create secgroup

### DIFF
--- a/pkg/cloudprovider/fakeregion.go
+++ b/pkg/cloudprovider/fakeregion.go
@@ -93,6 +93,10 @@ func (region *SFakeOnPremiseRegion) GetISecurityGroupById(id string) (ICloudSecu
 	return nil, ErrNotSupported
 }
 
+func (region *SFakeOnPremiseRegion) GetISecurityGroupByName(vpcId string, name string) (ICloudSecurityGroup, error) {
+	return nil, ErrNotSupported
+}
+
 func (region *SFakeOnPremiseRegion) CreateISecurityGroup(conf *SecurityGroupCreateInput) (ICloudSecurityGroup, error) {
 	return nil, ErrNotSupported
 }

--- a/pkg/cloudprovider/resources.go
+++ b/pkg/cloudprovider/resources.go
@@ -70,6 +70,7 @@ type ICloudRegion interface {
 	GetIDiskById(id string) (ICloudDisk, error)
 
 	GetISecurityGroupById(secgroupId string) (ICloudSecurityGroup, error)
+	GetISecurityGroupByName(vpcId string, name string) (ICloudSecurityGroup, error)
 	CreateISecurityGroup(conf *SecurityGroupCreateInput) (ICloudSecurityGroup, error)
 
 	CreateIVpc(name string, desc string, cidr string) (ICloudVpc, error)

--- a/pkg/multicloud/aliyun/region.go
+++ b/pkg/multicloud/aliyun/region.go
@@ -760,6 +760,20 @@ func (region *SRegion) GetISecurityGroupById(secgroupId string) (cloudprovider.I
 	return secgroup, nil
 }
 
+func (region *SRegion) GetISecurityGroupByName(vpcId string, name string) (cloudprovider.ICloudSecurityGroup, error) {
+	secgroups, total, err := region.GetSecurityGroups(vpcId, name, []string{}, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+	if total == 0 {
+		return nil, cloudprovider.ErrNotFound
+	}
+	if total > 1 {
+		return nil, cloudprovider.ErrDuplicateId
+	}
+	return &secgroups[0], nil
+}
+
 func (region *SRegion) CreateISecurityGroup(conf *cloudprovider.SecurityGroupCreateInput) (cloudprovider.ICloudSecurityGroup, error) {
 	externalId, err := region.CreateSecurityGroup(conf.VpcId, conf.Name, conf.Desc)
 	if err != nil {
@@ -770,7 +784,7 @@ func (region *SRegion) CreateISecurityGroup(conf *cloudprovider.SecurityGroupCre
 
 func (region *SRegion) SyncSecurityGroup(secgroupId string, vpcId string, name string, desc string, rules []secrules.SecurityRule) (string, error) {
 	if len(secgroupId) > 0 {
-		_, total, err := region.GetSecurityGroups("", []string{secgroupId}, 0, 1)
+		_, total, err := region.GetSecurityGroups("", "", []string{secgroupId}, 0, 1)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/multicloud/aliyun/securitygroup.go
+++ b/pkg/multicloud/aliyun/securitygroup.go
@@ -172,7 +172,7 @@ func (self *SSecurityGroup) Refresh() error {
 	}
 }
 
-func (self *SRegion) GetSecurityGroups(vpcId string, securityGroupIds []string, offset int, limit int) ([]SSecurityGroup, int, error) {
+func (self *SRegion) GetSecurityGroups(vpcId, name string, securityGroupIds []string, offset int, limit int) ([]SSecurityGroup, int, error) {
 	if limit > 50 || limit <= 0 {
 		limit = 50
 	}
@@ -182,6 +182,9 @@ func (self *SRegion) GetSecurityGroups(vpcId string, securityGroupIds []string, 
 	params["PageNumber"] = fmt.Sprintf("%d", (offset/limit)+1)
 	if len(vpcId) > 0 {
 		params["VpcId"] = vpcId
+	}
+	if len(name) > 0 {
+		params["SecurityGroupName"] = name
 	}
 
 	if securityGroupIds != nil && len(securityGroupIds) > 0 {

--- a/pkg/multicloud/aliyun/shell/secgroup.go
+++ b/pkg/multicloud/aliyun/shell/secgroup.go
@@ -24,12 +24,13 @@ import (
 func init() {
 	type SecurityGroupListOptions struct {
 		VpcId            string   `help:"VPC ID"`
+		Name             string   `help:"Secgroup Name"`
 		SecurityGroupIds []string `help:"SecurityGroup ids"`
 		Limit            int      `help:"page size"`
 		Offset           int      `help:"page offset"`
 	}
 	shellutils.R(&SecurityGroupListOptions{}, "security-group-list", "List security group", func(cli *aliyun.SRegion, args *SecurityGroupListOptions) error {
-		secgrps, total, e := cli.GetSecurityGroups(args.VpcId, args.SecurityGroupIds, args.Offset, args.Limit)
+		secgrps, total, e := cli.GetSecurityGroups(args.VpcId, args.Name, args.SecurityGroupIds, args.Offset, args.Limit)
 		if e != nil {
 			return e
 		}

--- a/pkg/multicloud/aliyun/vpc.go
+++ b/pkg/multicloud/aliyun/vpc.go
@@ -174,7 +174,7 @@ func (self *SVpc) GetIWireById(wireId string) (cloudprovider.ICloudWire, error) 
 func (self *SVpc) fetchSecurityGroups() error {
 	secgroups := make([]SSecurityGroup, 0)
 	for {
-		parts, total, err := self.region.GetSecurityGroups(self.VpcId, []string{}, len(secgroups), 50)
+		parts, total, err := self.region.GetSecurityGroups(self.VpcId, "", []string{}, len(secgroups), 50)
 		if err != nil {
 			return err
 		}

--- a/pkg/multicloud/aws/region.go
+++ b/pkg/multicloud/aws/region.go
@@ -1017,7 +1017,21 @@ func (self *SRegion) GetILoadBalancerBackendGroups() ([]cloudprovider.ICloudLoad
 }
 
 func (self *SRegion) GetISecurityGroupById(secgroupId string) (cloudprovider.ICloudSecurityGroup, error) {
-	secgroups, total, err := self.GetSecurityGroups("", secgroupId, 0, 1)
+	secgroups, total, err := self.GetSecurityGroups("", "", secgroupId, 0, 1)
+	if err != nil {
+		return nil, err
+	}
+	if total == 0 {
+		return nil, cloudprovider.ErrNotFound
+	}
+	if total > 1 {
+		return nil, cloudprovider.ErrDuplicateId
+	}
+	return &secgroups[0], nil
+}
+
+func (self *SRegion) GetISecurityGroupByName(vpcId string, name string) (cloudprovider.ICloudSecurityGroup, error) {
+	secgroups, total, err := self.GetSecurityGroups(vpcId, name, "", 0, 1)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/multicloud/aws/securitygroup.go
+++ b/pkg/multicloud/aws/securitygroup.go
@@ -321,7 +321,7 @@ func (self *SRegion) getSecurityGroupById(vpcId, secgroupId string) (*SSecurityG
 		return nil, httperrors.NewInputParameterError("security group id should not be empty")
 	}
 
-	secgroups, total, err := self.GetSecurityGroups(vpcId, secgroupId, 0, 0)
+	secgroups, total, err := self.GetSecurityGroups(vpcId, "", secgroupId, 0, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -437,11 +437,15 @@ func (self *SRegion) getSecRules(ingress []*ec2.IpPermission, egress []*ec2.IpPe
 	return rules
 }
 
-func (self *SRegion) GetSecurityGroups(vpcId string, secgroupId string, offset int, limit int) ([]SSecurityGroup, int, error) {
+func (self *SRegion) GetSecurityGroups(vpcId string, name string, secgroupId string, offset int, limit int) ([]SSecurityGroup, int, error) {
 	params := &ec2.DescribeSecurityGroupsInput{}
 	filters := make([]*ec2.Filter, 0)
 	if len(vpcId) > 0 {
 		filters = AppendSingleValueFilter(filters, "vpc-id", vpcId)
+	}
+
+	if len(name) > 0 {
+		filters = AppendSingleValueFilter(filters, "group-name", name)
 	}
 
 	if len(secgroupId) > 0 {

--- a/pkg/multicloud/aws/shell/secgroup.go
+++ b/pkg/multicloud/aws/shell/secgroup.go
@@ -22,11 +22,12 @@ import (
 func init() {
 	type SecurityGroupListOptions struct {
 		VpcId  string `help:"VPC ID"`
+		Name   string `help:"Secgroup name"`
 		Limit  int    `help:"page size"`
 		Offset int    `help:"page offset"`
 	}
 	shellutils.R(&SecurityGroupListOptions{}, "security-group-list", "List security group", func(cli *aws.SRegion, args *SecurityGroupListOptions) error {
-		secgrps, total, e := cli.GetSecurityGroups(args.VpcId, "", args.Offset, args.Limit)
+		secgrps, total, e := cli.GetSecurityGroups(args.VpcId, args.Name, "", args.Offset, args.Limit)
 		if e != nil {
 			return e
 		}

--- a/pkg/multicloud/aws/vpc.go
+++ b/pkg/multicloud/aws/vpc.go
@@ -233,7 +233,7 @@ func (self *SVpc) assignSecurityGroup(secgroupId string, instanceId string) erro
 }
 
 func (self *SVpc) fetchSecurityGroups() error {
-	secgroups, _, err := self.region.GetSecurityGroups(self.VpcId, "", 0, 0)
+	secgroups, _, err := self.region.GetSecurityGroups(self.VpcId, "", "", 0, 0)
 	if err != nil {
 		return err
 	}

--- a/pkg/multicloud/azure/classic_secruitygroup.go
+++ b/pkg/multicloud/azure/classic_secruitygroup.go
@@ -226,7 +226,7 @@ func (region *SRegion) CreateClassicSecurityGroup(name string) (*SClassicSecurit
 	return &secgroup, region.client.Create(jsonutils.Marshal(secgroup), &secgroup)
 }
 
-func (region *SRegion) GetClassicSecurityGroups() ([]SClassicSecurityGroup, error) {
+func (region *SRegion) GetClassicSecurityGroups(name string) ([]SClassicSecurityGroup, error) {
 	secgroups := []SClassicSecurityGroup{}
 	err := region.client.ListAll("Microsoft.ClassicNetwork/networkSecurityGroups", &secgroups)
 	if err != nil {
@@ -234,7 +234,7 @@ func (region *SRegion) GetClassicSecurityGroups() ([]SClassicSecurityGroup, erro
 	}
 	result := []SClassicSecurityGroup{}
 	for i := 0; i < len(secgroups); i++ {
-		if secgroups[i].Location == region.Name {
+		if secgroups[i].Location == region.Name && (len(name) == 0 || strings.ToLower(secgroups[i].Name) == strings.ToLower(name)) {
 			result = append(result, secgroups[i])
 		}
 	}

--- a/pkg/multicloud/azure/classic_vpc.go
+++ b/pkg/multicloud/azure/classic_vpc.go
@@ -121,7 +121,7 @@ func (self *SClassicVpc) fetchNetworks() error {
 }
 
 func (self *SClassicVpc) getClassicSecurityGroups() ([]SClassicSecurityGroup, error) {
-	securityGroups, err := self.region.GetClassicSecurityGroups()
+	securityGroups, err := self.region.GetClassicSecurityGroups("")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/multicloud/azure/region.go
+++ b/pkg/multicloud/azure/region.go
@@ -537,6 +537,33 @@ func (region *SRegion) GetISecurityGroupById(secgroupId string) (cloudprovider.I
 	return region.GetSecurityGroupDetails(secgroupId)
 }
 
+func (region *SRegion) GetISecurityGroupByName(vpcId string, name string) (cloudprovider.ICloudSecurityGroup, error) {
+	if strings.Contains(strings.ToLower(vpcId), "microsoft.classicnetwork") {
+		secgroups, err := region.GetClassicSecurityGroups(name)
+		if err != nil {
+			return nil, err
+		}
+		if len(secgroups) == 0 {
+			return nil, cloudprovider.ErrNotFound
+		}
+		if len(secgroups) > 1 {
+			return nil, cloudprovider.ErrDuplicateId
+		}
+		return &secgroups[0], nil
+	}
+	secgroups, err := region.GetSecurityGroups(name)
+	if err != nil {
+		return nil, err
+	}
+	if len(secgroups) == 0 {
+		return nil, cloudprovider.ErrNotFound
+	}
+	if len(secgroups) > 1 {
+		return nil, cloudprovider.ErrDuplicateId
+	}
+	return &secgroups[0], nil
+}
+
 func (region *SRegion) CreateISecurityGroup(conf *cloudprovider.SecurityGroupCreateInput) (cloudprovider.ICloudSecurityGroup, error) {
 	if conf.VpcId == "classic" {
 		return region.CreateClassicSecurityGroup(conf.Desc)

--- a/pkg/multicloud/azure/securitygroup.go
+++ b/pkg/multicloud/azure/securitygroup.go
@@ -363,7 +363,7 @@ func (region *SRegion) CreateSecurityGroup(secName string) (*SSecurityGroup, err
 	return &secgroup, region.client.Create(jsonutils.Marshal(secgroup), &secgroup)
 }
 
-func (region *SRegion) GetSecurityGroups() ([]SSecurityGroup, error) {
+func (region *SRegion) GetSecurityGroups(name string) ([]SSecurityGroup, error) {
 	secgroups := []SSecurityGroup{}
 	err := region.client.ListAll("Microsoft.Network/networkSecurityGroups", &secgroups)
 	if err != nil {
@@ -371,7 +371,7 @@ func (region *SRegion) GetSecurityGroups() ([]SSecurityGroup, error) {
 	}
 	result := []SSecurityGroup{}
 	for i := 0; i < len(secgroups); i++ {
-		if secgroups[i].Location == region.Name {
+		if secgroups[i].Location == region.Name && (len(name) == 0 || strings.ToLower(secgroups[i].Name) == strings.ToLower(name)) {
 			secgroups[i].region = region
 			result = append(result, secgroups[i])
 		}

--- a/pkg/multicloud/azure/shell/secgroup.go
+++ b/pkg/multicloud/azure/shell/secgroup.go
@@ -21,20 +21,21 @@ import (
 
 func init() {
 	type SecurityGroupListOptions struct {
-		Classic bool `help:"List classic secgroups"`
-		Limit   int  `help:"page size"`
-		Offset  int  `help:"page offset"`
+		Classic bool   `help:"List classic secgroups"`
+		Name    string `help:"Secgroup name"`
+		Limit   int    `help:"page size"`
+		Offset  int    `help:"page offset"`
 	}
 	shellutils.R(&SecurityGroupListOptions{}, "security-group-list", "List security group", func(cli *azure.SRegion, args *SecurityGroupListOptions) error {
 		if args.Classic {
-			secgrps, err := cli.GetClassicSecurityGroups()
+			secgrps, err := cli.GetClassicSecurityGroups(args.Name)
 			if err != nil {
 				return err
 			}
 			printList(secgrps, len(secgrps), args.Offset, args.Limit, []string{})
 			return nil
 		}
-		secgrps, err := cli.GetSecurityGroups()
+		secgrps, err := cli.GetSecurityGroups(args.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/multicloud/azure/vpc.go
+++ b/pkg/multicloud/azure/vpc.go
@@ -102,14 +102,14 @@ func (self *SRegion) DeleteVpc(vpcId string) error {
 }
 
 func (self *SVpc) getSecurityGroups() ([]SSecurityGroup, error) {
-	if securityGroups, err := self.region.GetSecurityGroups(); err != nil {
+	securityGroups, err := self.region.GetSecurityGroups("")
+	if err != nil {
 		return nil, err
-	} else {
-		for i := 0; i < len(securityGroups); i++ {
-			securityGroups[i].vpc = self
-		}
-		return securityGroups, nil
 	}
+	for i := 0; i < len(securityGroups); i++ {
+		securityGroups[i].vpc = self
+	}
+	return securityGroups, nil
 }
 
 func (self *SVpc) fetchSecurityGroups() error {

--- a/pkg/multicloud/huawei/region.go
+++ b/pkg/multicloud/huawei/region.go
@@ -513,6 +513,21 @@ func (self *SRegion) GetISecurityGroupById(secgroupId string) (cloudprovider.ICl
 	return self.GetSecurityGroupDetails(secgroupId)
 }
 
+func (self *SRegion) GetISecurityGroupByName(vpcId string, name string) (cloudprovider.ICloudSecurityGroup, error) {
+	secgroups, err := self.GetSecurityGroups(vpcId, name)
+	if err != nil {
+		return nil, err
+	}
+	if len(secgroups) == 0 {
+		return nil, cloudprovider.ErrNotFound
+	}
+	if len(secgroups) > 1 {
+		return nil, cloudprovider.ErrDuplicateId
+	}
+	secgroups[0].region = self
+	return &secgroups[0], nil
+}
+
 func (self *SRegion) CreateISecurityGroup(conf *cloudprovider.SecurityGroupCreateInput) (cloudprovider.ICloudSecurityGroup, error) {
 	return self.CreateSecurityGroup(conf.VpcId, conf.Name, conf.Desc)
 }

--- a/pkg/multicloud/huawei/securitygroup.go
+++ b/pkg/multicloud/huawei/securitygroup.go
@@ -294,7 +294,7 @@ func (self *SRegion) GetSecurityGroupDetails(secGroupId string) (*SSecurityGroup
 }
 
 // https://support.huaweicloud.com/api-vpc/zh-cn_topic_0020090617.html
-func (self *SRegion) GetSecurityGroups(vpcId string) ([]SSecurityGroup, error) {
+func (self *SRegion) GetSecurityGroups(vpcId string, name string) ([]SSecurityGroup, error) {
 	querys := map[string]string{}
 	if len(vpcId) > 0 {
 		querys["vpc_id"] = vpcId
@@ -329,7 +329,14 @@ func (self *SRegion) GetSecurityGroups(vpcId string) ([]SSecurityGroup, error) {
 		}
 	}
 
-	return securitygroups, nil
+	result := []SSecurityGroup{}
+	for _, secgroup := range securitygroups {
+		if len(name) == 0 || secgroup.Name == name {
+			result = append(result, secgroup)
+		}
+	}
+
+	return result, nil
 }
 
 func (self *SSecurityGroup) GetProjectId() string {

--- a/pkg/multicloud/huawei/shell/secgroup.go
+++ b/pkg/multicloud/huawei/shell/secgroup.go
@@ -22,9 +22,10 @@ import (
 func init() {
 	type SecurityGroupListOptions struct {
 		VpcId string `help:"VPC ID"`
+		Name  string `help:"Secgroup name"`
 	}
 	shellutils.R(&SecurityGroupListOptions{}, "security-group-list", "List security group", func(cli *huawei.SRegion, args *SecurityGroupListOptions) error {
-		secgrps, e := cli.GetSecurityGroups(args.VpcId)
+		secgrps, e := cli.GetSecurityGroups(args.VpcId, args.Name)
 		if e != nil {
 			return e
 		}

--- a/pkg/multicloud/huawei/vpc.go
+++ b/pkg/multicloud/huawei/vpc.go
@@ -88,7 +88,7 @@ func (self *SVpc) fetchNetworks() error {
 // 华为云安全组可以被同region的VPC使用
 func (self *SVpc) fetchSecurityGroups() error {
 	// todo： vpc 和 安全组的关联关系还需要进一步确认。
-	secgroups, err := self.region.GetSecurityGroups("")
+	secgroups, err := self.region.GetSecurityGroups("", "")
 	if err != nil {
 		return err
 	}

--- a/pkg/multicloud/openstack/region.go
+++ b/pkg/multicloud/openstack/region.go
@@ -511,6 +511,21 @@ func (region *SRegion) GetISecurityGroupById(secgroupId string) (cloudprovider.I
 	return region.GetSecurityGroup(secgroupId)
 }
 
+func (region *SRegion) GetISecurityGroupByName(vpcId string, name string) (cloudprovider.ICloudSecurityGroup, error) {
+	secgroups, err := region.GetSecurityGroups(name)
+	if err != nil {
+		return nil, err
+	}
+	if len(secgroups) == 0 {
+		return nil, cloudprovider.ErrNotFound
+	}
+	if len(secgroups) > 1 {
+		return nil, cloudprovider.ErrDuplicateId
+	}
+	secgroups[0].region = region
+	return &secgroups[0], nil
+}
+
 func (region *SRegion) CreateISecurityGroup(conf *cloudprovider.SecurityGroupCreateInput) (cloudprovider.ICloudSecurityGroup, error) {
 	return region.CreateSecurityGroup(conf.Name, conf.Desc)
 }

--- a/pkg/multicloud/openstack/securitygroup.go
+++ b/pkg/multicloud/openstack/securitygroup.go
@@ -92,8 +92,11 @@ func (region *SRegion) GetSecurityGroup(secgroupId string) (*SSecurityGroup, err
 	return secgroup, resp.Unmarshal(secgroup, "security_group")
 }
 
-func (region *SRegion) GetSecurityGroups() ([]SSecurityGroup, error) {
+func (region *SRegion) GetSecurityGroups(name string) ([]SSecurityGroup, error) {
 	url := "/v2.0/security-groups"
+	if len(name) > 0 {
+		url = fmt.Sprintf("%s?name=%s", url, name)
+	}
 	secgroups := []SSecurityGroup{}
 	for len(url) > 0 {
 		_, resp, err := region.List("network", url, "", nil)
@@ -258,7 +261,7 @@ func (region *SRegion) SyncSecurityGroup(secgroupId string, vpcId string, name s
 		}
 	}
 	if len(secgroupId) == 0 {
-		secgroups, err := region.GetSecurityGroups()
+		secgroups, err := region.GetSecurityGroups("")
 		if err != nil {
 			// 若返回 cloudprovider.ErrNotFound, 表明不支持安全组或者未安装安全组相关组件
 			if err == cloudprovider.ErrNotFound {

--- a/pkg/multicloud/openstack/shell/securitygroup.go
+++ b/pkg/multicloud/openstack/shell/securitygroup.go
@@ -21,9 +21,10 @@ import (
 
 func init() {
 	type SecurityGroupListOptions struct {
+		Name string
 	}
 	shellutils.R(&SecurityGroupListOptions{}, "security-group-list", "List security groups", func(cli *openstack.SRegion, args *SecurityGroupListOptions) error {
-		secgroup, err := cli.GetSecurityGroups()
+		secgroup, err := cli.GetSecurityGroups(args.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/multicloud/openstack/vpc.go
+++ b/pkg/multicloud/openstack/vpc.go
@@ -120,7 +120,7 @@ func (region *SRegion) DeleteVpc(vpcId string) error {
 }
 
 func (vpc *SVpc) GetISecurityGroups() ([]cloudprovider.ICloudSecurityGroup, error) {
-	secgroups, err := vpc.region.GetSecurityGroups()
+	secgroups, err := vpc.region.GetSecurityGroups("")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/multicloud/qcloud/region.go
+++ b/pkg/multicloud/qcloud/region.go
@@ -921,6 +921,20 @@ func (self *SRegion) GetISecurityGroupById(secgroupId string) (cloudprovider.ICl
 	return self.GetSecurityGroupDetails(secgroupId)
 }
 
+func (self *SRegion) GetISecurityGroupByName(vpcId string, name string) (cloudprovider.ICloudSecurityGroup, error) {
+	secgroups, total, err := self.GetSecurityGroups(vpcId, name, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+	if total == 0 {
+		return nil, cloudprovider.ErrNotFound
+	}
+	if total > 1 {
+		return nil, cloudprovider.ErrDuplicateId
+	}
+	return &secgroups[0], nil
+}
+
 func (self *SRegion) CreateISecurityGroup(conf *cloudprovider.SecurityGroupCreateInput) (cloudprovider.ICloudSecurityGroup, error) {
 	return self.CreateSecurityGroup(conf.Name, conf.Desc)
 }

--- a/pkg/multicloud/qcloud/securitygroup.go
+++ b/pkg/multicloud/qcloud/securitygroup.go
@@ -90,13 +90,18 @@ func (v SecurityGroupRuleSet) Less(i, j int) bool {
 	return false
 }
 
-func (self *SRegion) GetSecurityGroups(vpcId string, offset int, limit int) ([]SSecurityGroup, int, error) {
+func (self *SRegion) GetSecurityGroups(vpcId string, name string, offset int, limit int) ([]SSecurityGroup, int, error) {
 	if limit > 50 || limit <= 0 {
 		limit = 50
 	}
 	params := make(map[string]string)
 	params["Limit"] = fmt.Sprintf("%d", limit)
 	params["Offset"] = fmt.Sprintf("%d", offset)
+
+	if len(name) > 0 {
+		params["Filters.0.Name"] = "security-group-name"
+		params["Filters.0.Values.0"] = name
+	}
 
 	body, err := self.vpcRequest("DescribeSecurityGroups", params)
 	if err != nil {

--- a/pkg/multicloud/qcloud/shell/securitygroup.go
+++ b/pkg/multicloud/qcloud/shell/securitygroup.go
@@ -21,11 +21,12 @@ import (
 
 func init() {
 	type SecurityGroupListOptions struct {
-		Limit  int `help:"page size"`
-		Offset int `help:"page offset"`
+		Name   string `help:"Secgroup Name"`
+		Limit  int    `help:"page size"`
+		Offset int    `help:"page offset"`
 	}
 	shellutils.R(&SecurityGroupListOptions{}, "security-group-list", "List SecurityGroup", func(cli *qcloud.SRegion, args *SecurityGroupListOptions) error {
-		secgrps, total, err := cli.GetSecurityGroups("", args.Limit, args.Offset)
+		secgrps, total, err := cli.GetSecurityGroups("", args.Name, args.Limit, args.Offset)
 		if err != nil {
 			return err
 		}

--- a/pkg/multicloud/qcloud/vpc.go
+++ b/pkg/multicloud/qcloud/vpc.go
@@ -86,7 +86,7 @@ func (self *SVpc) Delete() error {
 func (self *SVpc) GetISecurityGroups() ([]cloudprovider.ICloudSecurityGroup, error) {
 	secgroups := make([]SSecurityGroup, 0)
 	for {
-		parts, total, err := self.region.GetSecurityGroups(self.VpcId, len(secgroups), 50)
+		parts, total, err := self.region.GetSecurityGroups(self.VpcId, "", len(secgroups), 50)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/multicloud/ucloud/instance.go
+++ b/pkg/multicloud/ucloud/instance.go
@@ -558,7 +558,7 @@ func (self *SInstance) Renew(bc billing.SBillingCycle) error {
 }
 
 func (self *SInstance) GetSecurityGroups() ([]SSecurityGroup, error) {
-	return self.host.zone.region.GetSecurityGroups("", self.GetId())
+	return self.host.zone.region.GetSecurityGroups("", self.GetId(), "")
 }
 
 // https://docs.ucloud.cn/api/uhost-api/get_uhost_instance_vnc_info

--- a/pkg/multicloud/ucloud/region.go
+++ b/pkg/multicloud/ucloud/region.go
@@ -202,6 +202,20 @@ func (self *SRegion) GetISecurityGroupById(secgroupId string) (cloudprovider.ICl
 	return self.GetSecurityGroupById(secgroupId)
 }
 
+func (self *SRegion) GetISecurityGroupByName(vpcId string, name string) (cloudprovider.ICloudSecurityGroup, error) {
+	secgroups, err := self.GetSecurityGroups("", "", name)
+	if err != nil {
+		return nil, err
+	}
+	if len(secgroups) == 0 {
+		return nil, cloudprovider.ErrNotFound
+	}
+	if len(secgroups) > 1 {
+		return nil, cloudprovider.ErrDuplicateId
+	}
+	return &secgroups[0], nil
+}
+
 func (self *SRegion) CreateISecurityGroup(conf *cloudprovider.SecurityGroupCreateInput) (cloudprovider.ICloudSecurityGroup, error) {
 	externalId, err := self.CreateDefaultSecurityGroup(conf.Name, conf.Desc)
 	if err != nil {

--- a/pkg/multicloud/ucloud/securitygroup.go
+++ b/pkg/multicloud/ucloud/securitygroup.go
@@ -175,7 +175,7 @@ func (self *SSecurityGroup) GetVpcId() string {
 }
 
 func (self *SRegion) GetSecurityGroupById(secGroupId string) (*SSecurityGroup, error) {
-	secgroups, err := self.GetSecurityGroups(secGroupId, "")
+	secgroups, err := self.GetSecurityGroups(secGroupId, "", "")
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func (self *SRegion) CreateSecurityGroup(name, description string, rules []strin
 }
 
 // https://docs.ucloud.cn/api/unet-api/describe_firewall
-func (self *SRegion) GetSecurityGroups(secGroupId string, resourceId string) ([]SSecurityGroup, error) {
+func (self *SRegion) GetSecurityGroups(secGroupId string, resourceId string, name string) ([]SSecurityGroup, error) {
 	secgroups := make([]SSecurityGroup, 0)
 
 	params := NewUcloudParams()
@@ -252,11 +252,16 @@ func (self *SRegion) GetSecurityGroups(secGroupId string, resourceId string) ([]
 		return nil, err
 	}
 
+	result := []SSecurityGroup{}
+
 	for i := range secgroups {
-		secgroups[i].region = self
+		if len(name) == 0 || secgroups[i].Name == name {
+			secgroups[i].region = self
+			result = append(result, secgroups[i])
+		}
 	}
 
-	return secgroups, nil
+	return result, nil
 }
 
 func (self *SSecurityGroup) SyncRules(rules []secrules.SecurityRule) error {

--- a/pkg/multicloud/ucloud/shell/secgroup.go
+++ b/pkg/multicloud/ucloud/shell/secgroup.go
@@ -23,9 +23,10 @@ import (
 
 func init() {
 	type SecurityGroupListOptions struct {
+		Name string
 	}
 	shellutils.R(&SecurityGroupListOptions{}, "security-group-list", "List security group", func(cli *ucloud.SRegion, args *SecurityGroupListOptions) error {
-		secgrps, e := cli.GetSecurityGroups("", "")
+		secgrps, e := cli.GetSecurityGroups("", "", args.Name)
 		if e != nil {
 			return e
 		}

--- a/pkg/multicloud/ucloud/vpc.go
+++ b/pkg/multicloud/ucloud/vpc.go
@@ -226,7 +226,7 @@ func (self *SRegion) GetNetworks(vpcId string) ([]SNetwork, error) {
 
 // UCLOUD 同一个项目共用安全组（防火墙）
 func (self *SVPC) fetchSecurityGroups() error {
-	secgroups, err := self.region.GetSecurityGroups("", "")
+	secgroups, err := self.region.GetSecurityGroups("", "", "")
 	if err != nil {
 		return err
 	}

--- a/pkg/multicloud/zstack/instance.go
+++ b/pkg/multicloud/zstack/instance.go
@@ -92,7 +92,7 @@ func (region *SRegion) GetInstances(hostId string, instanceId string, nicId stri
 
 func (instance *SInstance) GetSecurityGroupIds() ([]string, error) {
 	ids := []string{}
-	secgroups, err := instance.host.zone.region.GetSecurityGroups("", instance.UUID)
+	secgroups, err := instance.host.zone.region.GetSecurityGroups("", instance.UUID, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/multicloud/zstack/region.go
+++ b/pkg/multicloud/zstack/region.go
@@ -359,6 +359,20 @@ func (region *SRegion) GetISecurityGroupById(secgroupId string) (cloudprovider.I
 	return region.GetSecurityGroup(secgroupId)
 }
 
+func (region *SRegion) GetISecurityGroupByName(vpcId string, name string) (cloudprovider.ICloudSecurityGroup, error) {
+	secgroups, err := region.GetSecurityGroups("", "", name)
+	if err != nil {
+		return nil, err
+	}
+	if len(secgroups) == 0 {
+		return nil, cloudprovider.ErrNotFound
+	}
+	if len(secgroups) > 1 {
+		return nil, cloudprovider.ErrDuplicateId
+	}
+	return &secgroups[0], nil
+}
+
 func (region *SRegion) CreateISecurityGroup(conf *cloudprovider.SecurityGroupCreateInput) (cloudprovider.ICloudSecurityGroup, error) {
 	return region.CreateSecurityGroup(conf.Name, conf.Desc)
 }

--- a/pkg/multicloud/zstack/securitygroup.go
+++ b/pkg/multicloud/zstack/securitygroup.go
@@ -79,7 +79,7 @@ func (region *SRegion) GetSecurityGroup(secgroupId string) (*SSecurityGroup, err
 	return secgroup, region.client.getResource("security-groups", secgroupId, secgroup)
 }
 
-func (region *SRegion) GetSecurityGroups(secgroupId string, instanceId string) ([]SSecurityGroup, error) {
+func (region *SRegion) GetSecurityGroups(secgroupId string, instanceId string, name string) ([]SSecurityGroup, error) {
 	secgroups := []SSecurityGroup{}
 	params := []string{}
 	if len(secgroupId) > 0 {
@@ -87,6 +87,9 @@ func (region *SRegion) GetSecurityGroups(secgroupId string, instanceId string) (
 	}
 	if len(instanceId) > 0 {
 		params = append(params, "q=vmNic.vmInstanceUuid="+instanceId)
+	}
+	if len(name) > 0 {
+		params = append(params, "q=name="+name)
 	}
 	err := region.client.listAll("security-groups", params, &secgroups)
 	if err != nil {

--- a/pkg/multicloud/zstack/shell/securitygroup.go
+++ b/pkg/multicloud/zstack/shell/securitygroup.go
@@ -21,11 +21,12 @@ import (
 
 func init() {
 	type SecurityGroupListOptions struct {
+		Name       string
 		SecgroupId string
 		InstanceId string
 	}
 	shellutils.R(&SecurityGroupListOptions{}, "security-group-list", "List secgroups", func(cli *zstack.SRegion, args *SecurityGroupListOptions) error {
-		secgroups, err := cli.GetSecurityGroups(args.SecgroupId, args.InstanceId)
+		secgroups, err := cli.GetSecurityGroups(args.SecgroupId, args.InstanceId, args.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/multicloud/zstack/vpc.go
+++ b/pkg/multicloud/zstack/vpc.go
@@ -97,7 +97,7 @@ func (vpc *SVpc) GetIWireById(wireId string) (cloudprovider.ICloudWire, error) {
 }
 
 func (vpc *SVpc) GetISecurityGroups() ([]cloudprovider.ICloudSecurityGroup, error) {
-	secgroups, err := vpc.region.GetSecurityGroups("", "")
+	secgroups, err := vpc.region.GetSecurityGroups("", "", "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry pick of #3569 on release/2.13.

#3569: fix: avolid duplicate secgroup name error when create secgroup