### PR TITLE
Automated cherry pick of #4911: server get login info 404 not found

### DIFF
--- a/pkg/mcclient/modules/mod_servers.go
+++ b/pkg/mcclient/modules/mod_servers.go
@@ -15,13 +15,13 @@
 package modules
 
 import (
-	"fmt"
 	"strings"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/gotypes"
 	"yunion.io/x/pkg/utils"
 
+	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/onecloud/pkg/util/seclib2"
@@ -50,7 +50,7 @@ func (this *ServerManager) GetLoginInfo(s *mcclient.ClientSession, id string, pa
 
 	loginKey, e := data.GetString("metadata", "login_key")
 	if e != nil {
-		return nil, fmt.Errorf("No login key: %s", e)
+		return nil, httperrors.NewNotFoundError("No login key: %s", e)
 	}
 
 	if len(loginKey) > 0 {


### PR DESCRIPTION
Cherry pick of #4911 on release/2.13.

#4911: server get login info 404 not found