### PR TITLE
get login-info add 404 return & elasticcache account reset password api

### DIFF
--- a/pkg/compute/models/elasticcache_accounts.go
+++ b/pkg/compute/models/elasticcache_accounts.go
@@ -411,6 +411,13 @@ func (self *SElasticcacheAccount) AllowPerformResetPassword(ctx context.Context,
 }
 
 func (self *SElasticcacheAccount) ValidatorResetPasswordData(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+	if reset, _ := data.Bool("reset_password"); reset {
+		if _, err := data.GetString("password"); err != nil {
+			randomPasswd := seclib2.RandomPassword2(12)
+			data.(*jsonutils.JSONDict).Set("password", jsonutils.NewString(randomPasswd))
+		}
+	}
+
 	passwd, err := data.GetString("password")
 	if err == nil && !seclib2.MeetComplxity(passwd) {
 		return nil, httperrors.NewWeakPasswordError()
@@ -448,14 +455,9 @@ func (self *SElasticcacheAccount) AllowGetDetailsLoginInfo(ctx context.Context, 
 }
 
 func (self *SElasticcacheAccount) GetDetailsLoginInfo(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (jsonutils.JSONObject, error) {
-	password, err := self.GetDecodedPassword()
-	if err != nil {
-		return nil, err
-	}
-
 	ret := jsonutils.NewDict()
 	ret.Add(jsonutils.NewString(self.Name), "username")
-	ret.Add(jsonutils.NewString(password), "password")
+	ret.Add(jsonutils.NewString(self.Password), "password")
 	return ret, nil
 }
 

--- a/pkg/compute/models/elasticcache_instances.go
+++ b/pkg/compute/models/elasticcache_instances.go
@@ -229,14 +229,10 @@ func (self *SElasticcache) GetDetailsLoginInfo(ctx context.Context, userCred mcc
 		return nil, err
 	}
 
-	password, err := account.GetDecodedPassword()
-	if err != nil {
-		return nil, err
-	}
-
 	ret := jsonutils.NewDict()
+	ret.Add(jsonutils.NewString(account.Id), "account_id")
 	ret.Add(jsonutils.NewString(account.Name), "username")
-	ret.Add(jsonutils.NewString(password), "password")
+	ret.Add(jsonutils.NewString(account.Password), "password")
 	return ret, nil
 }
 

--- a/pkg/mcclient/modules/mod_dbinstanceaccounts.go
+++ b/pkg/mcclient/modules/mod_dbinstanceaccounts.go
@@ -15,13 +15,12 @@
 package modules
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/utils"
 
+	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
@@ -52,7 +51,7 @@ func (this *SDBInstanceAccountManager) GetLoginInfo(s *mcclient.ClientSession, i
 	}
 
 	if len(account.Secret) == 0 {
-		return nil, fmt.Errorf("No login secret found")
+		return nil, httperrors.NewNotFoundError("No login secret found")
 	}
 
 	password, err := utils.DescryptAESBase64(account.Id, account.Secret)

--- a/pkg/mcclient/modules/mod_hosts.go
+++ b/pkg/mcclient/modules/mod_hosts.go
@@ -42,7 +42,7 @@ func (this *HostManager) GetLoginInfo(s *mcclient.ClientSession, id string, para
 	ret := jsonutils.NewDict()
 	login_key, e := data.GetString("password")
 	if e != nil {
-		return nil, fmt.Errorf("No ssh password: %s", e)
+		return nil, httperrors.NewNotFoundError("No ssh password: %s", e)
 	}
 	passwd, e := utils.DescryptAESBase64(id, login_key)
 	if e != nil {


### PR DESCRIPTION
add input params

**这个 PR 实现什么功能/修复什么问题**:
* get login-info 当loginkey不存在时返回404错误
* 弹性缓存重置密码新增reset password参数

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0

/area region
/cc @swordqiu @yousong @ioito 
