### PR TITLE
Automated cherry pick of #4968: fix: network-reserve-ip ignores expired reserved ips

### DIFF
--- a/cmd/climc/shell/reservedips.go
+++ b/cmd/climc/shell/reservedips.go
@@ -28,6 +28,7 @@ func init() {
 		NOTES    string   `help:"Why reserve this IP"`
 		IPS      []string `help:"IPs to reserve"`
 		Duration string   `help:"reservation duration, e.g. 1I, 1H, 2M"`
+		Status   string   `help:"ip status"`
 	}
 	R(&NetworkReserveIPOptions{}, "network-reserve-ip", "Reserve an IP address from pool", func(s *mcclient.ClientSession, args *NetworkReserveIPOptions) error {
 		params := jsonutils.NewDict()
@@ -35,6 +36,9 @@ func init() {
 		params.Add(jsonutils.NewString(args.NOTES), "notes")
 		if len(args.Duration) > 0 {
 			params.Add(jsonutils.NewString(args.Duration), "duration")
+		}
+		if len(args.Status) > 0 {
+			params.Add(jsonutils.NewString(args.Status), "status")
 		}
 		net, err := modules.Networks.PerformAction(s, args.NETWORK, "reserve-ip", params)
 		if err != nil {

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -2674,7 +2674,7 @@ func (manager *SHostManager) ValidateCreateData(ctx context.Context, userCred mc
 			// if not, reserve this IP temporarily
 			err := net.reserveIpWithDuration(ctx, userCred, ipmiIpAddr, "reserve for baremetal ipmi IP", 30*time.Minute)
 			if err != nil {
-				return nil, errors.Wrap(err, "net.reserveIpWithDuration")
+				return nil, err
 			}
 		}
 		zoneObj := net.getZone()

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -2674,7 +2674,7 @@ func (manager *SHostManager) ValidateCreateData(ctx context.Context, userCred mc
 			// if not, reserve this IP temporarily
 			err := net.reserveIpWithDuration(ctx, userCred, ipmiIpAddr, "reserve for baremetal ipmi IP", 30*time.Minute)
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrap(err, "net.reserveIpWithDuration")
 			}
 		}
 		zoneObj := net.getZone()

--- a/pkg/compute/models/reservedips.go
+++ b/pkg/compute/models/reservedips.go
@@ -102,7 +102,7 @@ func (manager *SReservedipManager) ReserveIPWithDurationAndStatus(userCred mccli
 		err := manager.TableSpec().Insert(&rip)
 		if err != nil {
 			log.Errorf("ReserveIP fail: %s", err)
-			return errors.Wrap(err, "Insert")
+			return err
 		}
 	} else if rip.IsExpired() {
 		_, err := db.Update(rip, func() error {
@@ -114,10 +114,10 @@ func (manager *SReservedipManager) ReserveIPWithDurationAndStatus(userCred mccli
 			return nil
 		})
 		if err != nil {
-			return errors.Wrap(err, "Update")
+			return err
 		}
 	} else {
-		return errors.Wrapf(httperrors.ErrConflict, "Address %s has been reserved", ip)
+		return httperrors.NewConflictError("Address %s has been reserved", ip)
 	}
 	db.OpsLog.LogEvent(network, db.ACT_RESERVE_IP, ip, userCred)
 	return nil

--- a/pkg/compute/models/reservedips.go
+++ b/pkg/compute/models/reservedips.go
@@ -96,11 +96,28 @@ func (manager *SReservedipManager) ReserveIPWithDurationAndStatus(userCred mccli
 	if duration > 0 {
 		expiredAt = time.Now().UTC().Add(duration)
 	}
-	rip := SReservedip{NetworkId: network.Id, IpAddr: ip, Notes: notes, ExpiredAt: expiredAt, Status: status}
-	err := manager.TableSpec().Insert(&rip)
-	if err != nil {
-		log.Errorf("ReserveIP fail: %s", err)
-		return err
+	rip := manager.getReservedIP(network, ip)
+	if rip == nil {
+		rip := SReservedip{NetworkId: network.Id, IpAddr: ip, Notes: notes, ExpiredAt: expiredAt, Status: status}
+		err := manager.TableSpec().Insert(&rip)
+		if err != nil {
+			log.Errorf("ReserveIP fail: %s", err)
+			return errors.Wrap(err, "Insert")
+		}
+	} else if rip.IsExpired() {
+		_, err := db.Update(rip, func() error {
+			rip.Notes = notes
+			rip.ExpiredAt = expiredAt
+			if len(status) > 0 {
+				rip.Status = status
+			}
+			return nil
+		})
+		if err != nil {
+			return errors.Wrap(err, "Update")
+		}
+	} else {
+		return errors.Wrapf(httperrors.ErrConflict, "Address %s has been reserved", ip)
 	}
 	db.OpsLog.LogEvent(network, db.ACT_RESERVE_IP, ip, userCred)
 	return nil


### PR DESCRIPTION
Cherry pick of #4968 on release/2.12.

#4968: fix: network-reserve-ip ignores expired reserved ips