### PR TITLE
Automated cherry pick of #5444: fix(esxi): UnitNumber 7 is unavailable for scsi controller

### DIFF
--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -748,6 +748,9 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, data *jsonuti
 			ctrlKey = 1000
 			index = scsiIdx
 			scsiIdx += 1
+			if scsiIdx == 7 {
+				scsiIdx++
+			}
 		} else {
 			ctrlKey = 200 + ideIdx/2
 			index = ideIdx % 2

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -851,6 +851,12 @@ func (self *SVirtualMachine) CreateDisk(ctx context.Context, sizeMb int, uuid st
 		ctlKey += int32(index / 2)
 	}
 
+	// By default, the virtual SCSI controller is assigned to virtual device node (z:7),
+	// so that device node is unavailable for hard disks or other devices.
+	if index >= 7 && driver == "scsi" {
+		index++
+	}
+
 	return self.createDiskInternal(ctx, sizeMb, uuid, int32(index), diskKey, ctlKey, "", true)
 }
 


### PR DESCRIPTION
Cherry pick of #5444 on release/3.0.

#5444: fix(esxi): UnitNumber 7 is unavailable for scsi controller