### PR TITLE
fix: bucket get details missing cloudprovider info

### DIFF
--- a/pkg/apis/compute/bucket.go
+++ b/pkg/apis/compute/bucket.go
@@ -52,6 +52,7 @@ type BucketCreateInput struct {
 type BucketDetail struct {
 	apis.Meta
 	SBucket
+	CloudproviderDetails
 }
 
 type BucketObjectsActionInput struct {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：bucket的结构化details缺少cloudprovider相关的详情字段

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0

/area region

/cc @zexi 