### PR TITLE
Automated cherry pick of #4072: fix: 导出用户标签不加user:前缀

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1582,7 +1582,8 @@ func (manager *SGuestManager) ListItemExportKeys(ctx context.Context, q *sqlchem
 		guestUserTagsQuery.AppendField(sqlchemy.SubStr("guest_id", guestUserTagsQuery.Field("id"), len("server::")+1, 0))
 		guestUserTagsQuery.AppendField(
 			sqlchemy.GROUP_CONCAT("user_tags", sqlchemy.CONCAT("",
-				guestUserTagsQuery.Field("key"),
+				sqlchemy.SubStr("", guestUserTagsQuery.Field("key"), len(db.USER_TAG_PREFIX)+1, 0),
+				sqlchemy.NewStringField(":"),
 				guestUserTagsQuery.Field("value"),
 			)))
 		subQ := guestUserTagsQuery.SubQuery()


### PR DESCRIPTION
Cherry pick of #4072 on release/2.11.

#4072: fix: 导出用户标签不加user:前缀