### PR TITLE
fix: 子订阅更改项目时也同步更新external project项目信息

### DIFF
--- a/pkg/compute/models/external_projects.go
+++ b/pkg/compute/models/external_projects.go
@@ -185,6 +185,8 @@ func (self *SExternalProject) SyncWithCloudProject(ctx context.Context, userCred
 	diff, err := db.UpdateWithLock(ctx, self, func() error {
 		self.Name = ext.GetName()
 		self.IsEmulated = ext.IsEmulated()
+		self.ProjectId = provider.ProjectId
+		self.DomainId = provider.DomainId
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
子订阅更改项目时也同步更新external project项目信息

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu 
