### PR TITLE
netutils: isolate linux dependent parts

### DIFF
--- a/pkg/hostman/hostinfo/hostbridge/hostbridge.go
+++ b/pkg/hostman/hostinfo/hostbridge/hostbridge.go
@@ -185,6 +185,7 @@ func (d *SBaseBridgeDriver) SetupAddresses(mask net.IPMask) error {
 		if len(d.ip) == 0 {
 			addr, masklen = netutils2.GetSecretInterfaceAddress()
 		} else {
+			addr = d.ip
 			masklen, _ = mask.Size()
 		}
 		addrStr := fmt.Sprintf("%s/%d", addr, masklen)

--- a/pkg/util/iproute2/address.go
+++ b/pkg/util/iproute2/address.go
@@ -25,10 +25,13 @@ func NewAddress(ifname string, addresses ...string) *Address {
 		if err != nil {
 			r.addrBad = true
 			r.addErr(err, "parse addr")
+			continue
 		}
 		addrs[i] = addr
 	}
-	r.addrs = addrs
+	if !r.addrBad {
+		r.addrs = addrs
+	}
 	return r
 }
 

--- a/pkg/util/netutils2/netutils.go
+++ b/pkg/util/netutils2/netutils.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/vishvananda/netlink"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
@@ -33,7 +31,6 @@ import (
 	"yunion.io/x/pkg/util/regutils"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/types"
-	"yunion.io/x/onecloud/pkg/util/iproute2"
 	"yunion.io/x/onecloud/pkg/util/procutils"
 	"yunion.io/x/onecloud/pkg/util/regutils2"
 )
@@ -82,38 +79,6 @@ func MyIP() (ip string, err error) {
 		return
 	}
 	ip = addr.IP.String()
-	return
-}
-
-func DefaultSrcIpDev() (srcIp net.IP, ifname string, err error) {
-	destIp := net.ParseIP("114.114.114.114")
-	routes, err := netlink.RouteGet(destIp)
-	if err != nil {
-		err = errors.Wrap(err, "get route")
-		return
-	}
-	if len(routes) == 0 {
-		err = fmt.Errorf("no route")
-		return
-	}
-	var errs []error
-	for i := range routes {
-		route := &routes[i]
-		ip4 := route.Src.To4()
-		if len(ip4) != 4 || ip4.Equal(net.IPv4zero) {
-			errs = append(errs, fmt.Errorf("bad src ipv4 address: %s", ip4))
-			continue
-		}
-		link, err2 := netlink.LinkByIndex(route.LinkIndex)
-		if err2 != nil {
-			errs = append(errs, errors.Wrap(err2, "link by index"))
-			continue
-		}
-		srcIp = ip4
-		ifname = link.Attrs().Name
-		return
-	}
-	err = errors.NewAggregate(errs)
 	return
 }
 
@@ -425,24 +390,6 @@ func (n *SNetInterface) getRoutes(gwOnly bool, outputs []string) [][]string {
 		}
 	}
 	return res
-}
-
-func (n *SNetInterface) GetAddresses() [][]string {
-	ipnets, err := iproute2.NewAddress(n.name).List4()
-	if err != nil {
-		log.Errorf("list address %s: %v", n.name, err)
-		return nil
-	}
-	r := make([][]string, len(ipnets))
-	for i, ipnet := range ipnets {
-		ip := ipnet.IP
-		masklen, _ := ipnet.Mask.Size()
-		r[i] = []string{
-			ip.String(),
-			fmt.Sprintf("%d", masklen),
-		}
-	}
-	return r
 }
 
 func (n *SNetInterface) GetSlaveAddresses() [][]string {

--- a/pkg/util/netutils2/netutils_others.go
+++ b/pkg/util/netutils2/netutils_others.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package netutils2
+
+func (n *SNetInterface) GetAddresses() [][]string {
+	return nil
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
iproute2: skip setting addrs on parse error
netutils: isolate linux dependent parts
```

**是否需要 backport 到之前的 release 分支**:

- release/3.0

/area climc
/cc @tb364 @wanyaoqi 