### PR TITLE
fix: prevent quota usage from being negative

### DIFF
--- a/pkg/cloudcommon/db/quotas/interface.go
+++ b/pkg/cloudcommon/db/quotas/interface.go
@@ -41,6 +41,7 @@ type IQuota interface {
 	Update(quota IQuota)
 	Add(quota IQuota)
 	Sub(quota IQuota)
+	ResetNegative()
 	Exceed(request IQuota, quota IQuota) error
 	// IsEmpty() bool
 	ToJSON(prefix string) jsonutils.JSONObject

--- a/pkg/compute/models/projectquota.go
+++ b/pkg/compute/models/projectquota.go
@@ -118,6 +118,12 @@ func (self *SProjectQuota) FetchUsage(ctx context.Context) error {
 	return nil
 }
 
+func (self *SProjectQuota) ResetNegative() {
+	if self.Secgroup < 0 {
+		self.Secgroup = 0
+	}
+}
+
 func (self *SProjectQuota) IsEmpty() bool {
 	if self.Secgroup > 0 {
 		return false

--- a/pkg/compute/models/quotas.go
+++ b/pkg/compute/models/quotas.go
@@ -191,6 +191,27 @@ func (self *SQuota) FetchUsage(ctx context.Context) error {
 	return nil
 }
 
+func (self *SQuota) ResetNegative() {
+	if self.Count < 0 {
+		self.Count = 0
+	}
+	if self.Cpu < 0 {
+		self.Cpu = 0
+	}
+	if self.Memory < 0 {
+		self.Memory = 0
+	}
+	if self.Storage < 0 {
+		self.Storage = 0
+	}
+	if self.Group < 0 {
+		self.Group = 0
+	}
+	if self.IsolatedDevice < 0 {
+		self.IsolatedDevice = 0
+	}
+}
+
 func (self *SQuota) IsEmpty() bool {
 	if self.Count > 0 {
 		return false

--- a/pkg/compute/models/regionquota.go
+++ b/pkg/compute/models/regionquota.go
@@ -196,6 +196,42 @@ func (self *SRegionQuota) FetchUsage(ctx context.Context) error {
 	return nil
 }
 
+func (self *SRegionQuota) ResetNegative() {
+	if self.Port < 0 {
+		self.Port = 0
+	}
+	if self.Eip < 0 {
+		self.Eip = 0
+	}
+	if self.Eport < 0 {
+		self.Eport = 0
+	}
+	if self.Bw < 0 {
+		self.Bw = 0
+	}
+	if self.Ebw < 0 {
+		self.Ebw = 0
+	}
+	if self.Snapshot < 0 {
+		self.Snapshot = 0
+	}
+	if self.Bucket < 0 {
+		self.Bucket = 0
+	}
+	if self.ObjectGB < 0 {
+		self.ObjectGB = 0
+	}
+	if self.ObjectCnt < 0 {
+		self.ObjectCnt = 0
+	}
+	if self.Rds < 0 {
+		self.Rds = 0
+	}
+	if self.Cache < 0 {
+		self.Cache = 0
+	}
+}
+
 func (self *SRegionQuota) IsEmpty() bool {
 	if self.Port > 0 {
 		return false

--- a/pkg/compute/models/zonequota.go
+++ b/pkg/compute/models/zonequota.go
@@ -158,6 +158,12 @@ func (self *SZoneQuota) FetchUsage(ctx context.Context) error {
 	return nil
 }
 
+func (self *SZoneQuota) ResetNegative() {
+	if self.Loadbalancer < 0 {
+		self.Loadbalancer = 0
+	}
+}
+
 func (self *SZoneQuota) IsEmpty() bool {
 	if self.Loadbalancer > 0 {
 		return false

--- a/pkg/image/models/quotas.go
+++ b/pkg/image/models/quotas.go
@@ -132,6 +132,12 @@ func (self *SQuota) FetchUsage(ctx context.Context) error {
 	return nil
 }
 
+func (self *SQuota) ResetNegative() {
+	if self.Image < 0 {
+		self.Image = 0
+	}
+}
+
 func (self *SQuota) IsEmpty() bool {
 	if self.Image > 0 {
 		return false


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：quota允许为负值（代表无配额闲置），但是不允许使用量（usage）为负值

**是否需要 backport 到之前的 release 分支**:
- release/2.13

/cc @zexi @yousong 

/area region
/area image