### PR TITLE
fix(region): Fix the panic of nil map when syncing snapshotpolicy

### DIFF
--- a/pkg/compute/models/snapshotpolicy.go
+++ b/pkg/compute/models/snapshotpolicy.go
@@ -549,13 +549,15 @@ func (manager *SSnapshotPolicyManager) newFromCloudSnapshotPolicy(
 		// sync project
 		SyncCloudProject(userCred, &snapshotPolicyTmp, syncOwnerId, ext, provider.GetId())
 		// update snapshotpolicyCluster
-		key := snapshotPolicyTmp.Key()
-		list, ok := snapshotpolicyCluster[key]
-		if !ok {
-			list = make([]*SSnapshotPolicy, 0)
+		if snapshotpolicyCluster != nil {
+			key := snapshotPolicyTmp.Key()
+			list, ok := snapshotpolicyCluster[key]
+			if !ok {
+				list = make([]*SSnapshotPolicy, 0)
+			}
+			list = append(list, &snapshotPolicyTmp)
+			snapshotpolicyCluster[key] = list
 		}
-		list = append(list, &snapshotPolicyTmp)
-		snapshotpolicyCluster[key] = list
 		snapshotPolicy = &snapshotPolicyTmp
 	}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

同步快照策略的时候，如果新增的数量小于5的情况下，需要新建本地快照策略，不应该更新 此时 为nil 的 snapshotpolicyCluster

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
