### PR TITLE
Automated cherry pick of #5324: fix: clean up pending usage no matter whether object upload is success

### DIFF
--- a/pkg/compute/models/buckets.go
+++ b/pkg/compute/models/buckets.go
@@ -939,6 +939,9 @@ func (bucket *SBucket) PerformUpload(
 		if err := quotas.CheckSetPendingQuota(ctx, userCred, &pendingUsage); err != nil {
 			return nil, httperrors.NewOutOfQuotaError("%s", err)
 		}
+
+		// always cancel pending usage
+		defer quotas.CancelPendingUsage(ctx, userCred, &pendingUsage, &pendingUsage)
 	}
 
 	err = cloudprovider.UploadObject(ctx, iBucket, key, 0, appParams.Request.Body, sizeBytes, cloudprovider.TBucketACLType(aclStr), storageClass, meta, false)
@@ -950,10 +953,6 @@ func (bucket *SBucket) PerformUpload(
 	logclient.AddActionLogWithContext(ctx, bucket, logclient.ACT_UPLOAD_OBJECT, key, userCred, true)
 
 	bucket.syncWithCloudBucket(ctx, userCred, iBucket, nil, true)
-
-	if !pendingUsage.IsEmpty() {
-		quotas.CancelPendingUsage(ctx, userCred, &pendingUsage, &pendingUsage)
-	}
 
 	return nil, nil
 }


### PR DESCRIPTION
Cherry pick of #5324 on release/3.1.

#5324: fix: clean up pending usage no matter whether object upload is success