### PR TITLE
fix: globalvpc属于系统资源

### DIFF
--- a/pkg/cloudcommon/policy/resources.go
+++ b/pkg/cloudcommon/policy/resources.go
@@ -22,6 +22,7 @@ var (
 		"zones",
 		"storages",
 		"wires",
+		"globalvpcs",
 		"vpcs",
 		"route_tables",
 		"cloudregions",


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
globalvpc属于系统资源

**是否需要 backport 到之前的 release 分支**:
- release/2.13

/area region
/cc @swordqiu 
