### PR TITLE
fix: api gateway rpc handler redundant response

### DIFF
--- a/pkg/apigateway/handler/rpc.go
+++ b/pkg/apigateway/handler/rpc.go
@@ -117,21 +117,24 @@ func rpcHandler(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 		v, ok := retobj.Interface().(jsonutils.JSONObject)
 		if ok {
 			appsrv.SendJSON(w, v)
+			return
 		}
 
 		v2, ok := retobj.Interface().([]modulebase.SubmitResult)
 		if ok {
 			w.WriteHeader(207)
 			appsrv.SendJSON(w, modulebase.SubmitResults2JSON(v2))
-		} else {
-			httperrors.BadGatewayError(w, "recv invalid data")
+			return
 		}
+
+		httperrors.BadGatewayError(w, "recv invalid data")
 	} else {
 		v, ok := reterr.Interface().(*httputils.JSONClientError)
 		if ok {
 			httperrors.JsonClientError(w, v)
-		} else {
-			httperrors.BadGatewayError(w, fmt.Sprintf("%s", reterr.Interface()))
+			return
 		}
+
+		httperrors.BadGatewayError(w, fmt.Sprintf("%s", reterr.Interface()))
 	}
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：apigateway rpc会执行冗余的响应逻辑

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1

/cc @zexi 

/area apigateway