### PR TITLE
Automated cherry pick of #3728: fix: always lock login-failed user when PasswordErrorLockCount not initialized

### DIFF
--- a/pkg/keystone/driver/sql/sql.go
+++ b/pkg/keystone/driver/sql/sql.go
@@ -57,7 +57,7 @@ func (sql *SSQLDriver) Authenticate(ctx context.Context, ident mcclient.SAuthent
 	err = models.VerifyPassword(usrExt, ident.Password.User.Password)
 	if err != nil {
 		localUser.SaveFailedAuth()
-		if localUser.FailedAuthCount > o.Options.PasswordErrorLockCount {
+		if o.Options.PasswordErrorLockCount > 0 && localUser.FailedAuthCount > o.Options.PasswordErrorLockCount {
 			models.UserManager.LockUser(usrExt.Id)
 		}
 		return nil, errors.Wrap(err, "usrExt.VerifyPassword")


### PR DESCRIPTION
Cherry pick of #3728 on release/2.12.

#3728: fix: always lock login-failed user when PasswordErrorLockCount not initialized