### PR TITLE
bugfix: bm register find network

### DIFF
--- a/pkg/compute/misc/handler.go
+++ b/pkg/compute/misc/handler.go
@@ -50,12 +50,7 @@ func getBmAgentUrl(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	n, _ := models.NetworkManager.GetOnPremiseNetworkOfIP(
-		ipAddr, compute.NETWORK_TYPE_BAREMETAL, tristate.None)
-	if n == nil {
-		n, _ = models.NetworkManager.GetOnPremiseNetworkOfIP(
-			ipAddr, compute.NETWORK_TYPE_IPMI, tristate.None)
-	}
+	n, _ := models.NetworkManager.GetOnPremiseNetworkOfIP(ipAddr, "", tristate.None)
 	if n == nil {
 		httperrors.NotFoundError(w, "Network not found")
 		return


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
bugfix: bm register find network

创建裸金属的时候没有对网络类型做限制，所以这里也不做

**是否需要 backport 到之前的 release 分支**:
release/2.12
/cc @swordqiu @zexi 
/area region
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
