### PR TITLE
Automated cherry pick of #4994: fix(esxiagent): Lead to vCenter server '503' when deleting vm'disk

### DIFF
--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -513,13 +513,6 @@ func (self *SVirtualMachine) DeleteVM(ctx context.Context) error {
 	if err != nil {
 		return self.doUnregister(ctx)
 	}
-	for i := 0; i < len(self.vdisks); i += 1 {
-		err := self.doDetachAndDeleteDisk(ctx, &self.vdisks[i])
-		if err != nil {
-			log.Errorf("self.doDetachAndDeleteDisk(ctx, &self.vdisks[i]) fail %s", err)
-			return err
-		}
-	}
 	return self.doDelete(ctx)
 }
 
@@ -531,6 +524,10 @@ func (self *SVirtualMachine) doDetachDisk(ctx context.Context, vdisk *SVirtualDi
 	removeSpec := types.VirtualDeviceConfigSpec{}
 	removeSpec.Operation = types.VirtualDeviceConfigSpecOperationRemove
 	removeSpec.Device = vdisk.dev
+
+	if remove {
+		removeSpec.FileOperation = types.VirtualDeviceConfigSpecFileOperationDestroy
+	}
 
 	spec := types.VirtualMachineConfigSpec{}
 	spec.DeviceChange = []types.BaseVirtualDeviceConfigSpec{&removeSpec}
@@ -549,11 +546,7 @@ func (self *SVirtualMachine) doDetachDisk(ctx context.Context, vdisk *SVirtualDi
 		return err
 	}
 
-	if !remove {
-		return nil
-	}
-
-	return vdisk.Delete(ctx)
+	return nil
 }
 
 func (self *SVirtualMachine) GetVNCInfo() (jsonutils.JSONObject, error) {


### PR DESCRIPTION
Cherry pick of #4994 on release/3.0.

#4994: fix(esxiagent): Lead to vCenter server '503' when deleting vm'disk