### PR TITLE
fix: hide worker manager watchdog log

### DIFF
--- a/pkg/appsrv/workers_watchdog.go
+++ b/pkg/appsrv/workers_watchdog.go
@@ -43,8 +43,6 @@ func watchdog() {
 }
 
 func do_worker_watchdog() {
-	log.Debugf("worker manager watchdog runing")
-
 	for _, w := range workerManagers {
 		stats := w.getState()
 		busy := stats.IsBusy()


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：隐藏worker manager watchdog的日志

**是否需要 backport 到之前的 release 分支**:
- release/2.13

/area util

/cc @yousong 