### PR TITLE
bugfix: fix docker push script component name

### DIFF
--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -38,8 +38,8 @@ build_bin() {
 }
 
 build_bundle_libraries() {
-    for component in 'host' 'host-deployer'; do
-        if [ $1 == $component ]; then
+    for bundle_component in 'host' 'host-deployer'; do
+        if [ $1 == $bundle_component ]; then
             $CUR_DIR/bundle-libraries.sh _output/bin/bundles/$1 _output/bin/$1
             break
         fi


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
bugfix: fix docker push script component name
**是否需要 backport 到之前的 release 分支**:
NONE
/area utils
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
