### PR TITLE
Automated cherry pick of #4973: fix: bucket get details missing cloudprovider info

### DIFF
--- a/pkg/apis/compute/bucket.go
+++ b/pkg/apis/compute/bucket.go
@@ -52,6 +52,7 @@ type BucketCreateInput struct {
 type BucketDetail struct {
 	apis.Meta
 	SBucket
+	CloudproviderDetails
 }
 
 type BucketObjectsActionInput struct {


### PR DESCRIPTION
Cherry pick of #4973 on release/2.13.

#4973: fix: bucket get details missing cloudprovider info