### PR TITLE
Automated cherry pick of #4520: baremetal: fix megaraid check jbod always disabled

### DIFF
--- a/pkg/baremetal/utils/raid/megactl/megactl.go
+++ b/pkg/baremetal/utils/raid/megactl/megactl.go
@@ -688,7 +688,7 @@ func (adapter *MegaRaidAdaptor) storcliIsJBODEnabled() bool {
 		line = strings.ToLower(line)
 		if strings.HasPrefix(line, "jbod") {
 			data := strings.Split(line, " ")
-			if strings.TrimSpace(data[1]) == "on" {
+			if strings.TrimSpace(data[len(data)-1]) == "on" {
 				return true
 			}
 			return false


### PR DESCRIPTION
Cherry pick of #4520 on release/2.10.0.

#4520: baremetal: fix megaraid check jbod always disabled