### PR TITLE
fix(esxi): Fix bugs when using network with vlanID

### DIFF
--- a/pkg/multicloud/esxi/devtools.go
+++ b/pkg/multicloud/esxi/devtools.go
@@ -132,7 +132,7 @@ func NewVNICDev(host *SHost, mac, driver string, vlanId int32, key, ctlKey, inde
 	if err != nil {
 		return nil, errors.Wrap(err, "SHost.FindNetworkByVlanID")
 	}
-	if inet == nil {
+	if inet == nil || reflect.ValueOf(inet).IsNil() {
 		return nil, errors.Error(fmt.Sprintf("VLAN %d not found", vlanId))
 	}
 

--- a/pkg/multicloud/esxi/shell/host.go
+++ b/pkg/multicloud/esxi/shell/host.go
@@ -75,4 +75,18 @@ func init() {
 		printList(nics, nil)
 		return nil
 	})
+
+	shellutils.R(&HostShowOptions{}, "host-network", "Show all network of a given host", func(cli *esxi.SESXiClient,
+		args *HostShowOptions) error {
+		host, err := cli.FindHostByIp(args.IP)
+		if err != nil {
+			return err
+		}
+		networks, err := host.GetNetwork()
+		if err != nil {
+			return err
+		}
+		printList(networks, nil)
+		return nil
+	})
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

创建vmware机器选择带有 vlan id 的network是，无法正确找到 vlan id 对应的vmware的network。

onecloud中的 ip 子网对应到 vmware 的 netwrok ，分两类：host级别的，datacenter 级别的。
host级别的其实是portgroup，datacenter级别的是dvpg。
两者都可以设置vlan，遇到带有vlan的，先在host级别里面搜索，再在datacenter级别里面搜索。

**是否需要 backport 到之前的 release 分支**:
- release/3.0
- release/3.1
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
