### PR TITLE
fix: reduce action log for keystone authentication event

### DIFF
--- a/pkg/keystone/models/users.go
+++ b/pkg/keystone/models/users.go
@@ -646,12 +646,13 @@ func (manager *SUserManager) traceLoginEvent(ctx context.Context, token mcclient
 		usr.LastLoginSource = authCtx.Source
 		return nil
 	})
-	// ignore operator auth source
-	if authCtx.Source == mcclient.AuthSourceOperator {
+	db.OpsLog.LogEvent(usr, "auth", &s, token)
+	// to reduce auth event, log web console login only
+	if authCtx.Source == mcclient.AuthSourceWeb {
+		logclient.AddActionLogWithContext(ctx, usr, logclient.ACT_AUTHENTICATE, &s, token, true)
 		return
 	}
-	db.OpsLog.LogEvent(usr, "auth", &s, token)
-	logclient.AddActionLogWithContext(ctx, usr, logclient.ACT_AUTHENTICATE, &s, token, true)
+	// ignore any other auth source
 }
 
 type sLoginSession struct {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：只在actionlog记录通过web登录的操作日志，减少登录的日志

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/cc @zexi 

/area keystone