### PR TITLE
fix: 私有云同步的sku归属于default region

### DIFF
--- a/pkg/compute/models/skus.go
+++ b/pkg/compute/models/skus.go
@@ -1067,19 +1067,12 @@ func (manager *SServerSkuManager) newFromCloudSku(ctx context.Context, userCred 
 	sku.constructSku(extSku)
 
 	sku.Name = extSku.GetName()
+	sku.CloudregionId = api.DEFAULT_REGION_ID
 	sku.SetModelManager(manager, sku)
 	err := manager.TableSpec().Insert(sku)
 	if err != nil {
 		return errors.Wrapf(err, "newFromCloudSku.Insert")
 	}
-	_, err = sku.GetModelManager().TableSpec().Update(sku, func() error {
-		sku.CloudregionId = ""
-		return nil
-	})
-	if err != nil {
-		return errors.Wrapf(err, "Update sku %s cloudregion info", sku.Name)
-	}
-
 	db.OpsLog.LogEvent(sku, db.ACT_CREATE, sku.GetShortDesc(ctx), userCred)
 
 	return nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
私有云同步的sku归属于default region

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu 
