### PR TITLE
feature: service config update support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ require (
 	yunion.io/x/log v0.0.0-20190629062853-9f6483a7103d
 	yunion.io/x/pkg v0.0.0-20191221094533-5097f12f41ac
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
-	yunion.io/x/sqlchemy v0.0.0-20191217082202-5f99691a51c9
+	yunion.io/x/sqlchemy v0.0.0-20191223103213-67358d3737b6
 	yunion.io/x/structarg v0.0.0-20190809075558-115bed041de3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -675,7 +675,7 @@ yunion.io/x/pkg v0.0.0-20191221094533-5097f12f41ac h1:upUF6LBhCKx9c/OUzSUwfv50oC
 yunion.io/x/pkg v0.0.0-20191221094533-5097f12f41ac/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8J50Cise/HCylsOJngmo=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e/go.mod h1:0iFKpOs1y4lbCxeOmq3Xx/0AcQoewVPwj62eRluioEo=
-yunion.io/x/sqlchemy v0.0.0-20191217082202-5f99691a51c9 h1:2yZ6YgFi5NkfqSdpclOOuYGaubk+WC6Emnb78ibgTVY=
-yunion.io/x/sqlchemy v0.0.0-20191217082202-5f99691a51c9/go.mod h1:FTdwPdGhMgh4E+UFXc9klI1Ok34fMuybTT+jLhOaIjI=
+yunion.io/x/sqlchemy v0.0.0-20191223103213-67358d3737b6 h1:sxM1xAJetpHl+jRVqDWzMJuWw2usCRrhmOPdDPt7N9E=
+yunion.io/x/sqlchemy v0.0.0-20191223103213-67358d3737b6/go.mod h1:FTdwPdGhMgh4E+UFXc9klI1Ok34fMuybTT+jLhOaIjI=
 yunion.io/x/structarg v0.0.0-20190809075558-115bed041de3 h1:bfC8EhXYvyGYldRWlzxiCM39Zfj3s3+zham9mW2h2LE=
 yunion.io/x/structarg v0.0.0-20190809075558-115bed041de3/go.mod h1:EP6NSv2C0zzqBDTKumv8hPWLb3XvgMZDHQRfyuOrQng=

--- a/pkg/apigateway/options/options.go
+++ b/pkg/apigateway/options/options.go
@@ -35,3 +35,14 @@ type GatewayOptions struct {
 var (
 	Options GatewayOptions
 )
+
+func OnOptionsChange(oldO, newO interface{}) bool {
+	oldOpts := oldO.(*GatewayOptions)
+	newOpts := newO.(*GatewayOptions)
+
+	if common_options.OnCommonOptionsChange(&oldOpts.CommonOptions, &newOpts.CommonOptions) {
+		return true
+	}
+
+	return false
+}

--- a/pkg/apigateway/service/service.go
+++ b/pkg/apigateway/service/service.go
@@ -41,10 +41,7 @@ func StartService() {
 		log.Infof("Auth complete.")
 	})
 
-	err := app_common.MergeServiceConfig(opts, api.SERVICE_TYPE, api.SERVICE_VERSION)
-	if err != nil {
-		log.Fatalf("[MERGE CONFIG] Fail to merge service config %s", err)
-	}
+	common_options.StartOptionManager(opts, opts.ConfigSyncPeriodSeconds, api.SERVICE_TYPE, api.SERVICE_VERSION, options.OnOptionsChange)
 
 	if opts.DisableModuleApiVersion {
 		mcclient.DisableApiVersionByModule()

--- a/pkg/apis/identity/consts.go
+++ b/pkg/apis/identity/consts.go
@@ -89,17 +89,30 @@ var (
 		},
 	}
 
-	BlacklistOptionMap = map[string][]string{
+	CommonWhitelistOptionMap = map[string][]string{
 		"default": []string{
-			"region",
-			"sql_connection",
+			"default_quota_value",
+			"enable_rbac",
+			"non_default_domain_projects",
+			"time_zone",
+		},
+	}
+
+	ServiceBlacklistOptionMap = map[string][]string{
+		"default": []string{
+			"help",
+			"version",
 			"config",
+			"pid_file",
+
+			"region",
 			"application_id",
 			"log_level",
+			"log_verbose_level",
 			"temp_path",
-			"auto_sync_table",
 			"address",
 			"port",
+			"port_v2",
 			"admin_port",
 			"notify_admin_users",
 			"session_endpoint_type",
@@ -107,12 +120,30 @@ var (
 			"admin_project",
 			"admin_user",
 			"auth_url",
-			"default_aws_instance_type_file",
-			"port_v2",
 			"enable_ssl",
 			"ssl_certfile",
 			"ssl_keyfile",
 			"ssl_ca_certs",
+
+			"is_slave_node",
+			"config_sync_period_seconds",
+
+			"sql_connection",
+			"auto_sync_table",
+			"exit_after_db_init",
+			"global_virtual_resource_namespace",
+			"debug_sqlchemy",
+			"lockman_method",
+			"etcd_lock_prefix",
+			"etcd_lock_ttl",
+			"etcd_endpoints",
+			"etcd_username",
+			"etcd_password",
+			"etcd_use_tls",
+			"etcd_skip_tls_verify",
+			"etcd_cacert",
+			"etcd_cert",
+			"etcd_key",
 		},
 	}
 )

--- a/pkg/appsrv/workers_watchdog.go
+++ b/pkg/appsrv/workers_watchdog.go
@@ -1,0 +1,78 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appsrv
+
+import (
+	"time"
+
+	"yunion.io/x/log"
+)
+
+const (
+	WATCHDOG_SLEEP_SECONDS = 30
+)
+
+var (
+	busyWorkers map[*SWorkerManager]int
+
+	exitFlag bool
+)
+
+func init() {
+	busyWorkers = make(map[*SWorkerManager]int)
+
+	watchdog()
+}
+
+func watchdog() {
+	do_worker_watchdog()
+
+	time.AfterFunc(time.Second*WATCHDOG_SLEEP_SECONDS, watchdog)
+}
+
+func do_worker_watchdog() {
+	log.Debugf("worker manager watchdog runing")
+
+	for _, w := range workerManagers {
+		stats := w.getState()
+		busy := stats.IsBusy()
+		if busy {
+			if _, ok := busyWorkers[w]; ok {
+				busyWorkers[w] += 1
+			} else {
+				busyWorkers[w] = 1
+			}
+		} else {
+			if _, ok := busyWorkers[w]; ok {
+				delete(busyWorkers, w)
+			}
+		}
+	}
+	if len(busyWorkers) > 0 {
+		for w, k := range busyWorkers {
+			if k > 1 {
+				log.Warningf("WorkerManager %s has been busy for %d cycles...", w.name, k)
+			}
+		}
+	} else {
+		if exitFlag {
+			log.Fatalln("System is idle, no worker is busy, exitFlag is set, to exit ...")
+		}
+	}
+}
+
+func SetExitFlag() {
+	exitFlag = true
+}

--- a/pkg/cloudcommon/options/changes.go
+++ b/pkg/cloudcommon/options/changes.go
@@ -1,0 +1,38 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+func OnBaseOptionsChange(oOpts, nOpts interface{}) bool {
+	oldOpts := oOpts.(*BaseOptions)
+	newOpts := nOpts.(*BaseOptions)
+
+	if oldOpts.RequestWorkerCount != newOpts.RequestWorkerCount {
+		return true
+	}
+	if oldOpts.TimeZone != newOpts.TimeZone {
+		return true
+	}
+	return false
+}
+
+func OnCommonOptionsChange(oOpts, nOpts interface{}) bool {
+	oldOpts := oOpts.(*CommonOptions)
+	newOpts := nOpts.(*CommonOptions)
+
+	if OnBaseOptionsChange(&oldOpts.BaseOptions, &newOpts.BaseOptions) {
+		return true
+	}
+	return false
+}

--- a/pkg/cloudcommon/options/manager.go
+++ b/pkg/cloudcommon/options/manager.go
@@ -1,0 +1,105 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"reflect"
+	"time"
+
+	"yunion.io/x/log"
+
+	"yunion.io/x/onecloud/pkg/appsrv"
+)
+
+const (
+	MIN_REFRESH_INTERVAL_SECONDS = 30
+)
+
+type TOptionsChangeFunc func(oldOpts, newOpts interface{}) bool
+
+type SOptionManager struct {
+	serviceType    string
+	serviceVersion string
+
+	options interface{}
+
+	session IServiceConfigSession
+
+	refreshInterval time.Duration
+
+	onOptionsChange TOptionsChangeFunc
+}
+
+var (
+	OptionManager *SOptionManager
+)
+
+func StartOptionManager(option interface{}, refreshSeconds int, serviceType, serviceVersion string, onChange TOptionsChangeFunc) {
+	StartOptionManagerWithSessionDriver(option, refreshSeconds, serviceType, serviceVersion, onChange, newServiceConfigSession())
+}
+
+func StartOptionManagerWithSessionDriver(options interface{}, refreshSeconds int, serviceType, serviceVersion string, onChange TOptionsChangeFunc, session IServiceConfigSession) {
+	log.Infof("OptionManager start to fetch service configs ...")
+	if refreshSeconds <= MIN_REFRESH_INTERVAL_SECONDS {
+		// a minimal 30 seconds refresh interval
+		refreshSeconds = MIN_REFRESH_INTERVAL_SECONDS
+	}
+	refreshInterval := time.Duration(refreshSeconds) * time.Second
+	OptionManager = &SOptionManager{
+		serviceType:     serviceType,
+		serviceVersion:  serviceVersion,
+		options:         options,
+		session:         session,
+		refreshInterval: refreshInterval,
+		onOptionsChange: onChange,
+	}
+	OptionManager.firstSync()
+}
+
+func (manager *SOptionManager) newOptions() interface{} {
+	optType := reflect.ValueOf(manager.options).Elem().Type()
+	return reflect.New(optType).Interface()
+}
+
+func copyOptions(dst, src interface{}) {
+	dstValue := reflect.ValueOf(dst).Elem()
+	dstValue.Set(reflect.ValueOf(src).Elem())
+}
+
+func (manager *SOptionManager) doSync(first bool) {
+	newOpts := manager.newOptions()
+	copyOptions(newOpts, manager.options)
+	merged := manager.session.Merge(newOpts, manager.serviceType, manager.serviceVersion)
+
+	if merged && !reflect.DeepEqual(newOpts, manager.options) {
+		log.Infof("Service config changed ...")
+		if !first && manager.onOptionsChange != nil && manager.onOptionsChange(manager.options, newOpts) {
+			log.Infof("Option changes detected and going to restart the program...")
+			appsrv.SetExitFlag()
+		}
+		copyOptions(manager.options, newOpts)
+		manager.session.Upload()
+	}
+}
+
+func (manager *SOptionManager) firstSync() {
+	manager.doSync(true)
+	time.AfterFunc(manager.refreshInterval, manager.sync)
+}
+
+func (manager *SOptionManager) sync() {
+	manager.doSync(false)
+	time.AfterFunc(manager.refreshInterval, manager.sync)
+}

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -73,6 +73,8 @@ type BaseOptions struct {
 	RbacPolicySyncPeriodSeconds      int  `help:"policy sync interval in seconds, default 5 minutes" default:"300"`
 	RbacPolicySyncFailedRetrySeconds int  `help:"seconds to wait after a failed sync, default 30 seconds" default:"30"`
 
+	ConfigSyncPeriodSeconds int `help:"service config sync interval in seconds, default 300 seconds/5 minutes" default:"300"`
+
 	IsSlaveNode        bool `help:"Region service slave node"`
 	CronJobWorkerCount int  `help:"Cron job worker count" default:"4"`
 
@@ -80,7 +82,7 @@ type BaseOptions struct {
 
 	CalculateQuotaUsageIntervalSeconds int `help:"interval to calculate quota usages, default 30 minutes" default:"900"`
 
-	NonDefaultDomainProjects bool `help:"allow projects in non-default domains" default:"false"`
+	NonDefaultDomainProjects bool `help:"allow projects in non-default domains" default:"false" json:",allowfalse"`
 
 	TimeZone string `help:"time zone" default:"Asia/Shanghai"`
 

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -133,3 +133,13 @@ type SCapabilityOptions struct {
 var (
 	Options ComputeOptions
 )
+
+func OnOptionsChange(oldO, newO interface{}) bool {
+	oldOpts := oldO.(*ComputeOptions)
+	newOpts := newO.(*ComputeOptions)
+
+	if common_options.OnCommonOptionsChange(&oldOpts.CommonOptions, &newOpts.CommonOptions) {
+		return true
+	}
+	return false
+}

--- a/pkg/compute/service/service.go
+++ b/pkg/compute/service/service.go
@@ -61,14 +61,11 @@ func StartService() {
 	db.EnsureAppInitSyncDB(app, dbOpts, models.InitDB)
 	defer cloudcommon.CloseDB()
 
-	err := app_common.MergeServiceConfig(opts, api.SERVICE_TYPE, api.SERVICE_VERSION)
-	if err != nil {
-		log.Fatalf("[MERGE CONFIG] Fail to merge service config %s", err)
-	}
+	common_options.StartOptionManager(opts, opts.ConfigSyncPeriodSeconds, api.SERVICE_TYPE, api.SERVICE_VERSION, options.OnOptionsChange)
 
 	options.InitNameSyncResources()
 
-	err = setInfluxdbRetentionPolicy()
+	err := setInfluxdbRetentionPolicy()
 	if err != nil {
 		log.Errorf("setInfluxdbRetentionPolicy fail: %s", err)
 	}

--- a/pkg/image/options/options.go
+++ b/pkg/image/options/options.go
@@ -46,3 +46,14 @@ type SImageOptions struct {
 var (
 	Options SImageOptions
 )
+
+func OnOptionsChange(oldO, newO interface{}) bool {
+	oldOpts := oldO.(*SImageOptions)
+	newOpts := newO.(*SImageOptions)
+
+	if common_options.OnCommonOptionsChange(&oldOpts.CommonOptions, &newOpts.CommonOptions) {
+		return true
+	}
+
+	return false
+}

--- a/pkg/image/service/service.go
+++ b/pkg/image/service/service.go
@@ -93,10 +93,7 @@ func StartService() {
 
 	db.EnsureAppInitSyncDB(app, dbOpts, models.InitDB)
 
-	err := app_common.MergeServiceConfig(opts, api.SERVICE_TYPE, api.SERVICE_VERSION)
-	if err != nil {
-		log.Fatalf("[MERGE CONFIG] Fail to merge service config %s", err)
-	}
+	common_options.StartOptionManager(opts, opts.ConfigSyncPeriodSeconds, api.SERVICE_TYPE, api.SERVICE_VERSION, options.OnOptionsChange)
 
 	go models.CheckImages()
 

--- a/pkg/keystone/models/identity_provider.go
+++ b/pkg/keystone/models/identity_provider.go
@@ -228,7 +228,7 @@ func (ident *SIdentityProvider) PerformConfig(ctx context.Context, userCred mccl
 		return nil, httperrors.NewInputParameterError("invalid input data")
 	}
 	action, _ := data.GetString("action")
-	err = saveConfigs(action, ident, opts, nil, api.SensitiveDomainConfigMap)
+	err = saveConfigs(action, ident, opts, nil, nil, api.SensitiveDomainConfigMap)
 	if err != nil {
 		return nil, httperrors.NewInternalServerError("saveConfig fail %s", err)
 	}
@@ -327,7 +327,7 @@ func (ident *SIdentityProvider) PostCreate(ctx context.Context, userCred mcclien
 		log.Errorf("parse config error %s", err)
 		return
 	}
-	err = saveConfigs("", ident, opts, nil, api.SensitiveDomainConfigMap)
+	err = saveConfigs("", ident, opts, nil, nil, api.SensitiveDomainConfigMap)
 	if err != nil {
 		log.Errorf("saveConfig fail %s", err)
 		return

--- a/pkg/keystone/options/options.go
+++ b/pkg/keystone/options/options.go
@@ -27,10 +27,10 @@ type SKeystoneOptions struct {
 
 	TokenExpirationSeconds int    `default:"86400" help:"token expiration seconds" token:"expiration"`
 	FernetKeyRepository    string `help:"fernet key repo directory" token:"key_repository" default:"/etc/yunion/keystone/fernet-keys"`
-	SetupCredentialKeys    bool   `help:"setup standalone fernet keys for credentials" token:"setup_credential_key" default:"false"`
+	SetupCredentialKeys    bool   `help:"setup standalone fernet keys for credentials" token:"setup_credential_key" default:"false" json:",allowfalse"`
 
 	BootstrapAdminUserPassword string `help:"bootstreap sysadmin user password" default:"sysadmin"`
-	ResetAdminUserPassword     bool   `help:"reset sysadmin password if exists and this option is true"`
+	ResetAdminUserPassword     bool   `help:"reset sysadmin password if exists and this option is true" json:",allowfalse"`
 
 	AutoSyncIntervalSeconds int `help:"frequency to check auto sync tasks" default:"30"`
 
@@ -48,3 +48,14 @@ type SKeystoneOptions struct {
 var (
 	Options SKeystoneOptions
 )
+
+func OnOptionsChange(oldOptions, newOptions interface{}) bool {
+	oldOpts := oldOptions.(*SKeystoneOptions)
+	newOpts := newOptions.(*SKeystoneOptions)
+
+	if options.OnBaseOptionsChange(&oldOpts.BaseOptions, &newOpts.BaseOptions) {
+		return true
+	}
+
+	return false
+}

--- a/pkg/keystone/service/service.go
+++ b/pkg/keystone/service/service.go
@@ -21,15 +21,13 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang-plus/uuid"
 
-	"yunion.io/x/log"
-
 	api "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/cloudcommon"
 	app_common "yunion.io/x/onecloud/pkg/cloudcommon/app"
 	"yunion.io/x/onecloud/pkg/cloudcommon/cronman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
-	"yunion.io/x/onecloud/pkg/cloudcommon/policy" // "yunion.io/x/onecloud/pkg/keystone/keys"
+	"yunion.io/x/onecloud/pkg/cloudcommon/policy"
 	"yunion.io/x/onecloud/pkg/keystone/cronjobs"
 	_ "yunion.io/x/onecloud/pkg/keystone/driver/cas"
 	_ "yunion.io/x/onecloud/pkg/keystone/driver/ldap"
@@ -76,10 +74,7 @@ func StartService() {
 
 	app_common.InitBaseAuth(&opts.BaseOptions)
 
-	err := models.MergeServiceConfig(opts)
-	if err != nil {
-		log.Fatalf("[MERGE CONFIG] Fail to merge service config: %s", err)
-	}
+	common_options.StartOptionManagerWithSessionDriver(opts, opts.ConfigSyncPeriodSeconds, api.SERVICE_TYPE, "", options.OnOptionsChange, models.NewServiceConfigSession())
 
 	if !opts.IsSlaveNode {
 		cron := cronman.InitCronJobManager(true, opts.CronJobWorkerCount)

--- a/pkg/util/shellutils/edit.go
+++ b/pkg/util/shellutils/edit.go
@@ -1,0 +1,53 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shellutils
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	"yunion.io/x/pkg/errors"
+)
+
+func Edit(yaml string) (string, error) {
+	tmpfile, err := ioutil.TempFile("", "policy-blob")
+	if err != nil {
+		return "", errors.Wrap(err, "ioutil.TempFile")
+	}
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	if _, err := tmpfile.Write([]byte(yaml)); err != nil {
+		return "", errors.Wrap(err, "tmpfile.Write")
+	}
+	if err := tmpfile.Close(); err != nil {
+		return "", errors.Wrap(err, "tmpfile.Close")
+	}
+
+	cmd := exec.Command("vim", tmpfile.Name())
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	err = cmd.Run()
+	if err != nil {
+		return "", errors.Wrap(err, "cmd.Run")
+	}
+
+	policyBytes, err := ioutil.ReadFile(tmpfile.Name())
+	if err != nil {
+		return "", errors.Wrap(err, "ioutil.ReadFile")
+	}
+
+	return string(policyBytes), nil
+}

--- a/scripts/rbac/domainadmin.yaml
+++ b/scripts/rbac/domainadmin.yaml
@@ -3,6 +3,4 @@ roles:
   - domain_admin
 scope: domain
 policy:
-  *:
-    *:
-      *: allow
+  '*': allow

--- a/scripts/rbac/member.yaml
+++ b/scripts/rbac/member.yaml
@@ -1,8 +1,9 @@
 # rbac for normal user, not allow for delete
 scope: project
 policy:
-  *:
-    *:
-      *: allow
+  '*':
+    '*':
+      '*': allow
       create: deny
+      update: deny
       delete: deny

--- a/scripts/rbac/projectowner.yaml
+++ b/scripts/rbac/projectowner.yaml
@@ -3,6 +3,4 @@ roles:
   - project_owner
 scope: project
 policy:
-  *:
-    *:
-      *: allow
+  '*': allow

--- a/scripts/rbac/sysadmin.yaml
+++ b/scripts/rbac/sysadmin.yaml
@@ -5,4 +5,4 @@ roles:
   - admin
 scope: system
 policy:
-  *: allow
+  '*': allow

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -839,7 +839,7 @@ yunion.io/x/pkg/util/workqueue
 yunion.io/x/pkg/utils
 # yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 yunion.io/x/s3cli
-# yunion.io/x/sqlchemy v0.0.0-20191217082202-5f99691a51c9
+# yunion.io/x/sqlchemy v0.0.0-20191223103213-67358d3737b6
 yunion.io/x/sqlchemy
 # yunion.io/x/structarg v0.0.0-20190809075558-115bed041de3
 yunion.io/x/structarg

--- a/vendor/yunion.io/x/sqlchemy/column.go
+++ b/vendor/yunion.io/x/sqlchemy/column.go
@@ -701,8 +701,7 @@ func (c *CompoundColumn) IsZero(val interface{}) bool {
 	if c.isPointer && reflect.ValueOf(val).IsNil() {
 		return true
 	}
-	json := val.(gotypes.ISerializable)
-	return json.IsZero()
+	return false
 }
 
 func (c *CompoundColumn) ConvertFromValue(val interface{}) interface{} {
@@ -718,77 +717,3 @@ func NewCompoundColumn(name string, tagmap map[string]string, isPointer bool) Co
 	dtc := CompoundColumn{NewTextColumn(name, tagmap, isPointer)}
 	return dtc
 }
-
-/*type JSONDictColumn struct {
-	JSONColumn
-}
-
-type JSONArrayColumn struct {
-	JSONColumn
-}
-
-func (c *JSONDictColumn) ConvertFromValue(val interface{}) interface{} {
-	bVal, ok := val.(*jsonutils.JSONDict)
-	if ok && bVal != nil {
-		return bVal.String()
-	} else {
-		return nil
-	}
-}
-
-func (c *JSONDictColumn) ConvertToValue(val interface{}) interface{} {
-	iVal, ok := val.(string)
-	if ok && len(iVal) > 0 {
-		json, err := jsonutils.ParseString(iVal)
-		if err == nil {
-			return json.(*jsonutils.JSONDict)
-		}
-	}
-	return nil
-}
-
-func (c *JSONDictColumn) IsZero(val interface{}) bool {
-	if val == nil {
-		return true
-	}
-	dict := val.(*jsonutils.JSONDict)
-	return dict.Size() == 0
-}
-
-func (c *JSONArrayColumn) ConvertFromValue(val interface{}) interface{} {
-	bVal, ok := val.(*jsonutils.JSONArray)
-	if ok && bVal != nil {
-		return bVal.String()
-	} else {
-		return nil
-	}
-}
-
-func (c *JSONArrayColumn) ConvertToValue(val interface{}) interface{} {
-	iVal, ok := val.(string)
-	if ok && len(iVal) > 0 {
-		json, err := jsonutils.ParseString(iVal)
-		if err == nil {
-			return json.(*jsonutils.JSONArray)
-		}
-	}
-	return nil
-}
-
-func (c *JSONArrayColumn) IsZero(val interface{}) bool {
-	if val == nil {
-		return true
-	}
-	dict := val.(*jsonutils.JSONArray)
-	return dict.Size() == 0
-}
-
-func NewJSONDictColumn(name string, tagmap map[string]string) JSONDictColumn {
-	dtc := JSONDictColumn{NewJSONColumn(name, tagmap)}
-	return dtc
-}
-
-func NewJSONArrayColumn(name string, tagmap map[string]string) JSONArrayColumn {
-	dtc := JSONArrayColumn{NewJSONColumn(name, tagmap)}
-	return dtc
-}*/


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：远程修改服务配置后，服务周期性拉取配置，监测到配置变化后，由各个服务的OnOptionsChange方法判断是否需要重启，如果需要重启，则在所有worker队列都为空的情况下，自动退出服务

**是否需要 backport 到之前的 release 分支**:
- release/2.13

/cc @zexi @yousong 

/area region
/area image
/area keystone

/hold