### PR TITLE
Automated cherry pick of #5608: fix: allow list loadbalancer cluster by default

### DIFF
--- a/pkg/cloudcommon/policy/defaults.go
+++ b/pkg/cloudcommon/policy/defaults.go
@@ -163,6 +163,12 @@ var (
 					Result:   rbacutils.Allow,
 				},
 				{
+					Service:  "compute",
+					Resource: "loadbalancerclusters",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
 					Service:  "yunionagent",
 					Resource: "notices",
 					Action:   PolicyActionList,


### PR DESCRIPTION
Cherry pick of #5608 on release/3.0.

#5608: fix: allow list loadbalancer cluster by default