### PR TITLE
fix bm register get remote address 

### DIFF
--- a/pkg/baremetal/handler/middleware.go
+++ b/pkg/baremetal/handler/middleware.go
@@ -156,11 +156,15 @@ func bmRegisterMiddleware(h bmRegisterFunc) appsrv.FilterHandler {
 			newCtx.ResponseError(httperrors.NewMissingParameterError("hostname"))
 			return
 		}
-		remoteIp, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			newCtx.ResponseError(httperrors.NewInternalServerError("Parse ip error %s", err))
-			return
+		remoteIp, _ := newCtx.Data().GetString("ssh_ip")
+		if len(remoteIp) == 0 {
+			remoteIp, _, err = net.SplitHostPort(r.RemoteAddr)
+			if err != nil {
+				newCtx.ResponseError(httperrors.NewInternalServerError("Parse ip error %s", err))
+				return
+			}
 		}
+
 		sshPort, err := newCtx.Data().Int("ssh_port")
 		if err != nil {
 			newCtx.ResponseError(httperrors.NewMissingParameterError("ssh_port"))


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix bm register get remote address  because of http request is proxyed by k8s
RT
**是否需要 backport 到之前的 release 分支**:
release/3.0
/cc @swordqiu  @zexi 
/area region baremetal
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
