### PR TITLE
fix: gcp win os not support change config when vm running

### DIFF
--- a/pkg/compute/guestdrivers/aliyun.go
+++ b/pkg/compute/guestdrivers/aliyun.go
@@ -93,7 +93,7 @@ func (self *SAliyunGuestDriver) GetRebuildRootStatus() ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 
-func (self *SAliyunGuestDriver) GetChangeConfigStatus() ([]string, error) {
+func (self *SAliyunGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 

--- a/pkg/compute/guestdrivers/aws.go
+++ b/pkg/compute/guestdrivers/aws.go
@@ -139,7 +139,7 @@ func (self *SAwsGuestDriver) GetRebuildRootStatus() ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 
-func (self *SAwsGuestDriver) GetChangeConfigStatus() ([]string, error) {
+func (self *SAwsGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
 	return []string{api.VM_READY}, nil
 }
 

--- a/pkg/compute/guestdrivers/azure.go
+++ b/pkg/compute/guestdrivers/azure.go
@@ -94,7 +94,7 @@ func (self *SAzureGuestDriver) GetRebuildRootStatus() ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 
-func (self *SAzureGuestDriver) GetChangeConfigStatus() ([]string, error) {
+func (self *SAzureGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 

--- a/pkg/compute/guestdrivers/baremetals.go
+++ b/pkg/compute/guestdrivers/baremetals.go
@@ -115,7 +115,7 @@ func (self *SBaremetalGuestDriver) GetRebuildRootStatus() ([]string, error) {
 	return []string{api.VM_READY, api.VM_ADMIN}, nil
 }
 
-func (self *SBaremetalGuestDriver) GetChangeConfigStatus() ([]string, error) {
+func (self *SBaremetalGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
 	return nil, httperrors.NewUnsupportOperationError("Cannot change config for baremtal")
 }
 

--- a/pkg/compute/guestdrivers/base.go
+++ b/pkg/compute/guestdrivers/base.go
@@ -128,7 +128,7 @@ func (self *SBaseGuestDriver) IsRebuildRootSupportChangeImage() bool {
 	return true
 }
 
-func (self *SBaseGuestDriver) GetChangeConfigStatus() ([]string, error) {
+func (self *SBaseGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
 	return []string{}, fmt.Errorf("This Guest driver dose not implement GetChangeConfigStatus")
 }
 

--- a/pkg/compute/guestdrivers/ctyun.go
+++ b/pkg/compute/guestdrivers/ctyun.go
@@ -73,7 +73,7 @@ func (self *SCtyunGuestDriver) GetAttachDiskStatus() ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 
-func (self *SCtyunGuestDriver) GetChangeConfigStatus() ([]string, error) {
+func (self *SCtyunGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
 	return []string{api.VM_READY}, nil
 }
 

--- a/pkg/compute/guestdrivers/esxi.go
+++ b/pkg/compute/guestdrivers/esxi.go
@@ -97,7 +97,7 @@ func (self *SESXiGuestDriver) GetAttachDiskStatus() ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 
-func (self *SESXiGuestDriver) GetChangeConfigStatus() ([]string, error) {
+func (self *SESXiGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
 	return []string{api.VM_READY}, nil
 }
 

--- a/pkg/compute/guestdrivers/google.go
+++ b/pkg/compute/guestdrivers/google.go
@@ -101,7 +101,11 @@ func (self *SGoogleGuestDriver) GetRebuildRootStatus() ([]string, error) {
 	return []string{api.VM_READY}, nil
 }
 
-func (self *SGoogleGuestDriver) GetChangeConfigStatus() ([]string, error) {
+func (self *SGoogleGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
+	// Google Windows Server not support change config when vm running
+	if strings.ToLower(guest.OsType) == strings.ToLower(osprofile.OS_TYPE_WINDOWS) {
+		return []string{api.VM_READY}, nil
+	}
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 

--- a/pkg/compute/guestdrivers/huawei.go
+++ b/pkg/compute/guestdrivers/huawei.go
@@ -83,7 +83,7 @@ func (self *SHuaweiGuestDriver) GetRebuildRootStatus() ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 
-func (self *SHuaweiGuestDriver) GetChangeConfigStatus() ([]string, error) {
+func (self *SHuaweiGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
 	return []string{api.VM_READY}, nil
 }
 

--- a/pkg/compute/guestdrivers/kvm.go
+++ b/pkg/compute/guestdrivers/kvm.go
@@ -371,7 +371,7 @@ func (self *SKVMGuestDriver) GetRebuildRootStatus() ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 
-func (self *SKVMGuestDriver) GetChangeConfigStatus() ([]string, error) {
+func (self *SKVMGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 

--- a/pkg/compute/guestdrivers/openstack.go
+++ b/pkg/compute/guestdrivers/openstack.go
@@ -106,7 +106,7 @@ func (self *SOpenStackGuestDriver) GetRebuildRootStatus() ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING, api.VM_REBUILD_ROOT_FAIL}, nil
 }
 
-func (self *SOpenStackGuestDriver) GetChangeConfigStatus() ([]string, error) {
+func (self *SOpenStackGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 

--- a/pkg/compute/guestdrivers/qcloud.go
+++ b/pkg/compute/guestdrivers/qcloud.go
@@ -91,7 +91,7 @@ func (self *SQcloudGuestDriver) GetRebuildRootStatus() ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 
-func (self *SQcloudGuestDriver) GetChangeConfigStatus() ([]string, error) {
+func (self *SQcloudGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 

--- a/pkg/compute/guestdrivers/ucloud.go
+++ b/pkg/compute/guestdrivers/ucloud.go
@@ -73,7 +73,7 @@ func (self *SUCloudGuestDriver) GetAttachDiskStatus() ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 
-func (self *SUCloudGuestDriver) GetChangeConfigStatus() ([]string, error) {
+func (self *SUCloudGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
 	return []string{api.VM_READY}, nil
 }
 

--- a/pkg/compute/guestdrivers/zstack.go
+++ b/pkg/compute/guestdrivers/zstack.go
@@ -101,7 +101,7 @@ func (self *SZStackGuestDriver) GetRebuildRootStatus() ([]string, error) {
 	return []string{api.VM_READY}, nil
 }
 
-func (self *SZStackGuestDriver) GetChangeConfigStatus() ([]string, error) {
+func (self *SZStackGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
 	return []string{api.VM_READY, api.VM_RUNNING}, nil
 }
 

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -2247,7 +2247,7 @@ func (self *SGuest) PerformChangeConfig(ctx context.Context, userCred mcclient.T
 		return nil, httperrors.NewBadRequestError("Guest have backup not allow to change config")
 	}
 
-	changeStatus, err := self.GetDriver().GetChangeConfigStatus()
+	changeStatus, err := self.GetDriver().GetChangeConfigStatus(self)
 	if err != nil {
 		return nil, httperrors.NewInputParameterError(err.Error())
 	}

--- a/pkg/compute/models/guestdrivers.go
+++ b/pkg/compute/models/guestdrivers.go
@@ -133,7 +133,7 @@ type IGuestDriver interface {
 	GetDetachDiskStatus() ([]string, error)
 	GetAttachDiskStatus() ([]string, error)
 	GetRebuildRootStatus() ([]string, error)
-	GetChangeConfigStatus() ([]string, error)
+	GetChangeConfigStatus(guest *SGuest) ([]string, error)
 	GetDeployStatus() ([]string, error)
 	ValidateResizeDisk(guest *SGuest, disk *SDisk, storage *SStorage) error
 	CanKeepDetachDisk() bool


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
gcp win os not support change config when vm running

**是否需要 backport 到之前的 release 分支**:
- release/3.1

/area region
/cc @swordqiu 
