### PR TITLE
fix: storage details missing capacity fields since 3.1

### DIFF
--- a/pkg/apis/compute/storage.go
+++ b/pkg/apis/compute/storage.go
@@ -112,25 +112,29 @@ type StorageCreateInput struct {
 	NfsSharedDir string `json:"nfs_shared_dir"`
 }
 
+type SStorageCapacityInfo struct {
+	// 容量大小, 单位Mb
+	Capacity int64 `json:"capacity"`
+	// 已使用容量大小
+	UsedCapacity int64 `json:"used_capacity"`
+	// 浪费容量大小(异常磁盘大小总和)
+	WasteCapacity int64 `json:"waste_capacity"`
+	// 虚拟容量大小
+	VirtualCapacity int64 `json:"virtual_capacity"`
+	// 超分率
+	CommitRate float64 `json:"commit_rate"`
+	// 可使用容量
+	FreeCapacity int64 `json:"free_capacity"`
+}
+
 type StorageDetails struct {
 	apis.EnabledStatusStandaloneResourceDetails
 	ManagedResourceInfo
 	ZoneResourceInfo
 
-	SStorage
+	SStorageCapacityInfo
 
-	// 容量大小, 单位Mb
-	Capacity int64 `json:"capacity"`
-	// 已使用容量大小
-	Used int64 `json:"used"`
-	// 浪费容量大小(异常磁盘大小总和)
-	Wasted int64 `json:"wasted"`
-	// 虚拟容量大小
-	VCapacity int64 `json:"vcapacity"`
-	// 超分率
-	CommitRate float64 `json:"commit_rate"`
-	// 可使用容量
-	FreeCapacity int64 `json:"free_capacity"`
+	SStorage
 
 	Schedtags []SchedtagShortDescDetails `json:"schedtags"`
 

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -1160,11 +1160,15 @@ func (cap *SStorageCapacity) Add(cap2 SStorageCapacity) {
 	cap.VCapacity += cap2.VCapacity
 }
 
-func (cap *SStorageCapacity) ToJson() *jsonutils.JSONDict {
-	ret := jsonutils.Marshal(cap).(*jsonutils.JSONDict)
-	ret.Add(jsonutils.NewFloat(cap.GetCommitRate()), "commit_rate")
-	ret.Add(jsonutils.NewInt(int64(cap.GetFree())), "free_capacity")
-	return ret
+func (cap *SStorageCapacity) toCapacityInfo() api.SStorageCapacityInfo {
+	info := api.SStorageCapacityInfo{}
+	info.Capacity = cap.Capacity
+	info.UsedCapacity = cap.Used
+	info.WasteCapacity = cap.Wasted
+	info.VirtualCapacity = cap.VCapacity
+	info.CommitRate = cap.GetCommitRate()
+	info.FreeCapacity = cap.GetFree()
+	return info
 }
 
 func (self *SHost) GetAttachedLocalStorageCapacity() SStorageCapacity {

--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -410,13 +410,7 @@ func (self *SStorage) getStorageCapacity() SStorageCapacity {
 
 func (self *SStorage) getMoreDetails(ctx context.Context, out api.StorageDetails) api.StorageDetails {
 	capa := self.getStorageCapacity()
-	out.Capacity = capa.Capacity
-	out.Used = capa.Used
-	out.Wasted = capa.Wasted
-	out.VCapacity = capa.VCapacity
-	out.CommitRate = capa.GetCommitRate()
-	out.FreeCapacity = capa.GetFree()
-
+	out.SStorageCapacityInfo = capa.toCapacityInfo()
 	out.CommitBound = self.GetOvercommitBound()
 	out.Schedtags = GetSchedtagsDetailsToResourceV2(self, ctx)
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：因为json fieldname写错了，storage详情缺少capacity信息

**是否需要 backport 到之前的 release 分支**:
- release/3.1

/cc @ioito @zexi 

/area region