### PR TITLE
Automated cherry pick of #5388: fix: keystone prefers internal endpoint type

### DIFF
--- a/pkg/mcclient/modules/managers.go
+++ b/pkg/mcclient/modules/managers.go
@@ -76,13 +76,13 @@ func NewJointMonitorManager(keyword, keywordPlural string, columns, adminColumns
 
 func NewIdentityManager(keyword, keywordPlural string, columns, adminColumns []string) modulebase.ResourceManager {
 	return modulebase.ResourceManager{
-		BaseManager: *modulebase.NewBaseManager("identity", "adminURL", "v2.0", columns, adminColumns),
+		BaseManager: *modulebase.NewBaseManager("identity", "", "v2.0", columns, adminColumns),
 		Keyword:     keyword, KeywordPlural: keywordPlural}
 }
 
 func NewIdentityV3Manager(keyword, keywordPlural string, columns, adminColumns []string) modulebase.ResourceManager {
 	return modulebase.ResourceManager{
-		BaseManager: *modulebase.NewBaseManager("identity", "adminURL", "v3", columns, adminColumns),
+		BaseManager: *modulebase.NewBaseManager("identity", "", "v3", columns, adminColumns),
 		Keyword:     keyword, KeywordPlural: keywordPlural}
 }
 


### PR DESCRIPTION
Cherry pick of #5388 on release/3.0.

#5388: fix: keystone prefers internal endpoint type