### PR TITLE
climc: add server and host ssh terminal util

### DIFF
--- a/pkg/mcclient/options/servers.go
+++ b/pkg/mcclient/options/servers.go
@@ -70,6 +70,14 @@ type ServerLoginInfoOptions struct {
 	Key string `help:"File name of private key, if password is encrypted by key"`
 }
 
+type ServerSSHLoginOptions struct {
+	ServerLoginInfoOptions
+	Host     string `help:"IP address or hostname of the server"`
+	Port     int    `help:"SSH service port" default:"22"`
+	User     string `help:"SSH login user"`
+	Password string `help:"SSH password"`
+}
+
 type ServerIdsOptions struct {
 	ID []string `help:"ID of servers to operate" metavar:"SERVER" json:"-"`
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

climc 添加 'server-ssh' 和 'host-ssh' 两个自命令，方便快速登录到机器。

添加这两个命令的原因是，经常帮用户排查错误，需要登录机器，原来通过 `climc server-logininfo 获取登录信息，再 server-show 获取 ip，最后 ssh 的方式有些麻烦。`，现在添加这两个命令快速登录机器。

**是否需要 backport 到之前的 release 分支**:
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
- 3.1

/cc @swordqiu @yousong @wanyaoqi 