### PR TITLE
Automated cherry pick of #4357: fix: change service type of apigateway to yunionapi

### DIFF
--- a/pkg/apis/apigateway/consts.go
+++ b/pkg/apis/apigateway/consts.go
@@ -15,6 +15,6 @@
 package apigateway
 
 const (
-	SERVICE_TYPE    = "apigateway"
+	SERVICE_TYPE    = "yunionapi"
 	SERVICE_VERSION = ""
 )


### PR DESCRIPTION
Cherry pick of #4357 on release/2.13.

#4357: fix: change service type of apigateway to yunionapi