### PR TITLE
vpcagent: as k8s container

### DIFF
--- a/build/docker/Dockerfile.host
+++ b/build/docker/Dockerfile.host
@@ -1,11 +1,9 @@
-FROM registry.cn-beijing.aliyuncs.com/yunionio/host-base:v0.0.1
+FROM registry.cn-beijing.aliyuncs.com/yunionio/host-base:v0.1.0
 
 MAINTAINER "Yaoqi Wan wanyaoqi@yunionyun.com"
 
 ENV TZ Asia/Shanghai
 
+RUN apk add librados librbd
 RUN mkdir -p /opt/yunion/bin
-
-ADD ./_output/bin/host /opt/yunion/bin/host
-ADD ./_output/bin/.host.bin /opt/yunion/bin/.host.bin
-ADD ./_output/bin/bundles/host /opt/yunion/bin/bundles/host
+ADD ./_output/alpine-build/bin/host /opt/yunion/bin/host

--- a/build/docker/Dockerfile.vpcagent
+++ b/build/docker/Dockerfile.vpcagent
@@ -1,0 +1,6 @@
+FROM registry.cn-beijing.aliyuncs.com/yunionio/openvswitch:2.9.6-1
+
+MAINTAINER "Yousong Zhou <zhouyousong@yunion.cn>"
+
+RUN mkdir -p /opt/yunion/bin
+ADD ./_output/alpine-build/bin/vpcagent /opt/yunion/bin/vpcagent

--- a/pkg/hostman/hostinfo/hostinfohelper.go
+++ b/pkg/hostman/hostinfo/hostinfohelper.go
@@ -95,7 +95,7 @@ func DetectCpuInfo() (*SCPUInfo, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "parse dmi cpuinfo")
 	}
-	cpuArch, err := procutils.NewCommand("uname", "-p").Output()
+	cpuArch, err := procutils.NewCommand("uname", "-m").Output()
 	if err != nil {
 		return nil, errors.Wrap(err, "get cpu architecture")
 	}

--- a/pkg/hostman/hostinfo/hostovn.go
+++ b/pkg/hostman/hostinfo/hostovn.go
@@ -22,6 +22,7 @@ import (
 	"yunion.io/x/onecloud/pkg/hostman/options"
 	"yunion.io/x/onecloud/pkg/hostman/system_service"
 	"yunion.io/x/onecloud/pkg/util/netutils2"
+	"yunion.io/x/onecloud/pkg/util/ovsutils"
 	"yunion.io/x/onecloud/pkg/util/procutils"
 )
 
@@ -80,6 +81,11 @@ func (oh *OvnHelper) mustPrepOvsdbConfig() {
 		if opts.OvnSouthDatabase == "" {
 			panic(errors.Wrap(ErrOvnConfig, "bad config: ovn_south_database"))
 		}
+		db, err := ovsutils.NormalizeDbHost(opts.OvnSouthDatabase)
+		if err != nil {
+			panic(errors.Wrap(err, "normalize db host"))
+		}
+		opts.OvnSouthDatabase = db
 		args = append(args, fmt.Sprintf("external_ids:ovn-remote=%s",
 			opts.OvnSouthDatabase))
 	}

--- a/pkg/util/ovsutils/ovsutils.go
+++ b/pkg/util/ovsutils/ovsutils.go
@@ -15,10 +15,13 @@
 package ovsutils
 
 import (
+	"fmt"
+	"net"
 	"regexp"
 	"strings"
 
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/utils"
 
 	"yunion.io/x/onecloud/pkg/util/procutils"
@@ -102,4 +105,24 @@ func CleanAllHiddenPorts() {
 	for _, br := range brs {
 		CleanHiddenPorts(br)
 	}
+}
+
+func NormalizeDbHost(db string) (string, error) {
+	if strings.HasPrefix(db, "tcp:") {
+		host, port, err := net.SplitHostPort(db[4:])
+		if err != nil {
+			return "", errors.Wrapf(err, "split host port: %s", db)
+		}
+		if ip := net.ParseIP(host); len(ip) == 0 {
+			addrs, err := net.LookupHost(host)
+			if err != nil {
+				return "", errors.Wrapf(err, "dns lookup (%s) failed", host)
+			}
+			if len(addrs) == 0 {
+				return "", fmt.Errorf("dns lookup (%s) returned empty result", host)
+			}
+			return "tcp:" + addrs[0] + ":" + port, nil
+		}
+	}
+	return db, nil
 }

--- a/pkg/util/sysutils/hostname.go
+++ b/pkg/util/sysutils/hostname.go
@@ -22,7 +22,7 @@ import (
 )
 
 func setHostname7(name string) error {
-	return procutils.NewCommand("hostnamectl", "set-hostname", name).Run()
+	return procutils.NewRemoteCommandAsFarAsPossible("hostnamectl", "set-hostname", name).Run()
 }
 
 func setHostname6(name string) error {

--- a/pkg/vpcagent/options/options.go
+++ b/pkg/vpcagent/options/options.go
@@ -19,6 +19,7 @@ import (
 
 	"yunion.io/x/onecloud/pkg/apis/compute"
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
+	"yunion.io/x/onecloud/pkg/util/ovsutils"
 )
 
 const (
@@ -27,6 +28,7 @@ const (
 
 const (
 	ErrInvalidVpcProvider = errors.Error("invalid vpc provider")
+	ErrInvalidOvnDatabase = errors.Error("invalid ovn database")
 )
 
 type VpcAgentOptions struct {
@@ -63,6 +65,12 @@ func (opts *Options) ValidateThenInit() error {
 
 	if opts.OvnWorkerCheckInterval <= 60 {
 		opts.OvnWorkerCheckInterval = 60
+	}
+
+	if db, err := ovsutils.NormalizeDbHost(opts.OvnNorthDatabase); err != nil {
+		return err
+	} else {
+		opts.OvnNorthDatabase = db
 	}
 	return nil
 }

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -34,11 +34,21 @@ REGISTRY=${REGISTRY:-docker.io/yunion}
 TAG=${TAG:-latest}
 
 build_bin() {
-    if [[ "$1" == "climc" ]]; then
-        GOOS=linux make cmd/$1 cmd/*cli
-    else
-        GOOS=linux make cmd/$1
-    fi
+	case "$1" in
+		climc)
+			GOOS=linux make cmd/$1 cmd/*cli
+			;;
+		vpcagent)
+			docker run --rm \
+				-v $SRC_DIR:/root/go/src/yunion.io/x/onecloud \
+				-v $SRC_DIR/_output/alpine-build:/root/go/src/yunion.io/x/onecloud/_output \
+				registry.cn-beijing.aliyuncs.com/yunionio/alpine-build:1.0-1 \
+				/bin/sh -c "set -ex; cd /root/go/src/yunion.io/x/onecloud; make cmd/$1"
+			;;
+		*)
+			GOOS=linux make cmd/$1
+			;;
+	esac
 }
 
 

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -38,7 +38,7 @@ build_bin() {
 		climc)
 			GOOS=linux make cmd/$1 cmd/*cli
 			;;
-		vpcagent)
+		vpcagent|host)
 			docker run --rm \
 				-v $SRC_DIR:/root/go/src/yunion.io/x/onecloud \
 				-v $SRC_DIR/_output/alpine-build:/root/go/src/yunion.io/x/onecloud/_output \
@@ -53,12 +53,9 @@ build_bin() {
 
 
 build_bundle_libraries() {
-    for bundle_component in 'host' 'host-deployer' 'baremetal-agent'; do
+    for bundle_component in 'host-deployer' 'baremetal-agent'; do
         if [ $1 == $bundle_component ]; then
             $CUR_DIR/bundle_libraries.sh _output/bin/bundles/$1 _output/bin/$1
-            if [ $bundle_component == 'host' ]; then
-                $CUR_DIR/host_find_libraries.sh _output/bin/bundles/$1
-            fi
             break
         fi
     done


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
build: host: adjust build method
build: build vpcagent container
hostman: use "uname -m" for for fetch processor type
hostman: work with ovn-controller already in container
sysutils: use remote executor for hostnamectl as far as possible
vpcagent: resolve ovn db address at args validation time
```

**是否需要 backport 到之前的 release 分支**:

- release/3.1

/area vpcagent
/cc @swordqiu @zexi @wanyaoqi 