### PR TITLE
build: 避免并发构建rpm时触发file exists错误

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -134,7 +134,11 @@ fi
 
 rpmbuild --define "_topdir $BUILDROOT" -bb $SPEC_FILE
 
-mkdir -p $OUTPUT_DIR
-cp -fr $RPM_DIR/* $OUTPUT_DIR/
+find $RPM_DIR -type f | while read f; do
+	d="$(dirname "$f")"
+	d="$OUTPUT_DIR/${d#$RPM_DIR}"
+	mkdir -p "$d"
+	cp $f $d
+done
 
 rm -fr $BUILDROOT


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
build: 避免并发构建rpm时触发file exists错误
```

**是否需要 backport 到之前的 release 分支**:

- release/2.10.0

/cc @zhasm @swordqiu 