### PR TITLE
Automated cherry pick of #5087: fix(esxi): Create one if no suitable driver exists when creating disk

### DIFF
--- a/pkg/compute/hostdrivers/esxi.go
+++ b/pkg/compute/hostdrivers/esxi.go
@@ -132,7 +132,11 @@ func (self *SESXiHostDriver) CheckAndSetCacheImage(ctx context.Context, host *mo
 		}
 		content.SrcHostIp = srcHost.AccessIp
 		content.SrcPath = srcHostCacheImage.Path
-		srcStorage := srcHost.GetStorageByFilePath(srcHostCacheImage.Path)
+		srcStorageCache, err := srcHostCacheImage.GetStoragecache()
+		if err != nil {
+			return errors.Wrap(err, "StorageCacheImage.GetStoragecaceh")
+		}
+		srcStorage := host.GetStorageByFilePath(srcStorageCache.Path)
 		accessInfo, err := srcHost.GetCloudaccount().GetVCenterAccessInfo(srcStorage.ExternalId)
 		if err != nil {
 			return err


### PR DESCRIPTION
Cherry pick of #5087 on release/3.1.

#5087: fix(esxi): Create one if no suitable driver when creating disk