### PR TITLE
fix(scheduler): Candidater's CloudProvider maybe nil

### DIFF
--- a/pkg/scheduler/data_manager/candidate_manager.go
+++ b/pkg/scheduler/data_manager/candidate_manager.go
@@ -227,7 +227,9 @@ func (cm *CandidateManager) GetCandidates(args CandidateGetArgs) ([]core.Candida
 
 	matchCloudprovider := func(r core.Candidater, managerId string) bool {
 		if managerId != "" {
-			if r.Getter().Cloudprovider().GetId() == managerId {
+			cloudProvier := r.Getter().Cloudprovider()
+			// r who belongs to Provider Onecloud doesn't have cloudprovider
+			if cloudProvier != nil && cloudProvier.GetId() == managerId {
 				return true
 			}
 			return false


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:

Candidater(Host) in Provider Onecloud doesn't have CloudProvider.

**是否需要 backport 到之前的 release 分支**:

- release/3.1
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
