### PR TITLE
Automated cherry pick of #5121: fix(esxiagent): Delete image backup file after saving to glance instead of before

### DIFF
--- a/pkg/hostman/storageman/storage_agent.go
+++ b/pkg/hostman/storageman/storage_agent.go
@@ -416,7 +416,6 @@ func (as *SAgentStorage) PrepareSaveToGlance(ctx context.Context, taskId string,
 	destDir := as.GetImgsaveBackupPath()
 	as.checkDirC(destDir)
 	backupPath := filepath.Join(destDir, fmt.Sprintf("%s.%s", spec.Vm.PrivateId, taskId))
-	defer as.checkFileR(backupPath)
 
 	client, err := esxi.NewESXiClientFromAccessInfo(ctx, &spec.Vm)
 	if err != nil {
@@ -465,6 +464,8 @@ func (as *SAgentStorage) SaveToGlance(ctx context.Context, params interface{}) (
 		as.onSaveToGlanceFailed(ctx, imageId)
 		return nil, err
 	}
+	// delete the backup image
+	as.checkFileR(imagePath)
 
 	imagecacheManager := as.Manager.LocalStorageImagecacheManager
 	if len(imagecacheManager.GetId()) > 0 {


### PR DESCRIPTION
Cherry pick of #5121 on release/3.0.

#5121: fix(esxiagent): Delete image backup file after saving to glance instead of before