### PR TITLE
fix: not check domain quota if non_default_domain_project is off

### DIFF
--- a/pkg/cloudcommon/db/quotas/interface.go
+++ b/pkg/cloudcommon/db/quotas/interface.go
@@ -28,6 +28,8 @@ type IQuotaKeys interface {
 	Fields() []string
 	Values() []string
 	Compare(IQuotaKeys) int
+
+	OwnerId() mcclient.IIdentityProvider
 }
 
 type IQuota interface {

--- a/pkg/cloudcommon/db/quotas/quotas.go
+++ b/pkg/cloudcommon/db/quotas/quotas.go
@@ -22,6 +22,7 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 
+	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
@@ -220,6 +221,16 @@ func (manager *SQuotaBaseManager) checkQuota(ctx context.Context, request IQuota
 
 func (manager *SQuotaBaseManager) __checkQuota(ctx context.Context, quota IQuota, request IQuota) error {
 	keys := quota.GetKeys()
+
+	if !consts.GetNonDefaultDomainProjects() {
+		ownerId := keys.OwnerId()
+		if len(ownerId.GetProjectDomainId()) > 0 && len(ownerId.GetProjectId()) == 0 {
+			// if non_default_domain_projects == false
+			// skip domain quota check
+			return nil
+		}
+	}
+
 	used := manager.newQuota()
 	err := manager.usageStore.GetQuota(ctx, keys, used)
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：在关闭三级权限的情况下，不应该检查域配额

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1

/cc @zexi @yousong 

/area util