### PR TITLE
Bugfix & Feature: SnapshotPolicy

### DIFF
--- a/pkg/compute/models/snapshotpolicy.go
+++ b/pkg/compute/models/snapshotpolicy.go
@@ -287,7 +287,7 @@ func (sp *SSnapshotPolicy) DetachAfterDelete(ctx context.Context, userCred mccli
 }
 
 func (sp *SSnapshotPolicy) CustomizeDelete(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.
-JSONObject, data jsonutils.JSONObject) error {
+	JSONObject, data jsonutils.JSONObject) error {
 
 	// check if sp bind to some disks
 	sds, err := SnapshotPolicyDiskManager.FetchAllBySnapshotpolicyID(ctx, userCred, sp.GetId())
@@ -674,7 +674,7 @@ func (manager *SSnapshotPolicyManager) sSnapshotPolicyCreateInputToInternal(inpu
 }
 
 func (manager *SSnapshotPolicyManager) sSnapshotPolicyCreateInputFromInternal(input *api.
-SSnapshotPolicyCreateInternalInput) *api.SSnapshotPolicyCreateInput {
+	SSnapshotPolicyCreateInternalInput) *api.SSnapshotPolicyCreateInput {
 	return nil
 }
 

--- a/pkg/compute/models/snapshotpolicy.go
+++ b/pkg/compute/models/snapshotpolicy.go
@@ -189,6 +189,14 @@ func (manager *SSnapshotPolicyManager) ValidateCreateData(ctx context.Context, u
 	return data, nil
 }
 
+func (manager *SSnapshotPolicyManager) OnCreateComplete(ctx context.Context, items []db.IModel,
+	userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data jsonutils.JSONObject) {
+	for i := range items {
+		sp := items[i].(*SSnapshotPolicy)
+		sp.SetStatus(userCred, api.SNAPSHOT_POLICY_READY, "create complete")
+	}
+}
+
 // ==================================================== update =========================================================
 
 func (sp *SSnapshotPolicy) AllowPerformUpdate(ctx context.Context, userCred mcclient.TokenCredential,
@@ -279,7 +287,7 @@ func (sp *SSnapshotPolicy) DetachAfterDelete(ctx context.Context, userCred mccli
 }
 
 func (sp *SSnapshotPolicy) CustomizeDelete(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.
-	JSONObject, data jsonutils.JSONObject) error {
+JSONObject, data jsonutils.JSONObject) error {
 
 	// check if sp bind to some disks
 	sds, err := SnapshotPolicyDiskManager.FetchAllBySnapshotpolicyID(ctx, userCred, sp.GetId())
@@ -666,7 +674,7 @@ func (manager *SSnapshotPolicyManager) sSnapshotPolicyCreateInputToInternal(inpu
 }
 
 func (manager *SSnapshotPolicyManager) sSnapshotPolicyCreateInputFromInternal(input *api.
-	SSnapshotPolicyCreateInternalInput) *api.SSnapshotPolicyCreateInput {
+SSnapshotPolicyCreateInternalInput) *api.SSnapshotPolicyCreateInput {
 	return nil
 }
 

--- a/pkg/compute/models/snapshotpolicydisks.go
+++ b/pkg/compute/models/snapshotpolicydisks.go
@@ -367,7 +367,7 @@ func (sd *SSnapshotPolicyDisk) DetachBySnapshotpolicy(ctx context.Context, userC
 
 // ==================================================== create =========================================================
 
-var ErrExistSD = fmt.Errorf("snapshotpolicy disk has been exist")
+const ErrExistSD = errors.Error("snapshotpolicy disk has been exist")
 
 func (self *SSnapshotPolicyDiskManager) newSnapshotpolicyDisk(ctx context.Context, userCred mcclient.TokenCredential,
 	sp *SSnapshotPolicy, disk *SDisk) (*SSnapshotPolicyDisk, error) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 之前snapshotpolicy的状态 init 和 ready 都是正常，现在 修改为ready是正常，更普适。
2. 之前snapshotpolicy批量绑定/解绑disk，是后端单独写了一个接口 bind/unbind-disks，这个接口会启动多个task。现在前端要统一，所有的批量操作都通过网关修改为一系列相同的单个操作。所以snapshotpolicy绑定多个disk，应该使用：
`disks/bind-snapshotpolicy?id="..."&id="..."&id="..."`
并且设置body为：
`{
      snapshotpolicy:  "..."
}`
所以添加了相应的方法

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/2.14
- release/3.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
