### PR TITLE
fix: guess brand on guest create

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -404,10 +404,11 @@ func (self *SDisk) ValidateUpdateData(ctx context.Context, userCred mcclient.Tok
 
 func diskCreateInput2ComputeQuotaKeys(input api.DiskCreateInput, ownerId mcclient.IIdentityProvider) SComputeResourceKeys {
 	// input.Hypervisor must be set
+	brand := guessBrandForHypervisor(input.Hypervisor)
 	keys := GetDriver(input.Hypervisor).GetComputeQuotaKeys(
 		rbacutils.ScopeProject,
 		ownerId,
-		"",
+		brand,
 	)
 	if len(input.PreferHost) > 0 {
 		hostObj, _ := HostManager.FetchById(input.PreferHost)

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -872,10 +872,11 @@ func (self *SGuest) ValidateUpdateData(ctx context.Context, userCred mcclient.To
 
 func serverCreateInput2ComputeQuotaKeys(input api.ServerCreateInput, ownerId mcclient.IIdentityProvider) SComputeResourceKeys {
 	// input.Hypervisor must be set
+	brand := guessBrandForHypervisor(input.Hypervisor)
 	keys := GetDriver(input.Hypervisor).GetComputeQuotaKeys(
 		rbacutils.ScopeProject,
 		ownerId,
-		"",
+		brand,
 	)
 	if len(input.PreferHost) > 0 {
 		hostObj, _ := HostManager.FetchById(input.PreferHost)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：主机创建时具体使用的brand未知，通过hypervisor来猜测brand。如果一个hypervisor对应多个brand也会有问题，这个问题不太容易出现，后续再彻底解决。

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/2.14
- release/3.0

/cc @zexi 

/area region