### PR TITLE
fix: fail to find esxi admin vnic, use vnic with default IPv4 route

### DIFF
--- a/pkg/multicloud/esxi/shell/host.go
+++ b/pkg/multicloud/esxi/shell/host.go
@@ -38,6 +38,8 @@ func init() {
 
 	type HostShowOptions struct {
 		IP string `help:"Host IP"`
+
+		Debug bool `help:"show debug info"`
 	}
 	shellutils.R(&HostShowOptions{}, "host-show", "Show details of a host by IP", func(cli *esxi.SESXiClient, args *HostShowOptions) error {
 		host, err := cli.FindHostByIp(args.IP)
@@ -66,7 +68,7 @@ func init() {
 		if err != nil {
 			return err
 		}
-		nics, err := host.GetIHostNics()
+		nics, err := host.GetIHostNicsInternal(args.Debug)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：通过名称查找不到esxi6.7的管理vnic，选择具有缺省路由的vnic作为管理vnic

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
- release/3.0
- release/3.1

/cc @zexi @rainzm 

/area region