### PR TITLE
fix(region): Add public/private feature for Guest Image

### DIFF
--- a/pkg/image/models/image_guest.go
+++ b/pkg/image/models/image_guest.go
@@ -500,3 +500,35 @@ func (self *SGuestImageManager) CleanPendingDeleteImages(ctx context.Context, us
 		images[i].startDeleteTask(ctx, userCred, "", false, true)
 	}
 }
+
+func (self *SGuestImage) PerformPublic(ctx context.Context, userCred mcclient.TokenCredential,
+	query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+
+	images, err := GuestImageJointManager.GetImagesByGuestImageId(self.Id)
+	if err != nil {
+		return nil, errors.Wrap(err, "fail to fetch subimages of guest image")
+	}
+	for i := range images {
+		_, err := images[i].PerformPublic(ctx, userCred, query, data)
+		if err != nil {
+			return nil, errors.Wrapf(err, "fail to public subimage %s", images[i].GetId())
+		}
+	}
+	return self.SSharableVirtualResourceBase.PerformPublic(ctx, userCred, query, data)
+}
+
+func (self *SGuestImage) PerformPrivate(ctx context.Context, userCred mcclient.TokenCredential,
+	query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+
+	images, err := GuestImageJointManager.GetImagesByGuestImageId(self.Id)
+	if err != nil {
+		return nil, errors.Wrap(err, "fail to fetch subimages of guest image")
+	}
+	for i := range images {
+		_, err := images[i].PerformPrivate(ctx, userCred, query, data)
+		if err != nil {
+			return nil, errors.Wrapf(err, "fail to private subimage %s", images[i].GetId())
+		}
+	}
+	return self.SSharableVirtualResourceBase.PerformPrivate(ctx, userCred, query, data)
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

Public/private subimages firstly when do public/private for guest image.
Add cmd "guest-image-public" and "guest-image-private".

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
