### PR TITLE
feature: add network-status methods to change status of on-premise network

### DIFF
--- a/cmd/climc/shell/networks.go
+++ b/cmd/climc/shell/networks.go
@@ -445,4 +445,19 @@ func init() {
 		printObject(result)
 		return nil
 	})
+
+	type NetworkStatusOptions struct {
+		NETWORK string `help:"id or name of network to sync" json:"-"`
+		STATUS  string `help:"status of network" choices:"available|unavailable" json:"status"`
+		Reason  string `help:"reason to change status" json:"reason"`
+	}
+	R(&NetworkStatusOptions{}, "network-status", "Set on-premise network status", func(s *mcclient.ClientSession, args *NetworkStatusOptions) error {
+		params := jsonutils.Marshal(args)
+		result, err := modules.Networks.PerformAction(s, args.NETWORK, "status", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
 }

--- a/cmd/climc/shell/tasks.go
+++ b/cmd/climc/shell/tasks.go
@@ -44,16 +44,13 @@ func init() {
 		return nil
 	})
 
-	R(&TaskListOptions{}, "region-task-list", "List tasks on region server", func(s *mcclient.ClientSession, suboptions *TaskListOptions) error {
-		var params *jsonutils.JSONDict
-		{
-			var err error
-			params, err = suboptions.BaseListOptions.Params()
-			if err != nil {
-				return err
-
-			}
-		}
+	type RegionTaskListOptions struct {
+		ObjName  string `help:"object name"`
+		ObjId    string `help:"object id"`
+		TaskName string `help:"task name"`
+	}
+	R(&RegionTaskListOptions{}, "region-task-list", "List tasks on region server", func(s *mcclient.ClientSession, args *RegionTaskListOptions) error {
+		params := jsonutils.Marshal(args)
 		result, err := modules.ComputeTasks.List(s, params)
 		if err != nil {
 			return err

--- a/pkg/cloudcommon/db/statusstandalone.go
+++ b/pkg/cloudcommon/db/statusstandalone.go
@@ -21,6 +21,7 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/utils"
 
+	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
 )
@@ -66,12 +67,12 @@ func (model *SStatusStandaloneResourceBase) AllowPerformStatus(ctx context.Conte
 }
 
 func (model *SStatusStandaloneResourceBase) PerformStatus(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
-	status, err := data.GetString("status")
-	if err != nil {
-		return nil, err
+	status, _ := data.GetString("status")
+	if len(status) == 0 {
+		return nil, httperrors.NewMissingParameterError("status")
 	}
 	reason, _ := data.GetString("reason")
-	err = model.SetStatus(userCred, status, reason)
+	err := model.SetStatus(userCred, status, reason)
 	return nil, err
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：增加network-status方法修改on-premise network的状态。（maanged network的状态通过network-sync同步，不能更改）

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13

/area region

/cc @zexi @yousong 