### PR TITLE
Automated cherry pick of #5159: region: lbagent: deploy: use 'public' endpoint type

### DIFF
--- a/pkg/compute/models/loadbalanceragents_deploy.go
+++ b/pkg/compute/models/loadbalanceragents_deploy.go
@@ -436,6 +436,7 @@ auth_uri = '{{ auth_uri }}'
 admin_user = '{{ user }}'
 admin_password = '{{ pass }}'
 admin_tenant_name = '{{ proj }}'
+session_endpoint_type = 'public'
 
 data_preserve_n = 10
 base_data_dir = "/opt/cloud/workspace/lbagent"

--- a/pkg/lbagent/models/haproxy.go
+++ b/pkg/lbagent/models/haproxy.go
@@ -285,14 +285,18 @@ func (b *LoadbalancerCorpus) genHaproxyConfigBackend(data map[string]interface{}
 		stickyCookie := ""
 		switch listener.StickySessionType {
 		case "insert":
-			stickyCookie = "cookie SERVERID insert indirect nocache"
+			cookie := listener.StickySessionCookie
+			if cookie == "" {
+				cookie = "SERVERID"
+			}
+			stickyCookie = fmt.Sprintf("cookie %s insert indirect nocache", cookie)
 			if maxIdle := listener.StickySessionCookieTimeout; maxIdle > 0 {
 				stickyCookie += fmt.Sprintf(" maxidle %ds", maxIdle)
 			}
 		case "server":
 			cookie := listener.StickySessionCookie
 			if cookie != "" {
-				stickyCookie = fmt.Sprintf("cookie %q rewrite nocache", cookie)
+				stickyCookie = fmt.Sprintf("cookie %q rewrite", cookie)
 			}
 		}
 		if stickyCookie != "" {


### PR DESCRIPTION
Cherry pick of #5159 on release/3.1.

#5159: region: lbagent: deploy: use 'public' endpoint type