### PR TITLE
fix: 避免每次重启region同步rds sku, 避免新加公有云账号未能及时同步sku问题

### DIFF
--- a/pkg/compute/models/cloudsync.go
+++ b/pkg/compute/models/cloudsync.go
@@ -1001,6 +1001,7 @@ func syncPublicCloudProviderInfo(
 
 	if !driver.GetFactory().NeedSyncSkuFromCloud() {
 		syncRegionSkus(ctx, userCred, localRegion)
+		syncRegionDBInstanceSkus(ctx, userCred, localRegion.Id, true)
 	} else {
 		syncSkusFromPrivateCloud(ctx, userCred, syncResults, provider, remoteRegion)
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免每次重启region同步rds sku,
避免新加公有云账号未能及时同步sku问题

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu @yousong 
