### PR TITLE
feat(notify): Compatibility and repair

### DIFF
--- a/cmd/climc/shell/notification.go
+++ b/cmd/climc/shell/notification.go
@@ -41,7 +41,7 @@ func init() {
 		NotificationCreateOptions
 	}
 
-	R(&NotificationCreateSingleOptions{}, "notify", "Send a notification to someones", func(s *mcclient.ClientSession,
+	R(&NotificationCreateSingleOptions{}, "notify", "Send a notification to someone", func(s *mcclient.ClientSession,
 		args *NotificationCreateSingleOptions) error {
 
 		msg := notify.SNotifyMessage{}

--- a/pkg/apis/notify/contact.go
+++ b/pkg/apis/notify/contact.go
@@ -19,7 +19,7 @@ import "yunion.io/x/onecloud/pkg/apis"
 type ContactDetails struct {
 	apis.ResourceBaseDetails
 
-	Id      string `json:"id"`
+	UID     string `json:"uid"`
 	Name    string `json:"name"`
 	Details string `json:"details"`
 }

--- a/pkg/cloudcommon/db/usercache.go
+++ b/pkg/cloudcommon/db/usercache.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"fmt"
 	"runtime/debug"
+	"time"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
@@ -155,6 +156,7 @@ func (manager *SUserCacheManager) Save(ctx context.Context, idStr string, name s
 			obj.Name = name
 			obj.Domain = domain
 			obj.DomainId = domainId
+			obj.LastCheck = time.Now().UTC()
 			return nil
 		})
 		if err != nil {
@@ -169,7 +171,8 @@ func (manager *SUserCacheManager) Save(ctx context.Context, idStr string, name s
 		obj.Name = name
 		obj.Domain = domain
 		obj.DomainId = domainId
-		err = manager.TableSpec().Insert(obj)
+		obj.LastCheck = time.Now().UTC()
+		err = manager.TableSpec().InsertOrUpdate(obj)
 		if err != nil {
 			return nil, err
 		} else {

--- a/pkg/mcclient/modules/mod_contacts.go
+++ b/pkg/mcclient/modules/mod_contacts.go
@@ -40,22 +40,17 @@ func (this *ContactsManager) PerformActionWithArrayParams(s *mcclient.ClientSess
 }
 
 func (this *ContactsManager) DoBatchDeleteContacts(s *mcclient.ClientSession, params jsonutils.JSONObject) (jsonutils.JSONObject, error) {
-	path := "/contacts/delete-contact"
+	path := "/contacts/delete-contact?uname=true"
 
 	return modulebase.Post(this.ResourceManager, s, path, params, this.Keyword)
 }
 
-func (this *ContactsManager) CustomizedPerformAction(session *mcclient.ClientSession, id, action, pull string,
-	params jsonutils.JSONObject) (jsonutils.JSONObject, error) {
-
+func (this *ContactsManager) CustomizedPerformAction(session *mcclient.ClientSession, id, action string, params jsonutils.JSONObject) (jsonutils.JSONObject, error) {
 	body := jsonutils.NewDict()
 	if params != nil {
 		body.Add(params, this.Keyword)
 	}
 	path := fmt.Sprintf("/%s/%s/%s?uname=true", this.ContextPath(nil), url.PathEscape(id), url.PathEscape(action))
-	if len(pull) > 0 {
-		path += fmt.Sprintf("&pull=%s", pull)
-	}
 	return modulebase.Post(this.ResourceManager, session, path, body, this.KeywordPlural)
 }
 

--- a/pkg/notify/cache/usercache.go
+++ b/pkg/notify/cache/usercache.go
@@ -119,3 +119,7 @@ func (ucm *SUserCacheManager) FetchUserFromLoaclCache(ctx context.Context, q *sq
 	}
 	return users, nil
 }
+
+func (u *SUser) Delete(ctx context.Context, userCred mcclient.TokenCredential) error {
+	return u.SUser.Delete(ctx, userCred)
+}

--- a/pkg/notify/dispatcher.go
+++ b/pkg/notify/dispatcher.go
@@ -114,6 +114,7 @@ func (self *NotifyModelDispatcher) UpdateConfig(ctx context.Context, body jsonut
 			}
 		}
 	}
+	log.Debugf("update body: %s", data)
 	keys := data.SortedKeys()
 	config := make(map[string]string)
 	createDataList := make([]jsonutils.JSONObject, 0, len(keys))
@@ -131,6 +132,7 @@ func (self *NotifyModelDispatcher) UpdateConfig(ctx context.Context, body jsonut
 	}
 
 	// validate configs
+	log.Debugf("config: %#v", config)
 	isValid, message, err := models.NotifyService.ValidateConfig(ctx, contactType, config)
 	if err != nil {
 		if errors.Cause(err) != errors.ErrNotImplemented {
@@ -144,7 +146,7 @@ func (self *NotifyModelDispatcher) UpdateConfig(ctx context.Context, body jsonut
 
 	// create
 	for _, createData := range createDataList {
-		_, err := self.Create(ctx, jsonutils.JSONNull, createData, nil)
+		_, err := self.Create(ctx, jsonutils.NewDict(), createData, nil)
 		if err != nil {
 			return errors.Wrapf(err, "Create config %s for contact type %s failed", createData.String(), contactType)
 		}
@@ -155,31 +157,31 @@ func (self *NotifyModelDispatcher) UpdateConfig(ctx context.Context, body jsonut
 	return nil
 }
 
-func (self *NotifyModelDispatcher) ValidateConfig(ctx context.Context, contactType string, body jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+func (self *NotifyModelDispatcher) ValidateConfig(ctx context.Context, contactType string, body jsonutils.JSONObject) error {
 	dict, ok := body.(*jsonutils.JSONDict)
 	if !ok {
-		return nil, httperrors.NewInputParameterError("")
+		return httperrors.NewInputParameterError("")
 	}
 	dict = models.ConfigManager.Display2Database(contactType, dict)
 	configs := make(map[string]string)
 	for _, key := range dict.SortedKeys() {
 		value, err := dict.GetString(key)
 		if err != nil {
-			return nil, errors.Wrap(err, "jsonutils.JsonDict.GetString")
+			return errors.Wrap(err, "jsonutils.JsonDict.GetString")
 		}
 		configs[key] = value
 	}
 	isValid, message, err := models.NotifyService.ValidateConfig(ctx, contactType, configs)
 	if err != nil {
 		if errors.Cause(err) == errors.ErrNotImplemented {
-			return nil, httperrors.NewNotImplementedError("validating config of %s", contactType)
+			return httperrors.NewNotImplementedError("validating config of %s", contactType)
 		}
-		return nil, err
+		return err
 	}
-	ret := jsonutils.NewDict()
-	ret.Add(jsonutils.NewBool(isValid), "is_valid")
-	ret.Add(jsonutils.NewString(message), "message")
-	return ret, nil
+	if isValid == false {
+		return httperrors.NewInputParameterError(message)
+	}
+	return nil
 }
 
 // CreateNotification create new notifications and send them through rpc.RpcService.
@@ -229,7 +231,7 @@ func (self *NotifyModelDispatcher) getIds(data jsonutils.JSONObject, key string)
 		}
 		ret = append(ret, id)
 	}
-	return ret[:len(ret):len(ret)]
+	return ret
 }
 
 // Verify process:
@@ -348,12 +350,14 @@ func (self *NotifyModelDispatcher) VerifyTrigger(ctx context.Context, params map
 }
 
 // DeleteContacts delete a group of contacts
-func (self *NotifyModelDispatcher) DeleteContacts(ctx context.Context, uids2 []jsonutils.JSONObject) error {
+func (self *NotifyModelDispatcher) DeleteContacts(ctx context.Context, uidArray []jsonutils.JSONObject) error {
 	// Get all id of uid
-	uids := make([]string, len(uids2))
-	for i := range uids2 {
-		uids[i] = strings.Trim(uids2[i].String(), `"`)
+	uids := make([]string, len(uidArray))
+	log.Debugf("uidArray: %s", uidArray)
+	for i := range uidArray {
+		uids[i], _ = uidArray[i].GetString()
 	}
+	log.Debugf("uids: %#v", uids)
 	uname := false
 	if v := ctx.Value("uname"); v != nil {
 		uname = true
@@ -370,6 +374,8 @@ func (self *NotifyModelDispatcher) DeleteContacts(ctx context.Context, uids2 []j
 			deleteFailed = append(deleteFailed, contact.ID)
 		}
 	}
+	// clean cache
+	noutils.DeleteUsers(ctx, userCred, uids)
 	if len(deleteFailed) != 0 {
 		errInfo := strings.Join(deleteFailed, ", ") + " ; these contact delete failed."
 		return errors.Error(errInfo)
@@ -379,7 +385,8 @@ func (self *NotifyModelDispatcher) DeleteContacts(ctx context.Context, uids2 []j
 
 // UpdateContacts analysis the data and update corresponding contacts if they exist in the database create new ones.
 func (self *NotifyModelDispatcher) UpdateContacts(ctx context.Context, idstr string, query jsonutils.JSONObject,
-	datas []jsonutils.JSONObject, ctxIds []dispatcher.SResourceContext) (jsonutils.JSONObject, error) {
+	datas []jsonutils.JSONObject, pullCtypes []jsonutils.JSONObject, ctxIds []dispatcher.SResourceContext) (jsonutils.JSONObject,
+	error) {
 
 	type pair struct {
 		contact string
@@ -445,24 +452,56 @@ func (self *NotifyModelDispatcher) UpdateContacts(ctx context.Context, idstr str
 	// createFailed record the information of failed creation
 	createFailed := make([]string, 0, 1)
 	// Create contact info
-	newDatas := make([]map[string]interface{}, 0, len(contactInfos))
+	type CreateData struct {
+		UID         string
+		ContactType string
+		Contact     string
+		Enabled     string
+	}
+	newDatas := make([]CreateData, 0, len(contactInfos))
 	for conType, conPair := range contactInfos {
-		tmpMap := map[string]interface{}{
-			"uid":          idstr,
-			"contact_type": conType,
-			"contact":      conPair.contact,
+		tmp := CreateData{
+			UID:         idstr,
+			ContactType: conType,
+			Contact:     conPair.contact,
 		}
 		if conPair.enabled != "-1" {
-			tmpMap["enabled"] = conPair.enabled
+			tmp.Enabled = conPair.enabled
 		}
-		newDatas = append(newDatas, tmpMap)
+		newDatas = append(newDatas, tmp)
 	}
 
+	pulls := make([]string, len(pullCtypes))
+	for i := range pullCtypes {
+		pulls[i], _ = pullCtypes[i].GetString()
+	}
+
+	if len(pulls) > 0 {
+		contacts, err := models.ContactManager.FetchByUIDAndCType(idstr, pulls)
+		if err != nil {
+			return nil, err
+		}
+		set := sets.NewString(pulls...)
+		for i := range contacts {
+			set.Delete(contacts[i].ContactType)
+		}
+		for _, ct := range set.UnsortedList() {
+			tmp := CreateData{
+				UID:         idstr,
+				ContactType: ct,
+				Enabled:     "1",
+				Contact:     "user_id",
+			}
+			newDatas = append(newDatas, tmp)
+		}
+	}
+	log.Debugf("newDatas: %s", newDatas)
+
 	for _, newData := range newDatas {
-		_, err := self.Create(ctx, jsonutils.JSONNull, jsonutils.Marshal(newData), ctxIds)
+		_, err := self.Create(ctx, jsonutils.NewDict(), jsonutils.Marshal(newData), ctxIds)
 		if err != nil {
 			createFailed = append(createFailed, fmt.Sprintf(`uid:%q, contact_type:%q, contact:%q`, idstr,
-				newData["contact_type"], newData["contact"]))
+				newData.ContactType, newData.Contact))
 		}
 	}
 
@@ -485,10 +524,7 @@ func (self *NotifyModelDispatcher) UpdateContacts(ctx context.Context, idstr str
 		return nil, httperrors.NewGeneralError(errors.Error(errInfo))
 	}
 
-	if query.Contains("pull") {
-		cType, _ := query.GetString("pull")
-		models.PullContact(idstr, cType)
-	}
+	models.PullContact(idstr, pulls)
 
 	// keep the return value same as this of the GET interface
 	ret := jsonutils.NewDict()
@@ -496,6 +532,9 @@ func (self *NotifyModelDispatcher) UpdateContacts(ctx context.Context, idstr str
 	if err != nil {
 		log.Errorf(err.Error())
 		return ret, nil
+	}
+	if len(contact) == 0 {
+		return nil, nil
 	}
 	outDetails, err := contact[0].GetExtraDetails(ctx, userCred, ret, false)
 	if err != nil {

--- a/pkg/notify/models/consts.go
+++ b/pkg/notify/models/consts.go
@@ -18,7 +18,9 @@ const (
 	EMAIL      = "email"
 	MOBILE     = "mobile"
 	DINGTALK   = "dingtalk"
+	FEISHU     = "feishu"
 	WEBCONSOLE = "webconsole"
+	ROBOT      = "robot"
 
 	NOTIFY_RECEIVED = "received"  // Received a task about sending a notification
 	NOTIFY_SENT     = "sent"      // Nofity module has sent notification, but result unkown
@@ -40,5 +42,6 @@ const (
 // In webconsole, uid is the same as contact.
 var UpdateNotAllow = map[string]struct{}{
 	DINGTALK:   {},
+	FEISHU:     {},
 	WEBCONSOLE: {},
 }

--- a/pkg/notify/models/mod_config.go
+++ b/pkg/notify/models/mod_config.go
@@ -56,7 +56,7 @@ type SConfig struct {
 
 	Type      string `width:"15" nullable:"false" create:"required" list:"user"`
 	KeyText   string `width:"30" nullable:"false" create:"required" list:"user"`
-	ValueText string `width:"100" nullable:"false" create:"required" list:"user"`
+	ValueText string `width:"256" nullable:"false" create:"required" list:"user"`
 }
 
 // ListItemFilter is a hook function belong to IModelManager interface when Listing.

--- a/pkg/notify/models/mod_contact.go
+++ b/pkg/notify/models/mod_contact.go
@@ -56,7 +56,7 @@ func init() {
 type SContact struct {
 	SStatusStandaloneResourceBase
 
-	UID         string    `width:"128" nullable:"false" create:"required" update:"user"`
+	UID         string    `width:"128" nullable:"false" create:"required" update:"user" list:"user" get:"user"`
 	ContactType string    `width:"16" nullable:"false" create:"required" update:"user"`
 	Contact     string    `width:"64" nullable:"false" create:"required" update:"user"`
 	Enabled     string    `width:"5" nullable:"false" default:"1" create:"optional" update:"user"`
@@ -164,6 +164,7 @@ func (self *SContactManager) _UIDsFromUIDOrName(ctx context.Context, uidStrs []s
 	for _, uid = range uidSet.UnsortedList() {
 		uids = append(uids, uid)
 	}
+	log.Debugf("uids %s => %s", uidStrs, uids)
 	return uids, nil
 }
 
@@ -205,7 +206,7 @@ func (self *SContact) getMoreDetail(ctx context.Context, userCred mcclient.Token
 	if err != nil {
 		return out, errors.Wrapf(err, "fetch Contacts of uid %s error", self.UID)
 	}
-	out.Id = self.UID
+	out.UID = self.UID
 	out.Name = uname
 	out.Details = jsonutils.Marshal(contacts).String()
 
@@ -224,13 +225,16 @@ func (manager *SContactManager) FetchCustomizeColumns(
 
 	stdRows := manager.SStatusStandaloneResourceBaseManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields, isList)
 
+	var err error
 	for i := range rows {
 		rows[i] = api.ContactDetails{
 			ResourceBaseDetails: stdRows[i],
 		}
-		rows[i], _ = objs[i].(*SContact).getMoreDetail(ctx, userCred, rows[i])
+		rows[i], err = objs[i].(*SContact).getMoreDetail(ctx, userCred, rows[i])
+		if err != nil {
+			log.Errorf(err.Error())
+		}
 	}
-
 	return rows
 }
 
@@ -281,16 +285,60 @@ func (self *SContactManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQu
 	if !scope.HigherEqual(rbacutils.ScopeSystem) {
 		q = q.Equals("uid", userCred.GetUserId())
 	}
-	q = q.GroupBy("uid")
+	q = q.GroupBy("uid").Desc("created_at")
 
 	return q, nil
+}
+
+// Contacts query all contacts by uids and contactType
+func (self *SContactManager) Contacts(uids []string, contactType string) ([]SContact, error) {
+	contacts := make([]SContact, 0, len(uids))
+	if contactType == WEBCONSOLE {
+		for _, uid := range uids {
+			contacts = append(contacts, SContact{
+				UID:         uid,
+				ContactType: WEBCONSOLE,
+				Contact:     uid,
+			})
+		}
+		return contacts, nil
+	}
+
+	queryCon := contactType
+	if strings.Contains(contactType, ROBOT) {
+		queryCon = MOBILE
+	}
+	q := self.Query().Equals("contact_type", queryCon).Equals("enabled", "1").In("uid", uids)
+	err := db.FetchModelObjects(self, q, &contacts)
+	if err != nil {
+		return nil, err
+	}
+
+	// For Robot Sender, only one message of the same content is sent for multiple users,
+	// so the user's contact information is a collection of all contact information
+	if strings.Contains(contactType, ROBOT) {
+		// hack
+		contactVals := make([]string, len(contacts))
+		uidVals := make([]string, len(contacts))
+		for i := range contacts {
+			contactVals[i] = contacts[i].Contact
+			uidVals[i] = contacts[i].UID
+		}
+		contacts = []SContact{
+			{
+				UID:         strings.Join(uidVals, ","),
+				ContactType: contactType,
+				Contact:     strings.Join(contactVals, ","),
+			},
+		}
+	}
+	return contacts, nil
 }
 
 func (self *SContactManager) GetAllNotify(ctx context.Context, ids []string, contactType string, group bool) ([]SContact, error) {
 	var uids []string
 	var err error
 
-	q := self.Query()
 	if !group {
 		if v := ctx.Value("uname"); v != nil {
 			ids, err = self._UIDsFromUIDOrName(ctx, ids)
@@ -310,26 +358,7 @@ func (self *SContactManager) GetAllNotify(ctx context.Context, ids []string, con
 		}
 		uids = uid
 	}
-	q.Filter(sqlchemy.AND(sqlchemy.In(q.Field("uid"), uids), sqlchemy.Equals(q.Field("contact_type"),
-		contactType), sqlchemy.Equals(q.Field("status"), CONTACT_VERIFIED)))
-
-	if contactType == WEBCONSOLE {
-		ret := make([]SContact, len(uids))
-		for i := range uids {
-			ret[i] = SContact{
-				UID:         uids[i],
-				ContactType: WEBCONSOLE,
-				Contact:     uids[i],
-			}
-		}
-		return ret, nil
-	}
-	contacts := make([]SContact, 0, 2)
-	err = db.FetchModelObjects(self, q, &contacts)
-	if err != nil {
-		return nil, err
-	}
-	return contacts, nil
+	return self.Contacts(uids, contactType)
 }
 
 type SContactResponse struct {

--- a/pkg/notify/models/mod_template.go
+++ b/pkg/notify/models/mod_template.go
@@ -27,6 +27,7 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
+	"yunion.io/x/sqlchemy"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/httperrors"
@@ -207,4 +208,21 @@ func (manager *STemplateManager) ValidateCreateData(ctx context.Context, userCre
 		return nil, httperrors.NewInputParameterError("no such support for tempalte type %s", ty)
 	}
 	return data, nil
+}
+
+func (self *STemplateManager) ListItemFilter(ctx context.Context, q *sqlchemy.SQuery, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (*sqlchemy.SQuery, error) {
+	queryDict := query.(*jsonutils.JSONDict)
+	if queryDict.Contains("topic") {
+		val, _ := queryDict.GetString("topic")
+		q = q.Equals("topic", val)
+	}
+	if queryDict.Contains("template_type") {
+		val, _ := queryDict.GetString("template_type")
+		q = q.Equals("template_type", val)
+	}
+	if queryDict.Contains("contact_type") {
+		val, _ := queryDict.GetString("contact_type")
+		q = q.Equals("contact_type", val)
+	}
+	return q, nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. 兼容webhook 类型的 robot 消息：一条消息一次性发给多个人
2. 修复了之前一些对onecloud架构的修改引起的notify的bug
3. 修复了climc的一些问题
4. 更改了 update-contacts 时pull dingtalk feishu之类userid的接口
5. 修复了 一次性 发送多个消息 全部发送给一个人 的bug
6. 修复了usercache 没有及时更新lastcheck导致cache实际没有作用的bug
7. 删除contacts也会删除usercache

https://github.com/yunionio/notify-plugins/pull/32

**是否需要 backport 到之前的 release 分支**:
- release/3.1
- release/3.0
- release/2.13
- release/2.12
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
