### PR TITLE
azure的主机监控信息的获取

### DIFF
--- a/pkg/multicloud/azure/azure.go
+++ b/pkg/multicloud/azure/azure.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	net_url "net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -267,29 +268,25 @@ func (self *SAzureClient) ListResourcesOfMetirc(resourceType string, external_id
 	params map[string]string) (jsonutils.JSONObject, error) {
 	cli, err := self.getDefaultClient()
 	if err != nil {
-		return jsonutils.JSONNull, err
+		return nil, err
 	}
+	//azure的external_id中会包含请求相关的url的处理信息
 	url := external_id
 	if len(resourceType) > 0 {
 		url += fmt.Sprintf("/providers/%s", resourceType)
 	}
 	if len(params) > 0 {
-		first := true
+		values := net_url.Values{}
 		for param, value := range params {
-			if first {
-				url += fmt.Sprintf("?%s=%s", param, value)
-				first = false
-				continue
-			}
-			url += fmt.Sprintf("&%s=%s", param, value)
+			values.Add(param, value)
 		}
+		url += fmt.Sprintf("?%s", values.Encode())
 	}
 	//body, err := jsonRequest(cli, "GET", "https://management.azure.com", url, self.subscriptionId, "")
 	body, err := jsonRequest(cli, "GET", self.domain, url, self.subscriptionId, "")
 	if err != nil {
-		return jsonutils.JSONNull, err
+		return nil, err
 	}
-	// fmt.Printf("%s: %s\n", resourceType, body)
 	return body, nil
 }
 

--- a/pkg/multicloud/azure/azure.go
+++ b/pkg/multicloud/azure/azure.go
@@ -263,6 +263,36 @@ func (self *SAzureClient) ListResources(resourceType string, retVal interface{},
 	return err
 }
 
+func (self *SAzureClient) ListResourcesOfMetirc(resourceType string, external_id string,
+	params map[string]string) (jsonutils.JSONObject, error) {
+	cli, err := self.getDefaultClient()
+	if err != nil {
+		return jsonutils.JSONNull, err
+	}
+	url := external_id
+	if len(resourceType) > 0 {
+		url += fmt.Sprintf("/providers/%s", resourceType)
+	}
+	if len(params) > 0 {
+		first := true
+		for param, value := range params {
+			if first {
+				url += fmt.Sprintf("?%s=%s", param, value)
+				first = false
+				continue
+			}
+			url += fmt.Sprintf("&%s=%s", param, value)
+		}
+	}
+	//body, err := jsonRequest(cli, "GET", "https://management.azure.com", url, self.subscriptionId, "")
+	body, err := jsonRequest(cli, "GET", self.domain, url, self.subscriptionId, "")
+	if err != nil {
+		return jsonutils.JSONNull, err
+	}
+	// fmt.Printf("%s: %s\n", resourceType, body)
+	return body, nil
+}
+
 func (self *SAzureClient) ListSubscriptions() (jsonutils.JSONObject, error) {
 	cli, err := self.getDefaultClient()
 	if err != nil {

--- a/pkg/multicloud/azure/monitor.go
+++ b/pkg/multicloud/azure/monitor.go
@@ -1,0 +1,107 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"time"
+)
+
+type ResponseMetirc struct {
+	// Cost - The integer value representing the cost of the query, for data case.
+	Cost *float64 `json:"cost,omitempty"`
+	// Timespan - The timespan for which the data was retrieved. Its value consists of two datetimes concatenated, separated by '/'.  This may be adjusted in the future and returned back from what was originally requested.
+	Timespan *string `json:"timespan,omitempty"`
+	// Interval - The interval (window size) for which the metric data was returned in.  This may be adjusted in the future and returned back from what was originally requested.  This is not present if a metadata request was made.
+	Interval *string `json:"interval,omitempty"`
+	// Namespace - The namespace of the metrics been queried
+	Namespace *string `json:"namespace,omitempty"`
+	// Resourceregion - The region of the resource been queried for metrics.
+	Resourceregion *string `json:"resourceregion,omitempty"`
+	// Value - the value of the collection.
+	Value *[]Metric `json:"value,omitempty"`
+}
+
+// Metric the result data of a query.
+type Metric struct {
+	// ID - the metric Id.
+	ID *string `json:"id,omitempty"`
+	// Type - the resource type of the metric resource.
+	Type *string `json:"type,omitempty"`
+	// Name - the name and the display name of the metric, i.e. it is localizable string.
+	Name *LocalizableString `json:"name,omitempty"`
+	// Unit - the unit of the metric. Possible values include: 'UnitCount', 'UnitBytes', 'UnitSeconds', 'UnitCountPerSecond', 'UnitBytesPerSecond', 'UnitPercent', 'UnitMilliSeconds', 'UnitByteSeconds', 'UnitUnspecified', 'UnitCores', 'UnitMilliCores', 'UnitNanoCores', 'UnitBitsPerSecond'
+	Unit string `json:"unit,omitempty"`
+	// Timeseries - the time series returned when a data query is performed.
+	Timeseries *[]TimeSeriesElement `json:"timeseries,omitempty"`
+}
+
+type TimeSeriesElement struct {
+	// Metadatavalues - the metadata values returned if $filter was specified in the call.
+	Metadatavalues *[]MetadataValue `json:"metadatavalues,omitempty"`
+	// Data - An array of data points representing the metric values.  This is only returned if a result type of data is specified.
+	Data *[]MetricValue `json:"data,omitempty"`
+}
+
+type MetadataValue struct {
+	// Name - the name of the metadata.
+	Name *LocalizableString `json:"name,omitempty"`
+	// Value - the value of the metadata.
+	Value *string `json:"value,omitempty"`
+}
+
+type LocalizableString struct {
+	// Value - the invariant value.
+	Value *string `json:"value,omitempty"`
+	// LocalizedValue - the locale specific value.
+	LocalizedValue *string `json:"localizedValue,omitempty"`
+}
+
+type MetricValue struct {
+	// TimeStamp - the timestamp for the metric value in ISO 8601 format.
+	TimeStamp *time.Time `json:"timeStamp,omitempty"`
+	// Average - the average value in the time range.
+	Average *float64 `json:"average,omitempty"`
+	// Minimum - the least value in the time range.
+	Minimum *float64 `json:"minimum,omitempty"`
+	// Maximum - the greatest value in the time range.
+	Maximum *float64 `json:"maximum,omitempty"`
+	// Total - the sum of all of the values in the time range.
+	Total *float64 `json:"total,omitempty"`
+	// Count - the number of samples in the time range. Can be used to determine the number of values that contributed to the average value.
+	Count *float64 `json:"count,omitempty"`
+}
+
+func (self *SRegion) GetMonitorData(name string, ns string, external_id string, since time.Time,
+	until time.Time) (*ResponseMetirc, error) {
+	params := make(map[string]string)
+	params["metricnamespace"] = ns
+	params["interval"] = "PT1M"
+	//params["metricnames"] = name
+	params["aggregation"] = "Average"
+	params["api-version"] = "2018-01-01"
+	if !since.IsZero() && !until.IsZero() {
+		params["timespan"] = since.UTC().Format(time.RFC3339) + "/" + until.UTC().Format(time.RFC3339)
+	}
+	rtn, err := self.client.ListResourcesOfMetirc("microsoft.insights/metrics", external_id, params)
+	if err != nil {
+		return nil, err
+	}
+	elements := ResponseMetirc{}
+	err = rtn.Unmarshal(&elements)
+	if err != nil {
+		return nil, err
+	}
+	return &elements, nil
+}

--- a/pkg/multicloud/azure/monitor.go
+++ b/pkg/multicloud/azure/monitor.go
@@ -85,12 +85,12 @@ type MetricValue struct {
 
 func (self *SRegion) GetMonitorData(name string, ns string, external_id string, since time.Time,
 	until time.Time) (*ResponseMetirc, error) {
-	params := make(map[string]string)
-	params["metricnamespace"] = ns
-	params["interval"] = "PT1M"
-	//params["metricnames"] = name
-	params["aggregation"] = "Average"
-	params["api-version"] = "2018-01-01"
+	params := map[string]string{
+		"metricnamespace": ns,
+		"interval":        "PT1M",
+		"aggregation":     "Average",
+		"api-version":     "2018-01-01",
+	}
 	if !since.IsZero() && !until.IsZero() {
 		params["timespan"] = since.UTC().Format(time.RFC3339) + "/" + until.UTC().Format(time.RFC3339)
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
monitor.go中的GetMonitorData函数完成参数的组装，查询获取监控信息.

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1