### PR TITLE
glance: validate image share on delete, update pulibc scope on mark standard

### DIFF
--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -658,6 +658,9 @@ func (self *SImage) ValidateDeleteCondition(ctx context.Context) error {
 	if self.IsGuestImage.IsTrue() {
 		return httperrors.NewForbiddenError("image is the part of guest image")
 	}
+	if self.IsPublic || len(self.GetSharedProjects()) > 0 {
+		return httperrors.NewForbiddenError("image is shared")
+	}
 	return self.SVirtualResourceBase.ValidateDeleteCondition(ctx)
 }
 
@@ -1242,13 +1245,24 @@ func (self *SImage) PerformMarkStandard(
 	data jsonutils.JSONObject,
 ) (jsonutils.JSONObject, error) {
 	isStandard := jsonutils.QueryBoolean(data, "is_standard", false)
-	if (!self.IsStandard.IsTrue() && isStandard) || (self.IsStandard.IsTrue() && !isStandard) {
+	if !self.IsStandard.IsTrue() && isStandard {
+		params := jsonutils.NewDict()
+		params.Set("scope", jsonutils.NewString("system"))
+		_, err := self.PerformPublic(ctx, userCred, query, params)
+		if err != nil {
+			return nil, err
+		}
 		diff, err := db.Update(self, func() error {
-			if isStandard {
-				self.IsStandard = tristate.True
-			} else {
-				self.IsStandard = tristate.False
-			}
+			self.IsStandard = tristate.True
+			return nil
+		})
+		if err != nil {
+			return nil, httperrors.NewGeneralError(err)
+		}
+		db.OpsLog.LogEvent(self, db.ACT_UPDATE, diff, userCred)
+	} else if self.IsStandard.IsTrue() && !isStandard {
+		diff, err := db.Update(self, func() error {
+			self.IsStandard = tristate.False
 			return nil
 		})
 		if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
RT
**是否需要 backport 到之前的 release 分支**:
release/2.13
/area image
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
