### PR TITLE
fix: keystone prefers internal endpoint type

### DIFF
--- a/pkg/mcclient/modules/managers.go
+++ b/pkg/mcclient/modules/managers.go
@@ -82,13 +82,13 @@ func NewJointMonitorManager(keyword, keywordPlural string, columns, adminColumns
 
 func NewIdentityManager(keyword, keywordPlural string, columns, adminColumns []string) modulebase.ResourceManager {
 	return modulebase.ResourceManager{
-		BaseManager: *modulebase.NewBaseManager("identity", "adminURL", "v2.0", columns, adminColumns),
+		BaseManager: *modulebase.NewBaseManager("identity", "", "v2.0", columns, adminColumns),
 		Keyword:     keyword, KeywordPlural: keywordPlural}
 }
 
 func NewIdentityV3Manager(keyword, keywordPlural string, columns, adminColumns []string) modulebase.ResourceManager {
 	return modulebase.ResourceManager{
-		BaseManager: *modulebase.NewBaseManager("identity", "adminURL", "v3", columns, adminColumns),
+		BaseManager: *modulebase.NewBaseManager("identity", "", "v3", columns, adminColumns),
 		Keyword:     keyword, KeywordPlural: keywordPlural}
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：访问keystone尽量用internal URL

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1

/area climc

/cc @zexi 