### PR TITLE
_getModule fix

### DIFF
--- a/pkg/mcclient/modulebase/modules.go
+++ b/pkg/mcclient/modulebase/modules.go
@@ -249,6 +249,11 @@ func _getModule(session *mcclient.ClientSession, name string) (BaseManagerInterf
 	if !ok {
 		return nil, fmt.Errorf("No such module %s for version %s", name, session.GetApiVersion())
 	}
+
+	if len(mods) == 1 {
+		return mods[0], nil
+	}
+
 	for _, mod := range mods {
 		url, e := session.GetServiceURL(mod.ServiceType(), mod.EndpointType())
 		if e != nil {


### PR DESCRIPTION
这个 PR 实现什么功能/修复什么问题:
*_getModule mods长度为1时，直接返回mod，忽略版本检查

是否需要 backport 到之前的 release 分支:
release/3.0

/area region
/cc @swordqiu @yousong

