### PR TITLE
cloudregions: 统一"OneCloud" provider过滤条件

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1266,16 +1266,12 @@ func (manager *SNetworkManager) ValidateCreateData(ctx context.Context, userCred
 				}
 
 				if err != nil {
-					if err == sql.ErrNoRows {
-						return nil, httperrors.NewNotFoundError("wire not found for zone %s and vpc %s", zoneStr, vpcStr)
-					} else {
-						return nil, httperrors.NewInternalServerError("query wire for zone %s and vpc %s error %s", zoneStr, vpcStr, err)
-					}
+					return nil, httperrors.NewInternalServerError("query wire for zone %s and vpc %s: %v", zoneStr, vpcStr, err)
 				}
 				if len(wires) == 0 {
 					return nil, httperrors.NewNotFoundError("wire not found for zone %s and vpc %s", zoneStr, vpcStr)
 				} else if len(wires) > 1 {
-					return nil, httperrors.NewConflictError("more than 1 wire found for zone %s and vpc %s", zoneStr, vpcStr)
+					return nil, httperrors.NewConflictError("found %d wires for zone %s and vpc %s", len(wires), zoneStr, vpcStr)
 				} else {
 					data.Add(jsonutils.NewString(wires[0].Id), "wire_id")
 				}

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -203,7 +203,6 @@ func (manager *SWireManager) getWiresByVpcAndZone(vpc *SVpc, zone *SZone) ([]SWi
 	}
 	err := db.FetchModelObjects(manager, q, &wires)
 	if err != nil {
-		log.Errorf("getWiresByVpcAndZone error %s", err)
 		return nil, err
 	}
 	return wires, nil

--- a/pkg/compute/models/zones.go
+++ b/pkg/compute/models/zones.go
@@ -546,7 +546,7 @@ func (manager *SZoneManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQu
 		subq := regions.Query(regions.Field("id"))
 		subq = subq.Filter(sqlchemy.OR(
 			sqlchemy.In(regions.Field("provider"), cloudprovider.GetOnPremiseProviders()),
-			sqlchemy.IsNullOrEmpty(regions.Field("provider")),
+			sqlchemy.Equals(regions.Field("provider"), api.CLOUD_PROVIDER_ONECLOUD),
 		))
 		q = q.In("cloudregion_id", subq.SubQuery())
 	}
@@ -556,7 +556,7 @@ func (manager *SZoneManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQu
 		subq = subq.Filter(sqlchemy.OR(
 			sqlchemy.In(regions.Field("provider"), cloudprovider.GetPrivateProviders()),
 			sqlchemy.In(regions.Field("provider"), cloudprovider.GetOnPremiseProviders()),
-			sqlchemy.IsNullOrEmpty(regions.Field("provider")),
+			sqlchemy.Equals(regions.Field("provider"), api.CLOUD_PROVIDER_ONECLOUD),
 		))
 		q = q.In("cloudregion_id", subq.SubQuery())
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
networks: 改进创建错误处理
cloudregions: 统一"OneCloud" provider过滤条件
```

**是否需要 backport 到之前的 release 分支**:

- release/2.12.0

/area region
/cc @ioito @tb365 @swordqiu 
