### PR TITLE
Automated cherry pick of #4207: fix: ESXi fakeDC ID should matches any datacenter

### DIFF
--- a/pkg/multicloud/esxi/manager.go
+++ b/pkg/multicloud/esxi/manager.go
@@ -328,6 +328,10 @@ func findDatacenterByMoId(dcs []*SDatacenter, dcId string) (*SDatacenter, error)
 		if dcs[i].GetId() == dcId {
 			return dcs[i], nil
 		}
+		// defaultDcId means no premision to get datacenter, so return fake dc
+		if dcs[i].GetId() == defaultDcId {
+			return dcs[i], nil
+		}
 	}
 	return nil, cloudprovider.ErrNotFound
 }


### PR DESCRIPTION
Cherry pick of #4207 on release/2.12.

#4207: fix: ESXi fakeDC ID should matches any datacenter