### PR TITLE
fix: Fix the unexpected json field coverage after GetCustomizeColumns

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -363,7 +363,9 @@ func Query2List(manager IModelManager, ctx context.Context, userCred mcclient.To
 		if showDetails && !query.Contains("export_keys") {
 			extraDict := item.GetCustomizeColumns(ctx, userCred, query)
 			if extraDict != nil {
-				jsonDict.Update(extraDict)
+				// Fix for Now
+				extraDict.Update(jsonDict)
+				jsonDict = extraDict
 			}
 			// jsonDict = getModelExtraDetails(item, ctx, jsonDict)
 		}

--- a/pkg/compute/models/groups.go
+++ b/pkg/compute/models/groups.go
@@ -105,13 +105,10 @@ func (group *SGroup) GetExtraDetails(ctx context.Context, userCred mcclient.Toke
 
 func (group *SGroup) getMoreDetails(ctx context.Context, userCred mcclient.TokenCredential,
 	data jsonutils.JSONObject) (*api.InstanceGroupDetail, error) {
-	ret := data.(*jsonutils.JSONDict)
 	q := GroupguestManager.Query().Equals("group_id", group.Id)
 	count, _ := q.CountWithError()
-	ret.Add(jsonutils.NewInt(int64(count)), "guest_count")
 	output := new(api.InstanceGroupDetail)
-	data.Unmarshal(ret)
-	log.Errorf("output is %#v", output)
+	output.GuestCount = int64(count)
 	return output, nil
 }
 


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:

一般来说一个资源的detail版本的输出会放在 <ResoureName>Details
这样的结构体中，并且这个结构体包含资源本身。不过一般在 details
的处理函数中（比如GetCustomizeColumns）资源本身的结构体都是默认值，
而jsonutils的unmarshal函数会把默认值（零值）的int类型（也可能会有其他类型）
unmarshal到jsonutils.JSONDict中（string类型就不会有这种情况）。
这会导致返回的extraDict会覆盖掉原来的Dict中的一些字段，这种覆盖并不是所期望的。
所以现在暂时改为用后者来覆盖前者，前者是最终输出的全集。

优化了一点 group.getMoreDetails  的代码结构

**是否需要 backport 到之前的 release 分支**:
- release/2.13
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
