### PR TITLE
fix(region): Fix the return value when sycning snapshotpolicy

### DIFF
--- a/pkg/compute/models/snapshotpolicy.go
+++ b/pkg/compute/models/snapshotpolicy.go
@@ -412,7 +412,7 @@ func (manager *SSnapshotPolicyManager) SyncSnapshotPolicies(ctx context.Context,
 			syncResult.Add()
 		}
 	}
-	return compare.SyncResult{}
+	return syncResult
 }
 
 func (manager *SSnapshotPolicyManager) newFromCloudSnapshotPolicy(


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

This is a big bug: the return value of SyncSnapshotPolicies is a empty
value.

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12
- release/2.13
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
