### PR TITLE
fix(esxi): No distinction between ordinary scsi and pvscsi when creating disks

### DIFF
--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -879,7 +879,11 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SData
 	}
 	if len(scsiDevs) == 0 {
 		key := from.FindMinDiffKey(1000)
-		deviceChange = append(deviceChange, addDevSpec(NewSCSIDev(key, 100, "scsi")))
+		driver := "pvscsi"
+		if host.isVersion50() {
+			driver = "scsi"
+		}
+		deviceChange = append(deviceChange, addDevSpec(NewSCSIDev(key, 100, driver)))
 		ctlKey = key
 	} else {
 		ctlKey = minDevKey(scsiDevs)
@@ -914,7 +918,7 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SData
 			// find same disk
 			var index int32
 			var key int32 = 2000
-			sameDisk := from.FindDiskByDriver("scsi")
+			sameDisk := from.FindDiskByDriver("scsi", "pvscsi")
 			index += int32(len(sameDisk))
 			if len(sameDisk) > 0 {
 				key = minDiskKey(sameDisk)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

parascsi 是 vmware 中一种高性能的 scsi 控制器。

在此之前，scsi 只包括 "lsilogic", "lsilogicsas", "buslogic"; 而别名为 pvscsi
的 parascsi 没有被包含进来；并且，一个 pci controller只能挂一个 scsi controller，
这会导致如果在一个拥有 pvscsi 的机器上添加普通scsi驱动类型的磁盘，就会替换驱动；
反之亦然。这会导致驱动的 key 不是我们指定的key，并且在添加磁盘的时候替换驱动的
类型有些随意。再者，我们的驱动类型的选择其实并没有暴露给前端。

尽量避免在创建磁盘的时候做硬件的改动，所以在创建磁盘的时候不区分 scsi 和 pvscsi，如果两种 controller 均没有，就按照请求的类型创建一个。

此外，在 CloneVM 的时候，如果支持，优先使用 parascsi。


**是否需要 backport 到之前的 release 分支**:
- release/3.0
- release/3.1
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
