### PR TITLE
fix: approve_all fail to pull all cherry-pick PRs

### DIFF
--- a/scripts/approve_all.sh
+++ b/scripts/approve_all.sh
@@ -26,7 +26,7 @@ done
 
 PRNS=("$PRN")
 
-for INDEX in $(python -m json.tool $pulldata | grep "\"title\":" | cut -d '"' -f 4 | grep -nr "Automated cherry pick of #${PRN}:" | awk 'BEGIN{FS=":"}{print $2}')
+for INDEX in $(python -m json.tool $pulldata | grep "\"title\":" | cut -d '"' -f 4 | grep -n "Automated cherry pick of #${PRN}:" | awk 'BEGIN{FS=":"}{print $1}')
 do
     INDEX=$((INDEX-1))
     PRNS+=("${PR_NUMBERS[$INDEX]}")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正approve_all脚本在Linux下无法获得所有的cherry pick PR列表

**是否需要 backport 到之前的 release 分支**:
NONE

/are util

/cc @zexi 