### PR TITLE
fix(esxiagent): Lead to vCenter server '503' when deleting vm's disk

### DIFF
--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -513,13 +513,6 @@ func (self *SVirtualMachine) DeleteVM(ctx context.Context) error {
 	if err != nil {
 		return self.doUnregister(ctx)
 	}
-	for i := 0; i < len(self.vdisks); i += 1 {
-		err := self.doDetachAndDeleteDisk(ctx, &self.vdisks[i])
-		if err != nil {
-			log.Errorf("self.doDetachAndDeleteDisk(ctx, &self.vdisks[i]) fail %s", err)
-			return err
-		}
-	}
 	return self.doDelete(ctx)
 }
 
@@ -531,6 +524,10 @@ func (self *SVirtualMachine) doDetachDisk(ctx context.Context, vdisk *SVirtualDi
 	removeSpec := types.VirtualDeviceConfigSpec{}
 	removeSpec.Operation = types.VirtualDeviceConfigSpecOperationRemove
 	removeSpec.Device = vdisk.dev
+
+	if remove {
+		removeSpec.FileOperation = types.VirtualDeviceConfigSpecFileOperationDestroy
+	}
 
 	spec := types.VirtualMachineConfigSpec{}
 	spec.DeviceChange = []types.BaseVirtualDeviceConfigSpec{&removeSpec}
@@ -549,11 +546,7 @@ func (self *SVirtualMachine) doDetachDisk(ctx context.Context, vdisk *SVirtualDi
 		return err
 	}
 
-	if !remove {
-		return nil
-	}
-
-	return vdisk.Delete(ctx)
+	return nil
 }
 
 func (self *SVirtualMachine) GetVNCInfo() (jsonutils.JSONObject, error) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

问题：振华的环境中，删除vmware虚拟机的磁盘时，最终会返回EOF，并导致 vCenter server 503。
但是上述情况在我们的测试vCenter环境中没有出现。
经调试，是调用vdisk的Delete函数导致的，这个函数的会通过url来删除已经解除绑定的vdisk对应的vmdk文件。对于VMware来说，这个函数只会在deDetachDisk和删除虚拟机中调用。

解决方式：其实我们在对vm进行ReConfig操作时，除了解绑vdisk，还可以通过设置 FileOperation = types.VirtualDeviceConfigSpecFileOperationDestroy 直接删除对应的vmdk文件。
并且，删除虚拟机的时候其实并不需要事先删除vdisk。

**是否需要 backport 到之前的 release 分支**:
- release/3.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
