### PR TITLE
fix: apigateway option use pointer

### DIFF
--- a/pkg/apigateway/options/options.go
+++ b/pkg/apigateway/options/options.go
@@ -33,7 +33,7 @@ type GatewayOptions struct {
 }
 
 var (
-	Options GatewayOptions
+	Options *GatewayOptions
 )
 
 func OnOptionsChange(oldO, newO interface{}) bool {

--- a/pkg/apigateway/service/service.go
+++ b/pkg/apigateway/service/service.go
@@ -33,7 +33,8 @@ import (
 )
 
 func StartService() {
-	opts := &options.Options
+	options.Options = &options.GatewayOptions{}
+	opts := options.Options
 	baseOpts := &opts.BaseOptions
 	commonOpts := &opts.CommonOptions
 	common_options.ParseOptions(opts, os.Args, "apigateway.conf", api.SERVICE_TYPE)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：apigateway的option改为使用指针，便于和yunionapi集成

**是否需要 backport 到之前的 release 分支**:
- release/2.13

/cc @zexi 

/area apigateway