### PR TITLE
fix: recover baremetal status after cdrom operations

### DIFF
--- a/pkg/baremetal/tasks/cdrom.go
+++ b/pkg/baremetal/tasks/cdrom.go
@@ -106,6 +106,7 @@ func (self *SBaremetalCdromTask) DoInsertISO(ctx context.Context, args interface
 	if err != nil {
 		return errors.Wrap(err, "MountVirtualCdrom")
 	}
+	self.Baremetal.AutoSyncStatus()
 	SetTaskComplete(self, nil)
 	return nil
 }
@@ -119,6 +120,7 @@ func (self *SBaremetalCdromTask) DoEjectISO(ctx context.Context, args interface{
 	if err != nil {
 		return errors.Wrap(err, "UmountVirtualCdrom")
 	}
+	self.Baremetal.AutoSyncStatus()
 	SetTaskComplete(self, nil)
 	return nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：baremetal的cdrom挂载／卸载操作后需要回复baremetal的状态

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13

/area baremetal

/cc @zexi 