### PR TITLE
fix: cloudevent_tbl use new primary column event_id

### DIFF
--- a/pkg/cloudevent/models/cloudevents.go
+++ b/pkg/cloudevent/models/cloudevents.go
@@ -50,7 +50,7 @@ func init() {
 type SCloudevent struct {
 	db.SModelBase
 
-	Id           int64                `primary:"true" auto_increment:"true" list:"user"`
+	EventId      int64                `primary:"true" auto_increment:"true" list:"user"`
 	Name         string               `width:"128" charset:"utf8" nullable:"false" index:"true" list:"user"`
 	Service      string               `width:"64" charset:"utf8" nullable:"true" list:"user"`
 	ResourceType string               `width:"64" charset:"utf8" nullable:"true" list:"user"`


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：cloudevent_tbl的主键从id更改为新增auto_increment列event_id。原地更改id varchar(128)为id int auto_increment会报错：ALTER TABLE causes auto_increment resequencing, resulting in duplicate entry '1' for key 'PRIMARY'

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0

/cc @yousong 

/area cloudevent