### PR TITLE
Automated cherry pick of #4656: fix: 避免拥有带宽包的腾讯云创建机器失败

### DIFF
--- a/pkg/util/qcloud/bandwidthpackage.go
+++ b/pkg/util/qcloud/bandwidthpackage.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package qcloud
+
+import (
+	"fmt"
+	"time"
+
+	"yunion.io/x/pkg/errors"
+)
+
+type SBandwidthPackageSet struct {
+	AddressIp    string
+	ResourceId   string
+	ResourceType string
+}
+
+type SBandwidthPackage struct {
+	BandwidthPackageId   string
+	BandwidthPackageName string
+	ChargeType           string
+	CreatedTime          time.Time
+	NetworkType          string
+	Protocol             string
+	ResourceSet          []SBandwidthPackageSet
+}
+
+func (region *SRegion) GetBandwidthPackages(ids []string, offset int, limit int) ([]SBandwidthPackage, int, error) {
+	if limit < 1 || limit > 50 {
+		limit = 50
+	}
+	params := map[string]string{
+		"Region": region.Region,
+		"Limit":  fmt.Sprintf("%d", limit),
+		"Offset": fmt.Sprintf("%d", offset),
+	}
+	for idx, id := range ids {
+		params[fmt.Sprintf("BandwidthPackageIds.%d", idx)] = id
+	}
+	packages := []SBandwidthPackage{}
+	resp, err := region.vpcRequest("DescribeBandwidthPackages", params)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "DescribeBandwidthPackages")
+	}
+	err = resp.Unmarshal(&packages, "BandwidthPackageSet")
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "resp.Unmarshal")
+	}
+	total, _ := resp.Float("TotalCount")
+	return packages, int(total), nil
+}

--- a/pkg/util/qcloud/instance.go
+++ b/pkg/util/qcloud/instance.go
@@ -501,8 +501,6 @@ func (self *SRegion) CreateInstance(name string, imageId string, instanceType st
 	params["Placement.Zone"] = zoneId
 	params["InstanceName"] = name
 
-	params["InternetAccessible.InternetChargeType"] = "TRAFFIC_POSTPAID_BY_HOUR"
-	params["InternetAccessible.InternetMaxBandwidthOut"] = "100"
 	params["InternetAccessible.PublicIpAssigned"] = "FALSE"
 	//params["HostName"] = name
 	if len(keypair) > 0 {

--- a/pkg/util/qcloud/shell/bandwidthpackage.go
+++ b/pkg/util/qcloud/shell/bandwidthpackage.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shell
+
+import (
+	"yunion.io/x/onecloud/pkg/util/qcloud"
+	"yunion.io/x/onecloud/pkg/util/shellutils"
+)
+
+func init() {
+	type BandwidthPackageListOptions struct {
+		Ids    []string `help:"Bandwidth package ids"`
+		Offset int      `help:"List offset"`
+		Limit  int      `help:"List limit"`
+	}
+	shellutils.R(&BandwidthPackageListOptions{}, "bandwidth-package-list", "List bandwidth packages", func(cli *qcloud.SRegion, args *BandwidthPackageListOptions) error {
+		packages, total, err := cli.GetBandwidthPackages(args.Ids, args.Offset, args.Limit)
+		if err != nil {
+			return err
+		}
+		printList(packages, total, args.Offset, args.Limit, []string{})
+		return nil
+	})
+
+}


### PR DESCRIPTION
Cherry pick of #4656 on release/2.10.0.

#4656: fix: 避免拥有带宽包的腾讯云创建机器失败