### PR TITLE
fix(notify): Compatible with changes about list in schema

### DIFF
--- a/pkg/apis/notify/notification.go
+++ b/pkg/apis/notify/notification.go
@@ -23,8 +23,5 @@ import (
 type NotificationDetails struct {
 	apis.ResourceBaseDetails
 
-	Id   string `json:"id"`
-	Name string `json:"name"`
-
 	UserList jsonutils.JSONObject `json:"user_list"`
 }

--- a/pkg/notify/models/mod_notification.go
+++ b/pkg/notify/models/mod_notification.go
@@ -96,7 +96,7 @@ type SNotification struct {
 	SendAt      time.Time `nullable:"false"`
 	SendBy      string    `width:"128" nullable:"false"`
 	// ClusterID identify message with same topic, msg, priority
-	ClusterID string `width:"128" charset:"ascii" primary:"true" create:"optional"`
+	ClusterID string `width:"128" charset:"ascii" primary:"true" create:"optional" list:"user" get:"user"`
 }
 
 type UserDetail struct {
@@ -165,7 +165,6 @@ func (self *SNotification) getMoreDetails(ctx context.Context, query jsonutils.J
 		userDetails = []UserDetail{userDetail}
 	}
 
-	out.Id = self.ClusterID
 	out.UserList = jsonutils.Marshal(userDetails)
 	return out, nil
 }
@@ -289,7 +288,7 @@ func (self *SNotificationManager) ListItemFilter(ctx context.Context, q *sqlchem
 		q = q.Equals("uid", userCred.GetUserId())
 	}
 
-	q = q.GroupBy("cluster_id")
+	q = q.GroupBy("cluster_id").Desc("received_at")
 	return q, nil
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

onecloud框架代码修改之后，notification的list需要兼容一下
1. notification.Id => notification.ClusterId.
2. list order by received_by desc default.

**是否需要 backport 到之前的 release 分支**:
NONE
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/2.8.0
- release/2.6.0
-->
