### PR TITLE
Automated cherry pick of #3892: fix: baremetal restart fail after deployment

### DIFF
--- a/pkg/compute/guestdrivers/baremetals.go
+++ b/pkg/compute/guestdrivers/baremetals.go
@@ -425,6 +425,8 @@ func (self *SBaremetalGuestDriver) RequestDeployGuestOnHost(ctx context.Context,
 	}
 	if val == "rebuild" && jsonutils.QueryBoolean(task.GetParams(), "auto_start", false) {
 		config.Set("on_finish", jsonutils.NewString("restart"))
+	} else if val == "deploy" && jsonutils.QueryBoolean(task.GetParams(), "restart", false) {
+		config.Set("on_finish", jsonutils.NewString("shutdown"))
 	}
 	url := fmt.Sprintf("/baremetals/%s/servers/%s/%s", host.Id, guest.Id, val)
 	headers := task.GetTaskRequestHeader()


### PR DESCRIPTION
Cherry pick of #3892 on release/2.10.0.

#3892: fix: baremetal restart fail after deployment