### PR TITLE
feat(region): Add filter params "cloudregion" and "zone" for listing cloudprovider

### DIFF
--- a/cmd/climc/shell/cloudproviders.go
+++ b/cmd/climc/shell/cloudproviders.go
@@ -34,6 +34,8 @@ func init() {
 		HasObjectStorage bool     `help:"filter cloudproviders that has object storage"`
 		NoObjectStorage  bool     `help:"filter cloudproviders that has no object storage"`
 		Capability       []string `help:"capability filter" choices:"project|compute|network|loadbalancer|objectstore|rds|cache|event"`
+		Cloudregion      string   `help:"filter cloudprovider that has this cloudregion"`
+		Zone             string   `help:"filter cloudprovider that has this zone"`
 	}
 	R(&CloudproviderListOptions{}, "cloud-provider-list", "List cloud providers", func(s *mcclient.ClientSession, args *CloudproviderListOptions) error {
 		var params *jsonutils.JSONDict
@@ -56,6 +58,14 @@ func init() {
 
 			if len(args.Capability) > 0 {
 				params.Add(jsonutils.NewStringArray(args.Capability), "capability")
+			}
+
+			if len(args.Cloudregion) > 0 {
+				params.Add(jsonutils.NewString(args.Cloudregion), "cloudregion")
+			}
+
+			if len(args.Zone) > 0 {
+				params.Add(jsonutils.NewString(args.Zone), "zone")
 			}
 		}
 		result, err := modules.Cloudproviders.List(s, params)

--- a/pkg/apis/compute/cloudprovider.go
+++ b/pkg/apis/compute/cloudprovider.go
@@ -220,6 +220,12 @@ type CloudproviderListInput struct {
 
 	// 账号健康状态
 	HealthStatus []string `json:"health_status"`
+
+	// 域
+	Cloudregion string `json:"cloudregion"`
+
+	// 可用区
+	Zone string `json:"zone"`
 }
 
 func (input *CapabilityListInput) AfterUnmarshal() {

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -1069,6 +1069,15 @@ func (manager *SCloudproviderManager) ListItemFilter(
 		q = q.In("id", subq)
 	}
 
+	if len(query.Zone) > 0 {
+		subq := ZoneManager.Query("cloudregion_id").Equals("id", query.Zone).SubQuery()
+		subq = CloudproviderRegionManager.Query("cloudprovider_id").In("cloudregion_id", subq).SubQuery()
+		q = q.In("id", subq)
+	} else if len(query.Cloudregion) > 0 {
+		subq := CloudproviderRegionManager.Query("cloudprovider_id").Equals("cloudregion_id", query.Cloudregion).SubQuery()
+		q = q.In("id", subq)
+	}
+
 	if len(query.HealthStatus) > 0 {
 		q = q.In("health_status", query.HealthStatus)
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

cloudprovider-list增加了两个过滤的参数：cloudregion 和 zone

**是否需要 backport 到之前的 release 分支**:
NONE
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
