### PR TITLE
regiondrivers: kvm: dummy impl for RequestDeleteVpc

### DIFF
--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -801,6 +801,11 @@ func (self *SKVMRegionDriver) ValidateCreateVpcData(ctx context.Context, userCre
 	return data, nil
 }
 
+func (self *SKVMRegionDriver) RequestDeleteVpc(ctx context.Context, userCred mcclient.TokenCredential, region *models.SCloudregion, vpc *models.SVpc, task taskman.ITask) error {
+	task.ScheduleRun(nil)
+	return nil
+}
+
 func (self *SKVMRegionDriver) ValidateCreateEipData(ctx context.Context, userCred mcclient.TokenCredential, input *api.SElasticipCreateInput) error {
 	return httperrors.NewNotImplementedError("Not Implement EIP")
 }


### PR DESCRIPTION


**这个 PR 实现什么功能/修复什么问题**:

```
Regression since 4a6a4c594a30c580f970bcf2876dde487b75c734 ("feature:
google云操作支持")

	Feb 17 15:53:12 titan-10-168-222-196 region[20940]: [I 200217 15:53:12 appsrv.(*Application).ServeHTTP(appsrv.go:237)] Ao9tyX8XY4DXa3tBiUyXgPm_ipc= 200 f7a73c DELETE /vpcs/vpc1 (10.168.222.196:46354) 723.91ms
	Feb 17 15:53:13 titan-10-168-222-196 region[20940]: [E 200217 15:53:13 tasks.(*VpcDeleteTask).taskFailed(vpc_delete_task.go:41)] vpc delete task fail: RequestDeleteVpc: Not implement RequestDeleteVpc
	Feb 17 15:53:13 titan-10-168-222-196 region[20940]: [I 200217 15:53:13 taskman.(*STask).SetStageFailed(tasks.go:636)] XXX TASK VpcDeleteTask failed: RequestDeleteVpc: Not implement RequestDeleteVpc on stage OnDeleteVpcComplete
	Feb 17 15:53:13 titan-10-168-222-196 region[20940]: [I 200217 15:53:13 taskman.(*STask).NotifyParentTaskComplete(tasks.go:648)] notify_parent_task_complete: VpcDeleteTask params {"__failed_reason":"RequestDeleteVpc: Not implement RequestDeleteVpc","__request_context":{"request_id":"f7a73c","service_name":"compute_v2","trace":{"debug":true,"duration":0,"id":"0","kind":"SERVER","local_endpoint":{"port":0,"service_name":"compute_v2"},"name":"delete","remote_endpoint":{"addr":"10.168.222.196","port":46354,"service_name":"(unknown_service)"},"shared":false,"tags":{"resource":"vpcs"},"timestamp":"2020-02-17T07:53:12.052219Z","trace_id":"5cf3e014"}},"__stages":[{"complete_at":"2020-02-17T15:53:12Z","name":"on_init"},{"complete_at":"2020-02-17T15:53:13Z","name":"OnDeleteVpcComplete"}]}
```

**是否需要 backport 到之前的 release 分支**:

- release/3.1


/area region
/cc @ioito @swordqiu 
