### PR TITLE
fix: refresh quota usage may timeout

### DIFF
--- a/pkg/cloudcommon/db/quotas/handler.go
+++ b/pkg/cloudcommon/db/quotas/handler.go
@@ -124,7 +124,9 @@ func (manager *SQuotaBaseManager) queryQuota(ctx context.Context, quota IQuota, 
 
 	ret.Update(jsonutils.Marshal(keys))
 	ret.Update(quota.ToJSON(""))
-	ret.Update(usage.ToJSON("usage"))
+	if usage != nil {
+		ret.Update(usage.ToJSON("usage"))
+	}
 	if len(pendings) > 0 {
 		pendingArray := jsonutils.NewArray()
 		for _, q := range pendings {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：刷新配额使用量时，由于返回的channel存在未写入值的情况，导致请求阻塞timeout

**是否需要 backport 到之前的 release 分支**:
- release/2.13

/area region

/cc @zexi @yousong 