### PR TITLE
Automated cherry pick of #3994: fix: 避免每次重启region同步rds sku, 避免新加公有云账号未能及时同步sku问题

### DIFF
--- a/pkg/compute/models/cloudsync.go
+++ b/pkg/compute/models/cloudsync.go
@@ -1001,6 +1001,7 @@ func syncPublicCloudProviderInfo(
 
 	if !driver.GetFactory().NeedSyncSkuFromCloud() {
 		syncRegionSkus(ctx, userCred, localRegion)
+		syncRegionDBInstanceSkus(ctx, userCred, localRegion.Id, true)
 	} else {
 		syncSkusFromPrivateCloud(ctx, userCred, syncResults, provider, remoteRegion)
 	}


### PR DESCRIPTION
Cherry pick of #3994 on release/2.13.

#3994: fix: 避免每次重启region同步rds sku, 避免新加公有云账号未能及时同步sku问题