### PR TITLE
Automated cherry pick of #5151: fix: 1. adjust default response header timer to 30 seconds 2. set default paging limit to 20

### DIFF
--- a/pkg/cloudcommon/consts/consts.go
+++ b/pkg/cloudcommon/consts/consts.go
@@ -28,6 +28,9 @@ var (
 	tenantCacheExpireSeconds = 900
 
 	nonDefaultDomainProjects = false
+
+	defaultPagingLimit int64 = 20
+	maxPagingLimit     int64 = 2048
 )
 
 func SetRegion(region string) {
@@ -60,4 +63,12 @@ func SetNonDefaultDomainProjects(val bool) {
 
 func GetNonDefaultDomainProjects() bool {
 	return nonDefaultDomainProjects
+}
+
+func GetDefaultPagingLimit() int64 {
+	return defaultPagingLimit
+}
+
+func GetMaxPagingLimit() int64 {
+	return maxPagingLimit
 }

--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -442,7 +442,7 @@ func fetchContextObject(manager IModelManager, ctx context.Context, userCred mcc
 
 func ListItems(manager IModelManager, ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, ctxIds []dispatcher.SResourceContext) (*modulebase.ListResult, error) {
 	var err error
-	var maxLimit int64 = 2048
+	var maxLimit int64 = consts.GetMaxPagingLimit()
 	limit, _ := query.Int("limit")
 	offset, _ := query.Int("offset")
 	pagingMarker, _ := query.GetString("paging_marker")
@@ -473,6 +473,9 @@ func ListItems(manager IModelManager, ctx context.Context, userCred mcclient.Tok
 	var totalCnt int
 	pagingConf := manager.GetPagingConfig()
 	if pagingConf == nil {
+		if limit == 0 {
+			limit = consts.GetDefaultPagingLimit()
+		}
 		totalCnt, err = q.CountWithError()
 		if err != nil {
 			return nil, err

--- a/pkg/util/httputils/httputils.go
+++ b/pkg/util/httputils/httputils.go
@@ -51,6 +51,10 @@ const (
 	PATCH  = THttpMethod("PATCH")
 	DELETE = THttpMethod("DELETE")
 	OPTION = THttpMethod("OPTION")
+
+	IdleConnTimeout       = 60
+	TLSHandshakeTimeout   = 10
+	ResponseHeaderTimeout = 30
 )
 
 var (
@@ -149,17 +153,17 @@ func getTransport(insecure bool, adaptive bool) *http.Transport {
 		// (keep-alive) connection will remain idle before closing
 		// itself.
 		// Zero means no limit.
-		IdleConnTimeout: 60 * time.Second,
+		IdleConnTimeout: IdleConnTimeout * time.Second,
 		// 建立TCP连接后，等待TLS握手的超时时间
 		// TLSHandshakeTimeout specifies the maximum amount of time waiting to
 		// wait for a TLS handshake. Zero means no timeout.
-		TLSHandshakeTimeout: 10 * time.Second,
+		TLSHandshakeTimeout: TLSHandshakeTimeout * time.Second,
 		// 发送请求后，等待服务端http响应的超时时间
 		// ResponseHeaderTimeout, if non-zero, specifies the amount of
 		// time to wait for a server's response headers after fully
 		// writing the request (including its body, if any). This
 		// time does not include the time to read the response body.
-		ResponseHeaderTimeout: 10 * time.Second,
+		ResponseHeaderTimeout: ResponseHeaderTimeout * time.Second,
 		// 当请求携带Expect: 100-continue时，等待服务端100响应的超时时间
 		// ExpectContinueTimeout, if non-zero, specifies the amount of
 		// time to wait for a server's first response headers after fully

--- a/pkg/util/httputils/httputils_test.go
+++ b/pkg/util/httputils/httputils_test.go
@@ -136,7 +136,7 @@ func TestError(t *testing.T) {
 type ResponseHeaderTimeoutHandler struct{}
 
 func (h *ResponseHeaderTimeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	time.Sleep(12 * time.Second)
+	time.Sleep(time.Duration(ResponseHeaderTimeout+2) * time.Second)
 	w.Write([]byte("hello"))
 }
 


### PR DESCRIPTION
Cherry pick of #5151 on release/2.12.

#5151: fix: 1. adjust default response header timer to 30 seconds 2. set default paging limit to 20