### PR TITLE
fix: two default option changes: 1. do not convert vhd by default 2.sync purge server by default

### DIFF
--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -114,7 +114,7 @@ type ComputeOptions struct {
 
 	NameSyncResources []string `help:"resources that need synchronization of name"`
 
-	SyncPurgeRemovedResources []string `help:"resources that shoud be purged immediately if found removed"`
+	SyncPurgeRemovedResources []string `help:"resources that shoud be purged immediately if found removed" default:"server"`
 
 	DisconnectedCloudAccountRetryProbeIntervalHours int `help:"interval to wait to probe status of a disconnected cloud account" default:"24"`
 

--- a/pkg/image/options/options.go
+++ b/pkg/image/options/options.go
@@ -36,7 +36,7 @@ type SImageOptions struct {
 
 	EnableTorrentService bool `help:"Enable torrent service" default:"false"`
 
-	TargetImageFormats []string `help:"target image formats that the system will automatically convert to" default:"qcow2,vmdk,vhd"`
+	TargetImageFormats []string `help:"target image formats that the system will automatically convert to" default:"qcow2,vmdk"`
 
 	TorrentClientPath string `help:"path to torrent executable" default:"/opt/yunion/bin/torrent"`
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修改两个缺省参数： 1. 镜像不再默认转换为vhd 2. 主机默认会被同步删除

**是否需要 backport 到之前的 release 分支**:
None

/cc @zexi @yousong 

/area image region