### PR TITLE
Automated cherry pick of #4988: fix: cloudevent_tbl use new primary column event_id

### DIFF
--- a/pkg/cloudevent/models/cloudevents.go
+++ b/pkg/cloudevent/models/cloudevents.go
@@ -49,7 +49,7 @@ func init() {
 type SCloudevent struct {
 	db.SModelBase
 
-	Id           int64                `primary:"true" auto_increment:"true" list:"user"`
+	EventId      int64                `primary:"true" auto_increment:"true" list:"user"`
 	Name         string               `width:"128" charset:"utf8" nullable:"false" index:"true" list:"user"`
 	Service      string               `width:"64" charset:"utf8" nullable:"true" list:"user"`
 	ResourceType string               `width:"64" charset:"utf8" nullable:"true" list:"user"`


### PR DESCRIPTION
Cherry pick of #4988 on release/2.13.

#4988: fix: cloudevent_tbl use new primary column event_id