### PR TITLE
fix: 清理aliyun rds多余的包年包月参数转换

### DIFF
--- a/pkg/multicloud/aliyun/dbinstance.go
+++ b/pkg/multicloud/aliyun/dbinstance.go
@@ -604,10 +604,6 @@ func (region *SRegion) CreateIDBInstance(desc *cloudprovider.SManagedDBInstanceC
 			params["Period"] = "Year"
 			params["UsedTime"] = fmt.Sprintf("%d", desc.BillingCycle.GetYears())
 		}
-		err := billingCycle2Params(desc.BillingCycle, params)
-		if err != nil {
-			return nil, err
-		}
 		params["AutoRenew"] = "False"
 	}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
清理aliyun rds多余的包年包月参数转换

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu @yousong 
