### PR TITLE
fix: initialize service config on keystone when service boot

### DIFF
--- a/pkg/cloudcommon/options/mergeconf.go
+++ b/pkg/cloudcommon/options/mergeconf.go
@@ -82,9 +82,12 @@ func (s *mcclientServiceConfigSession) Merge(opts interface{}, serviceType strin
 		serviceConf, err := getServiceConfig(s.session, s.serviceId)
 		if err != nil {
 			log.Errorf("getServiceConfig for %s failed: %s", serviceType, err)
-		} else {
+		} else if serviceConf != nil {
 			s.config.Update(serviceConf)
 			merged = true
+		} else {
+			// not initialized
+			s.Upload()
 		}
 	}
 	commonServiceId, _ := getServiceIdByType(s.session, consts.COMMON_SERVICE, "")
@@ -92,9 +95,11 @@ func (s *mcclientServiceConfigSession) Merge(opts interface{}, serviceType strin
 		commonConf, err := getServiceConfig(s.session, commonServiceId)
 		if err != nil {
 			log.Errorf("getServiceConfig for %s failed: %s", consts.COMMON_SERVICE, err)
-		} else {
+		} else if commonConf != nil {
 			s.config.Update(commonConf)
 			merged = true
+		} else {
+			// common not initialized
 		}
 	}
 	if merged {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：服务启动时，如果该服务的service-config没有初始化，则初始化

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/2.14
- release/3.0

/cc @zexi @yousong 

/area region keystone