### PR TITLE
lbbackend: fix nil ref when getting details

### DIFF
--- a/pkg/compute/models/loadbalancerbackends.go
+++ b/pkg/compute/models/loadbalancerbackends.go
@@ -310,8 +310,9 @@ func (lbb *SLoadbalancerBackend) GetExtraDetails(ctx context.Context, userCred m
 	if err != nil {
 		log.Warningf("loadbalancer backend %s(%s): get vpc: %v", lbb.Name, lbb.Id, err)
 		return out, err
+	} else if vpc != nil {
+		out.VpcId = vpc.Id
 	}
-	out.VpcId = vpc.Id
 	return out, nil
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
Return arguments of lbbackend.getVpc() can be both nil

	[E 200224 10:13:18 httperrors.HTTPError(httperrors.go:53)] Send error {"fields":["runtime error: invalid memory address or nil pointer dereference"],"id":"Internal server error: {0}"}
	...
	panic(0x27da0c0, 0x57f4ff0)
		/usr/local/go/src/runtime/panic.go:522 +0x1b5
	yunion.io/x/onecloud/pkg/compute/models.(*SLoadbalancerBackend).GetExtraDetails(0xc0002af680, 0x33cde20, 0xc0010e61e0, 0x34246c0, 0xc008893de0, 0x341d940, 0xc012fe69d0, 0x1, 0x0, 0x0, ...)
		/data/git/yunion-build/work/go/src/yunion.io/x/onecloud/pkg/compute/models/loadbalancerbackends.go:314 +0x37c
	reflect.Value.call(0x2d87a00, 0xc0002af680, 0x8a13, 0x2db0aa8, 0x4, 0xc0044ad680, 0x4, 0x4, 0x2bd5d60, 0xc002a29cf0, ...)
		/usr/local/go/src/reflect/value.go:447 +0x461
	reflect.Value.Call(0x2d87a00, 0xc0002af680, 0x8a13, 0xc0044ad680, 0x4, 0x4, 0x2d87a00, 0xc0002af680, 0x16)
		/usr/local/go/src/reflect/value.go:308 +0xa4
	yunion.io/x/onecloud/pkg/cloudcommon/db.callFunc(0x2d87a00, 0xc0002af680, 0x8a13, 0xc000951688, 0x4, 0x4, 0xc0002af680, 0x8a13, 0x2dc0527, 0xb, ...)
		/data/git/yunion-build/work/go/src/yunion.io/x/onecloud/pkg/cloudcommon/db/caller.go:78 +0x397
	...
	[I 200224 10:13:18 appsrv.(*Application).ServeHTTP(appsrv.go:237)] MfQCvNyik-obRBzFjFZy5ARfXcE= 500 5c1d82 GET /loadbalancerbackends?backend_group=Yunion-Tools&details=true&limit=20&offset=0 (10.40.156.64:57606) 57.90ms

Fixes 76d974f6d ("feature: api -> response struct")
```

**是否需要 backport 到之前的 release 分支**:

NONE

@ioito @swordqiu 