### PR TITLE
Automated cherry pick of #4939: fix(esxi): Change AccountId as 'host:port'

### DIFF
--- a/pkg/multicloud/esxi/manager.go
+++ b/pkg/multicloud/esxi/manager.go
@@ -156,7 +156,7 @@ func (cli *SESXiClient) GetSubAccounts() ([]cloudprovider.SSubAccount, error) {
 }
 
 func (cli *SESXiClient) GetAccountId() string {
-	return cli.account
+	return fmt.Sprintf("%s:%d", cli.host, cli.port)
 }
 
 func (cli *SESXiClient) GetVersion() string {


### PR DESCRIPTION
Cherry pick of #4939 on release/2.12.

#4939: fix(esxi): Change AccountId as 'host:port'