### PR TITLE
Automated cherry pick of #5208: fix: reset paging limit to 2048 from 20

### DIFF
--- a/pkg/cloudcommon/consts/consts.go
+++ b/pkg/cloudcommon/consts/consts.go
@@ -29,7 +29,7 @@ var (
 
 	nonDefaultDomainProjects = false
 
-	defaultPagingLimit int64 = 20
+	defaultPagingLimit int64 = 2048
 	maxPagingLimit     int64 = 2048
 )
 


### PR DESCRIPTION
Cherry pick of #5208 on release/2.13.

#5208: fix: reset paging limit to 2048 from 20