### PR TITLE
Automated cherry pick of #4564: fix: minio fail to set object metadata

### DIFF
--- a/pkg/multicloud/objectstore/buckets.go
+++ b/pkg/multicloud/objectstore/buckets.go
@@ -297,7 +297,7 @@ func (bucket *SBucket) CopyObject(ctx context.Context, destKey string, srcBucket
 		return errors.Wrap(err, "GetIObject")
 	}
 	err = obj.SetAcl(cannedAcl)
-	if err != nil {
+	if err != nil && errors.Cause(err) != cloudprovider.ErrNotImplemented {
 		return errors.Wrap(err, "obj.SetAcl")
 	}
 	return nil


### PR DESCRIPTION
Cherry pick of #4564 on release/2.11.

#4564: fix: minio fail to set object metadata