### PR TITLE
fix: disabling cloud account should not turn off auto sync switch

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -216,12 +216,12 @@ func (self *SCloudaccount) PerformDisable(ctx context.Context, userCred mcclient
 			}
 		}
 	}
-	if self.EnableAutoSync {
+	/*if self.EnableAutoSync {
 		err := self.disableAutoSync(ctx, userCred)
 		if err != nil {
 			return nil, err
 		}
-	}
+	}*/
 	return nil, nil
 }
 

--- a/pkg/compute/models/cloudproviderregions.go
+++ b/pkg/compute/models/cloudproviderregions.go
@@ -142,7 +142,7 @@ func (self *SCloudproviderregion) getExtraDetails(extra *jsonutils.JSONDict) *js
 		extra.Add(jsonutils.NewString(account.Id), "cloudaccount_id")
 		extra.Add(jsonutils.NewString(account.Name), "cloudaccount")
 		extra.Add(jsonutils.NewString(account.DomainId), "cloudaccount_domain_id")
-		if account.EnableAutoSync {
+		if account.Enabled && account.EnableAutoSync {
 			extra.Add(jsonutils.JSONTrue, "enable_auto_sync")
 		} else {
 			extra.Add(jsonutils.JSONFalse, "enable_auto_sync")

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -499,6 +499,9 @@ func (self *SCloudprovider) PerformSync(ctx context.Context, userCred mcclient.T
 		return nil, httperrors.NewInvalidStatusError("Cloudprovider disabled")
 	}
 	account := self.GetCloudaccount()
+	if !account.Enabled {
+		return nil, httperrors.NewInvalidStatusError("Cloudaccount disabled")
+	}
 	if account.EnableAutoSync {
 		return nil, httperrors.NewInvalidStatusError("Account auto sync enabled")
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：禁用云账号不会关闭自动同步开关

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/cc @ioito @yousong 

/area region