### PR TITLE
Automated cherry pick of #3795: fix: recover baremetal status after cdrom operations

### DIFF
--- a/pkg/baremetal/tasks/cdrom.go
+++ b/pkg/baremetal/tasks/cdrom.go
@@ -106,6 +106,7 @@ func (self *SBaremetalCdromTask) DoInsertISO(ctx context.Context, args interface
 	if err != nil {
 		return errors.Wrap(err, "MountVirtualCdrom")
 	}
+	self.Baremetal.AutoSyncStatus()
 	SetTaskComplete(self, nil)
 	return nil
 }
@@ -119,6 +120,7 @@ func (self *SBaremetalCdromTask) DoEjectISO(ctx context.Context, args interface{
 	if err != nil {
 		return errors.Wrap(err, "UmountVirtualCdrom")
 	}
+	self.Baremetal.AutoSyncStatus()
 	SetTaskComplete(self, nil)
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #3795 on release/2.12.

#3795: fix: recover baremetal status after cdrom operations