### PR TITLE
fix: cloudaccount list duplicate entries due to join with cloudproviders

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -1666,6 +1666,7 @@ func (manager *SCloudaccountManager) FilterByOwner(q *sqlchemy.SQuery, owner mcc
 					q.Field("id"),
 					cloudproviders.Field("cloudaccount_id"),
 				))
+				q = q.Distinct()
 				q = q.Filter(sqlchemy.OR(
 					sqlchemy.AND(
 						sqlchemy.Equals(q.Field("domain_id"), owner.GetProjectDomainId()),


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：由于和cloudproviders表join导致cloudaccounts列表出现重复数据

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13

/area region

/cc @yousong @zexi 