### PR TITLE
fix(esxi): Change AccountId as 'host:port'

### DIFF
--- a/pkg/multicloud/esxi/manager.go
+++ b/pkg/multicloud/esxi/manager.go
@@ -188,7 +188,7 @@ func (cli *SESXiClient) GetSubAccounts() ([]cloudprovider.SSubAccount, error) {
 }
 
 func (cli *SESXiClient) GetAccountId() string {
-	return cli.account
+	return fmt.Sprintf("%s:%d", cli.host, cli.port)
 }
 
 func (cli *SESXiClient) GetVersion() string {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

**原因**：
cloudAccount 的 accountId 这个属性是希望能够独立于用户名和密码来唯一标示一个账户，但是在vmware中，用户名是唯一的且不可更改。所以在更新云账号的时候是没法修改用户名的。所以vmware的AccountId 可以设置为管理的vcenter 环境的 'host:port'。
进一步，其实我们是不希望同时有两个云账号管理一个vcenter环境的，所以如果存在uuid唯一标示一个vcenter就好了，但是没有找到。

**问题**：
如果同一个vcenter环境有着不同的 host:port，那是没法避免的。

**是否需要 backport 到之前的 release 分支**:

- release/3.0
- release/2.13
- release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->

/area region
/cc @swordqiu @wanyaoqi 