### PR TITLE
fix: createdAt should not be synced when update

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -2312,11 +2312,12 @@ func (self *SGuest) syncWithCloudVM(ctx context.Context, userCred mcclient.Token
 			self.ExpiredAt = extVM.GetExpiredAt()
 		}
 
-		if !recycle {
-			if createdAt := extVM.GetCreatedAt(); !createdAt.IsZero() {
-				self.CreatedAt = createdAt
-			}
-		}
+		// no need to sync CreatedAt
+		// if !recycle {
+		//	if createdAt := extVM.GetCreatedAt(); !createdAt.IsZero() {
+		//		self.CreatedAt = createdAt
+		//	}
+		// }
 
 		return nil
 	})


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：公有云虚拟机更新的时候不应该同步CreatedAt字段

**是否需要 backport 到之前的 release 分支**:
- release/2.10
- release/2.12
- release/2.13
- release/3.0
- release/3.1

/cc @ioito @yousong 

/area region