### PR TITLE
fix(region): The param of list instancegroup filter by Guest is 'server'

### DIFF
--- a/cmd/climc/shell/instance_group.go
+++ b/cmd/climc/shell/instance_group.go
@@ -29,7 +29,7 @@ func init() {
 		ServiceType string `help:"Service Type"`
 		ParentId    string `help:"Parent ID"`
 		ZoneId      string `help:"Zone ID"`
-		Guest       string `help:"Guest ID or Name"`
+		Server      string `help:"Guest ID or Name"`
 	}
 
 	R(&InstanceGroupListOptions{}, "instance-group-list", "List instance group", func(s *mcclient.ClientSession,

--- a/pkg/apis/compute/instance_group.go
+++ b/pkg/apis/compute/instance_group.go
@@ -26,7 +26,7 @@ type InstanceGroupListInput struct {
 	// Filter by zone id
 	ZoneId string `json:"zone_id"`
 	// Filter by guest id or name
-	Guest string `json:"guest"`
+	Server string `json:"server"`
 }
 
 type InstanceGroupDetail struct {

--- a/pkg/compute/models/groups.go
+++ b/pkg/compute/models/groups.go
@@ -75,7 +75,7 @@ type SGroup struct {
 
 func (sm *SGroupManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQuery, userCred mcclient.TokenCredential,
 	input *api.InstanceGroupListInput) (*sqlchemy.SQuery, error) {
-	guestFilter := input.Guest
+	guestFilter := input.Server
 	if len(guestFilter) != 0 {
 		guestObj, err := GuestManager.FetchByIdOrName(userCred, guestFilter)
 		if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

通过Guest过滤instancegroup的参数确定为server

**是否需要 backport 到之前的 release 分支**:
- release/2.13
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
