### PR TITLE
fix: SyncEip时同步项目应该在同步主机信息之前

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -4279,11 +4279,11 @@ func (manager *SGuestManager) DeleteExpiredPostpaidServers(ctx context.Context, 
 }
 
 func (self *SGuest) GetEip() (*SElasticip, error) {
-	return ElasticipManager.getEipForInstance("server", self.Id)
+	return ElasticipManager.getEipForInstance(api.EIP_ASSOCIATE_TYPE_SERVER, self.Id)
 }
 
 func (self *SGuest) GetPublicIp() (*SElasticip, error) {
-	return ElasticipManager.getEip("server", self.Id, api.EIP_MODE_INSTANCE_PUBLICIP)
+	return ElasticipManager.getEip(api.EIP_ASSOCIATE_TYPE_SERVER, self.Id, api.EIP_MODE_INSTANCE_PUBLICIP)
 }
 
 func (self *SGuest) SyncVMEip(ctx context.Context, userCred mcclient.TokenCredential, provider *SCloudprovider, extEip cloudprovider.ICloudEIP, syncOwnerId mcclient.IIdentityProvider) compare.SyncResult {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正: SyncEip时同步项目应该在同步主机信息之前

**是否需要 backport 到之前的 release 分支**:
- release/2.11
- release/2.12
- release/2.13

/area region

/cc @ioito @yousong 