### PR TITLE
httperrors: fix passing "params" argument

### DIFF
--- a/pkg/httperrors/errors.go
+++ b/pkg/httperrors/errors.go
@@ -197,9 +197,9 @@ func NewClientError(msg string, params ...interface{}) *httputils.JSONClientErro
 }
 
 func NewUnclassifiedError(msg string, params ...interface{}) *httputils.JSONClientError {
-	return httputils.NewJsonClientError(httpErrorCode[errors.ErrUnclassified], string(errors.ErrUnclassified), msg, params)
+	return httputils.NewJsonClientError(httpErrorCode[errors.ErrUnclassified], string(errors.ErrUnclassified), msg, params...)
 }
 
 func NewTooLargeEntityError(msg string, params ...interface{}) *httputils.JSONClientError {
-	return httputils.NewJsonClientError(httpErrorCode[ErrTooLarge], string(ErrTooLarge), msg, params)
+	return httputils.NewJsonClientError(httpErrorCode[ErrTooLarge], string(ErrTooLarge), msg, params...)
 }

--- a/pkg/httperrors/general_test.go
+++ b/pkg/httperrors/general_test.go
@@ -1,0 +1,26 @@
+package httperrors
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestGeneralError(t *testing.T) {
+	t.Run("unclassified", func(t *testing.T) {
+		t.Run("no fmt", func(t *testing.T) {
+			err := fmt.Errorf("i am an unclassified error")
+			jce := NewGeneralError(err)
+			if strings.Contains(jce.Details, "%!(EXTRA") {
+				t.Errorf("bad error formating: %v", jce)
+			}
+		})
+		t.Run("fmt", func(t *testing.T) {
+			err := fmt.Errorf("i am error with plain %%s")
+			jce := NewGeneralError(err)
+			if strings.Contains(jce.Details, "%!(EXTRA") {
+				t.Errorf("bad error formating: %v", jce)
+			}
+		})
+	})
+}

--- a/pkg/webconsole/command/ssh_command.go
+++ b/pkg/webconsole/command/ssh_command.go
@@ -94,7 +94,7 @@ func NewSSHtoolSolCommand(ctx context.Context, userCred mcclient.TokenCredential
 	}
 	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", ip, port), time.Second*2)
 	if err != nil {
-		return nil, fmt.Errorf("IPAddress %s:%d not accessable", ip, port)
+		return nil, fmt.Errorf("IPAddress %s:%d not accessible", ip, port)
 	}
 	defer conn.Close()
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
httperrors: fix passing "params" argument
webconsole: typo fix accessable -> accessible
```

- [x] 单元测试编写

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

- release/2.13

/area webconsole
/area util
/cc @ioito @zexi 