### PR TITLE
Automated cherry pick of #4592: fix(region): Fix that 'Can_delete' disappears due to parameter structuring

### DIFF
--- a/pkg/compute/models/groups.go
+++ b/pkg/compute/models/groups.go
@@ -91,7 +91,8 @@ func (group *SGroup) GetCustomizeColumns(ctx context.Context, userCred mcclient.
 	query jsonutils.JSONObject) *jsonutils.JSONDict {
 	extra := group.SVirtualResourceBase.GetCustomizeColumns(ctx, userCred, query)
 	ret, _ := group.getMoreDetails(ctx, userCred, extra)
-	return ret.JSON(ret)
+	extra.Update(ret.JSON(ret))
+	return extra
 }
 
 func (group *SGroup) GetExtraDetails(ctx context.Context, userCred mcclient.TokenCredential,


### PR DESCRIPTION
Cherry pick of #4592 on release/2.14.

#4592: fix(region): Fix that 'Can_delete' disappears due to parameter structuring