### PR TITLE
feature(esxiagent): Add Template VM as CachedImage

### DIFF
--- a/pkg/hostman/storageman/storage_agent.go
+++ b/pkg/hostman/storageman/storage_agent.go
@@ -146,21 +146,14 @@ func (as *SAgentStorage) agentCreateGuest(ctx context.Context, data *jsonutils.J
 	if !ok {
 		return errors.Wrap(hostutils.ParamsError, "agentCreateGuest data format error")
 	}
-	vm, err := host.DoCreateVM(ctx, ds, descDict)
+	createParam := esxi.SCreateVMParam{}
+	err = descDict.Unmarshal(&createParam)
 	if err != nil {
-		return errors.Wrap(err, "SHost.DoCreateVM")
+		return errors.Wrapf(err, "%s: fail to unmarshal to esxi.SCreateVMParam", hostutils.ParamsError)
 	}
-	/*
-		id, _ := data.GetString("guest_ext_id")
-		ivm, err := host.GetIVMById(id)
-		if err != nil {
-			return errors.Wrap(err, "SHost.GetIVMById")
-		}
-	*/
-	name, _ := descDict.GetString("name")
-	err = as.tryRenameVm(ctx, vm, name)
+	_, err = host.CreateVM2(ctx, ds, createParam)
 	if err != nil {
-		return errors.Wrapf(err, "RenameVm name '%s'", name)
+		return errors.Wrap(err, "SHost.CreateVM2")
 	}
 	return nil
 }

--- a/pkg/multicloud/esxi/datacenter.go
+++ b/pkg/multicloud/esxi/datacenter.go
@@ -166,26 +166,32 @@ func (dc *SDatacenter) getDcObj() *object.Datacenter {
 	return object.NewDatacenter(dc.manager.client.Client, dc.object.Reference())
 }
 
-func (dc *SDatacenter) fetchVms(vmRefs []types.ManagedObjectReference, all bool) ([]cloudprovider.ICloudVM, error) {
+// fetchVms will identify if VM is a template and return two different arrays; the latter contains all template vms.
+func (dc *SDatacenter) fetchVms(vmRefs []types.ManagedObjectReference, all bool) ([]cloudprovider.ICloudVM, []*SVirtualMachine, error) {
 	var vms []mo.VirtualMachine
 	if vmRefs != nil {
 		err := dc.manager.references2Objects(vmRefs, VIRTUAL_MACHINE_PROPS, &vms)
 		if err != nil {
-			return nil, errors.Wrap(err, "dc.manager.references2Objects")
+			return nil, nil, errors.Wrap(err, "dc.manager.references2Objects")
 		}
 	}
 
 	// avoid applying new memory and copying
-	retVms := make([]cloudprovider.ICloudVM, 0, len(vms))
+	retVms := make([]cloudprovider.ICloudVM, 0, len(vms)/2)
+	templateVMs := make([]*SVirtualMachine, 0, 2)
 	for i := 0; i < len(vms); i += 1 {
 		if all || !strings.HasPrefix(vms[i].Entity().Name, api.ESXI_IMAGE_CACHE_TMP_PREFIX) {
 			vmObj := NewVirtualMachine(dc.manager, &vms[i], dc)
+			if vms[i].Config.Template {
+				templateVMs = append(templateVMs, vmObj)
+				continue
+			}
 			if vmObj != nil {
 				retVms = append(retVms, vmObj)
 			}
 		}
 	}
-	return retVms, nil
+	return retVms, templateVMs, nil
 }
 
 func (dc *SDatacenter) fetchDatastores(datastoreRefs []types.ManagedObjectReference) ([]cloudprovider.ICloudStorage, error) {

--- a/pkg/multicloud/esxi/device.go
+++ b/pkg/multicloud/esxi/device.go
@@ -52,7 +52,11 @@ func (dev *SVirtualDevice) getLabel() string {
 }
 
 func (dev *SVirtualDevice) GetDriver() string {
-	val := reflect.Indirect(reflect.ValueOf(dev.dev))
+	return getDevName(dev.dev)
+}
+
+func getDevName(device types.BaseVirtualDevice) string {
+	val := reflect.Indirect(reflect.ValueOf(device))
 	driver := strings.ToLower(val.Type().Name())
 	if strings.Contains(driver, "virtualmachine") {
 		return strings.Replace(driver, "virtualmachine", "", -1)

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -988,7 +988,6 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SData
 	}
 
 	return NewVirtualMachine(host.manager, &moVM, host.datacenter), nil
-	return nil, nil
 }
 
 func (host *SHost) changeNic(device types.BaseVirtualDevice, update types.BaseVirtualDevice) {

--- a/pkg/multicloud/esxi/shell/virtualmachine.go
+++ b/pkg/multicloud/esxi/shell/virtualmachine.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"yunion.io/x/pkg/errors"
+
 	"yunion.io/x/onecloud/pkg/multicloud/esxi"
 	"yunion.io/x/onecloud/pkg/util/printutils"
 	"yunion.io/x/onecloud/pkg/util/shellutils"
@@ -25,12 +27,21 @@ import (
 
 func init() {
 	type VirtualMachineListOptions struct {
-		HOSTIP string `help:"Host IP"`
+		HOSTIP   string `help:"Host IP"`
+		Template bool   `help:"Whether it is tempalte virtual machine"`
 	}
 	shellutils.R(&VirtualMachineListOptions{}, "vm-list", "List vms of a host", func(cli *esxi.SESXiClient, args *VirtualMachineListOptions) error {
 		host, err := cli.FindHostByIp(args.HOSTIP)
 		if err != nil {
 			return err
+		}
+		if args.Template {
+			vms, err := host.GetTemplateVMs()
+			if err != nil {
+				return err
+			}
+			printList(vms, []string{})
+			return nil
 		}
 		vms, err := host.GetIVMs2()
 		if err != nil {
@@ -40,14 +51,62 @@ func init() {
 		return nil
 	})
 
+	type VirtualMachineCloneOptions struct {
+		HOSTIP     string `help:"Host IP"`
+		TEMPLATEID string `help:"id of template ma"`
+		NAME       string `help:"New VM's name'"`
+		Uuid       string `help:"Uuid of new VM"`
+		CpuNum     int    `help:"Number of CPU""`
+		MemSize    int    `help:"Size of Memory(MB)"`
+	}
+	shellutils.R(&VirtualMachineCloneOptions{}, "vm-clone", "Clone vm", func(cli *esxi.SESXiClient,
+		args *VirtualMachineCloneOptions) error {
+		host, err := cli.FindHostByIp(args.HOSTIP)
+		if err != nil {
+			return err
+		}
+		idss, err := host.GetDataStores()
+		if err != nil {
+			return err
+		}
+		if len(idss) == 0 {
+			return fmt.Errorf("no datastore")
+		}
+		temVm, err := host.GetTemplateVMById(args.TEMPLATEID)
+		if err != nil {
+			return err
+		}
+		createParams := esxi.SCreateVMParam{
+			Name: args.NAME,
+			Uuid: args.Uuid,
+			Cpu:  args.CpuNum,
+			Mem:  args.MemSize,
+		}
+		vm, err := host.CloneVM(context.Background(), temVm, idss[0].(*esxi.SDatastore), createParams)
+		if err != nil {
+			return errors.Wrap(err, "SHost.CloneVMFromTemplate")
+		}
+		printObject(vm)
+		return nil
+	})
+
 	type VirtualMachineShowOptions struct {
-		HOSTIP string `help:"Host IP"`
-		VMID   string `help:"VM ID"`
+		HOSTIP   string `help:"Host IP"`
+		VMID     string `help:"VM ID"`
+		Template bool
 	}
 	shellutils.R(&VirtualMachineShowOptions{}, "vm-show", "Show vm details", func(cli *esxi.SESXiClient, args *VirtualMachineShowOptions) error {
 		host, err := cli.FindHostByIp(args.HOSTIP)
 		if err != nil {
 			return err
+		}
+		if args.Template {
+			vm, err := host.GetTemplateVMById(args.VMID)
+			if err != nil {
+				return err
+			}
+			printObject(vm)
+			return nil
 		}
 		vm, err := host.GetIVMById(args.VMID)
 		if err != nil {

--- a/pkg/multicloud/esxi/storage.go
+++ b/pkg/multicloud/esxi/storage.go
@@ -259,7 +259,8 @@ func (self *SDatastore) getVMs() ([]cloudprovider.ICloudVM, error) {
 	if len(vms) == 0 {
 		return nil, nil
 	}
-	return dc.fetchVms(vms, false)
+	ret, _, err := dc.fetchVms(vms, false)
+	return ret, err
 }
 
 func (self *SDatastore) GetIDiskById(idStr string) (cloudprovider.ICloudDisk, error) {

--- a/pkg/multicloud/esxi/storagecache.go
+++ b/pkg/multicloud/esxi/storagecache.go
@@ -119,6 +119,20 @@ func (self *SDatastoreImageCache) GetIImages() ([]cloudprovider.ICloudImage, err
 		}
 	}
 
+	// get vm template with only one disk
+	tems, err := self.host.GetTemplateVMs()
+	if err != nil {
+		log.Errorf("fail to get templateVMs of host '%s' in SDatastoreImageCache.GetIImages", self.host.GetName())
+		return ret, nil
+	}
+	for _, tem := range tems {
+		// for now, add vm template with only one disk as cachedimage
+		if len(tem.vdisks) != 1 {
+			continue
+		}
+		ret = append(ret, NewVMTemplate(tem, self))
+	}
+
 	return ret, nil
 }
 

--- a/pkg/multicloud/esxi/template.go
+++ b/pkg/multicloud/esxi/template.go
@@ -1,0 +1,150 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package esxi
+
+import (
+	"context"
+	"time"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+)
+
+type SVMTemplate struct {
+	cache *SDatastoreImageCache
+	vm    *SVirtualMachine
+	uuid  string
+}
+
+func NewVMTemplate(vm *SVirtualMachine, cache *SDatastoreImageCache) *SVMTemplate {
+	return &SVMTemplate{
+		cache: cache,
+		vm:    vm,
+		uuid:  vm.GetGlobalId(),
+	}
+}
+
+func (t *SVMTemplate) GetId() string {
+	return t.uuid
+}
+
+func (t *SVMTemplate) GetName() string {
+	return t.vm.GetName()
+}
+
+func (t *SVMTemplate) GetGlobalId() string {
+	return t.GetId()
+}
+
+func (t *SVMTemplate) GetStatus() string {
+	_, err := t.cache.host.GetTemplateVMById(t.uuid)
+	if errors.Cause(err) == cloudprovider.ErrNotFound {
+		return api.CACHED_IMAGE_STATUS_CACHE_FAILED
+	}
+	return api.CACHED_IMAGE_STATUS_READY
+}
+
+func (t *SVMTemplate) Refresh() error {
+	vm, err := t.cache.host.GetTemplateVMById(t.uuid)
+	if errors.Cause(err) == cloudprovider.ErrNotFound {
+		return errors.Wrap(err, "no such vm template")
+	}
+	if err != nil {
+		return errors.Wrap(err, "SHost.GetTemplateVMById")
+	}
+	t.vm = vm
+	return nil
+}
+
+func (t *SVMTemplate) IsEmulated() bool {
+	return false
+}
+
+func (t *SVMTemplate) GetMetadata() *jsonutils.JSONDict {
+	return nil
+}
+
+func (t *SVMTemplate) Delete(ctx context.Context) error {
+	vm, err := t.cache.host.GetTemplateVMById(t.uuid)
+	if errors.Cause(err) == cloudprovider.ErrNotFound {
+		return nil
+	}
+	if err != nil {
+		return errors.Wrapf(err, "fail to get template vm '%s'", t.uuid)
+	}
+	return vm.DeleteVM(ctx)
+}
+
+func (t *SVMTemplate) GetIStoragecache() cloudprovider.ICloudStoragecache {
+	return t.cache
+}
+
+func (t *SVMTemplate) GetSizeByte() int64 {
+	return int64(t.GetMinRamSizeMb()) * 1024 * 1024
+}
+
+func (t *SVMTemplate) GetImageType() string {
+	return cloudprovider.CachedImageTypeSystem
+}
+
+func (t *SVMTemplate) GetImageStatus() string {
+	status := t.GetStatus()
+	if status == api.CACHED_IMAGE_STATUS_READY {
+		return cloudprovider.IMAGE_STATUS_ACTIVE
+	}
+	return cloudprovider.IMAGE_STATUS_DELETED
+}
+
+func (t *SVMTemplate) GetOsType() string {
+	return t.vm.GetOSType()
+}
+
+func (t *SVMTemplate) GetOsDist() string {
+	return t.vm.GetOsDistribution()
+}
+
+func (t *SVMTemplate) GetOsVersion() string {
+	return t.vm.GetOSVersion()
+}
+
+func (t *SVMTemplate) GetOsArch() string {
+	return t.vm.GetOsArch()
+}
+
+func (t *SVMTemplate) GetMinOsDiskSizeGb() int {
+	return t.GetMinRamSizeMb() / 1024
+}
+
+func (t *SVMTemplate) GetMinRamSizeMb() int {
+	if len(t.vm.vdisks) == 0 {
+		return 30 * 1024
+	}
+	return t.vm.vdisks[0].GetDiskSizeMB()
+}
+
+func (t *SVMTemplate) GetImageFormat() string {
+	return "vmdk"
+}
+
+// GetCreateAt return vm's create time by getting the sys disk's create time
+func (t *SVMTemplate) GetCreatedAt() time.Time {
+	if len(t.vm.vdisks) == 0 {
+		return time.Time{}
+	}
+	return t.vm.vdisks[0].GetCreatedAt()
+}

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -56,6 +56,8 @@ type SVirtualMachine struct {
 	ihost  cloudprovider.ICloudHost
 
 	guestIps map[string]string
+
+	devKeys []int32
 }
 
 type byDiskType []SVirtualDisk
@@ -332,7 +334,28 @@ func (self *SVirtualMachine) GetOSType() string {
 
 func (self *SVirtualMachine) GetOSName() string {
 	if osInfo, ok := GuestOsInfo[self.GetGuestId()]; ok {
-		return string(osInfo.OsDistribution)
+		return osInfo.OsDistribution
+	}
+	return ""
+}
+
+func (self *SVirtualMachine) GetOSVersion() string {
+	if osInfo, ok := GuestOsInfo[self.GetGuestId()]; ok {
+		return osInfo.OsVersion
+	}
+	return ""
+}
+
+func (self *SVirtualMachine) GetOsArch() string {
+	if osInfo, ok := GuestOsInfo[self.GetGuestId()]; ok {
+		return string(osInfo.OsArch)
+	}
+	return ""
+}
+
+func (self *SVirtualMachine) GetOsDistribution() string {
+	if osInfo, ok := GuestOsInfo[self.GetGuestId()]; ok {
+		return osInfo.OsDistribution
 	}
 	return ""
 }
@@ -725,6 +748,10 @@ func (self *SVirtualMachine) fetchHardwareInfo() error {
 		vdev := NewVirtualDevice(self, dev, 0)
 		self.devs[vdev.getKey()] = vdev
 	}
+	// sort disk based on index
+	sort.Slice(self.vdisks, func(i, j int) bool {
+		return self.vdisks[i].GetIndex() < self.vdisks[j].GetIndex()
+	})
 	return nil
 }
 
@@ -805,10 +832,10 @@ func minDiskKey(devs []SVirtualDisk) int32 {
 	return minKey
 }
 
-func (self *SVirtualMachine) CreateDisk(ctx context.Context, sizeMb int, uuid string, driver string) error {
+func (self *SVirtualMachine) FindController(ctx context.Context, driver string) ([]SVirtualDevice, error) {
 	aliasDrivers, ok := driverTable[driver]
 	if !ok {
-		return fmt.Errorf("Unsupported disk driver %s", driver)
+		return nil, fmt.Errorf("Unsupported disk driver %s", driver)
 	}
 	var devs []SVirtualDevice
 	for _, alias := range aliasDrivers {
@@ -817,16 +844,30 @@ func (self *SVirtualMachine) CreateDisk(ctx context.Context, sizeMb int, uuid st
 			break
 		}
 	}
+	return devs, nil
+}
+
+func (self *SVirtualMachine) FindDiskByDriver(driver string) []SVirtualDisk {
+	disks := make([]SVirtualDisk, 0)
+	for i := range self.vdisks {
+		if self.vdisks[i].GetDriver() == driver {
+			disks = append(disks, self.vdisks[i])
+		}
+	}
+	return disks
+}
+
+func (self *SVirtualMachine) CreateDisk(ctx context.Context, sizeMb int, uuid string, driver string) error {
+	devs, err := self.FindController(ctx, driver)
+	if err != nil {
+		return err
+	}
 	if len(devs) == 0 {
 		return fmt.Errorf("Driver %s not found", driver)
 	}
 	ctlKey := minDevKey(devs)
-	sameDisks := make([]SVirtualDisk, 0)
-	for i := 0; i < len(self.vdisks); i += 1 {
-		if self.vdisks[i].GetDriver() == driver {
-			sameDisks = append(sameDisks, self.vdisks[i])
-		}
-	}
+	sameDisks := self.FindDiskByDriver(driver)
+
 	var diskKey int32 = 2000
 	if len(sameDisks) == 0 {
 		diskKey = minDiskKey(sameDisks)
@@ -1081,4 +1122,29 @@ func (self *SVirtualMachine) ExportTemplate(ctx context.Context, idx int, diskPa
 
 func (self *SVirtualMachine) GetSerialOutput(port int) (string, error) {
 	return "", cloudprovider.ErrNotImplemented
+}
+
+func (self *SVirtualMachine) FindMinDiffKey(limit int32) int32 {
+	if self.devs == nil {
+		self.fetchHardwareInfo()
+	}
+	if self.devKeys == nil {
+		self.devKeys = make([]int32, 0, len(self.devs))
+		for key, _ := range self.devs {
+			self.devKeys = append(self.devKeys, key)
+		}
+		sort.Slice(self.devKeys, func(i int, j int) bool {
+			return self.devKeys[i] < self.devKeys[j]
+		})
+	}
+	for _, key := range self.devKeys {
+		switch {
+		case key < limit:
+		case key == limit:
+			limit += 1
+		case key > limit:
+			return limit
+		}
+	}
+	return limit
 }

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -56,8 +56,6 @@ type SVirtualMachine struct {
 	ihost  cloudprovider.ICloudHost
 
 	guestIps map[string]string
-
-	devKeys []int32
 }
 
 type byDiskType []SVirtualDisk
@@ -1128,16 +1126,14 @@ func (self *SVirtualMachine) FindMinDiffKey(limit int32) int32 {
 	if self.devs == nil {
 		self.fetchHardwareInfo()
 	}
-	if self.devKeys == nil {
-		self.devKeys = make([]int32, 0, len(self.devs))
-		for key, _ := range self.devs {
-			self.devKeys = append(self.devKeys, key)
-		}
-		sort.Slice(self.devKeys, func(i int, j int) bool {
-			return self.devKeys[i] < self.devKeys[j]
-		})
+	devKeys := make([]int32, 0, len(self.devs))
+	for key := range self.devs {
+		devKeys = append(devKeys, key)
 	}
-	for _, key := range self.devKeys {
+	sort.Slice(devKeys, func(i int, j int) bool {
+		return devKeys[i] < devKeys[j]
+	})
+	for _, key := range devKeys {
 		switch {
 		case key < limit:
 		case key == limit:


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

Vcenter支持template vm。
将拥有一个磁盘的temlate vm同步成我们的cached image，并且在创建vmware机器的时候可以直接使用。

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
