### PR TITLE
fix(region): Init database table 'guestgroup_tbl'

### DIFF
--- a/pkg/compute/service/handlers.go
+++ b/pkg/compute/service/handlers.go
@@ -59,6 +59,7 @@ func InitHandlers(app *appsrv.Application) {
 		models.QuotaUsageManager,
 
 		models.SnapshotPolicyCacheManager,
+		models.GroupguestManager,
 	} {
 		db.RegisterModelManager(manager)
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

That delete models.GroupguestManager in the second loop of InitHandlers
because of useless Groupguest's api cause that table 'guestgroup_tbl' will
not inited in a new system. So add models.GroupguestManager to the first
loop to accomplish the goal.

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
