### PR TITLE
fix: recode cloudprovider usable filter

### DIFF
--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -994,29 +994,24 @@ func (manager *SCloudproviderManager) ListItemFilter(
 		networks := NetworkManager.Query().SubQuery()
 		wires := WireManager.Query().SubQuery()
 		vpcs := VpcManager.Query().SubQuery()
+		providerRegions := CloudproviderRegionManager.Query().SubQuery()
 
 		sq := providers.Query(sqlchemy.DISTINCT("id", providers.Field("id")))
-		sq = sq.Join(vpcs, sqlchemy.Equals(vpcs.Field("manager_id"), providers.Field("id")))
+		sq = sq.Join(providerRegions, sqlchemy.Equals(providers.Field("id"), providerRegions.Field("cloudprovider_id")))
+		sq = sq.Join(vpcs, sqlchemy.Equals(providerRegions.Field("cloudregion_id"), vpcs.Field("cloudregion_id")))
 		sq = sq.Join(wires, sqlchemy.Equals(vpcs.Field("id"), wires.Field("vpc_id")))
 		sq = sq.Join(networks, sqlchemy.Equals(wires.Field("id"), networks.Field("wire_id")))
-		sq = sq.Filter(sqlchemy.Equals(networks.Field("status"), api.NETWORK_STATUS_AVAILABLE))
 		sq = sq.Filter(sqlchemy.IsTrue(providers.Field("enabled")))
 		sq = sq.Filter(sqlchemy.In(providers.Field("status"), api.CLOUD_PROVIDER_VALID_STATUS))
 		sq = sq.Filter(sqlchemy.In(providers.Field("health_status"), api.CLOUD_PROVIDER_VALID_HEALTH_STATUS))
 		sq = sq.Filter(sqlchemy.Equals(vpcs.Field("status"), api.VPC_STATUS_AVAILABLE))
-
-		sq2 := providers.Query(sqlchemy.DISTINCT("id", providers.Field("id")))
-		sq2 = sq2.Join(vpcs, sqlchemy.Equals(vpcs.Field("manager_id"), providers.Field("id")))
-		sq2 = sq2.Join(wires, sqlchemy.Equals(vpcs.Field("id"), wires.Field("vpc_id")))
-		sq2 = sq2.Join(networks, sqlchemy.Equals(wires.Field("id"), networks.Field("wire_id")))
-		sq2 = sq2.Filter(sqlchemy.Equals(networks.Field("status"), api.NETWORK_STATUS_AVAILABLE))
-		sq2 = sq2.Filter(sqlchemy.IsNullOrEmpty(vpcs.Field("manager_id")))
-		sq2 = sq2.Filter(sqlchemy.Equals(vpcs.Field("status"), api.VPC_STATUS_AVAILABLE))
-
-		q = q.Filter(sqlchemy.OR(
-			sqlchemy.In(q.Field("id"), sq.SubQuery()),
-			sqlchemy.In(q.Field("id"), sq2.SubQuery()),
+		sq = sq.Filter(sqlchemy.Equals(networks.Field("status"), api.NETWORK_STATUS_AVAILABLE))
+		sq = sq.Filter(sqlchemy.OR(
+			sqlchemy.IsNullOrEmpty(vpcs.Field("manager_id")),
+			sqlchemy.Equals(vpcs.Field("manager_id"), providers.Field("id")),
 		))
+
+		q = q.Filter(sqlchemy.In(q.Field("id"), sq.SubQuery()))
 	}
 
 	q, err := manager.SEnabledStatusStandaloneResourceBaseManager.ListItemFilter(ctx, q, userCred, query.EnabledStatusStandaloneResourceListInput)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：重写cloudprovider network usable的逻辑. 

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
- release/3.0
- release/3.1

/area region

/cc @ioito @zexi @yousong 