### PR TITLE
region: fix schedule input project and domain missing

### DIFF
--- a/pkg/apis/compute/api.go
+++ b/pkg/apis/compute/api.go
@@ -121,10 +121,8 @@ type ServerConfigs struct {
 	// ResourceType "shared|prepaid|dedicated"`
 	ResourceType string `json:"resource_type"`
 	InstanceType string `json:"instance_type"`
-	// Project      string `json:"project_id"`
-	// Domain       string `json:"domain_id"`
-	Backup bool `json:"backup"`
-	Count  int  `json:"count"`
+	Backup       bool   `json:"backup"`
+	Count        int    `json:"count"`
 
 	Disks                []*DiskConfig           `json:"disks"`
 	Networks             []*NetworkConfig        `json:"nets"`
@@ -161,8 +159,6 @@ type ServerCreateInput struct {
 
 	*ServerConfigs
 
-	// Name         string `json:"name"`
-	// GenerateName string `json:"generate_name"`
 	VmemSize  int    `json:"vmem_size"`
 	VcpuCount int    `json:"vcpu_count"`
 	UserData  string `json:"user_data"`

--- a/pkg/cloudcommon/cmdline/helper.go
+++ b/pkg/cloudcommon/cmdline/helper.go
@@ -337,6 +337,12 @@ func FetchScheduleInputByJSON(obj jsonutils.JSONObject) (*scheduler.ScheduleInpu
 	if err != nil {
 		return nil, err
 	}
+	if input.Domain == "" {
+		input.Domain = jsonutils.GetAnyString(obj, []string{"project_domain", "domain_id"})
+	}
+	if input.Project == "" {
+		input.Project = jsonutils.GetAnyString(obj, []string{"project", "project_id"})
+	}
 	return input, nil
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修改结构化参数导致 schedule input project domain 信息丢失

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- 2.13

/cc @swordqiu @ioito 