### PR TITLE
miscfix : host init set reserve memory

### DIFF
--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -372,9 +372,11 @@ func (self *SGuestnetwork) getJsonDescAtHost(host *SHost) jsonutils.JSONObject {
 
 func (self *SGuestnetwork) getJsonDescHostwire(network *SNetwork, hostwire *SHostwire) *jsonutils.JSONDict {
 	desc := self.getJsonDesc(network)
-	desc.Add(jsonutils.NewString(hostwire.Bridge), "bridge")
-	desc.Add(jsonutils.NewString(hostwire.WireId), "wire_id")
-	desc.Add(jsonutils.NewString(hostwire.Interface), "interface")
+	if hostwire != nil {
+		desc.Add(jsonutils.NewString(hostwire.Bridge), "bridge")
+		desc.Add(jsonutils.NewString(hostwire.WireId), "wire_id")
+		desc.Add(jsonutils.NewString(hostwire.Interface), "interface")
+	}
 	return desc
 }
 

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -705,7 +705,6 @@ func (h *SHostInfo) fetchAccessNetworkInfo() {
 	params := jsonutils.NewDict()
 	params.Set("ip", jsonutils.NewString(masterIp))
 	params.Set("is_on_premise", jsonutils.JSONTrue)
-	params.Set("server_type", jsonutils.NewString(api.NETWORK_TYPE_BAREMETAL))
 	params.Set("limit", jsonutils.NewInt(0))
 
 	res, err := modules.Networks.List(h.GetSession(), params)

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -705,6 +705,7 @@ func (h *SHostInfo) fetchAccessNetworkInfo() {
 	params := jsonutils.NewDict()
 	params.Set("ip", jsonutils.NewString(masterIp))
 	params.Set("is_on_premise", jsonutils.JSONTrue)
+	params.Set("server_type", jsonutils.NewString(api.NETWORK_TYPE_BAREMETAL))
 	params.Set("limit", jsonutils.NewInt(0))
 
 	res, err := modules.Networks.List(h.GetSession(), params)

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -856,6 +856,9 @@ func (h *SHostInfo) updateHostRecord(hostId string) {
 		h.onFail(err)
 	}
 	content.Set("mem_size", jsonutils.NewInt(int64(memTotal)))
+	if len(hostId) == 0 {
+		content.Set("mem_reserved", jsonutils.NewInt(int64(h.getReservedMem())))
+	}
 	content.Set("storage_driver", jsonutils.NewString(api.DISK_DRIVER_LINUX))
 	content.Set("storage_type", jsonutils.NewString(h.sysinfo.StorageType))
 	content.Set("storage_size", jsonutils.NewInt(int64(storageman.GetManager().GetTotalCapacity())))

--- a/pkg/hostman/storageman/storage_rbd.go
+++ b/pkg/hostman/storageman/storage_rbd.go
@@ -59,6 +59,10 @@ type SRbdStorage struct {
 func NewRBDStorage(manager *SStorageManager, path string) *SRbdStorage {
 	var ret = new(SRbdStorage)
 	ret.SBaseStorage = *NewBaseStorage(manager, path)
+	err := procutils.NewRemoteCommandAsFarAsPossible("mkdir", "-p", "/etc/ceph").Run()
+	if err != nil {
+		log.Errorf("Failed to mkdir /etc/ceph: %s", err)
+	}
 	return ret
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
- host init set reserve memory
- fix guest network get desc
- fix host register get network filter: add server_type baremetal
- makesure /etc/ceph created before connect

**是否需要 backport 到之前的 release 分支**:
release/2.13
/area region host
/cc @swordqiu @ioito 
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
