### PR TITLE
feature: Specify cloud provider when creating vm

### DIFF
--- a/pkg/apis/compute/api.go
+++ b/pkg/apis/compute/api.go
@@ -231,6 +231,9 @@ type BaremetalDiskConfig struct {
 }
 
 type ServerConfigs struct {
+	// 调度使用指定的云账号
+	PreferManager string `json:"prefer_manager_id"`
+
 	// 调度到指定区域,优先级低于prefer_zone_id
 	PreferRegion string `json:"prefer_region_id"`
 

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -476,7 +476,7 @@ func (self *SGuest) PerformClone(ctx context.Context, userCred mcclient.TokenCre
 	createInput.EipBw = cloneInput.EipBw
 	createInput.Eip = cloneInput.Eip
 	createInput.EipChargeType = cloneInput.EipChargeType
-	if err := GuestManager.validateEip(userCred, createInput, createInput.PreferRegion); err != nil {
+	if err := GuestManager.validateEip(userCred, createInput, createInput.PreferRegion, createInput.PreferManager); err != nil {
 		return nil, err
 	}
 

--- a/pkg/mcclient/options/servers.go
+++ b/pkg/mcclient/options/servers.go
@@ -124,6 +124,7 @@ func ParseServerDeployInfoList(list []string) ([]*computeapi.DeployConfig, error
 }
 
 type ServerConfigs struct {
+	Manager    string `help:"Preferred cloudprovider where virtual server should bd created" json:"prefer_manager"`
 	Region     string `help:"Preferred region where virtual server should be created" json:"prefer_region"`
 	Zone       string `help:"Preferred zone where virtual server should be created" json:"prefer_zone"`
 	Wire       string `help:"Preferred wire where virtual server should be created" json:"prefer_wire"`
@@ -148,6 +149,7 @@ type ServerConfigs struct {
 
 func (o ServerConfigs) Data() (*computeapi.ServerConfigs, error) {
 	data := &computeapi.ServerConfigs{
+		PreferManager:    o.Manager,
 		PreferRegion:     o.Region,
 		PreferZone:       o.Zone,
 		PreferWire:       o.Wire,

--- a/pkg/scheduler/data_manager/candidate_manager.go
+++ b/pkg/scheduler/data_manager/candidate_manager.go
@@ -30,6 +30,7 @@ type CandidateGetArgs struct {
 	ResType   string
 	RegionID  string
 	ZoneID    string
+	ManagerID string
 	HostTypes []string
 }
 
@@ -205,7 +206,7 @@ func (cm *CandidateManager) GetCandidates(args CandidateGetArgs) ([]core.Candida
 	result := []core.Candidater{}
 
 	matchZone := func(r core.Candidater, zoneId string) bool {
-		if args.ZoneID != "" {
+		if zoneId != "" {
 			if r.Getter().Zone().GetId() == zoneId {
 				return true
 			}
@@ -215,8 +216,18 @@ func (cm *CandidateManager) GetCandidates(args CandidateGetArgs) ([]core.Candida
 	}
 
 	matchRegion := func(r core.Candidater, regionId string) bool {
-		if args.RegionID != "" {
+		if regionId != "" {
 			if r.Getter().Region().GetId() == regionId {
+				return true
+			}
+			return false
+		}
+		return true
+	}
+
+	matchCloudprovider := func(r core.Candidater, managerId string) bool {
+		if managerId != "" {
+			if r.Getter().Cloudprovider().GetId() == managerId {
 				return true
 			}
 			return false
@@ -239,6 +250,10 @@ func (cm *CandidateManager) GetCandidates(args CandidateGetArgs) ([]core.Candida
 		}
 
 		if !matchZone(r, args.ZoneID) {
+			continue
+		}
+
+		if !matchCloudprovider(r, args.ManagerID) {
 			continue
 		}
 

--- a/pkg/scheduler/manager/scheduler.go
+++ b/pkg/scheduler/manager/scheduler.go
@@ -40,6 +40,7 @@ func candidatesByProvider(provider CandidatesProvider, schedData *api.SchedInfo)
 			ResType:   provider.CandidateType(),
 			ZoneID:    schedData.PreferZone,
 			RegionID:  schedData.PreferRegion,
+			ManagerID: schedData.PreferManager,
 			HostTypes: schedData.GetCandidateHostTypes(),
 		}
 		hosts, err = candidateManager.GetCandidates(args)


### PR DESCRIPTION


**这个 PR 实现什么功能/修复什么问题**:

1. Specify cloud provider when creating vm
2. Specifying the eip is equivalent to specifying the cloudprovider when
creating vm.

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
