### PR TITLE
Automated cherry pick of #5087: fix(esxi): Create one if no suitable driver when creating disk

### DIFF
--- a/pkg/compute/hostdrivers/esxi.go
+++ b/pkg/compute/hostdrivers/esxi.go
@@ -111,7 +111,11 @@ func (self *SESXiHostDriver) CheckAndSetCacheImage(ctx context.Context, host *mo
 		}
 		content.SrcHostIp = srcHost.AccessIp
 		content.SrcPath = srcHostCacheImage.Path
-		srcStorage := srcHost.GetStorageByFilePath(srcHostCacheImage.Path)
+		srcStorageCache, err := srcHostCacheImage.GetStoragecache()
+		if err != nil {
+			return errors.Wrap(err, "StorageCacheImage.GetStoragecaceh")
+		}
+		srcStorage := host.GetStorageByFilePath(srcStorageCache.Path)
 		accessInfo, err := srcHost.GetCloudaccount().GetVCenterAccessInfo(srcStorage.ExternalId)
 		if err != nil {
 			return err

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -1102,3 +1102,26 @@ func (self *SVirtualMachine) ExportTemplate(ctx context.Context, idx int, diskPa
 	log.Debugf("download to %s finish", diskPath)
 	return nil
 }
+
+func (self *SVirtualMachine) FindMinDiffKey(limit int32) int32 {
+	if self.devs == nil {
+		self.fetchHardwareInfo()
+	}
+	devKeys := make([]int32, 0, len(self.devs))
+	for key := range self.devs {
+		devKeys = append(devKeys, key)
+	}
+	sort.Slice(devKeys, func(i int, j int) bool {
+		return devKeys[i] < devKeys[j]
+	})
+	for _, key := range devKeys {
+		switch {
+		case key < limit:
+		case key == limit:
+			limit += 1
+		case key > limit:
+			return limit
+		}
+	}
+	return limit
+}

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -811,7 +811,7 @@ func (self *SVirtualMachine) CreateDisk(ctx context.Context, sizeMb int, uuid st
 		}
 	}
 	if len(devs) == 0 {
-		return fmt.Errorf("Driver %s not found", driver)
+		return self.createDriverAndDisk(ctx, sizeMb, uuid, driver)
 	}
 	ctlKey := minDevKey(devs)
 	sameDisks := make([]SVirtualDisk, 0)
@@ -832,13 +832,38 @@ func (self *SVirtualMachine) CreateDisk(ctx context.Context, sizeMb int, uuid st
 	return self.createDiskInternal(ctx, sizeMb, uuid, int32(index), diskKey, ctlKey, "", true)
 }
 
-func (self *SVirtualMachine) createDiskInternal(ctx context.Context, sizeMb int, uuid string, index int32,
-	diskKey int32, ctlKey int32, imagePath string, check bool) error {
+// createDriverAndDisk will create a driver and disk associated with the driver
+func (self *SVirtualMachine) createDriverAndDisk(ctx context.Context, sizeMb int, uuid string, driver string) error {
+	if driver != "scsi" && driver != "pvscsi" {
+		return fmt.Errorf("Driver %s is not supported", driver)
+	}
+
+	deviceChange := make([]types.BaseVirtualDeviceConfigSpec, 0, 2)
+
+	// find a suitable key for scsi or pvscsi driver
+	scsiKey := self.FindMinDiffKey(1000)
+	deviceChange = append(deviceChange, addDevSpec(NewSCSIDev(scsiKey, 100, driver)))
+
+	// find a suitable key for disk
+	diskKey := self.FindMinDiffKey(2000)
+
+	if diskKey == scsiKey {
+		// unarrivelable
+		log.Errorf("there is no suitable key between 1000 and 2000???!")
+	}
+
+	return self.createDiskWithDeviceChange(ctx, deviceChange, sizeMb, uuid, 0, diskKey, scsiKey, "", true)
+}
+
+func (self *SVirtualMachine) createDiskWithDeviceChange(ctx context.Context,
+	deviceChange []types.BaseVirtualDeviceConfigSpec, sizeMb int,
+	uuid string, index int32, diskKey int32, ctlKey int32, imagePath string, check bool) error {
+
 	devSpec := NewDiskDev(int64(sizeMb), imagePath, uuid, index, diskKey, ctlKey)
 	spec := addDevSpec(devSpec)
 	spec.FileOperation = types.VirtualDeviceConfigSpecFileOperationCreate
 	configSpec := types.VirtualMachineConfigSpec{}
-	configSpec.DeviceChange = []types.BaseVirtualDeviceConfigSpec{spec}
+	configSpec.DeviceChange = append(deviceChange, spec)
 
 	vmObj := self.getVmObj()
 
@@ -863,6 +888,12 @@ func (self *SVirtualMachine) createDiskInternal(ctx context.Context, sizeMb int,
 		}
 	}
 	return cloudprovider.ErrTimeout
+}
+
+func (self *SVirtualMachine) createDiskInternal(ctx context.Context, sizeMb int, uuid string, index int32,
+	diskKey int32, ctlKey int32, imagePath string, check bool) error {
+
+	return self.createDiskWithDeviceChange(ctx, nil, sizeMb, uuid, index, diskKey, ctlKey, imagePath, check)
 }
 
 func (self *SVirtualMachine) Renew(bc billing.SBillingCycle) error {


### PR DESCRIPTION
Cherry pick of #5087 on release/3.0.

#5087: fix(esxi): Create one if no suitable driver when creating disk