### PR TITLE
fix: 避免同步安全组失败后,没有任何日志记录

### DIFF
--- a/pkg/compute/tasks/guest_sync_task.go
+++ b/pkg/compute/tasks/guest_sync_task.go
@@ -24,6 +24,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/compute/models"
+	"yunion.io/x/onecloud/pkg/util/logclient"
 )
 
 type GuestSyncConfTask struct {
@@ -74,7 +75,7 @@ func (self *GuestSyncConfTask) OnDiskSyncComplete(ctx context.Context, guest *mo
 func (self *GuestSyncConfTask) OnDiskSyncCompleteFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
 	guest := obj.(*models.SGuest)
 	db.OpsLog.LogEvent(guest, db.ACT_SYNC_CONF_FAIL, data.String(), self.UserCred)
-	log.Errorf("Guest sync config failed: %v", data.String())
+	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_VM_SYNC_CONF, data, self.UserCred, false)
 	self.SetStageFailed(ctx, data.String())
 }
 
@@ -83,7 +84,7 @@ func (self *GuestSyncConfTask) OnSyncCompleteFailed(ctx context.Context, obj db.
 	if !jsonutils.QueryBoolean(self.Params, "without_sync_status", false) {
 		guest.SetStatus(self.GetUserCred(), api.VM_SYNC_FAIL, data.String())
 	}
-	log.Errorf("Guest sync config failed: %v", data.String())
+	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_VM_SYNC_CONF, data, self.UserCred, false)
 	db.OpsLog.LogEvent(guest, db.ACT_SYNC_CONF_FAIL, data.String(), self.UserCred)
 	self.SetStageFailed(ctx, data.String())
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免同步安全组失败后,没有任何日志记录

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @swordqiu 
