### PR TITLE
Automated cherry pick of #5303: build: github: add back ceph devel deps for baremetal-agent

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Build
       run: |
         sudo apt-get update
+        sudo apt-get install librados-dev librbd-dev # baremetal-agent needs this
         make cmd/apigateway cmd/climc cmd/keystone
         make cmd/logger cmd/region cmd/scheduler cmd/webconsole
         make cmd/yunionconf cmd/glance cmd/torrent cmd/s3gateway


### PR DESCRIPTION
Cherry pick of #5303 on release/3.1.

#5303: build: github: add back ceph devel deps for baremetal-agent