### PR TITLE
feature: support centos 8 deployment. centos 8 requiest NetworkManager

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -934,7 +934,11 @@ func (r *sRedhatLikeRootFs) deployNetworkingScripts(rootFs IDiskPartition, nics 
 		cmds.WriteString(nicDesc.Name)
 		cmds.WriteString("\n")
 		cmds.WriteString("ONBOOT=yes\n")
-		cmds.WriteString("NM_CONTROLLED=no\n")
+		if iv < 8 {
+			cmds.WriteString("NM_CONTROLLED=no\n")
+		} else {
+			cmds.WriteString("NM_CONTROLLED=yes\n")
+		}
 		cmds.WriteString("USERCTL=no\n")
 		if nicDesc.Mtu > 0 {
 			cmds.WriteString(fmt.Sprintf("MTU=%d\n", nicDesc.Mtu))


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：支持CentOS 8部署(启用NetworkManager)

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12
- release/2.13

/cc @wanyaoqi 

/are host-deployer