### PR TITLE
fix: 避免旧密码覆盖新重置的密码

### DIFF
--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -504,8 +504,10 @@ func (self *SManagedVirtualizedGuestDriver) RemoteDeployGuestForDeploy(ctx conte
 			return e
 		}
 
-		//可以从秘钥解密旧密码
-		desc.Password = guest.GetOldPassword(ctx, task.GetUserCred())
+		if len(desc.Password) == 0 {
+			//可以从秘钥解密旧密码
+			desc.Password = guest.GetOldPassword(ctx, task.GetUserCred())
+		}
 		return nil
 	}()
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免旧密码覆盖新重置的密码

**是否需要 backport 到之前的 release 分支**:
- release/2.11

/area region
/cc @swordqiu @yousong 
