### PR TITLE
server get login info 404 not found

### DIFF
--- a/pkg/mcclient/modules/mod_servers.go
+++ b/pkg/mcclient/modules/mod_servers.go
@@ -15,13 +15,13 @@
 package modules
 
 import (
-	"fmt"
 	"strings"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/gotypes"
 	"yunion.io/x/pkg/utils"
 
+	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/onecloud/pkg/util/seclib2"
@@ -50,7 +50,7 @@ func (this *ServerManager) GetLoginInfo(s *mcclient.ClientSession, id string, pa
 
 	loginKey, e := data.GetString("metadata", "login_key")
 	if e != nil {
-		return nil, fmt.Errorf("No login key: %s", e)
+		return nil, httperrors.NewNotFoundError("No login key: %s", e)
 	}
 
 	if len(loginKey) > 0 {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
* 虚拟机获取登录密码失败时返回404错误 

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0

/area region
/cc @swordqiu 
