### PR TITLE
fix(esxi): Create one if no suitable driver exists when creating disk

### DIFF
--- a/pkg/compute/hostdrivers/esxi.go
+++ b/pkg/compute/hostdrivers/esxi.go
@@ -132,7 +132,11 @@ func (self *SESXiHostDriver) CheckAndSetCacheImage(ctx context.Context, host *mo
 		}
 		content.SrcHostIp = srcHost.AccessIp
 		content.SrcPath = srcHostCacheImage.Path
-		srcStorage := srcHost.GetStorageByFilePath(srcHostCacheImage.Path)
+		srcStorageCache, err := srcHostCacheImage.GetStoragecache()
+		if err != nil {
+			return errors.Wrap(err, "StorageCacheImage.GetStoragecaceh")
+		}
+		srcStorage := host.GetStorageByFilePath(srcStorageCache.Path)
 		accessInfo, err := srcHost.GetCloudaccount().GetVCenterAccessInfo(srcStorage.ExternalId)
 		if err != nil {
 			return err


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. storagecacheimage 同步下来，path可能会为空，所以先获得storageCache然后通过storageCache进行进一步的操作
2. 同步下来的vmware机器创建磁盘可能会失败，因为没有对应的driver，现在创建磁盘如果找不到对应的driver，回先创建driver

**是否需要 backport 到之前的 release 分支**:

- release/3.0
- release/3.1
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
