### PR TITLE
fix: cpuCmtbound sync for zstack

### DIFF
--- a/pkg/cloudprovider/resources.go
+++ b/pkg/cloudprovider/resources.go
@@ -230,6 +230,7 @@ type ICloudHost interface {
 	GetCpuCmtbound() float32
 	GetMemSizeMB() int
 	GetMemCmtbound() float32
+	GetReservedMemoryMb() int
 	GetStorageSizeMB() int
 	GetStorageType() string
 	GetHostType() string

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -1423,6 +1423,10 @@ func (self *SHost) syncWithCloudHost(ctx context.Context, userCred mcclient.Toke
 			self.MemCmtbound = memCmt
 		}
 
+		if reservedMem := extHost.GetReservedMemoryMb(); reservedMem > 0 {
+			self.MemReserved = reservedMem
+		}
+
 		self.IsEmulated = extHost.IsEmulated()
 		self.Enabled = extHost.GetEnabled()
 
@@ -1522,6 +1526,10 @@ func (manager *SHostManager) newFromCloudHost(ctx context.Context, userCred mccl
 	host.MemCmtbound = 1.0
 	if memCmt := extHost.GetMemCmtbound(); memCmt > 0 {
 		host.MemCmtbound = memCmt
+	}
+
+	if reservedMem := extHost.GetReservedMemoryMb(); reservedMem > 0 {
+		host.MemReserved = reservedMem
 	}
 
 	host.ManagerId = provider.Id

--- a/pkg/multicloud/host_base.go
+++ b/pkg/multicloud/host_base.go
@@ -24,3 +24,7 @@ func (self *SHostBase) GetCpuCmtbound() float32 {
 func (self *SHostBase) GetMemCmtbound() float32 {
 	return 0.0
 }
+
+func (self *SHostBase) GetReservedMemoryMb() int {
+	return 0
+}

--- a/pkg/multicloud/openstack/host.go
+++ b/pkg/multicloud/openstack/host.go
@@ -27,6 +27,7 @@ import (
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/multicloud"
 )
 
 const (
@@ -56,6 +57,7 @@ type SResource struct {
 }
 
 type SHost struct {
+	multicloud.SHostBase
 	zone *SZone
 
 	CpuInfo string

--- a/pkg/multicloud/zstack/host.go
+++ b/pkg/multicloud/zstack/host.go
@@ -200,7 +200,26 @@ func (host *SHost) GetSN() string {
 	return ""
 }
 
+func (host *SHost) GetReservedMemoryMb() int {
+	host.zone.fetchHostCmtbound()
+	return host.zone.reservedMemeoryMb
+}
+
+func (host *SHost) GetCpuCmtbound() float32 {
+	host.zone.fetchHostCmtbound()
+	return host.zone.cpuCmtbound
+}
+
+func (host *SHost) GetMemCmtbound() float32 {
+	host.zone.fetchHostCmtbound()
+	return host.zone.memCmtbound
+}
+
 func (host *SHost) GetCpuCount() int {
+	cpuCmtBound := host.GetCpuCmtbound()
+	if cpuCmtBound > 0 {
+		return int(float32(host.TotalCPUCapacity) / cpuCmtBound)
+	}
 	return host.TotalCPUCapacity
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
同步zstack超售比及预留内存信息

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @swordqiu @yousong 
