### PR TITLE
Automated cherry pick of #5124: fix: disks_info typo

### DIFF
--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -141,7 +141,7 @@ type ServerDetails struct {
 	// 磁盘概要
 	Disks string `json:"disks"`
 	// 磁盘详情
-	DisksInfo *jsonutils.JSONArray `json:"disk_info"`
+	DisksInfo *jsonutils.JSONArray `json:"disks_info"`
 	// 虚拟机Ip列表
 	VirtualIps string `json:"virtual_ips"`
 	// 安全组规则


### PR DESCRIPTION
Cherry pick of #5124 on release/3.1.

#5124: fix: disks_info typo