### PR TITLE
fix: keystone resources list filter should support array

### DIFF
--- a/pkg/apis/identity/input.go
+++ b/pkg/apis/identity/input.go
@@ -286,13 +286,13 @@ type IdentityProviderListInput struct {
 	apis.EnabledStatusStandaloneResourceListInput
 
 	// 以驱动类型过滤
-	Driver string `json:"driver"`
+	Driver []string `json:"driver"`
 
 	// 以模板过滤
-	Template string `json:"template"`
+	Template []string `json:"template"`
 
 	// 以同步状态过滤
-	SyncStatus string `json:"sync_status"`
+	SyncStatus []string `json:"sync_status"`
 }
 
 type CredentialListInput struct {
@@ -301,7 +301,7 @@ type CredentialListInput struct {
 	UserFilterListInput
 	ProjectFilterListInput
 
-	Type string `json:"type"`
+	Type []string `json:"type"`
 
 	Enabled *bool `json:"enabled"`
 }
@@ -311,7 +311,7 @@ type PolicyListInput struct {
 	apis.SharableResourceBaseListInput
 
 	// 以类型查询
-	Type string `json:"type"`
+	Type []string `json:"type"`
 }
 
 type RegionFilterListInput struct {
@@ -330,7 +330,7 @@ type ServiceListInput struct {
 	apis.StandaloneResourceListInput
 
 	// 以Service Type过滤
-	Type string `json:"type"`
+	Type []string `json:"type"`
 
 	// 是否启用/禁用
 	Enabled *bool `json:"enabled"`

--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -1140,9 +1140,8 @@ func (manager *SImageManager) ListItemFilter(
 	if err != nil {
 		return nil, errors.Wrap(err, "SSharableVirtualResourceBaseManager.ListItemFilter")
 	}
-	fmtJsonArray := query.DiskFormats
-	if len(fmtJsonArray) > 0 {
-		q = q.In("disk_format", fmtJsonArray)
+	if len(query.DiskFormats) > 0 {
+		q = q.In("disk_format", query.DiskFormats)
 	}
 	if query.Uefi != nil && *query.Uefi {
 		imagePropertyQ := ImagePropertyManager.Query().

--- a/pkg/keystone/models/credentials.go
+++ b/pkg/keystone/models/credentials.go
@@ -310,7 +310,7 @@ func (manager *SCredentialManager) ListItemFilter(
 		}
 	}
 	if len(query.Type) > 0 {
-		q = q.Equals("type", query.Type)
+		q = q.In("type", query.Type)
 	}
 	return q, nil
 }

--- a/pkg/keystone/models/identity_provider.go
+++ b/pkg/keystone/models/identity_provider.go
@@ -843,13 +843,13 @@ func (manager *SIdentityProviderManager) ListItemFilter(
 		return nil, errors.Wrap(err, "SEnabledStatusStandaloneResourceBaseManager.ListItemFilter")
 	}
 	if len(query.Driver) > 0 {
-		q = q.Equals("driver", query.Driver)
+		q = q.In("driver", query.Driver)
 	}
 	if len(query.Template) > 0 {
-		q = q.Equals("template", query.Template)
+		q = q.In("template", query.Template)
 	}
 	if len(query.SyncStatus) > 0 {
-		q = q.Equals("sync_status", query.SyncStatus)
+		q = q.In("sync_status", query.SyncStatus)
 	}
 	return q, nil
 }

--- a/pkg/keystone/models/policies.go
+++ b/pkg/keystone/models/policies.go
@@ -223,7 +223,7 @@ func (manager *SPolicyManager) ListItemFilter(
 		return nil, errors.Wrap(err, "SSharableBaseResourceManager.ListItemFilter")
 	}
 	if len(query.Type) > 0 {
-		q = q.Equals("type", query.Type)
+		q = q.In("type", query.Type)
 	}
 	return q, nil
 }

--- a/pkg/keystone/models/services.go
+++ b/pkg/keystone/models/services.go
@@ -233,7 +233,7 @@ func (manager *SServiceManager) ListItemFilter(
 		return nil, errors.Wrap(err, "SStandaloneResourceBaseManager.ListItemFilter")
 	}
 	if len(query.Type) > 0 {
-		q = q.Equals("type", query.Type)
+		q = q.In("type", query.Type)
 	}
 	if query.Enabled != nil {
 		if *query.Enabled {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：keystone的list过滤参数应该支持array of string

**是否需要 backport 到之前的 release 分支**:
None

/cc @zexi 

/area keystone