### PR TITLE
fix(notify): Always update websocket config

### DIFF
--- a/pkg/notify/models/mod_config.go
+++ b/pkg/notify/models/mod_config.go
@@ -105,14 +105,6 @@ func (self *SConfigManager) InitializeData() error {
 	}
 
 	// init webconsole's config
-	q = self.Query().Equals("type", "webconsole")
-	n, err = q.CountWithError()
-	if err != nil {
-		return err
-	}
-	if n >= 4 {
-		return nil
-	}
 	sql := fmt.Sprintf("update %s set deleted='1' where type='webconsole'", self.TableSpec().Name())
 	q = sqlchemy.NewRawQuery(sql)
 	q.Row()


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

每次启动notify服务都应该更新websocket相关的配置。

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
- release/2.14
- release/3.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
