### PR TITLE
fix: baremetal diskconfig empty adaptor index

### DIFF
--- a/pkg/compute/baremetal/types.go
+++ b/pkg/compute/baremetal/types.go
@@ -65,23 +65,23 @@ var (
 )
 
 type BaremetalStorage struct {
-	Size         int64  `json:"size"`
+	Size         int64  `json:"size,allowzero"`
 	Driver       string `json:"driver"`
-	Rotate       bool   `json:"rotate"`
+	Rotate       bool   `json:"rotate,allowfalse"`
 	Dev          string `json:"dev,omitempty"`
 	Sector       int64  `json:"sector,omitempty"`
 	Block        int64  `json:"block,omitempty"`
 	ModuleInfo   string `json:"module,omitempty"`
 	Kernel       string `json:"kernel,omitempty"`
 	PCIClass     string `json:"pci_class,omitempty"`
-	Slot         int    `json:"slot,omitempty"`
+	Slot         int    `json:"slot,allowzero"`
 	Status       string `json:"status,omitempty"`
-	Adapter      int    `json:"adapter,omitempty"`
+	Adapter      int    `json:"adapter,allowzero"`
 	Model        string `json:"model,omitempty"`
-	Enclosure    int    `json:"enclousure,omitempty"`
+	Enclosure    int    `json:"enclousure,allowzero"`
 	MinStripSize int64  `json:"min_strip_size,omitempty"`
 	MaxStripSize int64  `json:"max_strip_size,omitempty"`
-	Index        int64  `json:"index"`
+	Index        int64  `json:"index,allowzero"`
 	Addr         string `json:"addr,omitempty"`
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：baremetal disk config的adapter index等字段在转为json后被忽略

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12
- release/2.13

/area baremetal

/cc @zexi 