### PR TITLE
Automated cherry pick of #3703: webconsole: skip spice access interval check

### DIFF
--- a/pkg/webconsole/session/session.go
+++ b/pkg/webconsole/session/session.go
@@ -84,8 +84,9 @@ func (man *SSessionManager) Get(accessToken string) (*SSession, bool) {
 		return nil, false
 	}
 	s := obj.(*SSession)
-	if time.Since(s.AccessedAt) < AccessInterval {
-		log.Warningf("Token: %s, Session: %s can't be accessed during %s, last accessed at: %s", accessToken, s.Id, AccessInterval, s.AccessedAt)
+	protocol := s.GetProtocol()
+	if protocol != SPICE && time.Since(s.AccessedAt) < AccessInterval {
+		log.Warningf("Protol: %q, Token: %s, Session: %s can't be accessed during %s, last accessed at: %s", s.GetProtocol(), accessToken, s.Id, AccessInterval, s.AccessedAt)
 		return nil, false
 	}
 	s.AccessedAt = time.Now()


### PR DESCRIPTION
Cherry pick of #3703 on release/2.13.

#3703: webconsole: skip spice access interval check