### PR TITLE
hostman: skip setting up ovn chassis when env support is not ready

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -141,8 +141,11 @@ func (h *SHostInfo) Init() error {
 	if err := h.parseConfig(); err != nil {
 		return err
 	}
-	if err := h.setupOvnChassis(); err != nil {
-		return err
+	if HasOvnSupport() {
+		if err := h.setupOvnChassis(); err != nil {
+			return err
+		}
+		return nil
 	}
 	log.Infof("Start detectHostInfo")
 	if err := h.detectHostInfo(); err != nil {

--- a/pkg/hostman/hostinfo/hostovn.go
+++ b/pkg/hostman/hostinfo/hostovn.go
@@ -107,7 +107,7 @@ func (oh *OvnHelper) mustPrepService() {
 }
 
 func MustGetOvnVersion() string {
-	output, err := procutils.NewCommand("ovn-controller", "--version").Output()
+	output, err := procutils.NewRemoteCommandAsFarAsPossible("ovn-controller", "--version").Output()
 	if err != nil {
 		return ""
 	}

--- a/pkg/hostman/hostinfo/hostovn.go
+++ b/pkg/hostman/hostinfo/hostovn.go
@@ -114,6 +114,14 @@ func MustGetOvnVersion() string {
 	return ovnExtractVersion(string(output))
 }
 
+func HasOvnSupport() bool {
+	ver := MustGetOvnVersion()
+	if ver != "" {
+		return true
+	}
+	return false
+}
+
 func ovnExtractVersion(in string) string {
 	r := make([]rune, 0, 8)
 	var (


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
hostman: fix detection of ovn controller version
hostman: skip setting up ovn chassis when env support is not ready
```

**是否需要 backport 到之前的 release 分支**:

- release/3.1

/area host
/cc @wanyaoqi @swordqiu 