### PR TITLE
fix: alter user email charset to utf8

### DIFF
--- a/pkg/keystone/models/users.go
+++ b/pkg/keystone/models/users.go
@@ -74,7 +74,7 @@ func init() {
 type SUser struct {
 	SEnabledIdentityBaseResource
 
-	Email  string `width:"64" charset:"ascii" nullable:"true" index:"true" list:"domain" update:"domain" create:"domain_optional"`
+	Email  string `width:"64" charset:"utf8" nullable:"true" index:"true" list:"domain" update:"domain" create:"domain_optional"`
 	Mobile string `width:"20" charset:"ascii" nullable:"true" index:"true" list:"domain" update:"domain" create:"domain_optional"`
 
 	Displayname string `with:"128" charset:"utf8" nullable:"true" list:"domain" update:"domain" create:"domain_optional"`


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
keystone user email charset更改为utf8

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12
- release/2.13

/cc @zexi 
/area keystone
