### PR TITLE
fix: 普通后台也返回cloudregion_id信息

### DIFF
--- a/pkg/compute/models/cloudregionresource.go
+++ b/pkg/compute/models/cloudregionresource.go
@@ -24,7 +24,7 @@ import (
 )
 
 type SCloudregionResourceBase struct {
-	CloudregionId string `width:"36" charset:"ascii" nullable:"false" list:"admin" default:"default" create:"optional"`
+	CloudregionId string `width:"36" charset:"ascii" nullable:"false" list:"user" default:"default" create:"optional"`
 }
 
 func (self *SCloudregionResourceBase) GetRegion() *SCloudregion {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
普通后台也返回cloudregion_id信息

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @swordqiu @yousong 
