### PR TITLE
fix: 避免/opt/yunion/tmp目录不存在导致自定义镜像创建azure服务器失败

### DIFF
--- a/pkg/multicloud/azure/storagecache.go
+++ b/pkg/multicloud/azure/storagecache.go
@@ -125,6 +125,10 @@ func (self *SStoragecache) UploadImage(ctx context.Context, userCred mcclient.To
 	} else {
 		log.Debugf("UploadImage: no external ID")
 	}
+	err := os.MkdirAll(options.Options.TempPath, os.ModePerm)
+	if err != nil {
+		log.Warningf("failed to create tmp path %s error: %v", options.Options.TempPath, err)
+	}
 	return self.uploadImage(ctx, userCred, image, isForce, options.Options.TempPath)
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免/opt/yunion/tmp目录不存在导致自定义镜像创建azure服务器失败

**是否需要 backport 到之前的 release 分支**:
None

/area region

/cc @swordqiu 