### PR TITLE
Automated cherry pick of #4498: fix: allow delete cloudaccount with auto-sync enabled

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -163,9 +163,10 @@ func (self *SCloudaccount) getCloudprovidersInternal(enabled tristate.TriState) 
 }
 
 func (self *SCloudaccount) ValidateDeleteCondition(ctx context.Context) error {
-	if self.EnableAutoSync {
-		return httperrors.NewInvalidStatusError("automatic syncing is enabled")
-	}
+	// allow delete cloudaccount if it is disabled
+	// if self.EnableAutoSync {
+	//	return httperrors.NewInvalidStatusError("automatic syncing is enabled")
+	// }
 	if self.Enabled {
 		return httperrors.NewInvalidStatusError("account is enabled")
 	}

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -109,10 +109,11 @@ func (self *SCloudprovider) AllowDeleteItem(ctx context.Context, userCred mcclie
 }
 
 func (self *SCloudprovider) ValidateDeleteCondition(ctx context.Context) error {
-	account := self.GetCloudaccount()
-	if account != nil && account.EnableAutoSync {
-		return httperrors.NewInvalidStatusError("auto syncing is enabled on account")
-	}
+	// allow delete cloudprovider if it is disabled
+	// account := self.GetCloudaccount()
+	// if account != nil && account.EnableAutoSync {
+	// 	return httperrors.NewInvalidStatusError("auto syncing is enabled on account")
+	// }
 	if self.Enabled {
 		return httperrors.NewInvalidStatusError("provider is enabled")
 	}


### PR DESCRIPTION
Cherry pick of #4498 on release/2.12.

#4498: fix: allow delete cloudaccount with auto-sync enabled