### PR TITLE
lb: support accessing backend with tls

### DIFF
--- a/pkg/compute/models/loadbalanceragents.go
+++ b/pkg/compute/models/loadbalanceragents.go
@@ -104,6 +104,7 @@ type SLoadbalancerAgentParamsHaproxy struct {
 	LogHttp        bool
 	LogTcp         bool
 	LogNormal      bool
+	TuneHttpMaxhdr int
 }
 
 type SLoadbalancerAgentParamsTelegraf struct {
@@ -195,6 +196,12 @@ func (p *SLoadbalancerAgentParamsHaproxy) Validate(data *jsonutils.JSONDict) err
 	if p.GlobalNbthread > 64 {
 		// This is a limit imposed by haproxy and arch word size
 		p.GlobalNbthread = 64
+	}
+	if p.TuneHttpMaxhdr < 0 {
+		p.TuneHttpMaxhdr = 0
+	}
+	if p.TuneHttpMaxhdr > 32767 {
+		p.TuneHttpMaxhdr = 32767
 	}
 	return nil
 }
@@ -761,6 +768,7 @@ global
 	maxconn 20480
 	tune.ssl.default-dh-param 2048
 	{{- println }}
+	{{- if .haproxy.tune_http_maxhdr }}	tune.http.maxhdr {{ println .haproxy.tune_http_maxhdr }} {{- end }}
 	{{- if .haproxy.global_stats_socket }}	{{ println .haproxy.global_stats_socket }} {{- end }}
 	{{- if .haproxy.global_nbthread }}	nbthread {{ println .haproxy.global_nbthread }} {{- end }}
 	{{- if .haproxy.global_log }}	{{ println .haproxy.global_log }} {{- end }}

--- a/pkg/compute/models/loadbalancerbackends.go
+++ b/pkg/compute/models/loadbalancerbackends.go
@@ -72,6 +72,7 @@ type SLoadbalancerBackend struct {
 	Port           int    `nullable:"false" list:"user" create:"required" update:"user"`
 
 	SendProxy string `width:"16" charset:"ascii" nullable:"false" list:"user" create:"optional" update:"user" default:"off"`
+	Ssl       string `width:"16" charset:"ascii" nullable:"true" list:"user" create:"optional" update:"user" default:"off"`
 }
 
 func (man *SLoadbalancerBackendManager) pendingDeleteSubs(ctx context.Context, userCred mcclient.TokenCredential, q *sqlchemy.SQuery) {

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -267,9 +267,9 @@ func (self *SKVMRegionDriver) ValidateCreateLoadbalancerBackendData(ctx context.
 
 func (self *SKVMRegionDriver) ValidateUpdateLoadbalancerBackendData(ctx context.Context, userCred mcclient.TokenCredential, data *jsonutils.JSONDict, lbbg *models.SLoadbalancerBackendGroup) (*jsonutils.JSONDict, error) {
 	keyV := map[string]validators.IValidator{
-		"weight":     validators.NewRangeValidator("weight", 1, 256).Optional(true),
-		"port":       validators.NewPortValidator("port").Optional(true),
-		"send_proxy": validators.NewStringChoicesValidator("send_proxy", api.LB_SENDPROXY_CHOICES).Optional(true),
+		"weight":     validators.NewRangeValidator("weight", 1, 256),
+		"port":       validators.NewPortValidator("port"),
+		"send_proxy": validators.NewStringChoicesValidator("send_proxy", api.LB_SENDPROXY_CHOICES),
 	}
 
 	if err := RunValidators(keyV, data, true); err != nil {

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -169,6 +169,7 @@ func (self *SKVMRegionDriver) ValidateCreateLoadbalancerBackendData(ctx context.
 		"weight":       validators.NewRangeValidator("weight", 1, 256).Default(1),
 		"port":         validators.NewPortValidator("port"),
 		"send_proxy":   validators.NewStringChoicesValidator("send_proxy", api.LB_SENDPROXY_CHOICES).Default(api.LB_SENDPROXY_OFF),
+		"ssl":          validators.NewStringChoicesValidator("ssl", api.LB_BOOL_VALUES).Default(api.LB_BOOL_OFF),
 	}
 
 	if err := RunValidators(keyV, data, false); err != nil {
@@ -270,6 +271,7 @@ func (self *SKVMRegionDriver) ValidateUpdateLoadbalancerBackendData(ctx context.
 		"weight":     validators.NewRangeValidator("weight", 1, 256),
 		"port":       validators.NewPortValidator("port"),
 		"send_proxy": validators.NewStringChoicesValidator("send_proxy", api.LB_SENDPROXY_CHOICES),
+		"ssl":        validators.NewStringChoicesValidator("ssl", api.LB_BOOL_VALUES),
 	}
 
 	if err := RunValidators(keyV, data, true); err != nil {

--- a/pkg/lbagent/models/haproxy.go
+++ b/pkg/lbagent/models/haproxy.go
@@ -195,10 +195,15 @@ func (b *LoadbalancerCorpus) genHaproxyConfigCommon(lb *Loadbalancer, listener *
 	{
 		agentHaproxyParams := opts.AgentModel.Params.Haproxy
 		if agentHaproxyParams.GlobalLog != "" {
-			if listener.ListenerType == "http" && agentHaproxyParams.LogHttp {
-				data["log"] = true
-			} else if listener.ListenerType == "tcp" && agentHaproxyParams.LogTcp {
-				data["log"] = true
+			switch listener.ListenerType {
+			case "http", "https":
+				if agentHaproxyParams.LogHttp {
+					data["log"] = true
+				}
+			case "tcp":
+				if agentHaproxyParams.LogTcp {
+					data["log"] = true
+				}
 			}
 		}
 	}

--- a/pkg/lbagent/models/haproxy.go
+++ b/pkg/lbagent/models/haproxy.go
@@ -324,6 +324,11 @@ func (b *LoadbalancerCorpus) genHaproxyConfigBackend(data map[string]interface{}
 			} else {
 				// nothing to do
 			}
+			if backend.Ssl == "on" {
+				serverLine += " ssl"
+				serverLine += " verify none"
+				serverLine += " check-ssl"
+			}
 			serverLines = append(serverLines, serverLine)
 		}
 		data["servers"] = serverLines

--- a/pkg/mcclient/models/loadbalancers.go
+++ b/pkg/mcclient/models/loadbalancers.go
@@ -234,6 +234,7 @@ type LoadbalancerAgentParamsHaproxy struct {
 	LogHttp        bool
 	LogTcp         bool
 	LogNormal      bool
+	TuneHttpMaxhdr int
 }
 
 type LoadbalancerAgentParamsTelegraf struct {

--- a/pkg/mcclient/models/loadbalancers.go
+++ b/pkg/mcclient/models/loadbalancers.go
@@ -157,6 +157,7 @@ type LoadbalancerBackend struct {
 	Port           int
 
 	SendProxy string
+	Ssl       string
 }
 
 type LoadbalancerAclEntry struct {

--- a/pkg/mcclient/options/loadbalanceragents.go
+++ b/pkg/mcclient/options/loadbalanceragents.go
@@ -43,6 +43,7 @@ type LoadbalancerAgentParamsOptions struct {
 	HaproxyLogHttp        string `choices:"true|false"`
 	HaproxyLogTcp         string `choices:"true|false"`
 	HaproxyLogNormal      string `choices:"true|false"`
+	HaproxyTuneHttpMaxhdr *int   `help:"max number of http headers allowed"`
 
 	TelegrafInfluxDbOutputUrl       string
 	TelegrafInfluxDbOutputName      string

--- a/pkg/mcclient/options/loadbalancerbackends.go
+++ b/pkg/mcclient/options/loadbalancerbackends.go
@@ -22,6 +22,7 @@ type LoadbalancerBackendCreateOptions struct {
 	Weight       *int   `default:"1"`
 
 	SendProxy string `choices:"off|v1|v2|v2-ssl|v2-ssl-on"`
+	Ssl       string `choices:"on|off"`
 }
 
 type LoadbalancerBackendListOptions struct {
@@ -34,6 +35,7 @@ type LoadbalancerBackendListOptions struct {
 	Port         *int
 
 	SendProxy string `choices:"off|v1|v2|v2-ssl|v2-ssl-on"`
+	Ssl       string `choices:"on|off"`
 }
 
 type LoadbalancerBackendUpdateOptions struct {
@@ -44,6 +46,7 @@ type LoadbalancerBackendUpdateOptions struct {
 	Port   *int
 
 	SendProxy string `choices:"off|v1|v2|v2-ssl|v2-ssl-on"`
+	Ssl       string `choices:"on|off"`
 }
 
 type LoadbalancerBackendGetOptions struct {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
lbagent: tunable tune.http.maxhdr
lbagent: fix not logging https listener
lbagent: support accessing backend with tls
climc: lbbackend: support ssl related options
lb: support accessing backend with tls
lb: regiondrivers: remove unneeded Optional(true) call
```

**是否需要 backport 到之前的 release 分支**:

- release/3.0

/area region
/area lbagent
/cc @ioito @tb365 @swordqiu 