### PR TITLE
fix(esxi-agent): Avoid redundant agent & Adjust workspace path

### DIFF
--- a/pkg/cloudcommon/agent/agent.go
+++ b/pkg/cloudcommon/agent/agent.go
@@ -24,6 +24,7 @@ import (
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/version"
 
+	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/agent/iagent"
 	"yunion.io/x/onecloud/pkg/cloudcommon/object"
 	"yunion.io/x/onecloud/pkg/hostman/storageman"
@@ -234,7 +235,9 @@ func (agent *SBaseAgent) createOrUpdateBaremetalAgent(session *mcclient.ClientSe
 	if err != nil {
 		return err
 	}
-	params.Add(jsonutils.NewString(naccessIP.String()), "access_ip")
+	if agent.IAgent().GetAgentType() != string(api.AgentTypeEsxi) {
+		params.Add(jsonutils.NewString(naccessIP.String()), "access_ip")
+	}
 	params.Add(jsonutils.NewString(agent.IAgent().GetAgentType()), "agent_type")
 	ret, err := modules.Baremetalagents.List(session, params)
 	if err != nil {

--- a/pkg/esxi/service/esxi_agent_service.go
+++ b/pkg/esxi/service/esxi_agent_service.go
@@ -44,7 +44,7 @@ func (s *SExsiAgentService) StartService() {
 	options_common.ParseOptions(&options.Options, os.Args, "esxiagent.conf", "esxiagent")
 
 	if len(options.Options.ImageCachePath) == 0 {
-		options.Options.ImageCachePath = filepath.Join(filepath.Dir(options.Options.EsxiAgentPath), "image_cache")
+		options.Options.ImageCachePath = filepath.Join(options.Options.EsxiAgentPath, "image_cache")
 		log.Infof("No cachepath, use default %s", options.Options.ImageCachePath)
 		err := os.MkdirAll(options.Options.ImageCachePath, 0760)
 		if err != nil {
@@ -52,7 +52,7 @@ func (s *SExsiAgentService) StartService() {
 		}
 	}
 	if len(options.Options.AgentTempPath) == 0 {
-		options.Options.AgentTempPath = filepath.Join(filepath.Dir(options.Options.EsxiAgentPath), "agent_tmp")
+		options.Options.AgentTempPath = filepath.Join(options.Options.EsxiAgentPath, "agent_tmp")
 		log.Infof("No agent temp path, use default %s", options.Options.AgentTempPath)
 		err := os.MkdirAll(options.Options.AgentTempPath, 0760)
 		if err != nil {

--- a/pkg/multicloud/esxi/storage.go
+++ b/pkg/multicloud/esxi/storage.go
@@ -766,7 +766,7 @@ func (self *SDatastore) domainName(name string) string {
 
 // ImportVMDK will upload local vmdk 'diskFile' to the 'remotePath' of remote datastore
 func (self *SDatastore) ImportVMDK(ctx context.Context, diskFile, remotePath string, host *SHost) error {
-	name := fmt.Sprintf("yunioncloud.%s%d", self.domainName(remotePath), rand.Int())
+	name := fmt.Sprintf("yunioncloud.%s%d", self.domainName(remotePath)[:20], rand.Int())
 	vm, err := self.ImportVM(ctx, diskFile, name, host)
 	if err != nil {
 		return errors.Wrap(err, "SDatastore.ImportVM")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. There is only one esxi agent needed in OneCloud.
2. Workspace path shoule be EsxiAgentPath not the parent directory of this.
3. The VM name is too long for vcenter when importing VM so shrink it.

**是否需要 backport 到之前的 release 分支**:
- release/3.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
