### PR TITLE
hostman: fix hostinfo init interrupted by ovn chassis setup

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -145,7 +145,6 @@ func (h *SHostInfo) Init() error {
 		if err := h.setupOvnChassis(); err != nil {
 			return err
 		}
-		return nil
 	}
 	log.Infof("Start detectHostInfo")
 	if err := h.detectHostInfo(); err != nil {


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:

```
Causing sysinfo.SSystemInfo not initialized

[E 200205 09:45:49 timeutils2.AddTimeout.func1.1(timeutils.go:31)] runtime error: invalid memory address or nil pointer dereference
goroutine 405 [running]:
runtime/debug.Stack(0x551210, 0xc0000de1c0, 0x0)
        /opt/hostedtoolcache/go/1.12.16/x64/src/runtime/debug/stack.go:24 +0x9d
runtime/debug.PrintStack()
        /opt/hostedtoolcache/go/1.12.16/x64/src/runtime/debug/stack.go:16 +0x22
yunion.io/x/onecloud/pkg/util/timeutils2.AddTimeout.func1.1()
        /home/runner/work/onecloud/onecloud/pkg/util/timeutils2/timeutils.go:32 +0x96
panic(0x1b208e0, 0x3bd1880)
        /opt/hostedtoolcache/go/1.12.16/x64/src/runtime/panic.go:522 +0x1b5
yunion.io/x/onecloud/pkg/hostman/hostinfo.(*SHostInfo).updateHostRecord(0xc0009a8a80, 0xc000aff3b0, 0x24)
        /home/runner/work/onecloud/onecloud/pkg/hostman/hostinfo/hostinfo.go:866 +0xbba
yunion.io/x/onecloud/pkg/hostman/hostinfo.(*SHostInfo).getHostInfo(0xc0009a8a80, 0xc00099a510, 0x24)
        /home/runner/work/onecloud/onecloud/pkg/hostman/hostinfo/hostinfo.go:782 +0x37d
yunion.io/x/onecloud/pkg/hostman/hostinfo.(*SHostInfo).getZoneInfo(0xc0009a8a80, 0xc00099a4b0, 0x24, 0x0)
        /home/runner/work/onecloud/onecloud/pkg/hostman/hostinfo/hostinfo.go:760 +0x55c
yunion.io/x/onecloud/pkg/hostman/hostinfo.(*SHostInfo).onGetWireId(0xc0009a8a80, 0xc000aff2f0, 0x24)
        /home/runner/work/onecloud/onecloud/pkg/hostman/hostinfo/hostinfo.go:734 +0x16a
yunion.io/x/onecloud/pkg/hostman/hostinfo.(*SHostInfo).fetchAccessNetworkInfo(0xc0009a8a80)
        /home/runner/work/onecloud/onecloud/pkg/hostman/hostinfo/hostinfo.go:719 +0x3ee
yunion.io/x/onecloud/pkg/hostman/hostinfo.(*SHostInfo).register(...)
        /home/runner/work/onecloud/onecloud/pkg/hostman/hostinfo/hostinfo.go:662
yunion.io/x/onecloud/pkg/util/timeutils2.AddTimeout.func1(0x77359400, 0xc000925520)
        /home/runner/work/onecloud/onecloud/pkg/util/timeutils2/timeutils.go:37 +0x6b
created by yunion.io/x/onecloud/pkg/util/timeutils2.AddTimeout
        /home/runner/work/onecloud/onecloud/pkg/util/timeutils2/timeutils.go:28 +0x49
```

**是否需要 backport 到之前的 release 分支**:

- release/3.1

/area host
/cc @wanyaoqi @swordqiu 