### PR TITLE
fix: keystone user password history check should skip system account

### DIFF
--- a/pkg/keystone/models/passwords.go
+++ b/pkg/keystone/models/passwords.go
@@ -112,12 +112,12 @@ func validatePasswordComplexity(password string) error {
 	return nil
 }
 
-func (manager *SPasswordManager) validatePassword(localUserId int, password string) error {
+func (manager *SPasswordManager) validatePassword(localUserId int, password string, skipHistoryCheck bool) error {
 	err := validatePasswordComplexity(password)
 	if err != nil {
 		return errors.Wrap(err, "validatePasswordComplexity")
 	}
-	if o.Options.PasswordUniqueHistoryCheck > 0 {
+	if !skipHistoryCheck && o.Options.PasswordUniqueHistoryCheck > 0 {
 		shaPass := shaPassword(password)
 		histPasses, err := manager.fetchByLocaluserId(localUserId)
 		if err != nil {

--- a/pkg/keystone/models/users.go
+++ b/pkg/keystone/models/users.go
@@ -468,7 +468,11 @@ func (user *SUser) ValidateUpdateData(ctx context.Context, userCred mcclient.Tok
 		if err != nil {
 			return nil, errors.Wrap(err, "UserManager.FetchUserExtended")
 		}
-		err = PasswordManager.validatePassword(usrExt.LocalId, passwd)
+		skipHistoryCheck := false
+		if user.IsSystemAccount.Bool() {
+			skipHistoryCheck = true
+		}
+		err = PasswordManager.validatePassword(usrExt.LocalId, passwd, skipHistoryCheck)
 		if err != nil {
 			return nil, httperrors.NewInputParameterError("invalid password: %s", err)
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：keystone的用户密码重复检查不对system account用户生效

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1

/area keystone

/cc @zexi 