### PR TITLE
lbagent:  校验pid对应进程的comm

### DIFF
--- a/pkg/lbagent/utils/pidfile.go
+++ b/pkg/lbagent/utils/pidfile.go
@@ -21,7 +21,83 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"yunion.io/x/pkg/errors"
 )
+
+const errPidNotRunning = errors.Error("pid not running")
+
+type PidFile struct {
+	Path string
+	Comm string
+}
+
+func NewPidFile(path, comm string) *PidFile {
+	pf := &PidFile{
+		Path: path,
+		Comm: comm,
+	}
+	return pf
+}
+
+func (pf *PidFile) findProcess() (*os.Process, error) {
+	data, err := ioutil.ReadFile(pf.Path)
+	if err != nil {
+		return nil, err
+	}
+	s := strings.TrimSpace(string(data))
+	pid, err := strconv.Atoi(s)
+	if err != nil {
+		return nil, err
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return nil, errPidNotRunning
+	}
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		return nil, errPidNotRunning
+	}
+	return proc, nil
+}
+
+func (pf *PidFile) findComm(pid int) (string, error) {
+	fp := fmt.Sprintf("/proc/%d/comm", pid)
+	data, err := ioutil.ReadFile(fp)
+	if err != nil {
+		return "", err
+	}
+	comm := strings.TrimSpace(string(data))
+	return comm, nil
+}
+
+// ConfirmedOrUnlink reads the pidfile, confirm that it's running and comm
+// matches pf.Comm
+//
+// When confirmed is true, proc must be non-nil
+func (pf *PidFile) ConfirmOrUnlink() (proc *os.Process, confirmed bool, err error) {
+	proc, err = pf.findProcess()
+	if err != nil {
+		if err == errPidNotRunning {
+			os.Remove(pf.Path)
+		}
+		err = errors.Wrapf(err, "pidfile %s: find process: %v", pf.Path, err)
+		return
+	}
+	comm, err := pf.findComm(proc.Pid)
+	if err != nil {
+		err = errors.Wrapf(err, "pidfile %s: find comm: %v", pf.Path, err)
+		return
+	}
+	if pf.Comm == comm {
+		confirmed = true
+		return
+	}
+	err = os.Remove(pf.Path)
+	if err != nil {
+		err = errors.Wrapf(err, "pidfile %s: unlink: %v", pf.Path, err)
+	}
+	return
+}
 
 func ReadPidFile(pidFile string) *os.Process {
 	data, err := ioutil.ReadFile(pidFile)

--- a/pkg/lbagent/utils/pidfile.go
+++ b/pkg/lbagent/utils/pidfile.go
@@ -99,26 +99,6 @@ func (pf *PidFile) ConfirmOrUnlink() (proc *os.Process, confirmed bool, err erro
 	return
 }
 
-func ReadPidFile(pidFile string) *os.Process {
-	data, err := ioutil.ReadFile(pidFile)
-	if err != nil {
-		return nil
-	}
-	s := strings.TrimSpace(string(data))
-	pid, err := strconv.Atoi(s)
-	if err != nil {
-		return nil
-	}
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return nil
-	}
-	if err := proc.Signal(syscall.Signal(0)); err != nil {
-		return nil
-	}
-	return proc
-}
-
 func WritePidFile(pid int, pidFile string) error {
 	data := fmt.Sprintf("%d\n", pid)
 	err := ioutil.WriteFile(pidFile, []byte(data), FileModeFile)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
lbagent: pidfile: remove ReadPidFile()
lbagent: stop daemons: use agentutils.PidFile
lbagent: haproxy: use agentutils.PidFile
lbagent: gobetween: use agentutils.PidFile
lbagent: telegraf: use agentutils.PidFile
lbagent: keepalived: use agentutils.PidFile
lbagent: pidfile: add PidFile
```

**是否需要 backport 到之前的 release 分支**:

- release/2.10.0

/area region
/cc @swordqiu 