### PR TITLE
Bugfix/guest template password

### DIFF
--- a/pkg/apis/compute/guesttemplate.go
+++ b/pkg/apis/compute/guesttemplate.go
@@ -55,6 +55,7 @@ type GuesttemplateConfigInfo struct {
 	Secgroup             string                 `json:"secgroup"`
 	IsolatedDeviceConfig []IsolatedDeviceConfig `json:"isolated_device_config"`
 	Image                string                 `json:"image"`
+	ResetPassword        bool                   `json:"reset_password"`
 }
 
 type GuesttemplateDisk struct {

--- a/pkg/compute/models/guest_template.go
+++ b/pkg/compute/models/guest_template.go
@@ -329,6 +329,13 @@ func (gt *SGuestTemplate) getMoreDetailsV2(ctx context.Context, userCred mcclien
 		// no arrivals
 	}
 
+	// reset_password
+	if input.ResetPassword == nil {
+		configInfo.ResetPassword = false
+	} else {
+		configInfo.ResetPassword = *input.ResetPassword
+	}
+
 	out.ConfigInfo = configInfo
 	return
 }

--- a/pkg/compute/models/service_catalog.go
+++ b/pkg/compute/models/service_catalog.go
@@ -102,6 +102,7 @@ func (scm *SServiceCatalogManager) ValidateCreateData(ctx context.Context, userC
 	if err != nil {
 		return nil, err
 	}
+	/*
 	gt := model.(*SGuestTemplate)
 	//scope := rbacutils.String2Scope(gt.PublicScope)
 	//if !gt.IsPublic || scope != rbacutils.ScopeSystem {
@@ -110,6 +111,7 @@ func (scm *SServiceCatalogManager) ValidateCreateData(ctx context.Context, userC
 	if userCred.GetProjectId() != gt.ProjectId {
 		return nil, httperrors.NewForbiddenError("guest template must has same project id with the request")
 	}
+	 */
 
 	data := input.JSON(input)
 	data.Remove("guest_template")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. 在guest template的configinfo中添加 reset_password 字段，表示密码是不是要保留镜像设置
2. 创建service catelog的时候取消对project的检查。

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/2.14
- release/3.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
