### PR TITLE
Automated cherry pick of #5286: host register use default vpc

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -706,6 +706,8 @@ func (h *SHostInfo) fetchAccessNetworkInfo() {
 	params.Set("ip", jsonutils.NewString(masterIp))
 	params.Set("is_on_premise", jsonutils.JSONTrue)
 	params.Set("limit", jsonutils.NewInt(0))
+	// use default vpc
+	params.Set("vpc", jsonutils.NewString("Default"))
 
 	res, err := modules.Networks.List(h.GetSession(), params)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #5286 on release/3.1.

#5286: host register use default vpc