### PR TITLE
fix: 避免旧套餐下架zone信息未知,导致同步rds异常

### DIFF
--- a/pkg/compute/models/dbinstances.go
+++ b/pkg/compute/models/dbinstances.go
@@ -1304,7 +1304,7 @@ func (self *SDBInstance) SyncWithCloudDBInstance(ctx context.Context, userCred m
 		self.ZoneId = extInstance.GetIZoneId()
 		err := self.setZoneInfo()
 		if err != nil {
-			return errors.Wrap(err, "setZoneInfo")
+			log.Errorf("failed to set zone info for dbinstance %s(%s) error: %v", self.Name, self.Id, err)
 		}
 
 		if createdAt := extInstance.GetCreatedAt(); !createdAt.IsZero() {
@@ -1371,7 +1371,7 @@ func (manager *SDBInstanceManager) newFromCloudDBInstance(ctx context.Context, u
 	instance.ZoneId = extInstance.GetIZoneId()
 	err = instance.setZoneInfo()
 	if err != nil {
-		return nil, errors.Wrap(err, "instance.setZoneInfo")
+		log.Errorf("failed to set zone info for dbinstance %s error: %v", instance.ExternalId, err)
 	}
 
 	if secgroupId := extInstance.GetSecurityGroupId(); len(secgroupId) > 0 {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免旧套餐下架zone信息未知,导致同步rds异常

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @swordqiu 
