### PR TITLE
fix(huawei): Add 'X-Project-Id' header for huawei nat reuqest

### DIFF
--- a/pkg/multicloud/huawei/client/modules/mod_dnat_rules.go
+++ b/pkg/multicloud/huawei/client/modules/mod_dnat_rules.go
@@ -23,7 +23,7 @@ type SNatDRuleManager struct {
 }
 
 func NewNatDManager(regionId string, projectId string, signer auth.Signer, debug bool) *SNatDRuleManager {
-	return &SNatDRuleManager{SResourceManager: SResourceManager{
+	man := &SNatDRuleManager{SResourceManager: SResourceManager{
 		SBaseManager:  NewBaseManager(signer, debug),
 		ServiceName:   ServiceNameNAT,
 		Region:        regionId,
@@ -34,4 +34,8 @@ func NewNatDManager(regionId string, projectId string, signer auth.Signer, debug
 
 		ResourceKeyword: "dnat_rules",
 	}}
+	if len(projectId) > 0 {
+		man.requestHook = &sProjectHook{projectId}
+	}
+	return man
 }

--- a/pkg/multicloud/huawei/client/modules/mod_natgateway.go
+++ b/pkg/multicloud/huawei/client/modules/mod_natgateway.go
@@ -16,14 +16,23 @@ package modules
 
 import (
 	"yunion.io/x/onecloud/pkg/multicloud/huawei/client/auth"
+	"yunion.io/x/onecloud/pkg/multicloud/huawei/client/requests"
 )
 
 type SNatGatewayManager struct {
 	SResourceManager
 }
 
+type sProjectHook struct {
+	projectId string
+}
+
+func (self *sProjectHook) Process(request requests.IRequest) {
+	request.AddHeaderParam("X-Project-Id", self.projectId)
+}
+
 func NewNatGatewayManager(regionId string, projectId string, signer auth.Signer, debug bool) *SNatGatewayManager {
-	return &SNatGatewayManager{SResourceManager: SResourceManager{
+	man := &SNatGatewayManager{SResourceManager: SResourceManager{
 		SBaseManager:  NewBaseManager(signer, debug),
 		ServiceName:   ServiceNameNAT,
 		Region:        regionId,
@@ -34,4 +43,8 @@ func NewNatGatewayManager(regionId string, projectId string, signer auth.Signer,
 
 		ResourceKeyword: "nat_gateways",
 	}}
+	if len(projectId) > 0 {
+		man.requestHook = &sProjectHook{projectId}
+	}
+	return man
 }

--- a/pkg/multicloud/huawei/client/modules/mod_snat_rules.go
+++ b/pkg/multicloud/huawei/client/modules/mod_snat_rules.go
@@ -23,7 +23,7 @@ type SNatSRuleManager struct {
 }
 
 func NewNatSManager(regionId string, projectId string, signer auth.Signer, debug bool) *SNatSRuleManager {
-	return &SNatSRuleManager{SResourceManager: SResourceManager{
+	man := &SNatSRuleManager{SResourceManager: SResourceManager{
 		SBaseManager:  NewBaseManager(signer, debug),
 		ServiceName:   ServiceNameNAT,
 		Region:        regionId,
@@ -34,4 +34,8 @@ func NewNatSManager(regionId string, projectId string, signer auth.Signer, debug
 
 		ResourceKeyword: "snat_rules",
 	}}
+	if len(projectId) > 0 {
+		man.requestHook = &sProjectHook{projectId}
+	}
+	return man
 }

--- a/pkg/multicloud/huawei/natgateway.go
+++ b/pkg/multicloud/huawei/natgateway.go
@@ -171,30 +171,18 @@ func (gateway *SNatGateway) GetINatSEntryByID(id string) (cloudprovider.ICloudNa
 	return &snat, nil
 }
 
-func (region *SRegion) GetNatGateway(natGatewayID string) ([]SNatGateway, error) {
+func (region *SRegion) GetNatGateways(vpcID, natGatewayID string) ([]SNatGateway, error) {
 	queues := make(map[string]string)
-	if natGatewayID != "" {
+	if len(natGatewayID) != 0 {
 		queues["id"] = natGatewayID
+	}
+	if len(vpcID) != 0 {
+		queues["router_id"] = vpcID
 	}
 	natGateways := make([]SNatGateway, 0, 2)
 	err := doListAllWithMarker(region.ecsClient.NatGateways.List, queues, &natGateways)
 	if err != nil {
 		return nil, errors.Wrapf(err, "get nat gateways error by natgatewayid")
-	}
-	for i := range natGateways {
-		natGateways[i].region = region
-	}
-	return natGateways, nil
-}
-
-func (region *SRegion) GetNatGateways(vpcID string) ([]SNatGateway, error) {
-	queues := map[string]string{
-		"router_id": vpcID,
-	}
-	natGateways := make([]SNatGateway, 0, 2)
-	err := doListAllWithMarker(region.ecsClient.NatGateways.List, queues, &natGateways)
-	if err != nil {
-		return nil, errors.Wrapf(err, "get nat gateways error by vpcid")
 	}
 	for i := range natGateways {
 		natGateways[i].region = region

--- a/pkg/multicloud/huawei/shell/natgateway.go
+++ b/pkg/multicloud/huawei/shell/natgateway.go
@@ -23,9 +23,10 @@ import (
 func init() {
 	type NatGatewayOptions struct {
 		NatGatewayID string `help:"Nat Gateway ID"`
+		VpcID        string `help:"Vpc ID"`
 	}
 	shellutils.R(&NatGatewayOptions{}, "nat-gateway-list", "List nat gateway", func(region *huawei.SRegion, args *NatGatewayOptions) error {
-		natGateways, err := region.GetNatGateway(args.NatGatewayID)
+		natGateways, err := region.GetNatGateways(args.VpcID, args.NatGatewayID)
 		if err != nil {
 			return err
 		}

--- a/pkg/multicloud/huawei/vpc.go
+++ b/pkg/multicloud/huawei/vpc.go
@@ -206,7 +206,7 @@ func (self *SVpc) GetIWireById(wireId string) (cloudprovider.ICloudWire, error) 
 }
 
 func (self *SVpc) GetINatGateways() ([]cloudprovider.ICloudNatGateway, error) {
-	nats, err := self.region.GetNatGateways(self.GetId())
+	nats, err := self.region.GetNatGateways(self.GetId(), "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. 华为云NAT网关的api比较特殊，project-id不能存在于url中，只能存在于header中，所以需要在header中添加 X-Project-Id 。之前测试只测试了默认项目的region，所以没有发现此问题。
2. 合并了两个函数
3. huaweicli natgateway-list 添加支持 vpc 过滤

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
- release/2.14
- release/3.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
