### PR TITLE
fix(esxi-agent): Adjust the VM Path in Datastore

### DIFF
--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -611,7 +611,7 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, data *jsonuti
 	if data.Contains("os_name") {
 		osName, _ = data.GetString("os_name")
 	}
-	datastorePath := fmt.Sprintf("[%s] %s", ds.GetRelName(), name)
+	datastorePath := fmt.Sprintf("[%s] ", ds.GetRelName())
 	if data.Contains("mem") {
 		memoryMB, _ = data.Int("mem")
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

假设虚拟机的id为 123456 ；现在 虚拟机 的路径是 [datastore] 123456/123456/* ；这样删除此机器之后，最外层的 123456 目录还是存在的。
因此去掉最外层的目录。

**是否需要 backport 到之前的 release 分支**:
- release/3.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
