### PR TITLE
fix: sync cloud provider should change its cloud account's sync_status

### DIFF
--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -551,6 +551,7 @@ func (self *SCloudprovider) StartSyncCloudProviderInfoTask(ctx context.Context, 
 	}
 	if cloudaccount := self.GetCloudaccount(); cloudaccount != nil {
 		cloudaccount.markAutoSync(userCred)
+		cloudaccount.MarkSyncing(userCred)
 	}
 	self.markStartSync(userCred)
 	db.OpsLog.LogEvent(self, db.ACT_SYNC_HOST_START, "", userCred)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：云订阅开始同步时没有更改云账号的同步状态

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
- release/3.0
- release/3.1

/cc @ioito @yousong 

/area region