### PR TITLE
Bugfix/yousong multicloud proxyfunc

### DIFF
--- a/cmd/climc/shell/cloudaccounts.go
+++ b/cmd/climc/shell/cloudaccounts.go
@@ -392,6 +392,19 @@ func init() {
 		return nil
 	})
 
+	R(&options.SGoogleCloudAccountUpdateOptions{}, "cloud-account-update-google", "update a google cloud account", func(s *mcclient.ClientSession, args *options.SGoogleCloudAccountUpdateOptions) error {
+		params := jsonutils.Marshal(args).(*jsonutils.JSONDict)
+		if params.Size() == 0 {
+			return InvalidUpdateError()
+		}
+		result, err := modules.Cloudaccounts.Update(s, args.ID, params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
 	R(&options.SAWSCloudAccountUpdateOptions{}, "cloud-account-update-aws", "update an AWS cloud account", func(s *mcclient.ClientSession, args *options.SAWSCloudAccountUpdateOptions) error {
 		params := jsonutils.Marshal(args).(*jsonutils.JSONDict)
 

--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -297,7 +297,7 @@ func (self *SCloudaccount) ValidateUpdateData(ctx context.Context, userCred mccl
 
 	v := validators.NewModelIdOrNameValidator(
 		"proxy_setting",
-		proxy.ProxySettingManager.KeywordPlural(),
+		proxy.ProxySettingManager.Keyword(),
 		userCred,
 	)
 	if err := v.Validate(data); err != nil {

--- a/pkg/mcclient/options/cloudaccounts.go
+++ b/pkg/mcclient/options/cloudaccounts.go
@@ -227,8 +227,9 @@ type SCloudAccountUpdateBaseOptions struct {
 	ID   string `help:"ID or Name of cloud account" json:"-"`
 	Name string `help:"New name to update"`
 
-	SyncIntervalSeconds int   `help:"auto synchornize interval in seconds"`
-	AutoCreateProject   *bool `help:"automatically create local project for new remote project"`
+	SyncIntervalSeconds int    `help:"auto synchornize interval in seconds"`
+	AutoCreateProject   *bool  `help:"automatically create local project for new remote project"`
+	ProxySetting        string `help:"proxy setting name or id"`
 
 	Desc string `help:"Description" json:"description" token:"desc"`
 }

--- a/pkg/mcclient/options/cloudaccounts.go
+++ b/pkg/mcclient/options/cloudaccounts.go
@@ -260,6 +260,10 @@ type SQcloudCloudAccountUpdateOptions struct {
 	SCloudAccountUpdateBaseOptions
 }
 
+type SGoogleCloudAccountUpdateOptions struct {
+	SCloudAccountUpdateBaseOptions
+}
+
 type SAWSCloudAccountUpdateOptions struct {
 	SCloudAccountUpdateBaseOptions
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
climc: add cloud-account-update-google
cloudaccounts: fix checking update data
mcclient: cloudaccounts: allow updating proxysetting
```

- [x] 冒烟测试
- [x] aws, google机器创建测试，确认走代理
- [x] 变更云账号代理配置
- [x] 正在使用中的proxysetting禁止删除

**是否需要 backport 到之前的 release 分支**:

NONE（之后与 #5554 一起backport至3.1）

/area climc
/area region
/cc @ioito @zexi @swordqiu 