### PR TITLE
devtool manager 去掉重复的 RegisterModelManager

### DIFF
--- a/pkg/devtool/models/devtoolcronjob.go
+++ b/pkg/devtool/models/devtoolcronjob.go
@@ -65,9 +65,6 @@ func init() {
 		),
 	}
 	CronjobManager.SetVirtualObject(CronjobManager)
-	db.RegisterModelManager(CronjobManager)
-	DevToolCronManager = cronman.InitCronJobManager(true, 8)
-	DevToolCronManager.Start()
 }
 
 func RunAnsibleCronjob(id string, s *mcclient.ClientSession) cronman.TCronJobFunction {
@@ -114,7 +111,8 @@ func AddOneCronjob(item *SCronjob, s *mcclient.ClientSession) error {
 }
 
 func InitializeCronjobs() error {
-
+	DevToolCronManager = cronman.InitCronJobManager(true, 8)
+	DevToolCronManager.Start()
 	Session := auth.GetAdminSession(nil, "", "")
 
 	go func() {

--- a/pkg/devtool/models/devtooltemplate.go
+++ b/pkg/devtool/models/devtooltemplate.go
@@ -51,7 +51,6 @@ func init() {
 		),
 	}
 	DevtoolTemplateManager.SetVirtualObject(DevtoolTemplateManager)
-	db.RegisterModelManager(DevtoolTemplateManager)
 }
 
 func (obj *SDevtoolTemplate) PerformBind(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
devtool manager 去掉重复的 RegisterModelManager
**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- release/2.13