### PR TITLE
fix: increase default sync worker count from 2 to 5

### DIFF
--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -106,7 +106,7 @@ type ComputeOptions struct {
 
 	MinimalIpAddrReusedIntervalSeconds int `help:"Minimal seconds when a release IP address can be reallocate" default:"30"`
 
-	CloudSyncWorkerCount         int `help:"how many current synchronization threads" default:"2"`
+	CloudSyncWorkerCount         int `help:"how many current synchronization threads" default:"5"`
 	CloudAutoSyncIntervalSeconds int `help:"frequency to check auto sync tasks" default:"30"`
 	DefaultSyncIntervalSeconds   int `help:"minimal synchronization interval, default 1 minutes" default:"900"`
 	MinimalSyncIntervalSeconds   int `help:"minimal synchronization interval, default 1 minutes" default:"300"`


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：将同步worker缺省数量从2改为5

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/2.14
- release/3.0

/cc @zexi 

/area region