### PR TITLE
fix: 腾讯云不支持描述字段参数

### DIFF
--- a/pkg/multicloud/qcloud/instance.go
+++ b/pkg/multicloud/qcloud/instance.go
@@ -503,7 +503,6 @@ func (self *SRegion) CreateInstance(name string, imageId string, instanceType st
 	params["SecurityGroupIds.0"] = securityGroupId
 	params["Placement.Zone"] = zoneId
 	params["InstanceName"] = name
-	params["Description"] = desc
 
 	params["InternetAccessible.InternetChargeType"] = "TRAFFIC_POSTPAID_BY_HOUR"
 	params["InternetAccessible.InternetMaxBandwidthOut"] = "100"


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
腾讯云不支持描述字段参数

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @zexi 
