### PR TITLE
Automated cherry pick of #4340: fix: separate delete-object and delete-prefix methods

### DIFF
--- a/pkg/multicloud/objectstore/shell.go
+++ b/pkg/multicloud/objectstore/shell.go
@@ -297,11 +297,20 @@ func S3Shell() {
 		if err != nil {
 			return err
 		}
-		if strings.HasSuffix(args.KEY, "/") {
-			err = cloudprovider.DeletePrefix(context.Background(), bucket, args.KEY)
-		} else {
-			err = bucket.DeleteObject(context.Background(), args.KEY)
+		err = bucket.DeleteObject(context.Background(), args.KEY)
+		if err != nil {
+			return err
 		}
+		fmt.Printf("Delete success\n")
+		return nil
+	})
+
+	shellutils.R(&BucketDeleteObjectOptions{}, "delete-prefix", "Delete object from a bucket", func(cli cloudprovider.ICloudRegion, args *BucketDeleteObjectOptions) error {
+		bucket, err := cli.GetIBucketById(args.BUCKET)
+		if err != nil {
+			return err
+		}
+		err = cloudprovider.DeletePrefix(context.Background(), bucket, args.KEY)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Cherry pick of #4340 on release/2.13.

#4340: fix: separate delete-object and delete-prefix methods