### PR TITLE
fix: 忽略名称条件，只要cpu,mem一致就不再同步

### DIFF
--- a/pkg/compute/models/skus.go
+++ b/pkg/compute/models/skus.go
@@ -882,7 +882,7 @@ func (manager *SServerSkuManager) GetOneCloudSkus() ([]string, error) {
 	}
 	result := []string{}
 	for _, sku := range skus {
-		result = append(result, fmt.Sprintf("%s/%d/%d", sku.Name, sku.CpuCoreCount, sku.MemorySizeMB))
+		result = append(result, fmt.Sprintf("%d/%d", sku.CpuCoreCount, sku.MemorySizeMB))
 	}
 	return result, nil
 }
@@ -975,14 +975,14 @@ func (manager *SServerSkuManager) SyncPrivateCloudSkus(ctx context.Context, user
 	defer lockman.ReleaseClass(ctx, manager, db.GetLockClassKey(manager, userCred))
 
 	syncResult := compare.SyncResult{}
-	names, err := manager.GetOneCloudSkus()
+	localskus, err := manager.GetOneCloudSkus()
 	if err != nil {
 		syncResult.Error(err)
 		return syncResult
 	}
 
 	for _, sku := range skus {
-		if !utils.IsInStringArray(fmt.Sprintf("%s/%d/%d", sku.GetName(), sku.GetCpuCoreCount(), sku.GetMemorySizeMB()), names) {
+		if !utils.IsInStringArray(fmt.Sprintf("%d/%d", sku.GetCpuCoreCount(), sku.GetMemorySizeMB()), localskus) {
 			err := manager.newFromCloudSku(ctx, userCred, sku)
 			if err != nil {
 				syncResult.AddError(err)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
忽略名称条件，只要cpu,mem一致就不再同步

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu @yousong 
