### PR TITLE
fix: 避免因太多锁导致删除安全组task失败

### DIFF
--- a/pkg/compute/models/secgrouprules.go
+++ b/pkg/compute/models/secgrouprules.go
@@ -68,6 +68,10 @@ type SSecurityGroupRule struct {
 	SecgroupID  string `width:"128" charset:"ascii" create:"required"`
 }
 
+func (self *SSecurityGroupRule) GetId() string {
+	return self.Id
+}
+
 type SecurityGroupRuleSet []SSecurityGroupRule
 
 func (v SecurityGroupRuleSet) Len() int {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免因太多锁导致删除安全组task失败

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @yousong 
