### PR TITLE
fix: allow list loadbalancer cluster by default

### DIFF
--- a/pkg/cloudcommon/policy/defaults.go
+++ b/pkg/cloudcommon/policy/defaults.go
@@ -163,6 +163,12 @@ var (
 					Result:   rbacutils.Allow,
 				},
 				{
+					Service:  "compute",
+					Resource: "loadbalancerclusters",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
 					Service:  "yunionagent",
 					Resource: "notices",
 					Action:   PolicyActionList,


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：增加list lb cluster的缺省权限

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/2.12
- release/2.13
- release/3.0
- release/3.1

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @yousong @zexi 
/area region