### PR TITLE
fix(hostdeployer): Umount VDDKDisk when IRootFsDriver is nil

### DIFF
--- a/pkg/hostman/diskutils/vddk.go
+++ b/pkg/hostman/diskutils/vddk.go
@@ -140,7 +140,8 @@ func (vd *VDDKDisk) Disconnect() bool {
 }
 
 func (vd *VDDKDisk) MountRootfs() fsdriver.IRootFsDriver {
-	if err := vd.Mount(); err == nil {
+	var err error
+	if err = vd.Mount(); err == nil {
 		for _, mntPath := range vd.PartDirs {
 			part := newVDDKPartition(mntPath)
 			if fs := guestfs.DetectRootFs(part); fs != nil {
@@ -149,6 +150,11 @@ func (vd *VDDKDisk) MountRootfs() fsdriver.IRootFsDriver {
 			}
 		}
 	}
+	if err != nil {
+		log.Errorf("VDDKDisk Mount failed: %s", err)
+	}
+	// something is wrong
+	vd.UmountRootfs(nil)
 	return nil
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

当VDDKDisk mount失败的时候应该打印日志，当mount成功却因为其他原因无法拿到IRootFsDriver，应该主动Umount。

**是否需要 backport 到之前的 release 分支**:
- release/3.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
