### PR TITLE
fix: filter out expire user passwords

### DIFF
--- a/pkg/keystone/models/users.go
+++ b/pkg/keystone/models/users.go
@@ -302,7 +302,7 @@ func localUserVerifyPassword(user *api.SUserExtended, passwd string) error {
 		return nil
 	}
 	// password expiration check skip system account
-	if !passes[0].ExpiresAt.IsZero() && passes[0].ExpiresAt.Before(time.Now()) && !user.IsSystemAccount {
+	if !passes[0].IsExpired() && !user.IsSystemAccount {
 		return errors.Error("password expires")
 	}
 	err = seclib2.BcryptVerifyPassword(passwd, passes[0].PasswordHash)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：去掉多余的过滤过期密码的查询条件，避免密码过期后，无法找到用户的密码

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13

/area keystone

/cc @zexi @yousong 