### PR TITLE
bugfix(notify): Fix the bug of notify config and verify

### DIFF
--- a/pkg/notify/dispatcher.go
+++ b/pkg/notify/dispatcher.go
@@ -118,9 +118,10 @@ func (self *NotifyModelDispatcher) UpdateConfig(ctx context.Context, body jsonut
 		createData.Add(jsonutils.NewString(key), "key_text")
 		createData.Add(jsonutils.NewString(contactType), "type")
 		_, err := self.Create(ctx, jsonutils.JSONNull, createData, nil)
-		config[key] = tmp.String()
+		value, _ := tmp.GetString()
+		config[key] = value
 		if err != nil {
-			return errors.Wrapf(err, "Create config (%s, %s, %s) failed", contactType, key, tmp)
+			return errors.Wrapf(err, "Create config (%s, %s, %s) failed", contactType, key, value)
 		}
 	}
 	// update config
@@ -250,7 +251,10 @@ func (self *NotifyModelDispatcher) VerifyTrigger(ctx context.Context, params map
 			return nil, httperrors.NewGeneralError(err)
 		}
 		processID := verification.ID
-		models.SendVerifyMessage(userCred, verification, uid, contactType, contact)
+		err := models.SendVerifyMessage(ctx, userCred, verification, &scontact)
+		if err != nil {
+			return nil, err
+		}
 		ret := map[string]map[string]string{
 			"contact": {
 				"process_id": processID,

--- a/pkg/notify/handlers.go
+++ b/pkg/notify/handlers.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
@@ -182,38 +181,6 @@ func AddNotifyDispatcher(prefix string, app *appsrv.Application) {
 	app.AddHandler2("POST",
 		fmt.Sprintf("%s/%s/delete-template", prefix, modelDispatcher.KeywordPlural()),
 		middleware(deleteTemplateHandler), metadata, "delete", tags)
-
-	app.AddHandler2("POST",
-		fmt.Sprintf("%s/%s/email-url", prefix, modelDispatcher.KeywordPlural()),
-		middleware(updateEmailUrlHandler), metadata, "update_email_url", tags)
-
-	app.AddHandler2("GET",
-		fmt.Sprintf("%s/%s/email-url", prefix, modelDispatcher.KeywordPlural()),
-		middleware(getEmailUrlHandler), metadata, "get_email_url", tags)
-}
-
-func updateEmailUrlHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	userCred := policy.FetchUserCredential(ctx)
-	if !userCred.HasSystemAdminPrivilege() {
-		httperrors.ForbiddenError(w, "only system admin can update email url")
-		return
-	}
-	_, _, _, body := fetchEnv(ctx, w, r)
-	if !body.Contains("email_url") {
-		httperrors.InputParameterError(w, "miss email_url")
-	}
-	emailUrl, _ := body.GetString("email_url")
-	eUrl, err := url.Parse(emailUrl)
-	if err != nil {
-		httperrors.InputParameterError(w, "invalid url")
-	}
-	models.TemplateManager.SetEmailUrl(eUrl.String())
-}
-
-func getEmailUrlHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	ret := jsonutils.NewDict()
-	ret.Add(jsonutils.NewString(models.TemplateManager.GetEmailUrl()), "email_url")
-	appsrv.Send(w, ret.PrettyString())
 }
 
 func templateUpdateHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {

--- a/pkg/notify/models/mod_template.go
+++ b/pkg/notify/models/mod_template.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
-	"sync"
 	ptem "text/template"
 
 	"yunion.io/x/jsonutils"
@@ -31,6 +30,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/notify/options"
 	"yunion.io/x/onecloud/pkg/notify/rpc/apis"
 	"yunion.io/x/onecloud/pkg/notify/template"
 )
@@ -58,12 +58,6 @@ const (
 	TEMPLATE_TYPE_REMOTE  = "remote"
 )
 
-var (
-	DefaultEmailUrl = ""
-	EmailUrl        = ""
-	EmailUrlLock    sync.RWMutex
-)
-
 type STemplate struct {
 	SStandaloneResourceBase
 
@@ -76,18 +70,7 @@ type STemplate struct {
 }
 
 func (tm *STemplateManager) GetEmailUrl() string {
-	EmailUrlLock.RLock()
-	defer EmailUrlLock.RUnlock()
-	if len(EmailUrl) == 0 {
-		return DefaultEmailUrl
-	}
-	return EmailUrl
-}
-
-func (tm *STemplateManager) SetEmailUrl(url string) {
-	EmailUrlLock.Lock()
-	defer EmailUrlLock.Unlock()
-	EmailUrl = url
+	return options.Options.VerifyEmailUrl
 }
 
 func (tm *STemplateManager) InitializeData() error {

--- a/pkg/notify/options/options.go
+++ b/pkg/notify/options/options.go
@@ -27,7 +27,7 @@ type NotifyOption struct {
 	UpdateInterval  int    `help:"Update send services interval(unit:s)" default:"30"`
 	VerifyEmailUrl  string `help:"url of verify email"`
 	ReSendScope     int    `help:"Resend all messages that have not been sent successfully within ReSendScope
-seconds"`
+seconds" default:"30"`
 	InitNotificationScope int `help:"initialize data of notification with in InitNotificationScope hours" default:"100"`
 }
 

--- a/pkg/notify/rpc/send.go
+++ b/pkg/notify/rpc/send.go
@@ -124,7 +124,7 @@ func (self *SRpcService) Send(ctx context.Context, contactType, contact, topic, 
 
 	_, err = self.execute(ctx, f, contactType)
 	if err != nil {
-		return errors.Wrapf(err, "contactType: %s", contactType)
+		return errors.Wrapf(err, "contactType '%s'", contactType)
 	}
 	return nil
 }

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -43,9 +43,6 @@ func StartService() {
 	baseOpts := &options.Options.BaseOptions
 	common_options.ParseOptions(opts, os.Args, "notify.conf", "notify")
 
-	// init email url
-	models.TemplateManager.SetEmailUrl(options.Options.VerifyEmailUrl)
-
 	// init auth
 	app.InitAuth(commonOpts, func() {
 		log.Infof("Auth complete!")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. 优化了报错信息
2. 将验证信息的发送由异步改成了同步，这样前端可以方便的展示验证消息发送失败的原因
3. 主动初始化webconsole的配置信息，使得websocket能够马上正常工作
4. 修复了验证信息发送失败之后联系方式状态不正确的bug
5. 去掉有关email回调地址的api
6. 修复了update config 首次不起作用的bug


**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
