### PR TITLE
networks: 确保外部network也有ifname_hint

### DIFF
--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -238,6 +238,9 @@ func (self *SGuestnetwork) getVirtualRand(width int, randomized bool) string {
 }
 
 func (self *SGuestnetwork) generateIfname(network *SNetwork, virtual bool, randomized bool) string {
+	// It may happen that external networks when synced can miss ifname hint
+	network.ensureIfnameHint()
+
 	pattern := regexp.MustCompile(`\W+`)
 	nName := pattern.ReplaceAllString(network.IfnameHint, "")
 	if len(nName) > MAX_IFNAME_SIZE-4 {
@@ -254,6 +257,7 @@ func (self *SGuestnetwork) generateIfname(network *SNetwork, virtual bool, rando
 }
 
 func (man *SGuestnetworkManager) ifnameUsed(ifname string) bool {
+	// inviable names are always used
 	if ifname == "" {
 		return true
 	}

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1163,6 +1163,24 @@ func isValidMaskLen(maskLen int64) bool {
 	}
 }
 
+func (self *SNetwork) ensureIfnameHint() {
+	if self.IfnameHint != "" {
+		return
+	}
+	hint, err := NetworkManager.newIfnameHint(self.Name)
+	if err != nil {
+		panic(errors.Wrap(err, "ensureIfnameHint: allocate hint"))
+	}
+	_, err = db.Update(self, func() error {
+		self.IfnameHint = hint
+		return nil
+	})
+	if err != nil {
+		panic(errors.Wrap(err, "ensureIfnameHint: db update"))
+	}
+	log.Infof("network %s(%s): initialized ifname hint: %s", self.Name, self.Id, hint)
+}
+
 func (manager *SNetworkManager) newIfnameHint(hint string) (string, error) {
 	isa := func(c byte) bool {
 		return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
networks: 确保外部network也有ifname_hint
```

**是否需要 backport 到之前的 release 分支**:

- release/2.10.0

/area region
/cc @swordqiu 