### PR TITLE
Automated cherry pick of #5444: fix(esxi): UnitNumber 7 is unavailable for scsi controller

### DIFF
--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -787,6 +787,9 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 			ctrlKey = 1000
 			index = scsiIdx
 			scsiIdx += 1
+			if scsiIdx == 7 {
+				scsiIdx++
+			}
 		} else {
 			ctrlKey = 200 + ideIdx/2
 			index = ideIdx % 2
@@ -951,6 +954,9 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SData
 			var key int32 = 2000
 			sameDisk := from.FindDiskByDriver("scsi", "pvscsi")
 			index += int32(len(sameDisk))
+			if index >= 7 {
+				index++
+			}
 			if len(sameDisk) > 0 {
 				key = minDiskKey(sameDisk)
 			}

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -876,6 +876,12 @@ func (self *SVirtualMachine) CreateDisk(ctx context.Context, sizeMb int, uuid st
 		ctlKey += int32(index / 2)
 	}
 
+	// By default, the virtual SCSI controller is assigned to virtual device node (z:7),
+	// so that device node is unavailable for hard disks or other devices.
+	if index >= 7 && driver == "scsi" {
+		index++
+	}
+
 	return self.createDiskInternal(ctx, sizeMb, uuid, int32(index), diskKey, ctlKey, "", true)
 }
 


### PR DESCRIPTION
Cherry pick of #5444 on release/3.1.

#5444: fix(esxi): UnitNumber 7 is unavailable for scsi controller