### PR TITLE
Automated cherry pick of #3731: build: 避免并发构建rpm时触发file exists错误

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -134,7 +134,11 @@ fi
 
 rpmbuild --define "_topdir $BUILDROOT" -bb $SPEC_FILE
 
-mkdir -p $OUTPUT_DIR
-cp -fr $RPM_DIR/* $OUTPUT_DIR/
+find $RPM_DIR -type f | while read f; do
+	d="$(dirname "$f")"
+	d="$OUTPUT_DIR/${d#$RPM_DIR}"
+	mkdir -p "$d"
+	cp $f $d
+done
 
 rm -fr $BUILDROOT


### PR DESCRIPTION
Cherry pick of #3731 on release/2.11.

#3731: build: 避免并发构建rpm时触发file exists错误