### PR TITLE
Automated cherry pick of #4260: fix: resourcebase和selflink,name重叠

### DIFF
--- a/pkg/multicloud/google/eip.go
+++ b/pkg/multicloud/google/eip.go
@@ -33,13 +33,11 @@ type SAddress struct {
 
 	Id                string
 	CreationTimestamp time.Time
-	Name              string
 	Description       string
 	Address           string
 	Status            string
 	Region            string
 	Users             []string
-	SelfLink          string
 	NetworkTier       string
 	AddressType       string
 	Kind              string

--- a/pkg/multicloud/google/storage.go
+++ b/pkg/multicloud/google/storage.go
@@ -29,11 +29,9 @@ type SStorage struct {
 	SResourceBase
 
 	CreationTimestamp time.Time
-	Name              string
 	Description       string
 	ValidDiskSize     string
 	Zone              string
-	SelfLink          string
 	DefaultDiskSizeGb string
 	Kind              string
 }


### PR DESCRIPTION
Cherry pick of #4260 on release/2.13.

#4260: fix: resourcebase和selflink,name重叠