### PR TITLE
fix(glance): Structured subimage info and add 'created_at' field

### DIFF
--- a/pkg/apis/image/guestimage.go
+++ b/pkg/apis/image/guestimage.go
@@ -15,6 +15,8 @@
 package image
 
 import (
+	"time"
+
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/pkg/apis"
@@ -27,13 +29,23 @@ type GuestImageDetails struct {
 	ImageIds jsonutils.JSONObject `json:"image_ids"`
 
 	//Status     string               `json:"status"`
-	Size       int64                `json:"size"`
-	MinRamMb   int32                `json:"min_ram_mb"`
-	DiskFormat string               `json:"disk_format"`
-	RootImage  jsonutils.JSONObject `json:"root_image"`
-	DataImages jsonutils.JSONObject `json:"data_images"`
+	Size       int64          `json:"size"`
+	MinRamMb   int32          `json:"min_ram_mb"`
+	DiskFormat string         `json:"disk_format"`
+	RootImage  SubImageInfo   `json:"root_image"`
+	DataImages []SubImageInfo `json:"data_images"`
 
 	Properties *jsonutils.JSONDict `json:"properties"`
 
 	DisableDelete bool `json:"disable_delete"`
+}
+
+type SubImageInfo struct {
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`
+	MinDiskMB  int32     `json:"min_disk_mb"`
+	DiskFormat string    `json:"disk_format"`
+	Size       int64     `json:"size"`
+	Status     string    `json:"status"`
+	CreatedAt  time.Time `json:"created_at"`
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

问题：
主机镜像的子镜像 created_at 字段没有传到前端，前端默认是undefined ，展示给用户就是不断刷新的当前时间。

解决：
子镜像信息结构化并且增加了 created_at  字段
Structured subimage info and add 'created_at' field.

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
