### PR TITLE
fix(region): Sync HostStorage in syncOnPremiseCloudProviderInfo

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -1639,6 +1639,11 @@ func (self *SHost) SyncHostStorages(ctx context.Context, userCred mcclient.Token
 	for i := 0; i < len(removed); i += 1 {
 		log.Infof("host %s not connected with %s any more, to detach...", self.Id, removed[i].Id)
 		err := self.syncRemoveCloudHostStorage(ctx, userCred, &removed[i])
+		if errors.Cause(err) == ErrStorageInUse && removed[i].StorageType == api.STORAGE_LOCAL {
+			removed[i].SetStatus(userCred, api.STORAGE_OFFLINE, "the only host used this local storage has detached")
+			// prevent generating a delete error for syncResult
+			continue
+		}
 		if err != nil {
 			syncResult.DeleteError(err)
 		} else {

--- a/pkg/compute/models/hoststorages.go
+++ b/pkg/compute/models/hoststorages.go
@@ -19,6 +19,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/sqlchemy"
 
@@ -30,6 +31,8 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
+
+const ErrStorageInUse = errors.Error("StorageInUse")
 
 type SHoststorageManager struct {
 	SHostJointsManager
@@ -257,7 +260,7 @@ func (self *SHoststorage) ValidateDeleteCondition(ctx context.Context) error {
 		return httperrors.NewInternalServerError("GetGuestDiskCount fail %s", err)
 	}
 	if cnt > 0 {
-		return httperrors.NewNotEmptyError("guest on the host are using disks on this storage")
+		return errors.Wrap(ErrStorageInUse, "guest on the host are using disks on this storage")
 	}
 	return self.SHostJointsBase.ValidateDeleteCondition(ctx)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

情景：绕过OneCloud，删除 storage 上的所有 vm 并且删除 storage 然后新建 storage。

问题：因为存在 vm 在使用此 storage ，所以在同步的时候，对应的 storage
会删除失败，并且阻止了 storagecache 的同步。这样在创建机器的时候，如果
使用旧的 storage 就会导致创建失败（因为此Host已经不在使用对应的 remote storage);
如果使用新的 storage 就会因为找不到对应的 storage cache 而失败。

修改：如果因为以上原因删除失败的 storage 的 storage_type 为 local
那么就把这个 storage 置为 offline，并且不再阻止 storage cache 的同步。

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
