### PR TITLE
netutils2: guard against possible nil members

### DIFF
--- a/pkg/util/iproute2/route.go
+++ b/pkg/util/iproute2/route.go
@@ -134,3 +134,9 @@ func (route *Route) Add(netStr, maskStr, gwStr string) *Route {
 	}
 	return route.AddByIPNet(ipnet, gw)
 }
+
+func RouteGetByDst(dstStr string) ([]netlink.Route, error) {
+	dstIp := net.ParseIP(dstStr)
+	routes, err := netlink.RouteGet(dstIp)
+	return routes, err
+}

--- a/pkg/util/iproute2/route_test.go
+++ b/pkg/util/iproute2/route_test.go
@@ -1,0 +1,37 @@
+package iproute2
+
+import (
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+func TestRoute(t *testing.T) {
+	t.Run("ensure non-nil route.dst", func(t *testing.T) {
+		dstStr := "114.114.114.114"
+		routes, err := RouteGetByDst(dstStr)
+		if err != nil {
+			t.Skipf("route get: %v", err)
+		}
+		if len(routes) == 0 {
+			t.Skipf("no route to %s", dstStr)
+		}
+		for _, r := range routes {
+			if r.LinkIndex <= 0 {
+				continue
+			}
+			nllink, err := netlink.LinkByIndex(r.LinkIndex)
+			if err != nil {
+				t.Errorf("link by index: %v", err)
+				continue
+			}
+			routes2, err := NewRoute(nllink.Attrs().Name).List4()
+			for _, r2 := range routes2 {
+				if r2.Dst.String() == "0.0.0.0/0" {
+					t.Logf("yeah, dst of default route is not nil: %s", r2)
+				}
+			}
+		}
+
+	})
+}

--- a/pkg/util/netutils2/netutils_linux.go
+++ b/pkg/util/netutils2/netutils_linux.go
@@ -55,8 +55,7 @@ func (n *SNetInterface) GetRoutes(gwOnly bool) [][]string {
 }
 
 func DefaultSrcIpDev() (srcIp net.IP, ifname string, err error) {
-	destIp := net.ParseIP("114.114.114.114")
-	routes, err := netlink.RouteGet(destIp)
+	routes, err := iproute2.RouteGetByDst("114.114.114.114")
 	if err != nil {
 		err = errors.Wrap(err, "get route")
 		return

--- a/pkg/util/netutils2/netutils_linux.go
+++ b/pkg/util/netutils2/netutils_linux.go
@@ -44,9 +44,13 @@ func (n *SNetInterface) GetRoutes(gwOnly bool) [][]string {
 			ok = false
 		}
 		if ok {
+			gwStr := ""
+			if len(r.Gw) > 0 {
+				gwStr = r.Gw.String()
+			}
 			res = append(res, []string{
 				r.Dst.IP.String(),
-				r.Gw.String(),
+				gwStr,
 				net.IP(r.Dst.Mask).String(),
 			})
 		}
@@ -67,6 +71,9 @@ func DefaultSrcIpDev() (srcIp net.IP, ifname string, err error) {
 	var errs []error
 	for i := range routes {
 		route := &routes[i]
+		if len(route.Src) == 0 {
+			continue
+		}
 		ip4 := route.Src.To4()
 		if len(ip4) != 4 || ip4.Equal(net.IPv4zero) {
 			errs = append(errs, fmt.Errorf("bad src ipv4 address: %s", ip4))


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
netutils2: guard against possible nil members
netutils: DefaultSrcIpDev: use iproute2.RouteGetByDst
iproute2: add RouteGetByDst()
iproute2: test against non-nil dst of routes returned by List4()
```

**是否需要 backport 到之前的 release 分支**:

- release/3.0

/area util
/cc @wanyaoqi @swordqiu 
