### PR TITLE
fix: init quota with negative value and negative quota means unlimited

### DIFF
--- a/pkg/cloudcommon/db/quotas/utils.go
+++ b/pkg/cloudcommon/db/quotas/utils.go
@@ -31,3 +31,10 @@ func KeyName(prefix, name string) string {
 		return name
 	}
 }
+
+func Exceed(used, request, quota int) bool {
+	if quota >= 0 && request > 0 && used+request > quota {
+		return true
+	}
+	return false
+}

--- a/pkg/compute/models/projectquota.go
+++ b/pkg/compute/models/projectquota.go
@@ -68,7 +68,7 @@ type SProjectQuota struct {
 
 	quotas.SBaseQuotaKeys
 
-	Secgroup int
+	Secgroup int `default:"-1"`
 }
 
 func (self *SProjectQuota) GetKeys() quotas.IQuotaKeys {
@@ -142,12 +142,12 @@ func (self *SProjectQuota) Update(quota quotas.IQuota) {
 	}
 }
 
-func (self *SProjectQuota) Exceed(request quotas.IQuota, quota quotas.IQuota) error {
+func (used *SProjectQuota) Exceed(request quotas.IQuota, quota quotas.IQuota) error {
 	err := quotas.NewOutOfQuotaError()
 	sreq := request.(*SProjectQuota)
 	squota := quota.(*SProjectQuota)
-	if sreq.Secgroup > 0 && self.Secgroup+sreq.Secgroup > squota.Secgroup {
-		err.Add("secgroup", squota.Secgroup, self.Secgroup, sreq.Secgroup)
+	if quotas.Exceed(used.Secgroup, sreq.Secgroup, squota.Secgroup) {
+		err.Add("secgroup", squota.Secgroup, used.Secgroup, sreq.Secgroup)
 	}
 	if err.IsError() {
 		return err

--- a/pkg/compute/models/regionquota.go
+++ b/pkg/compute/models/regionquota.go
@@ -70,20 +70,20 @@ type SRegionQuota struct {
 
 	quotas.SRegionalCloudResourceKeys
 
-	Eip   int
-	Port  int
-	Eport int
-	Bw    int
-	Ebw   int
+	Eip   int `default:"-1"`
+	Port  int `default:"-1"`
+	Eport int `default:"-1"`
+	Bw    int `default:"-1"`
+	Ebw   int `default:"-1"`
 
-	Snapshot int
+	Snapshot int `default:"-1"`
 
-	Bucket    int
-	ObjectGB  int
-	ObjectCnt int
+	Bucket    int `default:"-1"`
+	ObjectGB  int `default:"-1"`
+	ObjectCnt int `default:"-1"`
 
-	Rds   int
-	Cache int
+	Rds   int `default:"-1"`
+	Cache int `default:"-1"`
 }
 
 func (self *SRegionQuota) GetKeys() quotas.IQuotaKeys {
@@ -300,42 +300,42 @@ func (self *SRegionQuota) Update(quota quotas.IQuota) {
 	}
 }
 
-func (self *SRegionQuota) Exceed(request quotas.IQuota, quota quotas.IQuota) error {
+func (used *SRegionQuota) Exceed(request quotas.IQuota, quota quotas.IQuota) error {
 	err := quotas.NewOutOfQuotaError()
 	sreq := request.(*SRegionQuota)
 	squota := quota.(*SRegionQuota)
-	if sreq.Port > 0 && self.Port+sreq.Port > squota.Port {
-		err.Add("port", squota.Port, self.Port, sreq.Port)
+	if quotas.Exceed(used.Port, sreq.Port, squota.Port) {
+		err.Add("port", squota.Port, used.Port, sreq.Port)
 	}
-	if sreq.Eip > 0 && self.Eip+sreq.Eip > squota.Eip {
-		err.Add("eip", squota.Eip, self.Eip, sreq.Eip)
+	if quotas.Exceed(used.Eip, sreq.Eip, squota.Eip) {
+		err.Add("eip", squota.Eip, used.Eip, sreq.Eip)
 	}
-	if sreq.Eport > 0 && self.Eport+sreq.Eport > squota.Eport {
-		err.Add("eport", squota.Eport, self.Eport, sreq.Eport)
+	if quotas.Exceed(used.Eport, sreq.Eport, squota.Eport) {
+		err.Add("eport", squota.Eport, used.Eport, sreq.Eport)
 	}
-	if sreq.Bw > 0 && self.Bw+sreq.Bw > squota.Bw {
-		err.Add("bw", squota.Bw, self.Bw, sreq.Bw)
+	if quotas.Exceed(used.Bw, sreq.Bw, squota.Bw) {
+		err.Add("bw", squota.Bw, used.Bw, sreq.Bw)
 	}
-	if sreq.Ebw > 0 && self.Ebw+sreq.Ebw > squota.Ebw {
-		err.Add("ebw", squota.Ebw, self.Ebw, sreq.Ebw)
+	if quotas.Exceed(used.Bw, sreq.Ebw, squota.Ebw) {
+		err.Add("ebw", squota.Ebw, used.Ebw, sreq.Ebw)
 	}
-	if sreq.Snapshot > 0 && self.Snapshot+sreq.Snapshot > squota.Snapshot {
-		err.Add("snapshot", squota.Snapshot, self.Snapshot, sreq.Snapshot)
+	if quotas.Exceed(used.Snapshot, sreq.Snapshot, squota.Snapshot) {
+		err.Add("snapshot", squota.Snapshot, used.Snapshot, sreq.Snapshot)
 	}
-	if sreq.Bucket > 0 && self.Bucket+sreq.Bucket > squota.Bucket {
-		err.Add("bucket", squota.Bucket, self.Bucket, sreq.Bucket)
+	if quotas.Exceed(used.Bucket, sreq.Bucket, squota.Bucket) {
+		err.Add("bucket", squota.Bucket, used.Bucket, sreq.Bucket)
 	}
-	if sreq.ObjectGB > 0 && self.ObjectGB+sreq.ObjectGB > squota.ObjectGB {
-		err.Add("object_gb", squota.ObjectGB, self.ObjectGB, sreq.ObjectGB)
+	if quotas.Exceed(used.ObjectGB, sreq.ObjectGB, squota.ObjectGB) {
+		err.Add("object_gb", squota.ObjectGB, used.ObjectGB, sreq.ObjectGB)
 	}
-	if sreq.ObjectCnt > 0 && self.ObjectCnt+sreq.ObjectCnt > squota.ObjectCnt {
-		err.Add("object_cnt", squota.ObjectCnt, self.ObjectCnt, sreq.ObjectCnt)
+	if quotas.Exceed(used.ObjectCnt, sreq.ObjectCnt, squota.ObjectCnt) {
+		err.Add("object_cnt", squota.ObjectCnt, used.ObjectCnt, sreq.ObjectCnt)
 	}
-	if sreq.Rds > 0 && self.Rds+sreq.Rds > squota.Rds {
-		err.Add("rds", squota.Rds, self.Rds, sreq.Rds)
+	if quotas.Exceed(used.Rds, sreq.Rds, squota.Rds) {
+		err.Add("rds", squota.Rds, used.Rds, sreq.Rds)
 	}
-	if sreq.Cache > 0 && self.Cache+sreq.Cache > squota.Cache {
-		err.Add("cache", squota.Cache, self.Cache, sreq.Cache)
+	if quotas.Exceed(used.Cache, sreq.Cache, squota.Cache) {
+		err.Add("cache", squota.Cache, used.Cache, sreq.Cache)
 	}
 	if err.IsError() {
 		return err

--- a/pkg/compute/models/zonequota.go
+++ b/pkg/compute/models/zonequota.go
@@ -70,7 +70,7 @@ type SZoneQuota struct {
 
 	quotas.SZonalCloudResourceKeys
 
-	Loadbalancer int
+	Loadbalancer int `default:"-1"`
 }
 
 func (self *SZoneQuota) GetKeys() quotas.IQuotaKeys {
@@ -182,12 +182,12 @@ func (self *SZoneQuota) Update(quota quotas.IQuota) {
 	}
 }
 
-func (self *SZoneQuota) Exceed(request quotas.IQuota, quota quotas.IQuota) error {
+func (used *SZoneQuota) Exceed(request quotas.IQuota, quota quotas.IQuota) error {
 	err := quotas.NewOutOfQuotaError()
 	sreq := request.(*SZoneQuota)
 	squota := quota.(*SZoneQuota)
-	if sreq.Loadbalancer > 0 && self.Loadbalancer+sreq.Loadbalancer > squota.Loadbalancer {
-		err.Add("loadbalancer", squota.Loadbalancer, self.Loadbalancer, sreq.Loadbalancer)
+	if quotas.Exceed(used.Loadbalancer, sreq.Loadbalancer, squota.Loadbalancer) {
+		err.Add("loadbalancer", squota.Loadbalancer, used.Loadbalancer, sreq.Loadbalancer)
 	}
 	if err.IsError() {
 		return err

--- a/pkg/image/models/quotas.go
+++ b/pkg/image/models/quotas.go
@@ -72,7 +72,7 @@ type SQuota struct {
 
 	SImageQuotaKeys
 
-	Image int
+	Image int `default:"-1"`
 }
 
 func (self *SQuota) GetKeys() quotas.IQuotaKeys {
@@ -156,12 +156,12 @@ func (self *SQuota) Update(quota quotas.IQuota) {
 	}
 }
 
-func (self *SQuota) Exceed(request quotas.IQuota, quota quotas.IQuota) error {
+func (used *SQuota) Exceed(request quotas.IQuota, quota quotas.IQuota) error {
 	err := quotas.NewOutOfQuotaError()
 	sreq := request.(*SQuota)
 	squota := quota.(*SQuota)
-	if sreq.Image > 0 && self.Image+sreq.Image > squota.Image {
-		err.Add("image", squota.Image, self.Image, sreq.Image)
+	if quotas.Exceed(used.Image, sreq.Image, squota.Image) {
+		err.Add("image", squota.Image, used.Image, sreq.Image)
 	}
 	if err.IsError() {
 		return err


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：配额的缺省值为-1，并且负的配额意味着没有配额限制。解决升级后，新增配额为0的问题。

**是否需要 backport 到之前的 release 分支**:
- release/2.13

/cc @zexi @yousong 

/area region