### PR TITLE
Automated cherry pick of #5217: fix: Storage filter not work for Esxi

### DIFF
--- a/pkg/compute/guestdrivers/esxi.go
+++ b/pkg/compute/guestdrivers/esxi.go
@@ -50,6 +50,8 @@ func (self *SESXiGuestDriver) DoScheduleMemoryFilter() bool { return true }
 
 func (self *SESXiGuestDriver) DoScheduleSKUFilter() bool { return false }
 
+func (self *SESXiGuestDriver) DoScheduleStorageFilter() bool { return true }
+
 func (self *SESXiGuestDriver) GetHypervisor() string {
 	return api.HYPERVISOR_ESXI
 }

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -540,12 +540,16 @@ func (self *SHost) getStorages() []*SHostStorageAdapterInfo {
 }
 
 func (self *SHost) GetStorageSizeMB() int {
-	size := 0
-	storages := self.GetStorageInfo()
-	for i := 0; i < len(storages); i += 1 {
-		size += storages[i].Size
+	storages, err := self.GetIStorages()
+	if err != nil {
+		log.Errorf("SHost.GetStorageSizeMB: SHost.GetIStorages: %s", err)
+		return 0
 	}
-	return size
+	var size int64
+	for _, stor := range storages {
+		size += stor.GetCapacityMB()
+	}
+	return int(size)
 }
 
 func (self *SHost) GetStorageType() string {


### PR DESCRIPTION
Cherry pick of #5217 on release/2.12.

#5217: fix: Storage filter not work for Esxi