### PR TITLE
fix(region): Fix the bug of snapshotpolicy's list with details

### DIFF
--- a/pkg/compute/models/snapshotpolicy.go
+++ b/pkg/compute/models/snapshotpolicy.go
@@ -307,21 +307,24 @@ func (sp *SSnapshotPolicy) StartSnapshotPolicyDeleteTask(ctx context.Context, us
 
 func (sp *SSnapshotPolicy) GetCustomizeColumns(ctx context.Context, userCred mcclient.TokenCredential,
 	query jsonutils.JSONObject) *jsonutils.JSONDict {
-
-	ret, _ := sp.getMoreDetails(ctx, userCred, query)
+	extraDict := sp.SVirtualResourceBase.GetCustomizeColumns(ctx, userCred, query)
+	ret, _ := sp.getMoreDetails(ctx, userCred, extraDict)
 	return ret
 }
 
 func (sp *SSnapshotPolicy) GetExtraDetails(ctx context.Context, userCred mcclient.TokenCredential,
 	query jsonutils.JSONObject) (*jsonutils.JSONDict, error) {
-
-	return sp.getMoreDetails(ctx, userCred, query)
+	extraDict, err := sp.SVirtualResourceBase.GetExtraDetails(ctx, userCred, query)
+	if err != nil {
+		return nil, err
+	}
+	return sp.getMoreDetails(ctx, userCred, extraDict)
 }
 
 func (sp *SSnapshotPolicy) getMoreDetails(ctx context.Context, userCred mcclient.TokenCredential,
-	query jsonutils.JSONObject) (*jsonutils.JSONDict, error) {
+	extraDict *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
 
-	ret := query.(*jsonutils.JSONDict)
+	ret := extraDict
 	// more
 	weekdays := SnapshotPolicyManager.RepeatWeekdaysToIntArray(sp.RepeatWeekdays)
 	timePoints := SnapshotPolicyManager.TimePointsToIntArray(sp.TimePoints)


### PR DESCRIPTION


**这个 PR 实现什么功能/修复什么问题**:

snapshotpolicy的GetCustomizeColumns和GetExtraDetails本来写的就有问题，
不过在2.12版本没有展示出来，因为2.13版本参数结构化的原因，details获取
的时候extraDict和jsonDict的更新逻辑有所改变，使得query携带着list第一
个item的数据一直存在整个循环之中，最终数据都是一样的。

**是否需要 backport 到之前的 release 分支**:
- realease/2.12
- realease/2.13
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
