### PR TITLE
Automated cherry pick of #4902: use executor probe kernel mods

### DIFF
--- a/pkg/hostman/hostdeployer/deployserver/deployserver.go
+++ b/pkg/hostman/hostdeployer/deployserver/deployserver.go
@@ -244,11 +244,11 @@ func (s *SDeployService) PrepareEnv() error {
 	if err := s.FixPathEnv(); err != nil {
 		return err
 	}
-	output, err := procutils.NewCommand("rmmod", "nbd").Output()
+	output, err := procutils.NewRemoteCommandAsFarAsPossible("rmmod", "nbd").Output()
 	if err != nil {
 		log.Errorf("rmmod error: %s", output)
 	}
-	output, err = procutils.NewCommand("modprobe", "nbd", "max_part=16").Output()
+	output, err = procutils.NewRemoteCommandAsFarAsPossible("modprobe", "nbd", "max_part=16").Output()
 	if err != nil {
 		return fmt.Errorf("Failed to activate nbd device: %s", output)
 	}

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -290,11 +290,11 @@ func (h *SHostInfo) prepareEnv() error {
 		ioParams["queue/iosched/quantum"] = "32"
 	}
 	fileutils2.ChangeAllBlkdevsParams(ioParams)
-	_, err = procutils.NewCommand("modprobe", "tun").Output()
+	_, err = procutils.NewRemoteCommandAsFarAsPossible("modprobe", "tun").Output()
 	if err != nil {
 		return fmt.Errorf("Failed to activate tun/tap device")
 	}
-	output, err := procutils.NewCommand("modprobe", "vhost_net").Output()
+	output, err := procutils.NewRemoteCommandAsFarAsPossible("modprobe", "vhost_net").Output()
 	if err != nil {
 		log.Errorf("modprobe error: %s", output)
 	}

--- a/pkg/hostman/isolated_device/isolated_device.go
+++ b/pkg/hostman/isolated_device/isolated_device.go
@@ -333,7 +333,7 @@ func (dev *sGPUBaseDevice) GetVGACmd() string {
 func (dev *sGPUBaseDevice) CustomProbe() error {
 	// vfio kernel driver check
 	for _, driver := range []string{"vfio", "vfio_iommu_type1", "vfio-pci"} {
-		if err := procutils.NewCommand("modprobe", driver).Run(); err != nil {
+		if err := procutils.NewRemoteCommandAsFarAsPossible("modprobe", driver).Run(); err != nil {
 			return fmt.Errorf("modprobe %s: %v", driver, err)
 		}
 	}
@@ -432,7 +432,7 @@ func ParseOutput(output []byte) []string {
 
 func bashOutput(cmd string) ([]string, error) {
 	args := []string{"-c", cmd}
-	output, err := procutils.NewCommand("sh", args...).Output()
+	output, err := procutils.NewRemoteCommandAsFarAsPossible("bash", args...).Output()
 	if err != nil {
 		return nil, err
 	} else {

--- a/pkg/util/sysutils/kvm.go
+++ b/pkg/util/sysutils/kvm.go
@@ -96,7 +96,7 @@ func detectiveKVMModuleSupport() string {
 func ModprobeKvmModule(name string, remove, nest bool) bool {
 	var params = []string{"modprobe"}
 	if remove {
-		if err := procutils.NewCommand("rmmod", name).Run(); err != nil {
+		if err := procutils.NewRemoteCommandAsFarAsPossible("rmmod", name).Run(); err != nil {
 			log.Errorf("rmmod failed %s: %s", name, err)
 		}
 	}
@@ -104,7 +104,7 @@ func ModprobeKvmModule(name string, remove, nest bool) bool {
 	if nest {
 		params = append(params, "nested=1")
 	}
-	if err := procutils.NewCommand(params[0], params[1:]...).Run(); err != nil {
+	if err := procutils.NewRemoteCommandAsFarAsPossible(params[0], params[1:]...).Run(); err != nil {
 		log.Errorf("Modprobe kvm %v failed: %s", params, err)
 		return false
 	}
@@ -137,7 +137,7 @@ func detectNestSupport() string {
 }
 
 func isNestSupport(name string) bool {
-	output, err := procutils.NewCommand("modinfo", name).Output()
+	output, err := procutils.NewRemoteCommandAsFarAsPossible("modinfo", name).Output()
 	if err != nil {
 		log.Errorln(err)
 		return false
@@ -191,7 +191,7 @@ func GetKernelModuleParameter(name, moduel string) string {
 }
 
 func IsKernelModuleLoaded(name string) bool {
-	output, err := procutils.NewCommand("lsmod").Output()
+	output, err := procutils.NewRemoteCommandAsFarAsPossible("lsmod").Output()
 	if err != nil {
 		log.Errorln(err)
 		return false


### PR DESCRIPTION
Cherry pick of #4902 on release/3.0.

#4902: use executor probe kernel mods