### PR TITLE
fix: always lock login-failed user when PasswordErrorLockCount not initialized

### DIFF
--- a/pkg/keystone/driver/sql/sql.go
+++ b/pkg/keystone/driver/sql/sql.go
@@ -57,7 +57,7 @@ func (sql *SSQLDriver) Authenticate(ctx context.Context, ident mcclient.SAuthent
 	err = models.VerifyPassword(usrExt, ident.Password.User.Password)
 	if err != nil {
 		localUser.SaveFailedAuth()
-		if localUser.FailedAuthCount > o.Options.PasswordErrorLockCount {
+		if o.Options.PasswordErrorLockCount > 0 && localUser.FailedAuthCount > o.Options.PasswordErrorLockCount {
 			models.UserManager.LockUser(usrExt.Id)
 		}
 		return nil, errors.Wrap(err, "usrExt.VerifyPassword")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：当PasswordErrorLockCount未初始化时，只要用户登录失败就被lock

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13

/area keystone

/cc @zexi @yousong 