### PR TITLE
Automated cherry pick of #5275: fix: 谷歌云建议关机下调整配置，部分linux开机也调整不了配置

### DIFF
--- a/pkg/compute/guestdrivers/google.go
+++ b/pkg/compute/guestdrivers/google.go
@@ -102,11 +102,7 @@ func (self *SGoogleGuestDriver) GetRebuildRootStatus() ([]string, error) {
 }
 
 func (self *SGoogleGuestDriver) GetChangeConfigStatus(guest *models.SGuest) ([]string, error) {
-	// Google Windows Server not support change config when vm running
-	if strings.ToLower(guest.OsType) == strings.ToLower(osprofile.OS_TYPE_WINDOWS) {
-		return []string{api.VM_READY}, nil
-	}
-	return []string{api.VM_READY, api.VM_RUNNING}, nil
+	return []string{api.VM_READY}, nil
 }
 
 func (self *SGoogleGuestDriver) GetDeployStatus() ([]string, error) {


### PR DESCRIPTION
Cherry pick of #5275 on release/3.1.

#5275: fix: 谷歌云建议关机下调整配置，部分linux开机也调整不了配置