### PR TITLE
fix: 避免在初始化model时设置rds sku handler

### DIFF
--- a/pkg/compute/models/dbinstance_skus.go
+++ b/pkg/compute/models/dbinstance_skus.go
@@ -49,9 +49,6 @@ func init() {
 			"dbinstance_skus",
 		),
 	}
-
-	DBInstanceSkuManager.NameRequireAscii = true
-	db.RegisterModelManager(DBInstanceSkuManager)
 	DBInstanceSkuManager.SetVirtualObject(DBInstanceSkuManager)
 	DBInstanceSkuManager.NameRequireAscii = false
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免在初始化model时设置rds sku handler

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu
