### PR TITLE
Automated cherry pick of #5263: fix(esxiagent): SSHKey was not unmarshalled correctly

### DIFF
--- a/pkg/hostman/storageman/storage_agent.go
+++ b/pkg/hostman/storageman/storage_agent.go
@@ -253,7 +253,7 @@ func (as *SAgentStorage) AgentDeployGuest(ctx context.Context, data interface{})
 	rootPath := disks[0].(*esxi.SVirtualDisk).GetFilename()
 
 	key := deployapi.SSHKeys{}
-	err = dataDict.Unmarshal(&key, "desc")
+	err = dataDict.Unmarshal(&key)
 	if err != nil {
 		return nil, errors.Wrapf(err, "%s: unmarshal to deployapi.SSHKeys", hostutils.ParamsError.Error())
 	}


### PR DESCRIPTION
Cherry pick of #5263 on release/3.0.

#5263: fix(esxiagent): SSHKey was not unmarshalled correctly