### PR TITLE
fix: 1. service-config not support key=value pair 2.sync_purge_removed_resources not working

### DIFF
--- a/cmd/climc/shell/services.go
+++ b/cmd/climc/shell/services.go
@@ -184,17 +184,21 @@ func init() {
 		for _, c := range args.Config {
 			json, _ := jsonutils.ParseString(c)
 			if json != nil {
-				subconf := jsonutils.NewDict()
-				subconf.Add(json, "config")
-				config.Update(subconf)
-				continue
+				if _, ok := json.(*jsonutils.JSONDict); ok {
+					subconf := jsonutils.NewDict()
+					subconf.Add(json, "config")
+					config.Update(subconf)
+					continue
+				}
 			}
 			yaml, _ := jsonutils.ParseYAML(c)
 			if yaml != nil {
-				subconf := jsonutils.NewDict()
-				subconf.Add(yaml, "config")
-				config.Update(subconf)
-				continue
+				if _, ok := yaml.(*jsonutils.JSONDict); ok {
+					subconf := jsonutils.NewDict()
+					subconf.Add(yaml, "config")
+					config.Update(subconf)
+					continue
+				}
 			}
 			pos := strings.IndexByte(c, '=')
 			if pos < 0 {

--- a/pkg/compute/service/service.go
+++ b/pkg/compute/service/service.go
@@ -51,8 +51,6 @@ func StartService() {
 		commonOpts.Port = opts.PortV2
 	}
 
-	options.InitNameSyncResources()
-
 	app_common.InitAuth(commonOpts, func() {
 		log.Infof("Auth complete!!")
 	})
@@ -67,6 +65,8 @@ func StartService() {
 	if err != nil {
 		log.Fatalf("[MERGE CONFIG] Fail to merge service config %s", err)
 	}
+
+	options.InitNameSyncResources()
 
 	err = setInfluxdbRetentionPolicy()
 	if err != nil {


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:
修正：
1. climc service-config不支持key=value
2. sync_purge_removed_resources失效

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13

/area region

/cc @zexi 