### PR TITLE
Automated cherry pick of #4168: fix: 避免创建安全组规则时未能接收到安全组参数

### DIFF
--- a/pkg/apis/compute/secgroup.go
+++ b/pkg/apis/compute/secgroup.go
@@ -37,6 +37,7 @@ type SSecgroupRuleCreateInput struct {
 	CIDR        string
 	Action      string
 	Description string
+	Secgroup    string
 	SecgroupId  string
 }
 


### PR DESCRIPTION
Cherry pick of #4168 on release/2.13.

#4168: fix: 避免创建安全组规则时未能接收到安全组参数