### PR TITLE
Automated cherry pick of #5320: build: docker: chown _output dir to current user:group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,7 @@ set -o pipefail
 cd /home/build/onecloud
 export GOFLAGS=-mod=vendor
 make $(1)
+chown -R $(shell id -u):$(shell id -g) _output
 endef
 
 docker-centos-build: export dockerCentOSBuildCmd:=$(call dockerCentOSBuildCmd,$(F))
@@ -230,6 +231,7 @@ set -o pipefail
 cd /root/go/src/yunion.io/x/onecloud
 export GOFLAGS=-mod=vendor
 make $(1)
+chown -R $(shell id -u):$(shell id -g) _output
 endef
 
 docker-alpine-build: export dockerAlpineBuildCmd:=$(call dockerAlpineBuildCmd,$(F))

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -43,7 +43,7 @@ build_bin() {
 				-v $SRC_DIR:/root/go/src/yunion.io/x/onecloud \
 				-v $SRC_DIR/_output/alpine-build:/root/go/src/yunion.io/x/onecloud/_output \
 				registry.cn-beijing.aliyuncs.com/yunionio/alpine-build:1.0-1 \
-				/bin/sh -c "set -ex; cd /root/go/src/yunion.io/x/onecloud; make cmd/$1"
+				/bin/sh -c "set -ex; cd /root/go/src/yunion.io/x/onecloud; make cmd/$1; chown -R $(id -u):$(id -g) _output"
 			;;
 		*)
 			GOOS=linux make cmd/$1


### PR DESCRIPTION
Cherry pick of #5320 on release/3.1.

#5320: build: docker: chown _output dir to current user:group