### PR TITLE
bugfix(esxiagent): PrefetchImageCacheByCopy & SHost.FileUrlPathToDsPath

### DIFF
--- a/pkg/hostman/storageman/imagecachemanager_agent.go
+++ b/pkg/hostman/storageman/imagecachemanager_agent.go
@@ -18,12 +18,14 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"reflect"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
+	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/hostman/hostutils"
 	"yunion.io/x/onecloud/pkg/multicloud/esxi"
@@ -96,20 +98,20 @@ func (c *SAgentImageCacheManager) prefetchImageCacheByCopy(ctx context.Context, 
 	exists := false
 	log.Infof("check file: src=%s, dst=%s", srcPath, dstPath)
 	dstVmdkInfo, err := dstDs.GetVmdkInfo(ctx, dstPath)
-	if err != nil {
+	if err != nil && errors.Cause(err) != cloudprovider.ErrNotFound {
 		return nil, err
 	}
 	srcVmdkInfo, err := srcDs.GetVmdkInfo(ctx, srcPath)
 	if err != nil {
 		return nil, err
 	}
-	if dstVmdkInfo == srcVmdkInfo {
+	if dstVmdkInfo != nil && reflect.DeepEqual(dstVmdkInfo, srcVmdkInfo) {
 		exists = true
 	}
 
 	dstUrl := dstDs.GetPathUrl(dstPath)
 	if !exists || data.IsForce {
-		_, err = dstDs.MakeDir(ctx, dstPath)
+		err = dstDs.CheckDirC(filepath.Dir(dstPath))
 		if err != nil {
 			return nil, errors.Wrap(err, "dstDs.MakeDir")
 		}
@@ -124,11 +126,12 @@ func (c *SAgentImageCacheManager) prefetchImageCacheByCopy(ctx context.Context, 
 			return nil, errors.Wrap(err, "dstDs.GetVmdkInfo")
 		}
 	}
+	dstPath = dstDs.GetFullPath(dstPath)
 	ret := jsonutils.NewDict()
 	ret.Add(jsonutils.NewInt(dstVmdkInfo.Size()), "size")
-	ret.Add(jsonutils.NewString(dstUrl), "path")
+	ret.Add(jsonutils.NewString(dstPath), "path")
 	ret.Add(jsonutils.NewString(data.ImageId), "image_id")
-	_, err = hostutils.RemoteStoragecacheCacheImage(ctx, data.StoragecacheId, data.ImageId, "ready", dstUrl)
+	_, err = hostutils.RemoteStoragecacheCacheImage(ctx, data.StoragecacheId, data.ImageId, "ready", dstPath)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +192,7 @@ func (c *SAgentImageCacheManager) prefetchImageCacheByUpload(ctx context.Context
 			return nil, errors.Wrap(err, "SDatastore.ImportTemplate")
 		}
 	}
-	remotePath = filepath.Join(ds.GetUrl(), remotePath)
+	remotePath = ds.GetFullPath(remotePath)
 	remoteImg := localImage.(*jsonutils.JSONDict)
 	remoteImg.Add(jsonutils.NewString(remotePath), "path")
 

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -680,7 +680,7 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, data *jsonuti
 	if len(cdromPath) != 0 && !strings.HasPrefix(cdromPath, "[") {
 		cdromPath, err = self.FileUrlPathToDsPath(cdromPath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "SHost.FileUrlPathToDsPath for cdrom path '%s'", cdromPath)
+			return nil, errors.Wrapf(err, "SHost.FileUrlPathToDsPath", cdromPath)
 		}
 	}
 	deviceChange = append(deviceChange, addDevSpec(NewCDROMDev(cdromPath, 16000, 201)))
@@ -702,7 +702,7 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, data *jsonuti
 		} else {
 			imagePath, err = self.FileUrlPathToDsPath(imagePath)
 			if err != nil {
-				return nil, errors.Wrapf(err, "SHost.FileUrlPathToDsPath for image path '%s'", imagePath)
+				return nil, errors.Wrapf(err, "SHost.FileUrlPathToDsPath", imagePath)
 			}
 		}
 		uuid, _ := disk.GetString("disk_id")
@@ -928,10 +928,14 @@ func (host *SHost) FileUrlPathToDsPath(path string) (string, error) {
 	}
 	for _, ds := range dss {
 		rds := ds.(*SDatastore)
+		log.Debugf("rds: %s", rds.GetUrl())
 		if strings.HasPrefix(path, rds.GetUrl()) {
 			newPath = fmt.Sprintf("[%s] %s", rds.GetRelName(), path[len(rds.GetUrl()):])
+			break
 		}
-		break
+	}
+	if len(newPath) == 0 {
+		return newPath, fmt.Errorf("path '%s' don't belong any datastore of host '%s'", path, host.GetName())
 	}
 	return newPath, nil
 }

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -680,7 +680,7 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, data *jsonuti
 	if len(cdromPath) != 0 && !strings.HasPrefix(cdromPath, "[") {
 		cdromPath, err = self.FileUrlPathToDsPath(cdromPath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "SHost.FileUrlPathToDsPath", cdromPath)
+			return nil, errors.Wrapf(err, "SHost.FileUrlPathToDsPath")
 		}
 	}
 	deviceChange = append(deviceChange, addDevSpec(NewCDROMDev(cdromPath, 16000, 201)))
@@ -702,7 +702,7 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, data *jsonuti
 		} else {
 			imagePath, err = self.FileUrlPathToDsPath(imagePath)
 			if err != nil {
-				return nil, errors.Wrapf(err, "SHost.FileUrlPathToDsPath", imagePath)
+				return nil, errors.Wrapf(err, "SHost.FileUrlPathToDsPath")
 			}
 		}
 		uuid, _ := disk.GetString("disk_id")

--- a/pkg/multicloud/esxi/manager.go
+++ b/pkg/multicloud/esxi/manager.go
@@ -504,7 +504,7 @@ func (cli *SESXiClient) CopyDisk(ctx context.Context, src, dst string, isForce b
 	dm := object.NewVirtualDiskManager(cli.client.Client)
 	task, err := dm.CopyVirtualDisk(ctx, src, nil, dst, nil, nil, isForce)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "CopyVirtualDisk")
 	}
 	return task.Wait(ctx)
 }
@@ -513,7 +513,7 @@ func (cli *SESXiClient) MoveDisk(ctx context.Context, src, dst string, isForce b
 	dm := object.NewVirtualDiskManager(cli.client.Client)
 	task, err := dm.MoveVirtualDisk(ctx, src, nil, dst, nil, isForce)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "MoveVirtualDisk")
 	}
 	return task.Wait(ctx)
 }

--- a/pkg/multicloud/esxi/shell/store.go
+++ b/pkg/multicloud/esxi/shell/store.go
@@ -170,12 +170,11 @@ func init() {
 		if err != nil {
 			return err
 		}
-		ctx := context.Background()
-		path, err := dsObj.MakeDir(ctx, args.DIR)
+		err = dsObj.MakeDir(args.DIR)
 		if err != nil {
 			return err
 		}
-		fmt.Println("Make dir success", path)
+		fmt.Println("Make dir success")
 		return nil
 	})
 

--- a/pkg/multicloud/esxi/vdisk.go
+++ b/pkg/multicloud/esxi/vdisk.go
@@ -203,7 +203,7 @@ func (disk *SVirtualDisk) GetAccessPath() string {
 		return ""
 	}
 	ds := istore.(*SDatastore)
-	return ds.getFullPath(disk.getBackingInfo().GetFileName())
+	return ds.GetFullPath(disk.getBackingInfo().GetFileName())
 }
 
 func (disk *SVirtualDisk) GetDiskFormat() string {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. Fix the bug when preparing remote image by copy, 当一个vcenter下有多个宿主机的时候就会使用 COPY 来准备远端的镜像.
2. SHost.FileUrlPathToDsPath will not work when host has multiple storages.


**是否需要 backport 到之前的 release 分支**:
- release/3.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->

/area esxiagent