### PR TITLE
fix/notify: Fix the resend mechanism

### DIFF
--- a/pkg/notify/models/mod_notification.go
+++ b/pkg/notify/models/mod_notification.go
@@ -378,9 +378,9 @@ func (self *SNotificationManager) fetchUserDetailByClusterID(ctx context.Context
 	return ret, nil
 }
 
-func (self *SNotificationManager) FetchNotOK(lastTime time.Time) ([]SNotification, error) {
+func (self *SNotificationManager) FetchFailed(lastTime time.Time) ([]SNotification, error) {
 	q := self.Query()
-	q.Filter(sqlchemy.AND(sqlchemy.GE(q.Field("created_at"), lastTime), sqlchemy.NotEquals(q.Field("status"), NOTIFY_OK)))
+	q.Filter(sqlchemy.AND(sqlchemy.GE(q.Field("created_at"), lastTime), sqlchemy.Equals(q.Field("status"), NOTIFY_FAIL)))
 	records := make([]SNotification, 0, 10)
 	err := db.FetchModelObjects(self, q, &records)
 	if err != nil {
@@ -489,8 +489,8 @@ func sendWithoutUserCred(notifications []SNotification) {
 }
 
 func ReSend(seconds int) {
-	scope := time.Duration(seconds) * time.Second
-	notifications, err := NotificationManager.FetchNotOK(time.Now().Add(-scope))
+	scope := time.Duration(seconds+30) * time.Second
+	notifications, err := NotificationManager.FetchFailed(time.Now().Add(-scope))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复了重发机制的问题。

问题描述：
在notification处于sent的状态时，表示这封消息正在发送，如果这个时候重发机制检测到这封消息，就会重发，导致某些情况下会出现发送两封相同信息的问题。

问题修改：
1. 只重发 发送失败 的消息，即处于 sent_fail 状态的消息。
2. 假设重发的时间间隔为 scope  second，而重发机制会查询 now 之前 (scope+30) second 的消息，这样可以保证在临界时间点发送失败的邮件也能够被检测到。

**是否需要 backport 到之前的 release 分支**:
- release/3.1
- release/3.0
- release/2.13
- release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
