### PR TITLE
fix(glance): Cancel pending usage of image quota correctly

### DIFF
--- a/pkg/image/models/image_guest.go
+++ b/pkg/image/models/image_guest.go
@@ -99,6 +99,8 @@ func (gi *SGuestImage) PostCreate(ctx context.Context, userCred mcclient.TokenCr
 	ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data jsonutils.JSONObject) {
 
 	kwargs := data.(*jsonutils.JSONDict)
+	// get image number
+	imageNumber, _ := kwargs.Int("image_number")
 	// deal public params
 	kwargs.Remove("size")
 	kwargs.Remove("image_number")
@@ -146,7 +148,6 @@ func (gi *SGuestImage) PostCreate(ctx context.Context, userCred mcclient.TokenCr
 		}
 	}
 
-	imageNumber, _ := data.Int("image_number")
 	pendingUsage := SQuota{Image: int(imageNumber)}
 	keys := imageCreateInput2QuotaKeys(data, ownerId)
 	pendingUsage.SetKeys(keys)
@@ -156,6 +157,7 @@ func (gi *SGuestImage) PostCreate(ctx context.Context, userCred mcclient.TokenCr
 		gi.SetStatus(userCred, api.IMAGE_STATUS_KILLED, "create subimage failed")
 	}
 
+	gi.SetStatus(userCred, api.IMAGE_STATUS_SAVING, "")
 	// HACK
 	tmp := query.(*jsonutils.JSONDict)
 	tmp.Add(imageIds, "image_ids")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. 'image_number' 会被removed，所以PostCreate中image不能正确地cancel pending usage
2. guest image 添加一个saving 地状态

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
- release/2.14
- release/3.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
