### PR TITLE
Automated cherry pick of #4445: not return on recv packet failed

### DIFF
--- a/pkg/util/dhcp/server.go
+++ b/pkg/util/dhcp/server.go
@@ -104,7 +104,8 @@ func (s *DHCPServer) serveDHCP(handler DHCPHandler) error {
 	for {
 		pkt, addr, mac, intf, err := s.conn.RecvDHCP()
 		if err != nil {
-			return fmt.Errorf("Receiving DHCP packet: %s", err)
+			log.Errorf("Receiving DHCP packet: %s", err)
+			continue
 		}
 		// if intf == nil {
 		// 	return fmt.Errorf("Received DHCP packet with no interface information (this is a violation of dhcp4.Conn's contract)")


### PR DESCRIPTION
Cherry pick of #4445 on release/2.13.

#4445: not return on recv packet failed