### PR TITLE
fix: 避免创建安全组规则时未能接收到安全组参数

### DIFF
--- a/pkg/apis/compute/secgroup.go
+++ b/pkg/apis/compute/secgroup.go
@@ -37,6 +37,7 @@ type SSecgroupRuleCreateInput struct {
 	CIDR        string
 	Action      string
 	Description string
+	Secgroup    string
 	SecgroupId  string
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免创建安全组规则时未能接收到安全组参数

**是否需要 backport 到之前的 release 分支**:
- release/2.13

/area region
/cc @swordqiu