### PR TITLE
fix(region): Guest template & Service catalog

### DIFF
--- a/pkg/apis/compute/guesttemplate.go
+++ b/pkg/apis/compute/guesttemplate.go
@@ -7,14 +7,7 @@ import (
 )
 
 type GuesttemplateCreateInput struct {
-	apis.Meta
-
-	// description: guest template name
-	// unique: true
-	// required: true
-	// example: hello
-	Name string `json:"name"`
-
+	apis.SharableVirutalResourceCreateInput
 	// description: the content of guest template
 	// required: true
 	Content jsonutils.JSONObject `json:"content"`

--- a/pkg/apis/compute/service_catalog.go
+++ b/pkg/apis/compute/service_catalog.go
@@ -3,14 +3,7 @@ package compute
 import "yunion.io/x/onecloud/pkg/apis"
 
 type ServiceCatalogCreateInput struct {
-	apis.Meta
-
-	// description: service catalog name
-	// uniqure: true
-	// required: true
-	// example: hello
-	Name string `json:"name`
-
+	apis.SharableVirutalResourceCreateInput
 	// description: service catalog icon url
 	// example: https://yunion.io/files/hello.png
 	IconUrl string `json:"icon_url"`

--- a/pkg/apis/sharablevirtualresource.go
+++ b/pkg/apis/sharablevirtualresource.go
@@ -27,3 +27,9 @@ type SharableVirtualResourceDetails struct {
 type SharableVirtualResourceListInput struct {
 	StandaloneResourceListInput
 }
+
+type SharableVirutalResourceCreateInput struct {
+	VirtualResourceCreateInput
+	IsPublic    bool   `json:"is_public"`
+	PublicScope string `json:"public_scope"`
+}

--- a/pkg/apis/standaloneresource.go
+++ b/pkg/apis/standaloneresource.go
@@ -27,3 +27,14 @@ type StandaloneResourceListInput struct {
 	Tags            []string `json:"tags"`
 	WithoutUserMeta bool     `json:"without_user_meta"`
 }
+
+type StandaloneResourceCreatInput struct {
+	Meta
+	// description: resource name
+	// unique: true
+	// required: true
+	// example: yunion
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	IsEmulated  bool   `json:"is_emulated"`
+}

--- a/pkg/apis/virtualresource.go
+++ b/pkg/apis/virtualresource.go
@@ -17,3 +17,8 @@ package apis
 type VirtualResourceDetails struct {
 	ModelBaseDetails
 }
+
+type VirtualResourceCreateInput struct {
+	StandaloneResourceCreatInput
+	IsSystem bool `json:"is_system"`
+}

--- a/pkg/compute/models/guest_template.go
+++ b/pkg/compute/models/guest_template.go
@@ -395,3 +395,16 @@ func (gt *SGuestTemplate) genForbiddenError(resourceName, resourceStr, scope str
 	}
 	return httperrors.NewForbiddenError(msg)
 }
+
+func (gt *SGuestTemplate) ValidateDeleteCondition(ctx context.Context) error {
+	q := ServiceCatalogManager.Query("name").Equals("guest_template_id", gt.Id)
+	names := make([]string, 0, 1)
+	err := q.All(&names)
+	if err != nil {
+		return errors.Wrap(err, "SQuery.All")
+	}
+	if len(names) > 0 {
+		return httperrors.NewForbiddenError("guest template %s used by service catalog %s", gt.Id, names[0])
+	}
+	return nil
+}


### PR DESCRIPTION


**这个 PR 实现什么功能/修复什么问题**:

Add the common create input.
Not allow to delete the guest template used by some service catalog.

**是否需要 backport 到之前的 release 分支**:
- release/2.13
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
