### PR TITLE
Automated cherry pick of #5048: fix: google e2不支持本地盘

### DIFF
--- a/pkg/compute/guestdrivers/google.go
+++ b/pkg/compute/guestdrivers/google.go
@@ -150,6 +150,9 @@ func (self *SGoogleGuestDriver) ValidateCreateData(ctx context.Context, userCred
 	if localDisk > 8 {
 		return nil, httperrors.NewInputParameterError("%s disk cannot exceed 8", api.STORAGE_GOOGLE_LOCAL_SSD)
 	}
+	if localDisk > 0 && strings.HasPrefix(input.InstanceType, "e2") {
+		return nil, httperrors.NewNotSupportedError("%s for %s features are not compatible for creating instance", input.InstanceType, api.STORAGE_GOOGLE_LOCAL_SSD)
+	}
 	return input, nil
 }
 


### PR DESCRIPTION
Cherry pick of #5048 on release/3.1.

#5048: fix: google e2不支持本地盘