### PR TITLE
Automated cherry pick of #3910: fix: 避免有,Azure更新安全组规则出错

### DIFF
--- a/pkg/util/azure/securitygroup.go
+++ b/pkg/util/azure/securitygroup.go
@@ -411,6 +411,7 @@ func convertSecurityGroupRule(rule secrules.SecurityRule, priority int32) *Secur
 	name = strings.Replace(name, " ", "_", -1)
 	name = strings.Replace(name, "-", "_", -1)
 	name = strings.Replace(name, "/", "_", -1)
+	name = strings.Replace(name, ",", "_", -1)
 	name = fmt.Sprintf("%s_%d", name, rule.Priority)
 	destRule := SecurityRules{
 		Name: name,


### PR DESCRIPTION
Cherry pick of #3910 on release/2.10.0.

#3910: fix: 避免有,Azure更新安全组规则出错