### PR TITLE
fix: image-quotas not register model names

### DIFF
--- a/pkg/mcclient/modules/mod_quotas.go
+++ b/pkg/mcclient/modules/mod_quotas.go
@@ -159,5 +159,5 @@ func init() {
 	ImageQuotas = QuotaManager{NewImageManager("image_quota", "image_quotas",
 		quotaColumns,
 		[]string{})}
-	// registerV2(&ImageQuotas)
+	registerV2(&ImageQuotas)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：API网关访问images_quotas返回404

**是否需要 backport 到之前的 release 分支**:
- release/2.13

/cc @zexi 

/area apigateway