### PR TITLE
fix(esxiagent): SSHKey was not unmarshalled correctly

### DIFF
--- a/pkg/hostman/storageman/storage_agent.go
+++ b/pkg/hostman/storageman/storage_agent.go
@@ -246,7 +246,7 @@ func (as *SAgentStorage) AgentDeployGuest(ctx context.Context, data interface{})
 	rootPath := disks[0].(*esxi.SVirtualDisk).GetFilename()
 
 	key := deployapi.SSHKeys{}
-	err = dataDict.Unmarshal(&key, "desc")
+	err = dataDict.Unmarshal(&key)
 	if err != nil {
 		return nil, errors.Wrapf(err, "%s: unmarshal to deployapi.SSHKeys", hostutils.ParamsError.Error())
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

sshkey 没有被正确地 unmarshall 到

**是否需要 backport 到之前的 release 分支**:
- release/3.0
- release/3.1
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
