### PR TITLE
fix: bucket list object may skip first matched object

### DIFF
--- a/pkg/cloudprovider/objectstore.go
+++ b/pkg/cloudprovider/objectstore.go
@@ -296,8 +296,8 @@ func GetPagedObjects(bucket ICloudBucket, objectPrefix string, isRecursive bool,
 	}
 	// Send all objects
 	for i := range result.Objects {
-		// if delimited, skip the first object
-		if !isRecursive && result.Objects[i].GetKey() == objectPrefix {
+		// if delimited, skip the first object ends with delimiter
+		if !isRecursive && result.Objects[i].GetKey() == objectPrefix && strings.HasSuffix(objectPrefix, delimiter) {
 			continue
 		}
 		ret = append(ret, result.Objects[i])

--- a/pkg/cloudprovider/objectstore.go
+++ b/pkg/cloudprovider/objectstore.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -276,6 +277,12 @@ func GetIBucketStats(bucket ICloudBucket) (SBucketStats, error) {
 	return stats, nil
 }
 
+type cloudObjectList []ICloudObject
+
+func (a cloudObjectList) Len() int           { return len(a) }
+func (a cloudObjectList) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a cloudObjectList) Less(i, j int) bool { return a[i].GetKey() < a[j].GetKey() }
+
 func GetPagedObjects(bucket ICloudBucket, objectPrefix string, isRecursive bool, marker string, maxCount int) ([]ICloudObject, string, error) {
 	delimiter := "/"
 	if isRecursive {
@@ -289,11 +296,6 @@ func GetPagedObjects(bucket ICloudBucket, objectPrefix string, isRecursive bool,
 	if err != nil {
 		return nil, "", errors.Wrap(err, "bucket.ListObjects")
 	}
-	// Send all common prefixes if any.
-	// NOTE: prefixes are only present if the request is delimited.
-	if len(result.CommonPrefixes) > 0 {
-		ret = append(ret, result.CommonPrefixes...)
-	}
 	// Send all objects
 	for i := range result.Objects {
 		// if delimited, skip the first object ends with delimiter
@@ -303,6 +305,13 @@ func GetPagedObjects(bucket ICloudBucket, objectPrefix string, isRecursive bool,
 		ret = append(ret, result.Objects[i])
 		marker = result.Objects[i].GetKey()
 	}
+	// Send all common prefixes if any.
+	// NOTE: prefixes are only present if the request is delimited.
+	if len(result.CommonPrefixes) > 0 {
+		ret = append(ret, result.CommonPrefixes...)
+	}
+	// sort prefix by name in ascending order
+	sort.Sort(cloudObjectList(ret))
 	// If next marker present, save it for next request.
 	if result.NextMarker != "" {
 		marker = result.NextMarker


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：bucket的对象列表在前缀匹配时会忽略严格匹配的对象

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
- release/2.14
- release/3.0
