### PR TITLE
Automated cherry pick of #3763: fix: cloudaccount list duplicate entries due to join with cloudproviders

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -1656,6 +1656,7 @@ func (manager *SCloudaccountManager) FilterByOwner(q *sqlchemy.SQuery, owner mcc
 					q.Field("id"),
 					cloudproviders.Field("cloudaccount_id"),
 				))
+				q = q.Distinct()
 				q = q.Filter(sqlchemy.OR(
 					sqlchemy.AND(
 						sqlchemy.Equals(q.Field("domain_id"), owner.GetProjectDomainId()),


### PR DESCRIPTION
Cherry pick of #3763 on release/2.12.

#3763: fix: cloudaccount list duplicate entries due to join with cloudproviders