### PR TITLE
fix: bucket list objects with marker and limit

### DIFF
--- a/cmd/climc/shell/buckets.go
+++ b/cmd/climc/shell/buckets.go
@@ -107,9 +107,11 @@ func init() {
 	})
 
 	type BucketListObjectsOptions struct {
-		ID        string `help:"ID or name of bucket" json:"-"`
-		Prefix    string `help:"List objects with prefix"`
-		Recursive bool   `help:"List objects recursively"`
+		ID           string `help:"ID or name of bucket" json:"-"`
+		Prefix       string `help:"List objects with prefix"`
+		Recursive    bool   `help:"List objects recursively"`
+		Limit        int    `help:"maximal items per request"`
+		PagingMarker string `help:"paging marker"`
 	}
 	R(&BucketListObjectsOptions{}, "bucket-object-list", "List objects in a bucket", func(s *mcclient.ClientSession, args *BucketListObjectsOptions) error {
 		params, err := options.StructToParams(args)
@@ -121,8 +123,11 @@ func init() {
 			return err
 		}
 
-		arrays, _ := result.GetArray("objects")
-		listResult := modulebase.ListResult{Data: arrays}
+		listResult := modulebase.ListResult{}
+		err = result.Unmarshal(&listResult)
+		if err != nil {
+			return err
+		}
 		printList(&listResult, []string{})
 		return nil
 	})

--- a/pkg/cloudprovider/objectstore.go
+++ b/pkg/cloudprovider/objectstore.go
@@ -28,6 +28,7 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/s3cli"
+
 	"yunion.io/x/onecloud/pkg/httperrors"
 )
 
@@ -259,7 +260,7 @@ func GetIBucketByName(region ICloudRegion, name string) (ICloudBucket, error) {
 func GetIBucketStats(bucket ICloudBucket) (SBucketStats, error) {
 	stats := SBucketStats{
 		ObjectCount: -1,
-		SizeBytes: -1,
+		SizeBytes:   -1,
 	}
 	objs, err := bucket.ListObjects("", "", "", 1000)
 	if err != nil {

--- a/pkg/compute/models/buckets.go
+++ b/pkg/compute/models/buckets.go
@@ -663,6 +663,8 @@ func (bucket *SBucket) GetDetailsObjects(
 	ret.Add(retArray, "data")
 	if len(nextMarker) > 0 {
 		ret.Add(jsonutils.NewString(nextMarker), "next_marker")
+		ret.Add(jsonutils.NewString("key"), "marker_field")
+		ret.Add(jsonutils.NewString("DESC"), "marker_order")
 	}
 	return ret, nil
 }

--- a/pkg/multicloud/aliyun/bucket.go
+++ b/pkg/multicloud/aliyun/bucket.go
@@ -179,10 +179,6 @@ func (b *SBucket) ListObjects(prefix string, marker string, delimiter string, ma
 	return result, nil
 }
 
-func (b *SBucket) GetIObjects(prefix string, isRecursive bool) ([]cloudprovider.ICloudObject, error) {
-	return cloudprovider.GetIObjects(b, prefix, isRecursive)
-}
-
 func metaOpts(opts []oss.Option, meta http.Header) []oss.Option {
 	for k, v := range meta {
 		if len(v) == 0 {

--- a/pkg/multicloud/aws/bucket.go
+++ b/pkg/multicloud/aws/bucket.go
@@ -206,10 +206,6 @@ func (b *SBucket) ListObjects(prefix string, marker string, delimiter string, ma
 	return result, nil
 }
 
-func (b *SBucket) GetIObjects(prefix string, isRecursive bool) ([]cloudprovider.ICloudObject, error) {
-	return cloudprovider.GetIObjects(b, prefix, isRecursive)
-}
-
 func (b *SBucket) PutObject(ctx context.Context, key string, body io.Reader, sizeBytes int64, cannedAcl cloudprovider.TBucketACLType, storageClassStr string, meta http.Header) error {
 	if sizeBytes < 0 {
 		return errors.Error("content length expected")

--- a/pkg/multicloud/azure/storageaccount.go
+++ b/pkg/multicloud/azure/storageaccount.go
@@ -863,10 +863,6 @@ func (b *SStorageAccount) GetStats() cloudprovider.SBucketStats {
 	return stats
 }
 
-func (b *SStorageAccount) GetIObjects(prefix string, isRecursive bool) ([]cloudprovider.ICloudObject, error) {
-	return cloudprovider.GetIObjects(b, prefix, isRecursive)
-}
-
 func getBlobRefMeta(blob *storage.Blob) http.Header {
 	meta := http.Header{}
 	for k, v := range blob.Metadata {

--- a/pkg/multicloud/huawei/bucket.go
+++ b/pkg/multicloud/huawei/bucket.go
@@ -169,10 +169,6 @@ func (b *SBucket) GetStats() cloudprovider.SBucketStats {
 	return stats
 }
 
-func (b *SBucket) GetIObjects(prefix string, isRecursive bool) ([]cloudprovider.ICloudObject, error) {
-	return cloudprovider.GetIObjects(b, prefix, isRecursive)
-}
-
 func (b *SBucket) ListObjects(prefix string, marker string, delimiter string, maxCount int) (cloudprovider.SListObjectResult, error) {
 	result := cloudprovider.SListObjectResult{}
 	obscli, err := b.region.getOBSClient()

--- a/pkg/multicloud/qcloud/bucket.go
+++ b/pkg/multicloud/qcloud/bucket.go
@@ -165,10 +165,6 @@ func (b *SBucket) GetStats() cloudprovider.SBucketStats {
 	return stats
 }
 
-func (b *SBucket) GetIObjects(prefix string, isRecursive bool) ([]cloudprovider.ICloudObject, error) {
-	return cloudprovider.GetIObjects(b, prefix, isRecursive)
-}
-
 func (b *SBucket) ListObjects(prefix string, marker string, delimiter string, maxCount int) (cloudprovider.SListObjectResult, error) {
 	result := cloudprovider.SListObjectResult{}
 	coscli, err := b.region.GetCosClient(b)

--- a/pkg/multicloud/ucloud/ufile.go
+++ b/pkg/multicloud/ucloud/ufile.go
@@ -326,10 +326,6 @@ func (b *SBucket) GetStats() cloudprovider.SBucketStats {
 	return stats
 }
 
-func (b *SBucket) GetIObjects(prefix string, isRecursive bool) ([]cloudprovider.ICloudObject, error) {
-	return cloudprovider.GetIObjects(b, prefix, isRecursive)
-}
-
 func (b *SBucket) ListObjects(prefix string, marker string, delimiter string, maxCount int) (cloudprovider.SListObjectResult, error) {
 	result := cloudprovider.SListObjectResult{}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：bucket list object携带marker和limit参数，避免一次性拉取有很多objects的bucket

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13

/cc @zexi @yousong 

/area region