### PR TITLE
Automated cherry pick of #4317: fix: hide worker manager watchdog log

### DIFF
--- a/pkg/appsrv/workers_watchdog.go
+++ b/pkg/appsrv/workers_watchdog.go
@@ -43,8 +43,6 @@ func watchdog() {
 }
 
 func do_worker_watchdog() {
-	log.Debugf("worker manager watchdog runing")
-
 	for _, w := range workerManagers {
 		stats := w.getState()
 		busy := stats.IsBusy()


### PR DESCRIPTION
Cherry pick of #4317 on release/2.13.

#4317: fix: hide worker manager watchdog log