### PR TITLE
webconsole: use base64 encode connect_params

### DIFF
--- a/cmd/climc/shell/webconsole.go
+++ b/cmd/climc/shell/webconsole.go
@@ -15,6 +15,7 @@
 package shell
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/url"
 
@@ -45,6 +46,9 @@ func init() {
 		if err != nil {
 			return err
 		}
+		if decodeStr, err := base64.StdEncoding.DecodeString(connParams); err == nil {
+			connParams = string(decodeStr)
+		}
 		var query url.Values
 		connUrl, err := url.ParseRequestURI(connParams)
 		if err == nil {
@@ -64,7 +68,9 @@ func init() {
 			return nil
 		}
 
-		u.RawQuery = connParams
+		newQuery := url.Values(make(map[string][]string))
+		newQuery.Set("data", base64.StdEncoding.EncodeToString([]byte(connParams)))
+		u.RawQuery = newQuery.Encode()
 		fmt.Println(u.String())
 		return nil
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

base64 encode webconole connect params

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- 3.1

/cc @swordqiu 