### PR TITLE
fix: non-default-domain-projects changes not take effects after changing

### DIFF
--- a/pkg/cloudcommon/options/changes.go
+++ b/pkg/cloudcommon/options/changes.go
@@ -14,6 +14,10 @@
 
 package options
 
+import (
+	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
+)
+
 func OnBaseOptionsChange(oOpts, nOpts interface{}) bool {
 	oldOpts := oOpts.(*BaseOptions)
 	newOpts := nOpts.(*BaseOptions)
@@ -23,6 +27,9 @@ func OnBaseOptionsChange(oOpts, nOpts interface{}) bool {
 	}
 	if oldOpts.TimeZone != newOpts.TimeZone {
 		return true
+	}
+	if oldOpts.NonDefaultDomainProjects != newOpts.NonDefaultDomainProjects {
+		consts.SetNonDefaultDomainProjects(newOpts.NonDefaultDomainProjects)
 	}
 	return false
 }


### PR DESCRIPTION
through service-config

**这个 PR 实现什么功能/修复什么问题**:
修正：通过service-config开启三级权限不生效

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/2.14
- release/3.0

/area keystone
/cc @yousong @zexi 