### PR TITLE
fix: support empty dns domain

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -65,6 +65,14 @@ func (l *sLinuxRootFs) RootSignatures() []string {
 	return []string{"/bin", "/etc", "/boot", "/lib", "/usr"}
 }
 
+func getHostname(hostname, domain string) string {
+	if len(domain) > 0 {
+		return fmt.Sprintf("%s.%s", hostname, domain)
+	} else {
+		return hostname
+	}
+}
+
 func (l *sLinuxRootFs) DeployHosts(rootFs IDiskPartition, hostname, domain string, ips []string) error {
 	var etcHosts = "/etc/hosts"
 	var oldHostFile string
@@ -79,7 +87,7 @@ func (l *sLinuxRootFs) DeployHosts(rootFs IDiskPartition, hostname, domain strin
 	hf.Parse(oldHostFile)
 	hf.Add("127.0.0.1", "localhost")
 	for _, ip := range ips {
-		hf.Add(ip, fmt.Sprintf("%s.%s", hostname, domain), hostname)
+		hf.Add(ip, getHostname(hostname, domain), hostname)
 	}
 	return rootFs.FilePutContents(etcHosts, hf.String(), false, false)
 }
@@ -591,7 +599,9 @@ func (d *sDebianLikeRootFs) DeployNetworkingScripts(rootFs IDiskPartition, nics 
 			dnslist := netutils2.GetNicDns(nicDesc)
 			if len(dnslist) > 0 {
 				cmds.WriteString(fmt.Sprintf("    dns-nameservers %s\n", strings.Join(dnslist, " ")))
-				cmds.WriteString(fmt.Sprintf("    dns-search %s\n", nicDesc.Domain))
+				if len(nicDesc.Domain) > 0 {
+					cmds.WriteString(fmt.Sprintf("    dns-search %s\n", nicDesc.Domain))
+				}
 			}
 			if len(nicDesc.TeamingSlaves) > 0 {
 				cmds.WriteString(getNicTeamingConfigCmds(nicDesc.TeamingSlaves))
@@ -840,7 +850,7 @@ func (r *sRedhatLikeRootFs) DeployHostname(rootFs IDiskPartition, hn, domain str
 	var sPath = "/etc/sysconfig/network"
 	centosHn := ""
 	centosHn += "NETWORKING=yes\n"
-	centosHn += fmt.Sprintf("HOSTNAME=%s.%s\n", hn, domain)
+	centosHn += fmt.Sprintf("HOSTNAME=%s\n", getHostname(hn, domain))
 	if err := rootFs.FilePutContents(sPath, centosHn, false, false); err != nil {
 		return err
 	}
@@ -1009,7 +1019,9 @@ func (r *sRedhatLikeRootFs) deployNetworkingScripts(rootFs IDiskPartition, nics 
 				for i := 0; i < len(dnslist); i++ {
 					cmds.WriteString(fmt.Sprintf("DNS%d=%s\n", i+1, dnslist[i]))
 				}
-				cmds.WriteString(fmt.Sprintf("DOMAIN=%s\n", nicDesc.Domain))
+				if len(nicDesc.Domain) > 0 {
+					cmds.WriteString(fmt.Sprintf("DOMAIN=%s\n", nicDesc.Domain))
+				}
 			}
 		} else {
 			cmds.WriteString("BOOTPROTO=dhcp\n")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：允许DNS domain为空字符串

**是否需要 backport 到之前的 release 分支**:
- release/2.10.0
- release/2.11
- release/2.12
- release/2.13
- release/3.0
- release/3.1

/cc @wanyaoqi @yousong 

/area host