### PR TITLE
bugfix: is standard domain optional

### DIFF
--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -120,7 +120,7 @@ type SImage struct {
 	MinRamMB   int32  `name:"min_ram" nullable:"false" default:"0" list:"user" create:"optional" update:"user"`
 
 	Protected    tristate.TriState `nullable:"false" default:"true" list:"user" get:"user" create:"optional" update:"user"`
-	IsStandard   tristate.TriState `nullable:"false" default:"false" list:"user" get:"user" create:"admin_optional"`
+	IsStandard   tristate.TriState `nullable:"false" default:"false" list:"user" get:"user" create:"domain_optional"`
 	IsGuestImage tristate.TriState `nullable:"false" default:"false" create:"optional" list:"user"`
 	IsData       tristate.TriState `nullable:"false" default:"false" create:"optional" list:"user"`
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
- set image is standard domain optional

**是否需要 backport 到之前的 release 分支**:
release/2.13

/cc @swordqiu 
/area image
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
