### PR TITLE
Automated cherry pick of #4375: fix: 避免因太多锁导致删除安全组task失败

### DIFF
--- a/pkg/compute/models/secgrouprules.go
+++ b/pkg/compute/models/secgrouprules.go
@@ -66,6 +66,10 @@ type SSecurityGroupRule struct {
 	SecgroupID  string `width:"128" charset:"ascii" create:"required"`
 }
 
+func (self *SSecurityGroupRule) GetId() string {
+	return self.Id
+}
+
 type SecurityGroupRuleSet []SSecurityGroupRule
 
 func (v SecurityGroupRuleSet) Len() int {


### PR DESCRIPTION
Cherry pick of #4375 on release/2.10.0.

#4375: fix: 避免因太多锁导致删除安全组task失败