### PR TITLE
fix: 避免有些云不能创建default名称安全组

### DIFF
--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -1424,6 +1424,9 @@ func (self *SManagedVirtualizationRegionDriver) RequestSyncSecurityGroup(ctx con
 	}
 
 	if len(cache.ExternalId) == 0 {
+		if strings.ToLower(secgroup.Name) == "default" { //避免有些云不支持default关键字
+			secgroup.Name = "DefaultGroup"
+		}
 		// 避免有的云不支持重名安全组
 		groupName := secgroup.Name
 		for i := 0; i < 30; i++ {

--- a/pkg/multicloud/aws/securitygroup.go
+++ b/pkg/multicloud/aws/securitygroup.go
@@ -235,6 +235,9 @@ func (self *SRegion) CreateSecurityGroup(vpcId string, name string, secgroupIdTa
 		desc = "vpc default group"
 	}
 	params.SetDescription(desc)
+	if strings.ToLower(name) == "default" {
+		name = randomString(fmt.Sprintf("%s-", vpcId), 9)
+	}
 	params.SetGroupName(name)
 
 	group, err := self.ec2Client.CreateSecurityGroup(params)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免有些云不能创建default名称安全组

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu 
