### PR TITLE
hostman: hostinfo: turn off report_ignored_msrs

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -402,7 +402,8 @@ func (h *SHostInfo) PreventArpFlux() {
 // set swappiness=0 to avoid swap
 func (h *SHostInfo) TuneSystem() {
 	kv := map[string]string{"/proc/sys/vm/swappiness": "0",
-		"/sys/module/kvm/parameters/ignore_msrs": "1",
+		"/sys/module/kvm/parameters/ignore_msrs":         "1",
+		"/sys/module/kvm/parameters/report_ignored_msrs": "0",
 	}
 	for k, v := range kv {
 		sysutils.SetSysConfig(k, v)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
Quote mainline linux commit fab0aa3b ("KVM: x86: Allow suppressing
prints on RDMSR/WRMSR of unhandled MSRs")

> Some guests use these unhandled MSRs very frequently.
> This cause dmesg to be populated with lots of aggregated messages on
> usage of ignored MSRs. As ignore_msrs=true means that the user is
> well-aware his guest use ignored MSRs, allow to also disable the
> prints on their usage.
>
> An example of such guest is ESXi which tends to access a lot to MSR
> 0x34 (MSR_SMI_COUNT) very frequently.
>
> In addition, we have observed this to cause unnecessary delays to
> guest execution. Such an example is ESXi which experience networking
> delays in it's guests (L2 guests) because of these prints (even when
> prints are rate-limited). This can easily be reproduced by pinging
> from one L2 guest to another.  Once in a while, a peak in ping RTT
> will be observed. Removing these unhandled MSR prints solves the
> issue.
>
> Because these prints can help diagnose issues with guests,
> this commit only suppress them by a module parameter instead of
> removing them from code entirely.
```

**是否需要 backport 到之前的 release 分支**:

- release/2.10.0

/area host
/cc @wanyaoqi @swordqiu 