### PR TITLE
fix: 创建数据库时指定账号权限时，避免数据库出现中间状态

### DIFF
--- a/cmd/climc/shell/dbinstance_accounts.go
+++ b/cmd/climc/shell/dbinstance_accounts.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shell
+
+import (
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modules"
+	"yunion.io/x/onecloud/pkg/mcclient/options"
+)
+
+func init() {
+	type DBInstanceAccountListOptions struct {
+		options.BaseListOptions
+		DBInstance string `help:"ID or Name of DBInstance" json:"dbinstance"`
+	}
+	R(&DBInstanceAccountListOptions{}, "dbinstance-account-list", "List DB instance accounts", func(s *mcclient.ClientSession, opts *DBInstanceAccountListOptions) error {
+		params, err := options.ListStructToParams(opts)
+		if err != nil {
+			return err
+		}
+
+		result, err := modules.DBInstanceAccounts.List(s, params)
+		if err != nil {
+			return err
+		}
+		printList(result, modules.DBInstanceAccounts.GetColumns(s))
+		return nil
+	})
+
+	type DBInstanceAccountIdOptions struct {
+		ID string `help:"ID or Name of DBInstanceaccount"`
+	}
+
+	R(&DBInstanceAccountIdOptions{}, "dbinstance-account-show", "Show DB instance account", func(s *mcclient.ClientSession, opts *DBInstanceAccountIdOptions) error {
+		account, err := modules.DBInstanceAccounts.Get(s, opts.ID, nil)
+		if err != nil {
+			return err
+		}
+		printObject(account)
+		return nil
+	})
+
+	R(&DBInstanceAccountIdOptions{}, "dbinstance-account-delete", "Delete DB instance account", func(s *mcclient.ClientSession, opts *DBInstanceAccountIdOptions) error {
+		account, err := modules.DBInstanceAccounts.Delete(s, opts.ID, nil)
+		if err != nil {
+			return err
+		}
+		printObject(account)
+		return nil
+	})
+
+}

--- a/cmd/climc/shell/dbinstances.go
+++ b/cmd/climc/shell/dbinstances.go
@@ -312,37 +312,6 @@ func init() {
 		return nil
 	})
 
-	type DBInstanceAccountListOptions struct {
-		options.BaseListOptions
-		DBInstance string `help:"ID or Name of DBInstance" json:"dbinstance"`
-	}
-	R(&DBInstanceAccountListOptions{}, "dbinstance-account-list", "List DB instance accounts", func(s *mcclient.ClientSession, opts *DBInstanceAccountListOptions) error {
-		params, err := options.ListStructToParams(opts)
-		if err != nil {
-			return err
-		}
-
-		result, err := modules.DBInstanceAccounts.List(s, params)
-		if err != nil {
-			return err
-		}
-		printList(result, modules.DBInstanceAccounts.GetColumns(s))
-		return nil
-	})
-
-	type DBInstanceAccountIdOptions struct {
-		ID string `help:"ID or Name of DBInstanceaccount"`
-	}
-
-	R(&DBInstanceAccountIdOptions{}, "dbinstance-account-show", "Show DB instance account", func(s *mcclient.ClientSession, opts *DBInstanceAccountIdOptions) error {
-		account, err := modules.DBInstanceAccounts.Get(s, opts.ID, nil)
-		if err != nil {
-			return err
-		}
-		printObject(account)
-		return nil
-	})
-
 	type DBInstancePrivilegeListOptions struct {
 		options.BaseListOptions
 		DBInstanceaccount  string `help:"ID or Name of DBInstanceaccount" json:"dbinstanceaccount"`
@@ -359,6 +328,23 @@ func init() {
 			return err
 		}
 		printList(result, modules.DBInstancePrivileges.GetColumns(s))
+		return nil
+	})
+
+	type DBInstanceChangeOwnerOptions struct {
+		ID      string `help:"DBInstance to change owner" json:"-"`
+		PROJECT string `help:"Project ID or change" json:"tenant"`
+	}
+	R(&DBInstanceChangeOwnerOptions{}, "dbinstance-change-owner", "Change owner porject of a dbinstance", func(s *mcclient.ClientSession, opts *DBInstanceChangeOwnerOptions) error {
+		params, err := options.StructToParams(opts)
+		if err != nil {
+			return err
+		}
+		result, err := modules.DBInstance.PerformAction(s, opts.ID, "change-owner", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
 		return nil
 	})
 

--- a/pkg/apis/compute/dbinstance_const.go
+++ b/pkg/apis/compute/dbinstance_const.go
@@ -56,11 +56,12 @@ const (
 	BACKUP_MODE_MANUAL    = "manual"    //手动
 
 	//实例数据库状态
-	DBINSTANCE_DATABASE_CREATING      = "creating"      //创建中
-	DBINSTANCE_DATABASE_CREATE_FAILE  = "create_failed" //创建失败
-	DBINSTANCE_DATABASE_RUNNING       = "running"       //正常
-	DBINSTANCE_DATABASE_DELETING      = "deleting"      //删除中
-	DBINSTANCE_DATABASE_DELETE_FAILED = "delete_failed" //删除失败
+	DBINSTANCE_DATABASE_CREATING        = "creating"        //创建中
+	DBINSTANCE_DATABASE_CREATE_FAILE    = "create_failed"   //创建失败
+	DBINSTANCE_DATABASE_RUNNING         = "running"         //正常
+	DBINSTANCE_DATABASE_GRANT_PRIVILEGE = "grant_privilege" //赋予权限中
+	DBINSTANCE_DATABASE_DELETING        = "deleting"        //删除中
+	DBINSTANCE_DATABASE_DELETE_FAILED   = "delete_failed"   //删除失败
 
 	//实例用户状态
 	DBINSTANCE_USER_UNAVAILABLE         = "unavailable"         //不可用

--- a/pkg/apis/compute/dbinstance_database.go
+++ b/pkg/apis/compute/dbinstance_database.go
@@ -18,7 +18,7 @@ import "yunion.io/x/onecloud/pkg/apis"
 
 type SDBInstanceDatabasePrivilege struct {
 	Account             string
-	DBInstancedccountId string
+	DBInstanceaccountId string
 	Privilege           string
 }
 

--- a/pkg/compute/models/dbinstance_databases.go
+++ b/pkg/compute/models/dbinstance_databases.go
@@ -138,7 +138,7 @@ func (manager *SDBInstanceDatabaseManager) ValidateCreateData(ctx context.Contex
 		if err != nil {
 			return nil, httperrors.NewInputParameterError("failed to found dbinstance %s(%s) account %s: %v", instance.Name, instance.Id, _account.Account, err)
 		}
-		input.Accounts[i].DBInstancedccountId = account.Id
+		input.Accounts[i].DBInstanceaccountId = account.Id
 	}
 
 	input, err = region.GetDriver().ValidateCreateDBInstanceDatabaseData(ctx, userCred, ownerId, instance, input)
@@ -176,6 +176,15 @@ func (self *SDBInstanceDatabase) GetDBInstance() (*SDBInstance, error) {
 		return nil, err
 	}
 	return instance.(*SDBInstance), nil
+}
+
+func (self *SDBInstanceDatabase) GetExtraDetails(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (*jsonutils.JSONDict, error) {
+	extra, err := self.SVirtualResourceBase.GetExtraDetails(ctx, userCred, query)
+	if err != nil {
+		return nil, err
+	}
+
+	return self.getMoreDetails(ctx, userCred, extra)
 }
 
 func (self *SDBInstanceDatabase) GetCustomizeColumns(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) *jsonutils.JSONDict {

--- a/pkg/multicloud/aliyun/shell/dbinstance_account.go
+++ b/pkg/multicloud/aliyun/shell/dbinstance_account.go
@@ -63,7 +63,7 @@ func init() {
 		AccountType string `help:"account type" choices:"Normal|Super" default:"Normal"`
 	}
 
-	shellutils.R(&DBInstanceAccountResetOptions{}, "dbinstance-account-delete", "Delete dbintance account", func(cli *aliyun.SRegion, args *DBInstanceAccountResetOptions) error {
+	shellutils.R(&DBInstanceAccountResetOptions{}, "dbinstance-account-reset-password", "Reset dbintance account password", func(cli *aliyun.SRegion, args *DBInstanceAccountResetOptions) error {
 		return cli.ResetDBInstanceAccountPassword(args.INSTANCE, args.NAME, args.PASSWORD, args.AccountType)
 	})
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
创建数据库时指定账号权限时，避免数据库出现中间状态

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu @yousong 
