### PR TITLE
Automated cherry pick of #4856: fix(esxi-agent): Export CGO_ENABLED=0 when building esxi-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ test:
 vet:
 	go vet ./...
 
+cmd/esxi-agent: prepare_dir
+	CGO_ENABLED=0 $(GO_BUILD) -o $(BIN_DIR)/$(shell basename $@) $(REPO_PREFIX)/$@
+
 cmd/%: prepare_dir
 	$(GO_BUILD) -o $(BIN_DIR)/$(shell basename $@) $(REPO_PREFIX)/$@
 


### PR DESCRIPTION
Cherry pick of #4856 on release/3.0.

#4856: fix(esxi-agent): Export CGO_ENABLED=0 when building esxi-agent