### PR TITLE
Automated cherry pick of #5455: fix structure host storage output: storagecache_id

### DIFF
--- a/pkg/apis/compute/hoststorage.go
+++ b/pkg/apis/compute/hoststorage.go
@@ -51,7 +51,7 @@ type HoststorageDetails struct {
 	// 镜像缓存路径
 	ImagecachePath string `json:"imagecache_path"`
 	// 存储缓存Id
-	StoragecacheId string `json:"storagecached_id"`
+	StoragecacheId string `json:"storagecache_id"`
 
 	GuestDiskCount int `json:"guest_disk_count,allowempty"`
 }


### PR DESCRIPTION
Cherry pick of #5455 on release/3.1.

#5455: fix structure host storage output: storagecache_id