### PR TITLE
Fix(notify): Unified the api params and fix some bug.

### DIFF
--- a/cmd/climc/shell/contacts.go
+++ b/cmd/climc/shell/contacts.go
@@ -50,15 +50,13 @@ func init() {
 
 		arr.Add(tmpObj)
 
-		tmpObj = jsonutils.NewDict()
-		tmpObj.Add(arr, "contacts")
 		params := jsonutils.NewDict()
-		params.Add(tmpObj, "contact")
+		params.Add(arr, "contacts")
 		if args.UpdateDingtalk {
 			params.Add(jsonutils.JSONTrue, "update_dingtalk")
 		}
 
-		contact, err := modules.Contacts.PerformAction(s, args.UID, "update-contact", params)
+		contact, err := modules.Contacts.CustomizedPerformAction(s, args.UID, "update-contact", params)
 
 		if err != nil {
 			return err
@@ -80,7 +78,7 @@ func init() {
 		arr.Add(tmpObj)
 		params := jsonutils.NewDict()
 		params.Add(arr, "contacts")
-		contact, err := modules.Contacts.PerformAction(s, args.UID, "update-contact", params)
+		contact, err := modules.Contacts.CustomizedPerformAction(s, args.UID, "update-contact", params)
 		if err != nil {
 			return err
 		}
@@ -135,7 +133,7 @@ func init() {
 
 		params.Add(jsonutils.JSONTrue, "details")
 
-		result, err := modules.Contacts.Get(s, args.UID, params)
+		result, err := modules.Contacts.CustomizedGet(s, args.UID, params)
 		if err != nil {
 			return err
 		}
@@ -168,12 +166,10 @@ func init() {
 		CONTACT      string `help:"The contacts details mobile number or email address"`
 	}
 	R(&ContactsVerifyOptions{}, "contact-verify-trigger", "Trigger contact verify", func(s *mcclient.ClientSession, args *ContactsVerifyOptions) error {
-		params := jsonutils.NewDict()
 		tmpDict := jsonutils.NewDict()
 		tmpDict.Add(jsonutils.NewString(args.CONTACT_TYPE), "contact_type")
 		tmpDict.Add(jsonutils.NewString(args.CONTACT), "contact")
-		params.Add(tmpDict, "contact")
-		_, err := modules.Contacts.PerformAction(s, args.UID, "verify", params)
+		_, err := modules.Contacts.CustomizedPerformAction(s, args.UID, "verify", tmpDict)
 		if err != nil {
 			return err
 		}

--- a/cmd/climc/shell/notify_template.go
+++ b/cmd/climc/shell/notify_template.go
@@ -25,17 +25,17 @@ import (
 func init() {
 	type NotifyTemplateUpdateOptions struct {
 		CONTACTTYPE  string `help:"the contanct type, such as 'email', 'mobile'"`
-		Topic        string `help:"the topic of temlate, such as 'VERIFY', 'ALARM'"`
-		TemplateType string `help:"the type of template" choices:"content|title|remote"`
-		Content      string `help:"the content of template"`
+		TOPIC        string `help:"the topic of temlate, such as 'VERIFY', 'ALARM'"`
+		TEMPLATETYPE string `help:"the type of template" choices:"content|title|remote"`
+		CONTENT      string `help:"the content of template"`
 	}
 	R(&NotifyTemplateUpdateOptions{}, "notify-template-update", "Create, update contact for user", func(s *mcclient.ClientSession,
 		args *NotifyTemplateUpdateOptions) error {
 		arr := jsonutils.NewArray()
 		tmpObj := jsonutils.NewDict()
-		tmpObj.Add(jsonutils.NewString(args.Topic), "topic")
-		tmpObj.Add(jsonutils.NewString(args.TemplateType), "template_type")
-		tmpObj.Add(jsonutils.NewString(args.Content), "content")
+		tmpObj.Add(jsonutils.NewString(args.TOPIC), "topic")
+		tmpObj.Add(jsonutils.NewString(args.TEMPLATETYPE), "template_type")
+		tmpObj.Add(jsonutils.NewString(args.CONTENT), "content")
 		arr.Add(tmpObj)
 
 		params := jsonutils.NewDict()

--- a/pkg/mcclient/modules/mod_contacts.go
+++ b/pkg/mcclient/modules/mod_contacts.go
@@ -45,14 +45,19 @@ func (this *ContactsManager) DoBatchDeleteContacts(s *mcclient.ClientSession, pa
 	return modulebase.Post(this.ResourceManager, s, path, params, this.Keyword)
 }
 
-func (this *ContactsManager) PerformAction(session *mcclient.ClientSession, id string, action string,
+func (this *ContactsManager) CustomizedPerformAction(session *mcclient.ClientSession, id string, action string,
 	params jsonutils.JSONObject) (jsonutils.JSONObject, error) {
 
+	body := jsonutils.NewDict()
+	if params != nil {
+		body.Add(params, this.Keyword)
+	}
 	path := fmt.Sprintf("/%s/%s/%s?uname=true", this.ContextPath(nil), url.PathEscape(id), url.PathEscape(action))
 	return modulebase.Post(this.ResourceManager, session, path, params, this.KeywordPlural)
 }
 
-func (this *ContactsManager) Get(session *mcclient.ClientSession, id string, params jsonutils.JSONObject) (jsonutils.JSONObject,
+func (this *ContactsManager) CustomizedGet(session *mcclient.ClientSession, id string,
+	params jsonutils.JSONObject) (jsonutils.JSONObject,
 	error) {
 
 	q := params.(*jsonutils.JSONDict)

--- a/pkg/mcclient/modules/notify/mod_notification.go
+++ b/pkg/mcclient/modules/notify/mod_notification.go
@@ -15,6 +15,8 @@
 package notify
 
 import (
+	"fmt"
+
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -42,7 +44,12 @@ type NotificationManager struct {
 }
 
 func (manager *NotificationManager) Send(s *mcclient.ClientSession, msg SNotifyMessage) error {
-	_, err := manager.Create(s, jsonutils.Marshal(&msg))
+	params := jsonutils.Marshal(&msg)
+	body := jsonutils.NewDict()
+	body.Add(params, manager.Keyword)
+
+	path := fmt.Sprintf("/%s?uname=true", manager.ContextPath(nil))
+	_, err := modulebase.Post(manager.ResourceManager, s, path, body, manager.KeywordPlural)
 	return err
 }
 

--- a/pkg/notify/handlers.go
+++ b/pkg/notify/handlers.go
@@ -187,8 +187,8 @@ func templateUpdateHandler(ctx context.Context, w http.ResponseWriter, r *http.R
 	manager, params, query, body := fetchEnv(ctx, w, r)
 	data, err := body.GetArray(manager.Keyword(), manager.KeywordPlural())
 	if err != nil {
-		httperrors.GeneralServerError(w, httperrors.NewInputParameterError("need %s or %s", manager.Keyword(),
-			manager.KeywordPlural()))
+		httperrors.GeneralServerError(w, httperrors.NewInputParameterError("need %s and %s",
+			manager.Keyword(), manager.KeywordPlural()))
 		return
 	}
 	ctype := params["<ctype>"]
@@ -282,8 +282,8 @@ func contactUpdateHandler(ctx context.Context, w http.ResponseWriter, r *http.Re
 	data, err := body.GetArray(manager.Keyword(), manager.KeywordPlural())
 	if err != nil {
 		log.Errorf("body: %s, err: %s\n", body.String(), err)
-		httperrors.GeneralServerError(w, httperrors.NewInputParameterError("need %s or %s", manager.Keyword(),
-			manager.KeywordPlural()))
+		httperrors.GeneralServerError(w, httperrors.NewInputParameterError("need %s and %s",
+			manager.Keyword(), manager.KeywordPlural()))
 		return
 	}
 
@@ -329,7 +329,7 @@ func verifyTriggerHandler(ctx context.Context, w http.ResponseWriter, r *http.Re
 	manager, params, _, body := fetchEnv(ctx, w, r)
 	data, err := body.Get(models.ContactManager.Keyword())
 	if err != nil {
-		httperrors.BadRequestError(w, "request body should have %s", manager.KeywordPlural())
+		httperrors.BadRequestError(w, "request body should have %s", manager.Keyword())
 		return
 	}
 	ret, err := manager.VerifyTrigger(ctx, params, data)

--- a/pkg/notify/models/mod_template.go
+++ b/pkg/notify/models/mod_template.go
@@ -74,6 +74,7 @@ func (tm *STemplateManager) GetEmailUrl() string {
 }
 
 func (tm *STemplateManager) InitializeData() error {
+	// init email VERIFY template
 	q := tm.Query().Equals("contact_type", "email").Equals("topic", "VERIFY").Equals("template_type", "content")
 	count, _ := q.CountWithError()
 	if count > 0 {
@@ -89,13 +90,13 @@ func (tm *STemplateManager) InitializeData() error {
 	contentTem := STemplate{
 		ContactType:  "email",
 		Topic:        "VERIFY",
-		TemplateType: "content",
+		TemplateType: TEMPLATE_TYPE_CONTENT,
 		Content:      string(content),
 	}
 	titleTem := STemplate{
 		ContactType:  "email",
 		Topic:        "VERIFY",
-		TemplateType: "title",
+		TemplateType: TEMPLATE_TYPE_TITLE,
 		Content:      template.EMAIL_VERIFY_TITLE,
 	}
 	err = tm.TableSpec().InsertOrUpdate(&contentTem)
@@ -105,6 +106,32 @@ func (tm *STemplateManager) InitializeData() error {
 	tm.TableSpec().InsertOrUpdate(&titleTem)
 	if err != nil {
 		return errors.Wrap(err, "sqlchemy.TableSpec.InsertOrUpdate")
+	}
+	// init email IMAGE_ACTIVED template
+	q = tm.Query().Equals("contact_type", "email").Equals("topic", "IMAGE_ACTIVED")
+	count, _ = q.CountWithError()
+	if count > 1 {
+		return nil
+	}
+	titleTem = STemplate{
+		ContactType:  "email",
+		Topic:        "IMAGE_ACTIVED",
+		TemplateType: TEMPLATE_TYPE_TITLE,
+		Content:      template.IMAGE_ACTIVED_TITLE,
+	}
+	contentTem = STemplate{
+		ContactType:  "email",
+		Topic:        "IMAGE_ACTIVED",
+		TemplateType: TEMPLATE_TYPE_CONTENT,
+		Content:      template.IMAGE_ACTIVED_CONTENT,
+	}
+	err = tm.TableSpec().InsertOrUpdate(&titleTem)
+	if err != nil {
+		return errors.Wrapf(err, "fail to InsertOrUpdate for email IMAGE_ACTIVED title template")
+	}
+	err = tm.TableSpec().InsertOrUpdate(&contentTem)
+	if err != nil {
+		return errors.Wrapf(err, "fail to InsertOrUpdate for email IMAGE_ACTIVED content template")
 	}
 	return nil
 }

--- a/pkg/notify/options/options.go
+++ b/pkg/notify/options/options.go
@@ -24,7 +24,7 @@ type NotifyOption struct {
 
 	DingtalkEnabled bool   `help:"Enable dingtalk"`
 	SocketFileDir   string `help:"Socket file directory" default:"/etc/yunion/notify"`
-	UpdateInterval  int    `help:"Update send services interval(unit:s)" default:"30"`
+	UpdateInterval  int    `help:"Update send services interval(unit:min)" default:"30"`
 	VerifyEmailUrl  string `help:"url of verify email"`
 	ReSendScope     int    `help:"Resend all messages that have not been sent successfully within ReSendScope
 seconds" default:"30"`

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -66,9 +66,9 @@ func StartService() {
 
 	cron := cronman.InitCronJobManager(true, 2)
 	// update service
-	cron.AddJobAtIntervals("UpdateServices", time.Duration(opts.UpdateInterval)*time.Second, models.NotifyService.UpdateServices)
+	cron.AddJobAtIntervals("UpdateServices", time.Duration(opts.UpdateInterval)*time.Minute, models.NotifyService.UpdateServices)
 
-	// resend notifications
+	// wrapped func to resend notifications
 	resend := func(ctx context.Context, userCred mcclient.TokenCredential, isStart bool) {
 		models.ReSend(opts.ReSendScope)
 	}

--- a/pkg/notify/template/template.go
+++ b/pkg/notify/template/template.go
@@ -17,4 +17,7 @@ package template
 const (
 	EMAIL_VERIFY_CONTENT_PATH = "/opt/yunion/share/notify/email_verify_template"
 	EMAIL_VERIFY_TITLE        = "Yunion Verify"
+
+	IMAGE_ACTIVED_TITLE   = "镜像 {{.name}} 上传完成"
+	IMAGE_ACTIVED_CONTENT = "{{.os_type}} 镜像 {{.name}} 上传完成"
 )


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. Config Verify 和 Contact 的 InitalizeData 写得过于直接了。
会导致正常的数据被覆盖。实际上，数据的Init只需要更换数据
库的时候更新，如何判断数据库要被更新了，就是判断新出现的
column 有没有非零值的，如果有，就说明数据库不是第一次更新。

2. 前端的请求经过yunionapi，最终会调用climc里面注册的ResourceManager，
所以这个地方一定要和后端的参数处理统一。之前因为添加 uname
的支持破坏了这个地方的统一，虽然climc可以调用成功但是前端接口调用会失败。

3. Resend 的bug，会导致任务的阻塞。

4. 为了兼容kapacitor对climc notify的调用，分成了notify和notify-batch两个命令。

5. 增加了topic为IMAGE_ACTIVED的email template

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
