### PR TITLE
Automated cherry pick of #5054: fix: createdAt should not be synced when update

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -2128,11 +2128,12 @@ func (self *SGuest) syncWithCloudVM(ctx context.Context, userCred mcclient.Token
 			self.ExpiredAt = extVM.GetExpiredAt()
 		}
 
-		if !recycle {
-			if createdAt := extVM.GetCreatedAt(); !createdAt.IsZero() {
-				self.CreatedAt = createdAt
-			}
-		}
+		// no need to sync CreatedAt
+		// if !recycle {
+		//	if createdAt := extVM.GetCreatedAt(); !createdAt.IsZero() {
+		//		self.CreatedAt = createdAt
+		//	}
+		// }
 
 		return nil
 	})


### PR DESCRIPTION
Cherry pick of #5054 on release/2.10.0.

#5054: fix: createdAt should not be synced when update