### PR TITLE
Automated cherry pick of #4307: fix: 同步openstack宿主机关闭服务后状态

### DIFF
--- a/pkg/multicloud/openstack/host.go
+++ b/pkg/multicloud/openstack/host.go
@@ -424,6 +424,9 @@ func (host *SHost) GetHostType() string {
 }
 
 func (host *SHost) GetHostStatus() string {
+	if host.Status == "disabled" {
+		return api.HOST_OFFLINE
+	}
 	switch host.State {
 	case "up", "":
 		return api.HOST_ONLINE


### PR DESCRIPTION
Cherry pick of #4307 on release/2.11.

#4307: fix: 同步openstack宿主机关闭服务后状态