### PR TITLE
Automated cherry pick of #5008: hostman: fix hostinfo init interrupted by ovn chassis setup

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -145,7 +145,6 @@ func (h *SHostInfo) Init() error {
 		if err := h.setupOvnChassis(); err != nil {
 			return err
 		}
-		return nil
 	}
 	log.Infof("Start detectHostInfo")
 	if err := h.detectHostInfo(); err != nil {


### PR DESCRIPTION
Cherry pick of #5008 on release/3.1.

#5008: hostman: fix hostinfo init interrupted by ovn chassis setup