### PR TITLE
fix: 避免私有云调整配置匹配不到sku

### DIFF
--- a/pkg/compute/models/skus.go
+++ b/pkg/compute/models/skus.go
@@ -816,9 +816,18 @@ func (manager *SServerSkuManager) ListItemFilter(ctx context.Context, q *sqlchem
 func (manager *SServerSkuManager) GetMatchedSku(regionId string, cpu int64, memMB int64) (*SServerSku, error) {
 	ret := &SServerSku{}
 
+	_region, err := CloudregionManager.FetchById(regionId)
+	if err != nil {
+		return nil, errors.Wrapf(err, "CloudregionManager.FetchById(%s)", regionId)
+	}
+	region := _region.(*SCloudregion)
+	if utils.IsInStringArray(region.Provider, api.PRIVATE_CLOUD_PROVIDERS) {
+		regionId = api.DEFAULT_REGION_ID
+	}
+
 	q := manager.Query()
 	q = q.Equals("cpu_core_count", cpu).Equals("memory_size_mb", memMB).Equals("cloudregion_id", regionId).Equals("postpaid_status", api.SkuStatusAvailable)
-	err := q.First(ret)
+	err = q.First(ret)
 	if err != nil {
 		return nil, errors.Wrap(err, "ServerSkuManager.GetMatchedSku")
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免私有云调整配置匹配不到sku

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu 
