### PR TITLE
fix: host支持标签

### DIFF
--- a/pkg/apis/compute/api.go
+++ b/pkg/apis/compute/api.go
@@ -162,7 +162,7 @@ type ServerCreateInput struct {
 	VmemSize  int               `json:"vmem_size"`
 	VcpuCount int               `json:"vcpu_count"`
 	UserData  string            `json:"user_data"`
-	Metadata  map[string]string `json:"metadata"`
+	Metadata  map[string]string `json:"__meta__"`
 
 	KeypairId string `json:"keypair_id"`
 	Password  string `json:"password"`

--- a/pkg/cloudcommon/db/metadata.go
+++ b/pkg/cloudcommon/db/metadata.go
@@ -80,6 +80,7 @@ func init() {
 		"eip":        {SStatusStandaloneResourceBaseManager: NewStatusStandaloneResourceBaseManager(SVirtualResourceBase{}, "elasticips_tbl", "eip", "eips")},
 		"snapshot":   {SStatusStandaloneResourceBaseManager: NewStatusStandaloneResourceBaseManager(SVirtualResourceBase{}, "snapshots_tbl", "snpashot", "snpashots")},
 		"dbinstance": {SStatusStandaloneResourceBaseManager: NewStatusStandaloneResourceBaseManager(SVirtualResourceBase{}, "dbinstances_tbl", "dbinstance", "dbinstances")},
+		"host":       {SStatusStandaloneResourceBaseManager: NewStatusStandaloneResourceBaseManager(SVirtualResourceBase{}, "hosts_tbl", "host", "hosts")},
 	}
 }
 

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1520,11 +1520,6 @@ func (guest *SGuest) PostCreate(ctx context.Context, userCred mcclient.TokenCred
 		gs.GuestId = guest.Id
 		GuestsecgroupManager.TableSpec().Insert(&gs)
 	}
-	if data.Contains("metadata") {
-		metadata := map[string]interface{}{}
-		data.Unmarshal(&metadata, "metadata")
-		guest.SetAllMetadata(ctx, metadata, userCred)
-	}
 }
 
 func (guest *SGuest) setApptags(ctx context.Context, appTags []string, userCred mcclient.TokenCredential) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. host支持标签
2. standalone 自身已经接收了__meta__作为标签的参数了，虚拟机不需要再设置metdata标签

**是否需要 backport 到之前的 release 分支**:
- release/2.13

/area region
/cc @swordqiu 
