### PR TITLE
Hotfix/qj minio fail set object metadata

### DIFF
--- a/pkg/multicloud/objectstore/buckets.go
+++ b/pkg/multicloud/objectstore/buckets.go
@@ -341,7 +341,7 @@ func (bucket *SBucket) CopyObject(ctx context.Context, destKey string, srcBucket
 		cannedAcl = bucket.GetAcl()
 	}
 	err = obj.SetAcl(cannedAcl)
-	if err != nil {
+	if err != nil && errors.Cause(err) != cloudprovider.ErrNotImplemented {
 		return errors.Wrap(err, "obj.SetAcl")
 	}
 	return nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：minio设置object metadata时报SetAcl NotImplemented的错

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
- release/2.14
- release/3.0

/cc @zexi 

/area region