### PR TITLE
fix: cloudaccount try get info of empty project

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -886,8 +886,10 @@ func (self *SCloudaccount) getMoreDetails(extra *jsonutils.JSONDict) *jsonutils.
 	extra.Set("sync_interval_seconds", jsonutils.NewInt(int64(self.getSyncIntervalSeconds())))
 	extra.Set("sync_status2", jsonutils.NewString(self.getSyncStatus2()))
 	extra.Set("cloud_env", jsonutils.NewString(self.getCloudEnv()))
-	if proj, _ := db.TenantCacheManager.FetchTenantById(context.Background(), self.ProjectId); proj != nil {
-		extra.Add(jsonutils.NewString(proj.Name), "tenant")
+	if len(self.ProjectId) > 0 {
+		if proj, _ := db.TenantCacheManager.FetchTenantById(context.Background(), self.ProjectId); proj != nil {
+			extra.Add(jsonutils.NewString(proj.Name), "tenant")
+		}
 	}
 	return extra
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：cloudaccount的projectId可能为空，导致详情中获取空的项目详情

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13

/area region

/cc @yousong 