### PR TITLE
feat: Add useridByMobile and accessToken cache for feishu

### DIFF
--- a/pkg/monitor/notifydrivers/feishu/cache.go
+++ b/pkg/monitor/notifydrivers/feishu/cache.go
@@ -1,0 +1,68 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package feishu
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"time"
+)
+
+type IExpirable interface {
+	CreatedAt() int64
+	ExpiresIn() int64
+}
+
+type ICache interface {
+	Set(data IExpirable) error
+	Get(data IExpirable) error
+}
+
+type FileCache struct {
+	Path string
+}
+
+func NewFileCache(path string) *FileCache {
+	return &FileCache{
+		Path: path,
+	}
+}
+
+func (c *FileCache) Set(data IExpirable) error {
+	bytes, err := json.Marshal(data)
+	if err == nil {
+		ioutil.WriteFile(c.Path, bytes, 0644)
+	}
+	return err
+}
+
+func (c *FileCache) Get(data IExpirable) error {
+	bytes, err := ioutil.ReadFile(c.Path)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(bytes, data)
+	if err != nil {
+		return err
+	}
+	created := data.CreatedAt()
+	expires := data.ExpiresIn()
+	// The operator '-120' can give us a head start on the expiration date
+	if time.Now().Unix() > created+expires-120 {
+		err = fmt.Errorf("Data is already expired")
+	}
+	return err
+}

--- a/pkg/monitor/notifydrivers/feishu/cache_test.go
+++ b/pkg/monitor/notifydrivers/feishu/cache_test.go
@@ -1,0 +1,65 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package feishu
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestFileCache(t *testing.T) {
+	token := "atokeexamplenomeaning"
+	cache := NewFileCache(".test_auth_file")
+	defer func() {
+		os.Remove(".test_auth_file")
+	}()
+	t.Run("unexpired", func(t *testing.T) {
+		tokenIn := TenantAccesstoken{
+			TenantAccessToken: token,
+			Expire:            3600,
+			Created:           time.Now().Unix(),
+		}
+		err := cache.Set(tokenIn)
+		if err != nil {
+			t.Fatalf("cache set error: %s", err)
+		}
+		var tokenOut TenantAccesstoken
+		err = cache.Get(&tokenOut)
+		if err != nil {
+			t.Fatalf("cache get error: %s", err)
+		}
+		if tokenIn.TenantAccessToken != tokenOut.TenantAccessToken {
+			t.Fatalf("the token value stored in cache is incorrect")
+		}
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		tokenIn := TenantAccesstoken{
+			TenantAccessToken: token,
+			Expire:            119,
+			Created:           time.Now().Unix(),
+		}
+		err := cache.Set(tokenIn)
+		if err != nil {
+			t.Fatalf("cache set error: %s", err)
+		}
+		var tokenOut TenantAccesstoken
+		err = cache.Get(&tokenOut)
+		if err == nil {
+			t.Fatalf("Getting expired token from cache should produce an error")
+		}
+	})
+}

--- a/pkg/monitor/notifydrivers/feishu/types.go
+++ b/pkg/monitor/notifydrivers/feishu/types.go
@@ -14,6 +14,8 @@
 
 package feishu
 
+import "yunion.io/x/jsonutils"
+
 type CommonResp struct {
 	Code int    `json:"code"`
 	Msg  string `json:"msg"`
@@ -34,8 +36,21 @@ type CommonResponser interface {
 
 type TenantAccesstokenResp struct {
 	CommonResp
+	TenantAccesstoken
+}
+
+type TenantAccesstoken struct {
 	TenantAccessToken string `json:"tenant_access_token"`
 	Expire            int64  `json:"expire"`
+	Created           int64
+}
+
+func (t TenantAccesstoken) CreatedAt() int64 {
+	return t.Created
+}
+
+func (t TenantAccesstoken) ExpiresIn() int64 {
+	return t.Expire
 }
 
 type GroupListResp struct {
@@ -223,4 +238,17 @@ type MsgResp struct {
 
 type MsgRespData struct {
 	MessageId string `json:"message_id"`
+}
+
+type UserIDResp struct {
+	CommonResp
+
+	Data UserIDRespData `json:"data"`
+}
+
+type UserIDRespData struct {
+	EmailUsers      jsonutils.JSONObject `json:"email_users"`
+	EmailsNotExist  []string             `json:"emails_not_exist"`
+	MobileUsers     jsonutils.JSONObject `json:"mobile_users"`
+	MobilesNotExist []string             `json:"mobiles_not_exist"`
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

为飞书的SDK添加了，accessToken cache 功能以及 useridByMobile功能

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->

/cc @zexi @swordqiu 