### PR TITLE
Automated cherry pick of #4212: guestnetworks: ignore empty preferIfname

### DIFF
--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -234,6 +234,9 @@ func (self *SGuestnetwork) generateIfname(network *SNetwork, virtual bool, rando
 }
 
 func (man *SGuestnetworkManager) ifnameUsed(ifname string) bool {
+	if ifname == "" {
+		return true
+	}
 	count, err := GuestnetworkManager.Query().Equals("ifname", ifname).CountWithError()
 	if err != nil {
 		panic(errors.Wrap(err, "query if ifname is used"))


### PR DESCRIPTION
Cherry pick of #4212 on release/2.10.0.

#4212: guestnetworks: ignore empty preferIfname