### PR TITLE
Automated cherry pick of #4226: fix: globalvpc属于系统资源

### DIFF
--- a/pkg/cloudcommon/policy/resources.go
+++ b/pkg/cloudcommon/policy/resources.go
@@ -22,6 +22,7 @@ var (
 		"zones",
 		"storages",
 		"wires",
+		"globalvpcs",
 		"vpcs",
 		"route_tables",
 		"cloudregions",


### PR DESCRIPTION
Cherry pick of #4226 on release/2.13.

#4226: fix: globalvpc属于系统资源