### PR TITLE
Automated cherry pick of #5480: fix(esxi): VlanID '1' is default value

### DIFF
--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -979,7 +979,7 @@ func (host *SHost) FileUrlPathToDsPath(path string) (string, error) {
 }
 
 func (host *SHost) FindNetworkByVlanID(vlanID int32) (IVMNetwork, error) {
-	if vlanID >= 1 && vlanID < 4095 {
+	if host.IsActiveVlanID(vlanID) {
 		net, err := host.findBasicNetwork(vlanID)
 		if err != nil {
 			return nil, errors.Wrap(err, "findBasicNetwork error")
@@ -1005,6 +1005,14 @@ func (host *SHost) FindNetworkByVlanID(vlanID int32) (IVMNetwork, error) {
 	return host.findNovlanDVPG()
 }
 
+// IsActiveVlanID will detect if vlanID is active that means vlanID in (1, 4095).
+func (host *SHost) IsActiveVlanID(vlanID int32) bool {
+	if vlanID > 1 && vlanID < 4095 {
+		return true
+	}
+	return false
+}
+
 func (host *SHost) findBasicNetwork(vlanID int32) (*SNetwork, error) {
 	nets, err := host.GetNetwork()
 	if err != nil {
@@ -1013,7 +1021,7 @@ func (host *SHost) findBasicNetwork(vlanID int32) (*SNetwork, error) {
 	if len(nets) == 0 {
 		return nil, nil
 	}
-	if vlanID < 1 || vlanID >= 4095 {
+	if !host.IsActiveVlanID(vlanID) {
 		return &nets[0], nil
 	}
 	for i := range nets {
@@ -1070,7 +1078,7 @@ func (host *SHost) findNovlanDVPG() (*SDistributedVirtualPortgroup, error) {
 			continue
 		}
 		nvlan := dvpg.GetVlanId()
-		if nvlan <= 1 || nvlan >= 4095 {
+		if !host.IsActiveVlanID(nvlan) {
 			return dvpg, nil
 		}
 	}


### PR DESCRIPTION
Cherry pick of #5480 on release/3.0.

#5480: fix(esxi): VlanID '1' is default value