### PR TITLE
Automated cherry pick of #3857: fix: 避免旧密码覆盖新重置的密码

### DIFF
--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -504,8 +504,10 @@ func (self *SManagedVirtualizedGuestDriver) RemoteDeployGuestForDeploy(ctx conte
 			return e
 		}
 
-		//可以从秘钥解密旧密码
-		desc.Password = guest.GetOldPassword(ctx, task.GetUserCred())
+		if len(desc.Password) == 0 {
+			//可以从秘钥解密旧密码
+			desc.Password = guest.GetOldPassword(ctx, task.GetUserCred())
+		}
 		return nil
 	}()
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #3857 on release/2.13.

#3857: fix: 避免旧密码覆盖新重置的密码