### PR TITLE
Automated cherry pick of #3873: fix: 修复rds重置密码未正确接收参数问题

### DIFF
--- a/pkg/compute/models/dbinstance_accounts.go
+++ b/pkg/compute/models/dbinstance_accounts.go
@@ -403,7 +403,7 @@ func (self *SDBInstanceAccount) PerformResetPassword(ctx context.Context, userCr
 	if err != nil {
 		return nil, err
 	}
-	passwdStr, _ := query.GetString("password")
+	passwdStr, _ := data.GetString("password")
 	if len(passwdStr) > 0 {
 		if !seclib2.MeetComplxity(passwdStr) {
 			return nil, httperrors.NewWeakPasswordError()


### PR DESCRIPTION
Cherry pick of #3873 on release/2.12.

#3873: fix: 修复rds重置密码未正确接收参数问题