### PR TITLE
fix: Add snapshotpolicycache module for yunionapi

### DIFF
--- a/pkg/compute/service/handlers.go
+++ b/pkg/compute/service/handlers.go
@@ -58,7 +58,6 @@ func InitHandlers(app *appsrv.Application) {
 		models.QuotaManager,
 		models.QuotaUsageManager,
 
-		models.SnapshotPolicyCacheManager,
 		models.GroupguestManager,
 	} {
 		db.RegisterModelManager(manager)

--- a/pkg/mcclient/modules/mod_snapshotpolicycache.go
+++ b/pkg/mcclient/modules/mod_snapshotpolicycache.go
@@ -1,0 +1,28 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modules
+
+import "yunion.io/x/onecloud/pkg/mcclient/modulebase"
+
+var SnapshotPolicyCache modulebase.ResourceManager
+
+func init() {
+	SnapshotPolicyCache = NewComputeManager("snapshotpolicycache", "snapshotpolicycaches",
+		[]string{"Snapshotpolicy_Id", "External_Id", "Cloudregion_Id", "Manager_Id"},
+		[]string{},
+	)
+
+	registerCompute(&SnapshotPolicyCache)
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

Remove extra 'models.SnapshotPolicyCache' in the first loop in
handlers.go.
Registered the moduels of snapshotpolicycache for yunionapi.

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
