### PR TITLE
fix: 避免创建azure时指定高级ssd失效

### DIFF
--- a/pkg/multicloud/azure/host.go
+++ b/pkg/multicloud/azure/host.go
@@ -173,7 +173,7 @@ func (self *SHost) _createVM(desc *cloudprovider.SManagedVMCreateConfig, nicId s
 					Name:    fmt.Sprintf("vdisk_%s_%d", desc.Name, time.Now().UnixNano()),
 					Caching: "ReadWrite",
 					ManagedDisk: &ManagedDiskParameters{
-						StorageAccountType: storage.Name,
+						StorageAccountType: storage.storageType,
 					},
 					CreateOption: "FromImage",
 					DiskSizeGB:   &sysDiskSize,

--- a/pkg/multicloud/azure/instance.go
+++ b/pkg/multicloud/azure/instance.go
@@ -355,7 +355,6 @@ func (self *SInstance) getStorageInfoByUri(uri string) (*SStorage, *SClassicStor
 		if storageaccounts[i].Name == storageName {
 			storage := SStorage{
 				zone:        self.host.zone,
-				Name:        storageName,
 				storageType: storageaccounts[i].Sku.Name,
 			}
 			return &storage, nil, nil

--- a/pkg/multicloud/azure/storage.go
+++ b/pkg/multicloud/azure/storage.go
@@ -36,7 +36,6 @@ type SStorage struct {
 	zone *SZone
 
 	storageType  string
-	Name         string
 	ResourceType string
 	Tier         string
 	Kind         string


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免创建azure时指定高级ssd失效

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0

/area region
/cc @swordqiu 