### PR TITLE
fix(esxi-agent): Export CGO_ENABLED=0 when building esxi-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ test:
 vet:
 	go vet ./...
 
+cmd/esxi-agent: prepare_dir
+	CGO_ENABLED=0 $(GO_BUILD) -o $(BIN_DIR)/$(shell basename $@) $(REPO_PREFIX)/$@
+
 cmd/%: prepare_dir
 	$(GO_BUILD) -o $(BIN_DIR)/$(shell basename $@) $(REPO_PREFIX)/$@
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

**是否需要 backport 到之前的 release 分支**:
- release/3.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
