### PR TITLE
feature(notify): Add query and return value for contact UPDATE interface

### DIFF
--- a/cmd/climc/shell/contacts.go
+++ b/cmd/climc/shell/contacts.go
@@ -29,11 +29,11 @@ func init() {
 	 * 操作用户的通信地址（如果用户的通信地址不存在则进行添加；如果已存在则进行修改；如果设置空则进行删除。）
 	 */
 	type ContactsUpdateOptions struct {
-		UID            string `help:"The user you wanna add contact to (Keystone User ID)"`
-		CONTACTTYPE    string `help:"The contact type email|mobile" choices:"email|mobile|dingtalk"`
-		CONTACT        string `help:"The contacts details mobile number or email address or dingtalk's userid, if set it the empty str means delete"`
-		Status         string `help:"Enabled or disabled contact status" choices:"enable|disable"`
-		UpdateDingtalk bool   `help:"if update dingtalk"`
+		UID         string `help:"The user you wanna add contact to (Keystone User ID)"`
+		CONTACTTYPE string `help:"The contact type email|mobile" choices:"email|mobile|dingtalk"`
+		CONTACT     string `help:"The contacts details mobile number or email address or dingtalk's userid, if set it the empty str means delete"`
+		Status      string `help:"Enabled or disabled contact status" choices:"enable|disable"`
+		Pull        string `help:"pull some subcontacts(e.g., dingtalk, feishu, etc) related to mobile"`
 	}
 	R(&ContactsUpdateOptions{}, "contact-update", "Create, delete or update contact for user", func(s *mcclient.ClientSession, args *ContactsUpdateOptions) error {
 		arr := jsonutils.NewArray()
@@ -52,16 +52,27 @@ func init() {
 
 		params := jsonutils.NewDict()
 		params.Add(arr, "contacts")
-		if args.UpdateDingtalk {
-			params.Add(jsonutils.JSONTrue, "update_dingtalk")
-		}
 
-		contact, err := modules.Contacts.CustomizedPerformAction(s, args.UID, "update-contact", params)
-
+		contact, err := modules.Contacts.CustomizedPerformAction(s, args.UID, "update-contact", args.Pull, params)
 		if err != nil {
 			return err
 		}
 
+		printObject(contact)
+		return nil
+	})
+
+	type ContactsPullOptions struct {
+		UID         string `help:"The user you wanna pull contact"`
+		CONTACTTYPE string `help:"The contact type"`
+	}
+	R(&ContactsPullOptions{}, "contact-pull", "Pull contact", func(s *mcclient.ClientSession, args *ContactsPullOptions) error {
+		params := jsonutils.NewDict()
+		params.Set("contacts", jsonutils.NewArray())
+		contact, err := modules.Contacts.CustomizedPerformAction(s, args.UID, "update-contact", args.CONTACTTYPE, params)
+		if err != nil {
+			return err
+		}
 		printObject(contact)
 		return nil
 	})
@@ -78,7 +89,7 @@ func init() {
 		arr.Add(tmpObj)
 		params := jsonutils.NewDict()
 		params.Add(arr, "contacts")
-		contact, err := modules.Contacts.CustomizedPerformAction(s, args.UID, "update-contact", params)
+		contact, err := modules.Contacts.CustomizedPerformAction(s, args.UID, "update-contact", "", params)
 		if err != nil {
 			return err
 		}
@@ -169,7 +180,7 @@ func init() {
 		tmpDict := jsonutils.NewDict()
 		tmpDict.Add(jsonutils.NewString(args.CONTACT_TYPE), "contact_type")
 		tmpDict.Add(jsonutils.NewString(args.CONTACT), "contact")
-		_, err := modules.Contacts.CustomizedPerformAction(s, args.UID, "verify", tmpDict)
+		_, err := modules.Contacts.CustomizedPerformAction(s, args.UID, "verify", "", tmpDict)
 		if err != nil {
 			return err
 		}

--- a/cmd/climc/shell/notification.go
+++ b/cmd/climc/shell/notification.go
@@ -29,7 +29,7 @@ func init() {
 	 */
 
 	type NotificationCreateOptions struct {
-		CONTACTTYPE string `help:"User's contacts type" choices:"email|mobile|dingtalk|webconsole"`
+		CONTACTTYPE string `help:"User's contacts type"`
 		TOPIC       string `help:"Title or topic of the notification"`
 		PRIORITY    string `help:"Priority of the notification" choices:"normal|important|fatal"`
 		MSG         string `help:"The content of the notification"`

--- a/pkg/mcclient/modules/mod_contacts.go
+++ b/pkg/mcclient/modules/mod_contacts.go
@@ -45,7 +45,7 @@ func (this *ContactsManager) DoBatchDeleteContacts(s *mcclient.ClientSession, pa
 	return modulebase.Post(this.ResourceManager, s, path, params, this.Keyword)
 }
 
-func (this *ContactsManager) CustomizedPerformAction(session *mcclient.ClientSession, id string, action string,
+func (this *ContactsManager) CustomizedPerformAction(session *mcclient.ClientSession, id, action, pull string,
 	params jsonutils.JSONObject) (jsonutils.JSONObject, error) {
 
 	body := jsonutils.NewDict()
@@ -53,7 +53,10 @@ func (this *ContactsManager) CustomizedPerformAction(session *mcclient.ClientSes
 		body.Add(params, this.Keyword)
 	}
 	path := fmt.Sprintf("/%s/%s/%s?uname=true", this.ContextPath(nil), url.PathEscape(id), url.PathEscape(action))
-	return modulebase.Post(this.ResourceManager, session, path, params, this.KeywordPlural)
+	if len(pull) > 0 {
+		path += fmt.Sprintf("&pull=%s", pull)
+	}
+	return modulebase.Post(this.ResourceManager, session, path, body, this.KeywordPlural)
 }
 
 func (this *ContactsManager) CustomizedGet(session *mcclient.ClientSession, id string,

--- a/pkg/notify/handlers.go
+++ b/pkg/notify/handlers.go
@@ -306,19 +306,13 @@ func contactUpdateHandler(ctx context.Context, w http.ResponseWriter, r *http.Re
 	}
 
 	uid := params["<uid>"]
-	queryDict := mergeQueryParams(params, query)
-	update, _ := body.Bool(manager.Keyword(), "update_dingtalk")
-	if update {
-		dict := queryDict.(*jsonutils.JSONDict)
-		dict.Add(jsonutils.JSONTrue, "update_dingtalk")
-	}
-	err = manager.UpdateContacts(ctx, uid, queryDict, data, nil)
+	out, err := manager.UpdateContacts(ctx, uid, mergeQueryParams(params, query), data, nil)
 	if err != nil {
 		log.Errorf(err.Error())
 		httperrors.BadRequestError(w, "")
 		return
 	}
-	return
+	appsrv.SendJSON(w, wrap(out, manager.Keyword()))
 }
 
 // delete contact handler

--- a/pkg/notify/models/mod_contact.go
+++ b/pkg/notify/models/mod_contact.go
@@ -115,6 +115,8 @@ func (self *SContactManager) InitializeData() error {
 	return nil
 }
 
+// FetchByUIDs fetch all SContancts whose uid included in uids.
+// If some elements of uids are uname of users, setting param 'uname' as true will fetch correct results.
 func (self *SContactManager) FetchByUIDs(ctx context.Context, uids []string, uname bool) ([]SContact, error) {
 	var err error
 	if uname {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. Add same return value with contact GET interface when updating
2. Add pull params for query to pull subcontact by mobile number.
   For example, pull user_id from dingtalk throught user's mobile
   number.
3. Add corresponding feature based on above for climc.
4. UserCache will try FetchByName if there is no id matched user when
   fetching users from KeyStone.

其中有一部分是为了“以后添加发送信息的driver，不用更改notify 服务的代码”所做的修改

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
- release/3.0
- release/3.1
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
