### PR TITLE
Automated cherry pick of #5378: fix: Add 'scope=system' and 'system' for Caches when querying from Keystone.

### DIFF
--- a/cmd/climc/shell/groups.go
+++ b/cmd/climc/shell/groups.go
@@ -79,7 +79,7 @@ func init() {
 		if err != nil {
 			return err
 		}
-		users, err := modules.Groups.GetUsers(s, grpId)
+		users, err := modules.Groups.GetUsers(s, grpId, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/cloudcommon/db/tenantcache.go
+++ b/pkg/cloudcommon/db/tenantcache.go
@@ -174,8 +174,13 @@ func (manager *STenantCacheManager) fetchTenantFromKeystone(ctx context.Context,
 		log.Debugf("fetch empty tenant!!!!\n%s", debug.Stack())
 		return nil, fmt.Errorf("Empty idStr")
 	}
+
+	// It is to query all domain's project.
+	query := jsonutils.NewDict()
+	query.Set("scope", jsonutils.NewString("system"))
+
 	s := auth.GetAdminSession(ctx, consts.GetRegion(), "v1")
-	tenant, err := modules.Projects.GetById(s, idStr, nil)
+	tenant, err := modules.Projects.GetById(s, idStr, query)
 	if err != nil {
 		if je, ok := err.(*httputils.JSONClientError); ok && je.Code == 404 {
 			return nil, sql.ErrNoRows

--- a/pkg/mcclient/modules/mod_groups.go
+++ b/pkg/mcclient/modules/mod_groups.go
@@ -17,6 +17,8 @@ package modules
 import (
 	"fmt"
 
+	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
@@ -25,8 +27,14 @@ type GroupManager struct {
 	modulebase.ResourceManager
 }
 
-func (this *GroupManager) GetUsers(s *mcclient.ClientSession, gid string) (*modulebase.ListResult, error) {
+func (this *GroupManager) GetUsers(s *mcclient.ClientSession, gid string, query jsonutils.JSONObject) (*modulebase.ListResult, error) {
 	url := fmt.Sprintf("/groups/%s/users", gid)
+	if query != nil {
+		qs := query.QueryString()
+		if len(qs) > 0 {
+			url = fmt.Sprintf("%s?%s", url, qs)
+		}
+	}
 	return modulebase.List(this.ResourceManager, s, url, "users")
 }
 


### PR DESCRIPTION
Cherry pick of #5378 on release/2.12.

#5378: fix: Add 'scope=system' and 'system' for Caches when querying from Keystone.