### PR TITLE
Automated cherry pick of #5173: fix: sync cloud provider should change its cloud account's sync_status

### DIFF
--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -532,6 +532,7 @@ func (self *SCloudprovider) StartSyncCloudProviderInfoTask(ctx context.Context, 
 	}
 	if cloudaccount := self.GetCloudaccount(); cloudaccount != nil {
 		cloudaccount.markAutoSync(userCred)
+		cloudaccount.MarkSyncing(userCred)
 	}
 	self.markStartSync(userCred)
 	db.OpsLog.LogEvent(self, db.ACT_SYNC_HOST_START, "", userCred)


### PR DESCRIPTION
Cherry pick of #5173 on release/2.13.

#5173: fix: sync cloud provider should change its cloud account's sync_status