### PR TITLE
fix(esxi): UnitNumber 7 is unavailable for scsi controller

### DIFF
--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -787,6 +787,9 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 			ctrlKey = 1000
 			index = scsiIdx
 			scsiIdx += 1
+			if scsiIdx == 7 {
+				scsiIdx++
+			}
 		} else {
 			ctrlKey = 200 + ideIdx/2
 			index = ideIdx % 2
@@ -951,6 +954,9 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SData
 			var key int32 = 2000
 			sameDisk := from.FindDiskByDriver("scsi", "pvscsi")
 			index += int32(len(sameDisk))
+			if index >= 7 {
+				index++
+			}
 			if len(sameDisk) > 0 {
 				key = minDiskKey(sameDisk)
 			}

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -876,6 +876,12 @@ func (self *SVirtualMachine) CreateDisk(ctx context.Context, sizeMb int, uuid st
 		ctlKey += int32(index / 2)
 	}
 
+	// By default, the virtual SCSI controller is assigned to virtual device node (z:7),
+	// so that device node is unavailable for hard disks or other devices.
+	if index >= 7 && driver == "scsi" {
+		index++
+	}
+
 	return self.createDiskInternal(ctx, sizeMb, uuid, int32(index), diskKey, ctlKey, "", true)
 }
 


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:

By default, the virtual SCSI controller is assigned to virtual device node (z:7),
so that device node is unavailable for hard disks or other devices.
https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vm_admin.doc/GUID-5872D173-A076-42FE-8D0B-9DB0EB0E7362.html

**是否需要 backport 到之前的 release 分支**:
- release/3.0
- release/3.1
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
