### PR TITLE
fix: 避免onecloud lb未返回provider及brand信息

### DIFF
--- a/pkg/compute/models/managedresource.go
+++ b/pkg/compute/models/managedresource.go
@@ -430,6 +430,8 @@ func MakeCloudProviderInfo(region *SCloudregion, zone *SZone, provider *SCloudpr
 		info.Region = region.GetName()
 		info.RegionId = region.GetId()
 		info.CloudregionId = region.GetId()
+		info.Brand = region.Provider
+		info.Provider = region.Provider
 	}
 
 	if provider != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免onecloud lb未返回provider及brand信息

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @zexi 
