### PR TITLE
Automated cherry pick of #3663: fix: aws 安全组desc为必传字段

### DIFF
--- a/pkg/multicloud/aws/region.go
+++ b/pkg/multicloud/aws/region.go
@@ -1045,7 +1045,7 @@ func (self *SRegion) GetISecurityGroupByName(vpcId string, name string) (cloudpr
 }
 
 func (self *SRegion) CreateISecurityGroup(conf *cloudprovider.SecurityGroupCreateInput) (cloudprovider.ICloudSecurityGroup, error) {
-	groupId, err := self.createSecurityGroup(conf.VpcId, conf.Name, "", conf.Desc)
+	groupId, err := self.CreateSecurityGroup(conf.VpcId, conf.Name, "", conf.Desc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/multicloud/aws/securitygroup.go
+++ b/pkg/multicloud/aws/securitygroup.go
@@ -227,10 +227,13 @@ func (self *SRegion) updateSecurityGroupRuleDescription(secGrpId string, rule *s
 	return nil
 }
 
-func (self *SRegion) createSecurityGroup(vpcId string, name string, secgroupIdTag string, desc string) (string, error) {
+func (self *SRegion) CreateSecurityGroup(vpcId string, name string, secgroupIdTag string, desc string) (string, error) {
 	params := &ec2.CreateSecurityGroupInput{}
 	params.SetVpcId(vpcId)
 	// 这里的描述aws 上层代码拼接的描述。并非用户提交的描述，用户描述放置在Yunion本地数据库中。）
+	if len(desc) == 0 {
+		desc = "vpc default group"
+	}
 	params.SetDescription(desc)
 	params.SetGroupName(name)
 
@@ -259,7 +262,7 @@ func (self *SRegion) createSecurityGroup(vpcId string, name string, secgroupIdTa
 
 func (self *SRegion) createDefaultSecurityGroup(vpcId string) (string, error) {
 	name := randomString(fmt.Sprintf("%s-", vpcId), 9)
-	secId, err := self.createSecurityGroup(vpcId, name, "default", "vpc default group")
+	secId, err := self.CreateSecurityGroup(vpcId, name, "default", "vpc default group")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/multicloud/aws/shell/secgroup.go
+++ b/pkg/multicloud/aws/shell/secgroup.go
@@ -15,6 +15,8 @@
 package shell
 
 import (
+	"fmt"
+
 	"yunion.io/x/onecloud/pkg/multicloud/aws"
 	"yunion.io/x/onecloud/pkg/util/shellutils"
 )
@@ -46,4 +48,20 @@ func init() {
 		printObject(secgrp)
 		return nil
 	})
+
+	type SecurityGroupCreateOptions struct {
+		VPC  string `help:"vpcId"`
+		NAME string `help:"group name"`
+		DESC string `help:"group desc"`
+		Tag  string `help:"group tag"`
+	}
+	shellutils.R(&SecurityGroupCreateOptions{}, "security-group-create", "Create  security group", func(cli *aws.SRegion, args *SecurityGroupCreateOptions) error {
+		id, err := cli.CreateSecurityGroup(args.VPC, args.NAME, args.Tag, args.DESC)
+		if err != nil {
+			return err
+		}
+		fmt.Println(id)
+		return nil
+	})
+
 }

--- a/pkg/multicloud/aws/vpc.go
+++ b/pkg/multicloud/aws/vpc.go
@@ -168,7 +168,7 @@ func (self *SRegion) SyncSecurityGroup(secgroupId string, vpcId string, name str
 			desc = fmt.Sprintf("security group %s for vpc %s", name, vpcId)
 		}
 
-		if secgrpId, err = self.createSecurityGroup(vpcId, name, secgroupId, desc); err != nil {
+		if secgrpId, err = self.CreateSecurityGroup(vpcId, name, secgroupId, desc); err != nil {
 			return "", err
 		}
 


### PR DESCRIPTION
Cherry pick of #3663 on release/2.12.

#3663: fix: aws 安全组desc为必传字段