### PR TITLE
fix: 避免onecloud lb未返回provider及brand信息

### DIFF
--- a/pkg/compute/models/loadbalancers.go
+++ b/pkg/compute/models/loadbalancers.go
@@ -394,20 +394,11 @@ func (lb *SLoadbalancer) ValidateUpdateData(ctx context.Context, userCred mcclie
 
 func (lb *SLoadbalancer) GetCustomizeColumns(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) *jsonutils.JSONDict {
 	extra := lb.SVirtualResourceBase.GetCustomizeColumns(ctx, userCred, query)
-	providerInfo := lb.SManagedResourceBase.GetCustomizeColumns(ctx, userCred, query)
-	if providerInfo != nil {
-		extra.Update(providerInfo)
-	}
-
-	zoneInfo := lb.SZoneResourceBase.GetCustomizeColumns(ctx, userCred, query)
-	if zoneInfo != nil {
-		extra.Update(zoneInfo)
-	} else {
-		regionInfo := lb.SCloudregionResourceBase.GetCustomizeColumns(ctx, userCred, query)
-		if regionInfo != nil {
-			extra.Update(regionInfo)
-		}
-	}
+	region := lb.GetRegion()
+	zone := lb.GetZone()
+	provider := lb.GetCloudprovider()
+	info := MakeCloudProviderInfo(region, zone, provider)
+	extra.Update(jsonutils.Marshal(info))
 
 	eip, _ := lb.GetEip()
 	if eip != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
避免onecloud lb未返回provider及brand信息

**是否需要 backport 到之前的 release 分支**:
- release/2.12

/area region
/cc @zexi 