### PR TITLE
fix: cloud-region filter by domain not support share_mode

### DIFF
--- a/pkg/compute/models/capabilities.go
+++ b/pkg/compute/models/capabilities.go
@@ -126,8 +126,15 @@ func getDomainManagerSubq(domainId string) *sqlchemy.SSubQuery {
 	q := providers.Query(providers.Field("id"))
 	q = q.Join(accounts, sqlchemy.Equals(accounts.Field("id"), providers.Field("cloudaccount_id")))
 	q = q.Filter(sqlchemy.OR(
-		sqlchemy.Equals(accounts.Field("domain_id"), domainId),
+		sqlchemy.AND(
+			sqlchemy.Equals(providers.Field("domain_id"), domainId),
+			sqlchemy.Equals(accounts.Field("share_mode"), api.CLOUD_ACCOUNT_SHARE_MODE_PROVIDER_DOMAIN),
+		),
 		sqlchemy.Equals(accounts.Field("share_mode"), api.CLOUD_ACCOUNT_SHARE_MODE_SYSTEM),
+		sqlchemy.AND(
+			sqlchemy.Equals(accounts.Field("domain_id"), domainId),
+			sqlchemy.Equals(accounts.Field("share_mode"), api.CLOUD_ACCOUNT_SHARE_MODE_ACCOUNT_DOMAIN),
+		),
 	))
 	q = q.Filter(sqlchemy.Equals(accounts.Field("status"), api.CLOUD_PROVIDER_CONNECTED))
 	q = q.Filter(sqlchemy.IsTrue(accounts.Field("enabled")))

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -1311,8 +1311,15 @@ func (manager *SCloudproviderManager) FilterByOwner(q *sqlchemy.SQuery, owner mc
 					cloudaccounts.Field("id"),
 				))
 				q = q.Filter(sqlchemy.OR(
-					sqlchemy.Equals(q.Field("domain_id"), owner.GetProjectDomainId()),
+					sqlchemy.AND(
+						sqlchemy.Equals(q.Field("domain_id"), owner.GetProjectDomainId()),
+						sqlchemy.Equals(cloudaccounts.Field("share_mode"), api.CLOUD_ACCOUNT_SHARE_MODE_PROVIDER_DOMAIN),
+					),
 					sqlchemy.Equals(cloudaccounts.Field("share_mode"), api.CLOUD_ACCOUNT_SHARE_MODE_SYSTEM),
+					sqlchemy.AND(
+						sqlchemy.Equals(cloudaccounts.Field("domain_id"), owner.GetProjectDomainId()),
+						sqlchemy.Equals(cloudaccounts.Field("share_mode"), api.CLOUD_ACCOUNT_SHARE_MODE_ACCOUNT_DOMAIN),
+					),
 				))
 			}
 		}

--- a/pkg/compute/models/cloudregions.go
+++ b/pkg/compute/models/cloudregions.go
@@ -538,8 +538,15 @@ func getCloudRegionIdByDomainId(domainId string) *sqlchemy.SSubQuery {
 	q2 = q2.Join(providers, sqlchemy.Equals(providers.Field("id"), cloudproviderregions.Field("cloudprovider_id")))
 	q2 = q2.Join(accounts, sqlchemy.Equals(providers.Field("cloudaccount_id"), accounts.Field("id")))
 	q2 = q2.Filter(sqlchemy.OR(
-		sqlchemy.Equals(accounts.Field("domain_id"), domainId),
-		sqlchemy.IsTrue(accounts.Field("is_public")),
+		sqlchemy.AND(
+			sqlchemy.Equals(providers.Field("domain_id"), domainId),
+			sqlchemy.Equals(accounts.Field("share_mode"), api.CLOUD_ACCOUNT_SHARE_MODE_PROVIDER_DOMAIN),
+		),
+		sqlchemy.Equals(accounts.Field("share_mode"), api.CLOUD_ACCOUNT_SHARE_MODE_SYSTEM),
+		sqlchemy.AND(
+			sqlchemy.Equals(accounts.Field("domain_id"), domainId),
+			sqlchemy.Equals(accounts.Field("share_mode"), api.CLOUD_ACCOUNT_SHARE_MODE_ACCOUNT_DOMAIN),
+		),
 	))
 
 	return sqlchemy.Union(q1, q2).Query().SubQuery()

--- a/pkg/compute/models/managedresource.go
+++ b/pkg/compute/models/managedresource.go
@@ -161,8 +161,15 @@ func managedResourceFilterByDomain(q *sqlchemy.SQuery, query jsonutils.JSONObjec
 		subq := providers.Query(providers.Field("id"))
 		subq = subq.Join(accounts, sqlchemy.Equals(providers.Field("cloudaccount_id"), accounts.Field("id")))
 		subq = subq.Filter(sqlchemy.OR(
-			sqlchemy.Equals(providers.Field("domain_id"), domain.GetId()),
+			sqlchemy.AND(
+				sqlchemy.Equals(providers.Field("domain_id"), domain.GetId()),
+				sqlchemy.Equals(accounts.Field("share_mode"), api.CLOUD_ACCOUNT_SHARE_MODE_PROVIDER_DOMAIN),
+			),
 			sqlchemy.Equals(accounts.Field("share_mode"), api.CLOUD_ACCOUNT_SHARE_MODE_SYSTEM),
+			sqlchemy.AND(
+				sqlchemy.Equals(accounts.Field("domain_id"), domain.GetId()),
+				sqlchemy.Equals(accounts.Field("share_mode"), api.CLOUD_ACCOUNT_SHARE_MODE_ACCOUNT_DOMAIN),
+			),
 		))
 		if len(filterField) == 0 {
 			q = q.Filter(sqlchemy.OR(


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：cloud-region的domain过滤没有支持cloud-account的share_mode字段

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13

/area region

/cc @zexi 