### PR TITLE
fix(esxiagent): Delete image backup file after saving to glance instead of before

### DIFF
--- a/pkg/hostman/storageman/storage_agent.go
+++ b/pkg/hostman/storageman/storage_agent.go
@@ -409,7 +409,6 @@ func (as *SAgentStorage) PrepareSaveToGlance(ctx context.Context, taskId string,
 	destDir := as.GetImgsaveBackupPath()
 	as.checkDirC(destDir)
 	backupPath := filepath.Join(destDir, fmt.Sprintf("%s.%s", spec.Vm.PrivateId, taskId))
-	defer as.checkFileR(backupPath)
 
 	client, err := esxi.NewESXiClientFromAccessInfo(ctx, &spec.Vm)
 	if err != nil {
@@ -458,6 +457,8 @@ func (as *SAgentStorage) SaveToGlance(ctx context.Context, params interface{}) (
 		as.onSaveToGlanceFailed(ctx, imageId)
 		return nil, err
 	}
+	// delete the backup image
+	as.checkFileR(imagePath)
 
 	imagecacheManager := as.Manager.LocalStorageImagecacheManager
 	if len(imagecacheManager.GetId()) > 0 {


### PR DESCRIPTION


**这个 PR 实现什么功能/修复什么问题**:

vmware机器保存镜像的备份文件 应该在 SaveToGlance 之后完成而不是之前

**是否需要 backport 到之前的 release 分支**:
- release/3.0
- release/3.1
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
