### PR TITLE
Automated cherry pick of #5252: fix: use globalEndpointType as default endpoint type

### DIFF
--- a/pkg/compute/service/influxdb.go
+++ b/pkg/compute/service/influxdb.go
@@ -23,7 +23,7 @@ import (
 )
 
 func setInfluxdbRetentionPolicy() error {
-	urls, err := auth.GetServiceURLs("influxdb", options.Options.Region, "", "internal")
+	urls, err := auth.GetServiceURLs("influxdb", options.Options.Region, "", "")
 	if err != nil {
 		return err
 	}

--- a/pkg/hostman/storageman/imagecache_local.go
+++ b/pkg/hostman/storageman/imagecache_local.go
@@ -174,7 +174,7 @@ func (l *SLocalImageCache) prepare(ctx context.Context, zone, srcUrl, format str
 		l.consumerCount++
 		return true, true
 	}
-	url, err := auth.GetServiceURL("image", "", zone, "public")
+	url, err := auth.GetServiceURL("image", "", zone, "")
 	if err != nil {
 		log.Errorf("Failed to acquire image %s", err)
 		return false, true

--- a/pkg/mcclient/auth/auth.go
+++ b/pkg/mcclient/auth/auth.go
@@ -210,10 +210,16 @@ func (a *authManager) reAuth() {
 }
 
 func (a *authManager) GetServiceURL(service, region, zone, endpointType string) (string, error) {
+	if endpointType == "" && globalEndpointType != "" {
+		endpointType = globalEndpointType
+	}
 	return a.adminCredential.GetServiceURL(service, region, zone, endpointType)
 }
 
 func (a *authManager) GetServiceURLs(service, region, zone, endpointType string) ([]string, error) {
+	if endpointType == "" && globalEndpointType != "" {
+		endpointType = globalEndpointType
+	}
 	return a.adminCredential.GetServiceURLs(service, region, zone, endpointType)
 }
 


### PR DESCRIPTION
Cherry pick of #5252 on release/3.1.

#5252: fix: use globalEndpointType as default endpoint type