### PR TITLE
fix: 避免nova external_id duplicate

### DIFF
--- a/pkg/multicloud/openstack/novastorage.go
+++ b/pkg/multicloud/openstack/novastorage.go
@@ -32,7 +32,7 @@ func (storage *SNovaStorage) GetMetadata() *jsonutils.JSONDict {
 }
 
 func (storage *SNovaStorage) GetId() string {
-	return fmt.Sprintf("%s-%s", storage.zone.GetId(), storage.GetName())
+	return fmt.Sprintf("%s-%s-%s", storage.zone.region.client.providerID, storage.zone.GetGlobalId(), storage.GetName())
 }
 
 func (storage *SNovaStorage) GetName() string {

--- a/pkg/multicloud/openstack/zone.go
+++ b/pkg/multicloud/openstack/zone.go
@@ -137,8 +137,8 @@ func (zone *SZone) getStorageByCategory(category string) (*SStorage, error) {
 		return nil, err
 	}
 	for i := 0; i < len(storages); i++ {
-		storage := storages[i].(*SStorage)
-		if strings.ToLower(storage.Name) == strings.ToLower(category) {
+		storage, ok := storages[i].(*SStorage)
+		if ok && strings.ToLower(storage.Name) == strings.ToLower(category) {
 			return storage, nil
 		}
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 避免openstack nova存储duplicate id
2. 避免同步guest disk storage转换异常

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu 
