### PR TITLE
fix: misc quota bugs

### DIFF
--- a/pkg/cloudcommon/db/namevalidator.go
+++ b/pkg/cloudcommon/db/namevalidator.go
@@ -46,7 +46,7 @@ func NewNameValidator(manager IModelManager, ownerId mcclient.IIdentityProvider,
 		return err
 	}
 	if !uniq {
-		return httperrors.NewDuplicateNameError("name", name)
+		return httperrors.NewDuplicateNameError(manager.Keyword(), name)
 	}
 	return nil
 }

--- a/pkg/cloudcommon/db/quotas/quotas.go
+++ b/pkg/cloudcommon/db/quotas/quotas.go
@@ -86,12 +86,12 @@ func (manager *SQuotaBaseManager) _cancelPendingUsage(ctx context.Context, userC
 	}
 	//
 	if localUsage != nil {
-		localUsage.Sub(cancelUsage)
+		localUsage.Sub(pendingUsage)
 	}
 
-	log.Debugf("cancelUsage: %s localUsage: %s", jsonutils.Marshal(cancelUsage), jsonutils.Marshal(localUsage))
+	log.Debugf("cancelUsage: %s localUsage: %s pendingUsage: %s", jsonutils.Marshal(cancelUsage), jsonutils.Marshal(localUsage), jsonutils.Marshal(pendingUsage))
 
-	err = manager.changeUsage(ctx, userCred, cancelUsage, true)
+	err = manager.changeUsage(ctx, userCred, pendingUsage, true)
 	if err != nil {
 		return errors.Wrap(err, "manager.changelUsage")
 	}

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -2104,7 +2104,7 @@ func (self *SGuest) PerformAttachnetwork(ctx context.Context, userCred mcclient.
 			//Bw:    ibw,
 			//Ebw:   ebw,
 		}
-		keys, err := self.GetQuotaKeys()
+		keys, err := self.GetRegionalQuotaKeys()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/compute/models/loadbalancers.go
+++ b/pkg/compute/models/loadbalancers.go
@@ -147,6 +147,8 @@ func (man *SLoadbalancerManager) ValidateCreateData(ctx context.Context, userCre
 		return nil, httperrors.NewBadRequestError("cannot find region info")
 	}
 
+	data.Set("cloudregion_id", jsonutils.NewString(region.Id))
+
 	input := apis.VirtualResourceCreateInput{}
 	err := data.Unmarshal(&input)
 	if err != nil {

--- a/pkg/compute/models/quotas.go
+++ b/pkg/compute/models/quotas.go
@@ -484,15 +484,19 @@ func fetchCloudQuotaKeys(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityP
 func fetchRegionalQuotaKeys(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityProvider, region *SCloudregion, manager *SCloudprovider) quotas.SRegionalCloudResourceKeys {
 	keys := quotas.SRegionalCloudResourceKeys{}
 	keys.SCloudResourceKeys = fetchCloudQuotaKeys(scope, ownerId, manager)
-	keys.RegionId = region.Id
+	if region != nil {
+		keys.RegionId = region.Id
+	}
 	return keys
 }
 
 func fetchZonalQuotaKeys(scope rbacutils.TRbacScope, ownerId mcclient.IIdentityProvider, zone *SZone, manager *SCloudprovider) quotas.SZonalCloudResourceKeys {
 	keys := quotas.SZonalCloudResourceKeys{}
 	keys.SCloudResourceKeys = fetchCloudQuotaKeys(scope, ownerId, manager)
-	keys.RegionId = zone.CloudregionId
-	keys.ZoneId = zone.Id
+	if zone != nil {
+		keys.RegionId = zone.CloudregionId
+		keys.ZoneId = zone.Id
+	}
 	return keys
 }
 

--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -287,6 +287,12 @@ func (manager *SSnapshotManager) ValidateCreateData(
 }
 
 func (self *SSnapshot) CustomizeCreate(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data jsonutils.JSONObject) error {
+	// use disk's ownerId instead of default ownerId
+	diskObj, err := DiskManager.FetchById(self.DiskId)
+	if err != nil {
+		return errors.Wrap(err, "DiskManager.FetchById")
+	}
+	ownerId = diskObj.(*SDisk).GetOwnerId()
 	return self.SVirtualResourceBase.CustomizeCreate(ctx, userCred, ownerId, query, data)
 }
 


### PR DESCRIPTION
1. snapshot pending usage not cleaned after created
2. server-attach-network error
3. loadbalancer fail to set cloudregion_id

**这个 PR 实现什么功能/修复什么问题**:
修正：
1. 快照配额的pending-usage在快照创建后没有正确清理
2. server-attach-network报quotakey转换错误
3. loadbalancer没有设置cloudregion_id
 
**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/2.14
- release/3.0

/cc @yousong @zexi 

/area region