### PR TITLE
fix: sql query errors for missing manager_id and cloudregion_id

### DIFF
--- a/pkg/compute/models/cloudregions.go
+++ b/pkg/compute/models/cloudregions.go
@@ -191,9 +191,12 @@ func (self *SCloudregion) GetDBInstanceBackups(provider *SCloudprovider, instanc
 func (self *SCloudregion) GetElasticcaches(provider *SCloudprovider) ([]SElasticcache, error) {
 	instances := []SElasticcache{}
 	// .IsFalse("pending_deleted")
-	q := ElasticcacheManager.Query().Equals("cloudregion_id", self.Id)
+	vpcs := VpcManager.Query().SubQuery()
+	q := ElasticcacheManager.Query()
+	q = q.Join(vpcs, sqlchemy.Equals(q.Field("vpc_id"), vpcs.Field("id")))
+	q = q.Filter(sqlchemy.Equals(vpcs.Field("cloudregion_id"), self.Id))
 	if provider != nil {
-		q = q.Equals("manager_id", provider.Id)
+		q = q.Filter(sqlchemy.Equals(vpcs.Field("manager_id"), provider.Id))
 	}
 	err := db.FetchModelObjects(ElasticcacheManager, q, &instances)
 	if err != nil {

--- a/pkg/lbagent/models/reflect.go
+++ b/pkg/lbagent/models/reflect.go
@@ -100,17 +100,19 @@ func GetModels(opts *GetModelsOptions) error {
 		return newTime, nil
 	}
 
+	isManaged := false
 	listOptions := options.BaseListOptions{
 		Admin:   options.Bool(true),
 		Details: options.Bool(true),
 		Filter: []string{
 			minUpdatedAtFilter(minUpdatedAt), // order matters, filter.0
-			"manager_id.isnullorempty()",     // len(manager_id) > 0 is for pubcloud objects
+			// "manager_id.isnullorempty()",     // len(manager_id) > 0 is for pubcloud objects
 		},
-		OrderBy: []string{"updated_at", "id"},
-		Order:   "asc",
-		Limit:   options.Int(opts.BatchListSize),
-		Offset:  options.Int(0),
+		OrderBy:   []string{"updated_at", "id"},
+		Order:     "asc",
+		IsManaged: &isManaged,
+		Limit:     options.Int(opts.BatchListSize),
+		Offset:    options.Int(0),
 	}
 	if !minUpdatedAt.Equal(PseudoZeroTime) {
 		// Only fetching pending deletes when we are doing incremental fetch


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：loadbalancer和elasticcache_instance去掉manager_id和cloudregion_id后报错

**是否需要 backport 到之前的 release 分支**:
None

/cc @ioito @yousong @zexi 

/area region