### PR TITLE
fix(region): Cluster automatically when syncing snapshotpolicy

### DIFF
--- a/pkg/compute/models/snapshotpolicy_test.go
+++ b/pkg/compute/models/snapshotpolicy_test.go
@@ -1,0 +1,72 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"testing"
+
+	"yunion.io/x/log"
+	"yunion.io/x/pkg/tristate"
+)
+
+func TestSSnapshotPolicy_Key(t *testing.T) {
+	cases := []struct {
+		in   *SSnapshotPolicy
+		want uint64
+	}{
+		{
+			&SSnapshotPolicy{
+				RepeatWeekdays: 0,
+				TimePoints:     0,
+				RetentionDays:  7,
+				IsActivated:    tristate.True,
+			},
+			15 + 2,
+		},
+		{
+			&SSnapshotPolicy{
+				RepeatWeekdays: 11,
+			},
+			11<<56 + 2,
+		},
+		{
+			&SSnapshotPolicy{
+				TimePoints: 234,
+			},
+			234<<24 + 2,
+		},
+		{
+			&SSnapshotPolicy{
+				RetentionDays: -1,
+			},
+			0,
+		},
+		{
+			&SSnapshotPolicy{
+				RepeatWeekdays: 13,
+				TimePoints:     123,
+				RetentionDays:  7,
+			},
+			936748724556660752,
+		},
+	}
+
+	for i, c := range cases {
+		g := c.in.Key()
+		if c.want != g {
+			log.Errorf("the %d case, want %d, get %d", i, c.want, g)
+		}
+	}
+}

--- a/pkg/compute/models/snapshotpolicycache.go
+++ b/pkg/compute/models/snapshotpolicycache.go
@@ -76,7 +76,7 @@ func (spcm *SSnapshotPolicyCacheManager) ListItemFilter(ctx context.Context, q *
 	if err != nil {
 		return nil, err
 	}
-	if snapshotpolicyIden, _ := query.GetString("snapshotpolicyIden"); len(snapshotpolicyIden) > 0 {
+	if snapshotpolicyIden, _ := query.GetString("snapshotpolicy"); len(snapshotpolicyIden) > 0 {
 		snapshotpolicy, err := SnapshotPolicyManager.FetchByIdOrName(userCred, snapshotpolicyIden)
 		if err != nil {
 			if errors.Cause(err) == sql.ErrNoRows {
@@ -116,6 +116,10 @@ func (spc *SSnapshotPolicyCache) GetCustomizeColumns(ctx context.Context, userCr
 	regionInfo := spc.SCloudregionResourceBase.GetCustomizeColumns(ctx, userCred, query)
 	if regionInfo != nil {
 		extra.Update(regionInfo)
+	}
+	accountInfo := spc.SManagedResourceBase.GetCustomizeColumns(ctx, userCred, query)
+	if accountInfo != nil {
+		extra.Update(accountInfo)
 	}
 	return extra
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

Fix two bug about listing snapshotpolicycache:
1. no accont info 
2. filter error

The func 'Key' of snapshotpolicy generate a Identification for
snapshotpolicy. If the key of cloud snapshotpolicy is same with local
snaphotpolicy, the cloud sp became a cache of this local sp.

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
