### PR TITLE
Automated cherry pick of #4513: fix: 腾讯云不支持描述字段参数

### DIFF
--- a/pkg/util/qcloud/instance.go
+++ b/pkg/util/qcloud/instance.go
@@ -500,7 +500,6 @@ func (self *SRegion) CreateInstance(name string, imageId string, instanceType st
 	params["SecurityGroupIds.0"] = securityGroupId
 	params["Placement.Zone"] = zoneId
 	params["InstanceName"] = name
-	params["Description"] = desc
 
 	params["InternetAccessible.InternetChargeType"] = "TRAFFIC_POSTPAID_BY_HOUR"
 	params["InternetAccessible.InternetMaxBandwidthOut"] = "100"


### PR DESCRIPTION
Cherry pick of #4513 on release/2.10.0.

#4513: fix: 腾讯云不支持描述字段参数