### PR TITLE
fix: 避免解绑eip后可以立即syncstatus操作导致同步eip出现问题

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -2763,16 +2763,30 @@ func (self *SGuest) PerformDissociateEip(ctx context.Context, userCred mcclient.
 		return nil, httperrors.NewInvalidStatusError("No eip to dissociate")
 	}
 
-	self.SetStatus(userCred, api.VM_DISSOCIATE_EIP, "associate eip")
+	if eip.Mode != api.EIP_MODE_STANDALONE_EIP {
+		return nil, httperrors.NewNotSupportedError("%s not support dissociate", eip.Mode)
+	}
 
 	autoDelete := jsonutils.QueryBoolean(data, "auto_delete", false)
-
-	err = eip.StartEipDissociateTask(ctx, userCred, autoDelete, "")
+	err = self.StartGuestDissociateEipTask(ctx, userCred, eip, autoDelete, "")
 	if err != nil {
-		log.Errorf("fail to start dissociate task %s", err)
-		return nil, httperrors.NewGeneralError(err)
+		return nil, errors.Wrap(err, "StartGuestDissociateEipTask")
 	}
 	return nil, nil
+}
+
+func (self *SGuest) StartGuestDissociateEipTask(ctx context.Context, userCred mcclient.TokenCredential, eip *SElasticip, autoDelete bool, parentTaskId string) error {
+	self.SetStatus(userCred, api.VM_DISSOCIATE_EIP, "associate eip")
+	eip.SetStatus(userCred, api.EIP_STATUS_DISSOCIATE, "start to dissociate")
+	params := jsonutils.NewDict()
+	params.Add(jsonutils.NewBool(autoDelete), "auto_delete")
+	task, err := taskman.TaskManager.NewTask(ctx, "GuestDissociateEipTask", self, userCred, params, parentTaskId, "", nil)
+	if err != nil {
+		eip.SetStatus(userCred, api.EIP_STATUS_READY, "")
+		return errors.Wrap(err, "NewTask")
+	}
+	task.ScheduleRun(nil)
+	return nil
 }
 
 func (self *SGuest) AllowPerformCreateEip(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) bool {

--- a/pkg/compute/tasks/guest_dissociate_eip_task.go
+++ b/pkg/compute/tasks/guest_dissociate_eip_task.go
@@ -1,0 +1,91 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"context"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/compute/models"
+	"yunion.io/x/onecloud/pkg/util/logclient"
+)
+
+type GuestDissociateEipTask struct {
+	SGuestBaseTask
+}
+
+func init() {
+	taskman.RegisterTask(GuestDissociateEipTask{})
+}
+
+func (self *GuestDissociateEipTask) TaskFail(ctx context.Context, guest *models.SGuest, eip *models.SElasticip, err error) {
+	guest.SetStatus(self.UserCred, api.VM_DISSOCIATE_EIP_FAILED, err.Error())
+	if eip != nil {
+		eip.SetStatus(self.UserCred, api.EIP_STATUS_READY, err.Error())
+		logclient.AddActionLogWithStartable(self, eip, logclient.ACT_VM_DISSOCIATE, err, self.UserCred, false)
+	}
+	self.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(guest, db.ACT_EIP_DETACH, err.Error(), self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_EIP_DISSOCIATE, err, self.UserCred, false)
+}
+
+func (self *GuestDissociateEipTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
+	guest := obj.(*models.SGuest)
+	eip, err := guest.GetEip()
+	if err != nil {
+		self.TaskFail(ctx, guest, nil, errors.Wrap(err, "guest.GetEip"))
+		return
+	}
+
+	extEip, err := eip.GetIEip()
+	if err != nil && errors.Cause(err) != cloudprovider.ErrNotFound {
+		self.TaskFail(ctx, guest, eip, errors.Wrap(err, "eip.GetIEip"))
+		return
+	}
+
+	if err == nil && len(extEip.GetAssociationExternalId()) > 0 {
+		err = extEip.Dissociate()
+		if err != nil {
+			self.TaskFail(ctx, guest, eip, errors.Wrap(err, "extEip.Dissociate"))
+			return
+		}
+	}
+
+	err = eip.Dissociate(ctx, self.UserCred)
+	if err != nil {
+		self.TaskFail(ctx, guest, eip, errors.Wrap(err, "eip.Dissociate"))
+		return
+	}
+
+	eip.SetStatus(self.UserCred, api.EIP_STATUS_READY, "dissociate")
+	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_EIP_DISSOCIATE, nil, self.UserCred, true)
+	logclient.AddActionLogWithStartable(self, eip, logclient.ACT_VM_DISSOCIATE, nil, self.UserCred, true)
+
+	guest.StartSyncstatus(ctx, self.UserCred, "")
+	self.SetStageComplete(ctx, nil)
+
+	autoDelete := jsonutils.QueryBoolean(self.GetParams(), "auto_delete", false)
+
+	if eip.AutoDellocate.IsTrue() || autoDelete {
+		eip.StartEipDeallocateTask(ctx, self.UserCred, "")
+	}
+
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免解绑eip后可以立即syncstatus操作导致同步eip出现问题

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu @yousong 
