### PR TITLE
hostman: linux_bridge: flush addr on member iface down

### DIFF
--- a/pkg/hostman/hostinfo/hostbridge/linux_bridge.go
+++ b/pkg/hostman/hostinfo/hostbridge/linux_bridge.go
@@ -109,6 +109,7 @@ func (l *SLinuxBridgeDriver) getDownScripts(nic jsonutils.JSONObject) (string, e
 	s += "if [ $? -ne '0' ]; then\n"
 	s += "    exit 0\n"
 	s += "fi\n"
+	s += "ip addr flush dev $1\n"
 	s += "ip link set dev $1 down\n"
 	s += "brctl delif ${switch} $1\n"
 	return s, nil


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:

```
Previously it was done by "ifconfig xx 0.0.0.0 down"

Fixes 4d8d20f ("hostman: use package iproute2")
```

**是否需要 backport 到之前的 release 分支**:

- release/3.0

/area host
/cc @wanyaoqi 