### PR TITLE
fix: 同步openstack宿主机关闭服务后状态

### DIFF
--- a/pkg/multicloud/openstack/host.go
+++ b/pkg/multicloud/openstack/host.go
@@ -424,6 +424,9 @@ func (host *SHost) GetHostType() string {
 }
 
 func (host *SHost) GetHostStatus() string {
+	if host.Status == "disabled" {
+		return api.HOST_OFFLINE
+	}
 	switch host.State {
 	case "up", "":
 		return api.HOST_ONLINE


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
同步openstack宿主机关闭服务后状态

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @swordqiu 
