### PR TITLE
Automated cherry pick of #4869: fix: first load of service config not effective

### DIFF
--- a/pkg/cloudcommon/options/changes.go
+++ b/pkg/cloudcommon/options/changes.go
@@ -28,6 +28,9 @@ func OnBaseOptionsChange(oOpts, nOpts interface{}) bool {
 	if oldOpts.TimeZone != newOpts.TimeZone {
 		return true
 	}
+	if oldOpts.EnableRbac != newOpts.EnableRbac {
+		return true
+	}
 	if oldOpts.NonDefaultDomainProjects != newOpts.NonDefaultDomainProjects {
 		consts.SetNonDefaultDomainProjects(newOpts.NonDefaultDomainProjects)
 	}

--- a/pkg/cloudcommon/options/manager.go
+++ b/pkg/cloudcommon/options/manager.go
@@ -85,7 +85,7 @@ func (manager *SOptionManager) doSync(first bool) {
 
 	if merged && !reflect.DeepEqual(newOpts, manager.options) {
 		log.Infof("Service config changed ...")
-		if !first && manager.onOptionsChange != nil && manager.onOptionsChange(manager.options, newOpts) {
+		if manager.onOptionsChange != nil && manager.onOptionsChange(manager.options, newOpts) && !first {
 			log.Infof("Option changes detected and going to restart the program...")
 			appsrv.SetExitFlag()
 		}


### PR DESCRIPTION
Cherry pick of #4869 on release/2.13.

#4869: fix: first load of service config not effective