### PR TITLE
fix: 避免在域管理后台rules不可见

### DIFF
--- a/pkg/compute/models/secgrouprules.go
+++ b/pkg/compute/models/secgrouprules.go
@@ -115,13 +115,7 @@ func (manager *SSecurityGroupRuleManager) FilterByOwner(q *sqlchemy.SQuery, user
 	if userCred != nil {
 		sq := SecurityGroupManager.Query("id")
 		ssq := SecurityGroupManager.FilterByOwner(sq, userCred, scope)
-		switch scope {
-		case rbacutils.ScopeProject:
-			return q.In("secgroup_id", ssq.SubQuery())
-		case rbacutils.ScopeDomain:
-			sq = sq.Equals("domain_id", userCred.GetProjectDomainId())
-			return q.In("secgroup_id", ssq.SubQuery())
-		}
+		return q.In("secgroup_id", ssq.SubQuery())
 	}
 	return q
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免在域管理后台rules不可见

**是否需要 backport 到之前的 release 分支**:
- release/2.11

/area region
/cc @swordqiu 
