### PR TITLE
Automated cherry pick of #4904: fix: 避免创建azure时指定高级ssd失效

### DIFF
--- a/pkg/util/azure/host.go
+++ b/pkg/util/azure/host.go
@@ -173,7 +173,7 @@ func (self *SHost) _createVM(desc *cloudprovider.SManagedVMCreateConfig, nicId s
 					Name:    fmt.Sprintf("vdisk_%s_%d", desc.Name, time.Now().UnixNano()),
 					Caching: "ReadWrite",
 					ManagedDisk: &ManagedDiskParameters{
-						StorageAccountType: storage.Name,
+						StorageAccountType: storage.storageType,
 					},
 					CreateOption: "FromImage",
 					DiskSizeGB:   &sysDiskSize,

--- a/pkg/util/azure/instance.go
+++ b/pkg/util/azure/instance.go
@@ -355,7 +355,6 @@ func (self *SInstance) getStorageInfoByUri(uri string) (*SStorage, *SClassicStor
 		if storageaccounts[i].Name == storageName {
 			storage := SStorage{
 				zone:        self.host.zone,
-				Name:        storageName,
 				storageType: storageaccounts[i].Sku.Name,
 			}
 			return &storage, nil, nil

--- a/pkg/util/azure/storage.go
+++ b/pkg/util/azure/storage.go
@@ -36,7 +36,6 @@ type SStorage struct {
 	zone *SZone
 
 	storageType  string
-	Name         string
 	ResourceType string
 	Tier         string
 	Kind         string


### PR DESCRIPTION
Cherry pick of #4904 on release/2.10.0.

#4904: fix: 避免创建azure时指定高级ssd失效