### PR TITLE
fix: 避免未接收到tenant参数

### DIFF
--- a/pkg/apis/compute/cloudaccount.go
+++ b/pkg/apis/compute/cloudaccount.go
@@ -30,6 +30,7 @@ type CloudaccountCreateInput struct {
 	Brand               string
 	IsPublicCloud       bool
 	IsOnPremise         bool
+	Tenant              string
 	TenantId            string
 	EnableAutoSync      bool
 	SyncIntervalSeconds int

--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -883,6 +883,9 @@ func (self *SCloudaccount) getMoreDetails(extra *jsonutils.JSONDict) *jsonutils.
 	extra.Set("sync_interval_seconds", jsonutils.NewInt(int64(self.getSyncIntervalSeconds())))
 	extra.Set("sync_status2", jsonutils.NewString(self.getSyncStatus2()))
 	extra.Set("cloud_env", jsonutils.NewString(self.getCloudEnv()))
+	if proj, _ := db.TenantCacheManager.FetchTenantById(context.Background(), self.ProjectId); proj != nil {
+		extra.Add(jsonutils.NewString(proj.Name), "tenant")
+	}
 	return extra
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 避免未接收到tenant参数
2. cloud-account-list 返回自身tenant信息

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu
