### PR TITLE
fix(region): Fix that 'Can_delete' disappears due to parameter structuring

### DIFF
--- a/pkg/compute/models/groups.go
+++ b/pkg/compute/models/groups.go
@@ -91,7 +91,8 @@ func (group *SGroup) GetCustomizeColumns(ctx context.Context, userCred mcclient.
 	query jsonutils.JSONObject) *jsonutils.JSONDict {
 	extra := group.SVirtualResourceBase.GetCustomizeColumns(ctx, userCred, query)
 	ret, _ := group.getMoreDetails(ctx, userCred, extra)
-	return ret.JSON(ret)
+	extra.Update(ret.JSON(ret))
+	return extra
 }
 
 func (group *SGroup) GetExtraDetails(ctx context.Context, userCred mcclient.TokenCredential,


### PR DESCRIPTION


**这个 PR 实现什么功能/修复什么问题**:

因为参数结构化导致的‘can_delete‘的消失

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/2.14
- release/3.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
