### PR TITLE
feature: recode cloudcommon policy default/resource codes

### DIFF
--- a/pkg/apigateway/service/policy.go
+++ b/pkg/apigateway/service/policy.go
@@ -12,4 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package service
+
+import (
+	_ "yunion.io/x/onecloud/pkg/cloudevent/policy"
+	_ "yunion.io/x/onecloud/pkg/compute/policy"
+	_ "yunion.io/x/onecloud/pkg/image/policy"
+	_ "yunion.io/x/onecloud/pkg/keystone/policy"
+	_ "yunion.io/x/onecloud/pkg/logger/policy"
+	_ "yunion.io/x/onecloud/pkg/notify/policy"
+	_ "yunion.io/x/onecloud/pkg/yunionconf/policy"
+)

--- a/pkg/apis/cloudcommon/proxy/proxy.go
+++ b/pkg/apis/cloudcommon/proxy/proxy.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package proxy
 
 import (

--- a/pkg/apis/cloudevent/cloudevent_const.go
+++ b/pkg/apis/cloudevent/cloudevent_const.go
@@ -15,6 +15,8 @@
 package cloudevent
 
 const (
+	SERVICE_TYPE = "cloudevent"
+
 	CLOUD_EVENT_SERVICE_COMPUTE = "compute"
 	CLOUD_EVENT_SERVICE_UNKNOWN = "unknown"
 

--- a/pkg/apis/logger/consts.go
+++ b/pkg/apis/logger/consts.go
@@ -12,4 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package logger
+
+const (
+	SERVICE_TYPE = "log"
+)

--- a/pkg/apis/yunionconf/consts.go
+++ b/pkg/apis/yunionconf/consts.go
@@ -12,4 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package yunionconf
+
+const (
+	SERVICE_TYPE = "yunionconf"
+)

--- a/pkg/cloudcommon/db/proxy/doc.go
+++ b/pkg/cloudcommon/db/proxy/doc.go
@@ -1,1 +1,15 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package proxy // import "yunion.io/x/onecloud/pkg/cloudcommon/db/proxy"

--- a/pkg/cloudcommon/db/proxy/proxysetting.go
+++ b/pkg/cloudcommon/db/proxy/proxysetting.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package proxy
 
 import (

--- a/pkg/cloudcommon/policy/resources.go
+++ b/pkg/cloudcommon/policy/resources.go
@@ -14,52 +14,11 @@
 
 package policy
 
-import "yunion.io/x/pkg/utils"
+import (
+	"yunion.io/x/pkg/utils"
+)
 
 var (
-	computeSystemResources = []string{
-		"zones",
-		"cloudregions",
-		"serverskus",
-		"cachedimages",
-		"dynamicschedtags",
-		"baremetalagents",
-		"schedpolicies",
-		"dnsrecords",
-		"metadatas",
-		"loadbalancerclusters",
-		"loadbalanceragents",
-		"isolated-devices",
-		"reservedips",
-	}
-	computeDomainResources = []string{
-		"cloudaccounts",
-		"cloudproviders",
-		"recyclebins",
-		// migrate system resources to domain resources
-		"hosts",
-		"vpcs",
-		"storages",
-		"wires",
-		"globalvpcs",
-		"route_tables",
-		"networkinterfaces",
-		"natgateways",
-		"natsentries",
-		"natdentries",
-	}
-	computeUserResources = []string{
-		"keypairs",
-	}
-
-	notifySystemResources = []string{
-		"configs",
-	}
-	notifyDomainResources = []string{}
-	notifyUserResources   = []string{
-		"contacts",
-	}
-
 	meterSystemResources = []string{
 		"rates",
 		"res_results",
@@ -79,75 +38,30 @@ var (
 	yunionagentDomainResources = []string{}
 	yunionagentUserResources   = []string{}
 
-	yunionconfSystemResources = []string{}
-	yunionconfDomainResources = []string{}
-	yunionconfUserResources   = []string{
-		"parameters",
-	}
-
-	logSystemResources = []string{}
-	logDomainResources = []string{}
-	logUserResources   = []string{}
-
-	identitySystemResources = []string{
-		"identity_providers",
-		"domains",
-		"services",
-		"endpoints",
-	}
-	identityDomainResources = []string{
-		"users",
-		"groups",
-		"projects",
-		"roles",
-		"policies",
-	}
-	identityUserResources = []string{}
-
 	itsmSystemResources = []string{
 		"process-definitions",
 	}
 	itsmDomainResources = []string{}
 	itsmUserResources   = []string{}
 
-	cloudeventSystemResoruces = []string{
-		"cloudevents",
-	}
-
 	systemResources = map[string][]string{
-		"compute":     computeSystemResources,
-		"notify":      notifySystemResources,
 		"meter":       meterSystemResources,
 		"k8s":         k8sSystemResources,
 		"yunionagent": yunionagentSystemResources,
-		"yunionconf":  yunionconfSystemResources,
-		"log":         logSystemResources,
-		"identity":    identitySystemResources,
 		"itsm":        itsmSystemResources,
-		"cloudevent":  cloudeventSystemResoruces,
 	}
 
 	domainResources = map[string][]string{
-		"compute":     computeDomainResources,
-		"notify":      notifyDomainResources,
 		"meter":       meterDomainResources,
 		"k8s":         k8sDomainResources,
 		"yunionagent": yunionagentDomainResources,
-		"yunionconf":  yunionconfDomainResources,
-		"log":         logDomainResources,
-		"identity":    identityDomainResources,
 		"itsm":        itsmDomainResources,
 	}
 
 	userResources = map[string][]string{
-		"compute":     computeUserResources,
-		"notify":      notifyUserResources,
 		"meter":       meterUserResources,
 		"k8s":         k8sUserResources,
 		"yunionagent": yunionagentUserResources,
-		"yunionconf":  yunionconfUserResources,
-		"log":         logUserResources,
-		"identity":    identityUserResources,
 		"itsm":        itsmUserResources,
 	}
 )
@@ -205,4 +119,16 @@ func isProjectResource(service string, resource string) bool {
 		return false
 	}
 	return true
+}
+
+func RegisterSystemResources(service string, resources []string) {
+	systemResources[service] = resources
+}
+
+func RegisterDomainResources(service string, resources []string) {
+	domainResources[service] = resources
+}
+
+func RegisterUserResources(service string, resources []string) {
+	userResources[service] = resources
 }

--- a/pkg/cloudevent/policy/doc.go
+++ b/pkg/cloudevent/policy/doc.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package policy // import "yunion.io/x/onecloud/pkg/cloudevent/policy"

--- a/pkg/cloudevent/policy/resources.go
+++ b/pkg/cloudevent/policy/resources.go
@@ -12,4 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package policy
+
+import (
+	api "yunion.io/x/onecloud/pkg/apis/cloudevent"
+	common_policy "yunion.io/x/onecloud/pkg/cloudcommon/policy"
+)
+
+var (
+	cloudeventSystemResources = []string{
+		"cloudevents",
+	}
+	cloudeventDomainResources = []string{}
+	cloudeventUserResources   = []string{}
+)
+
+func init() {
+	common_policy.RegisterSystemResources(api.SERVICE_TYPE, cloudeventSystemResources)
+	common_policy.RegisterDomainResources(api.SERVICE_TYPE, cloudeventDomainResources)
+	common_policy.RegisterUserResources(api.SERVICE_TYPE, cloudeventUserResources)
+}

--- a/pkg/cloudevent/service/service.go
+++ b/pkg/cloudevent/service/service.go
@@ -22,6 +22,7 @@ import (
 
 	"yunion.io/x/log"
 
+	api "yunion.io/x/onecloud/pkg/apis/cloudevent"
 	"yunion.io/x/onecloud/pkg/cloudcommon"
 	common_app "yunion.io/x/onecloud/pkg/cloudcommon/app"
 	"yunion.io/x/onecloud/pkg/cloudcommon/cronman"
@@ -29,6 +30,7 @@ import (
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
 	"yunion.io/x/onecloud/pkg/cloudevent/models"
 	"yunion.io/x/onecloud/pkg/cloudevent/options"
+	_ "yunion.io/x/onecloud/pkg/cloudevent/policy"
 	_ "yunion.io/x/onecloud/pkg/cloudevent/tasks"
 	_ "yunion.io/x/onecloud/pkg/mcclient/modules"
 	_ "yunion.io/x/onecloud/pkg/multicloud/loader"
@@ -36,7 +38,7 @@ import (
 
 func StartService() {
 	opts := &options.Options
-	common_options.ParseOptions(opts, os.Args, "yunionevent.conf", "yunionevent")
+	common_options.ParseOptions(opts, os.Args, "yunionevent.conf", api.SERVICE_TYPE)
 
 	commonOpts := &opts.CommonOptions
 	common_app.InitAuth(commonOpts, func() {

--- a/pkg/compute/policy/defaults.go
+++ b/pkg/compute/policy/defaults.go
@@ -1,0 +1,327 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+	common_policy "yunion.io/x/onecloud/pkg/cloudcommon/policy"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
+)
+
+const (
+	PolicyActionPerform = common_policy.PolicyActionPerform
+	PolicyActionList    = common_policy.PolicyActionList
+	PolicyActionGet     = common_policy.PolicyActionGet
+	PolicyActionCreate  = common_policy.PolicyActionCreate
+	PolicyActionUpdate  = common_policy.PolicyActionUpdate
+	PolicyActionDelete  = common_policy.PolicyActionDelete
+)
+
+var (
+	predefinedDefaultPolicies = []rbacutils.SRbacPolicy{
+		{
+			Auth:  true,
+			Scope: rbacutils.ScopeSystem,
+			Rules: []rbacutils.SRbacRule{
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "zones",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "zones",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "metadatas",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "cloudregions",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "cloudregions",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "cachedimages",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "cachedimages",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "dbinstance_skus",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "dbinstance_skus",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "serverskus",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "serverskus",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "secgrouprules",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "elasticcacheskus",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "elasticcacheskus",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "secgrouprules",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "loadbalancerclusters",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "schedtags",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+			},
+		},
+		{
+			Auth:  true,
+			Scope: rbacutils.ScopeUser,
+			Rules: []rbacutils.SRbacRule{
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "keypairs",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "keypairs",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "keypairs",
+					Action:   PolicyActionCreate,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "keypairs",
+					Action:   PolicyActionUpdate,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "keypairs",
+					Action:   PolicyActionDelete,
+					Result:   rbacutils.Allow,
+				},
+			},
+		},
+		{
+			Auth:  true,
+			Scope: rbacutils.ScopeDomain,
+			Rules: []rbacutils.SRbacRule{
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "cloudaccounts",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "domain_quotas",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "domain_quotas",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "storages",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "storages",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "hosts",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "vpcs",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "vpcs",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "wires",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "wires",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+			},
+		},
+		{
+			Auth:  true,
+			Scope: rbacutils.ScopeProject,
+			Rules: []rbacutils.SRbacRule{
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "quotas",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "quotas",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "region_quotas",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "region_quotas",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "zone_quotas",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "zone_quotas",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "project_quotas",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "project_quotas",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "networks",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "networks",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "cloudproviders",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "cloudproviders",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+			},
+		},
+	}
+)
+
+func init() {
+	common_policy.AppendDefaultPolicies(predefinedDefaultPolicies)
+}

--- a/pkg/compute/policy/doc.go
+++ b/pkg/compute/policy/doc.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package policy // import "yunion.io/x/onecloud/pkg/compute/policy"

--- a/pkg/compute/policy/resources.go
+++ b/pkg/compute/policy/resources.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+	common_policy "yunion.io/x/onecloud/pkg/cloudcommon/policy"
+)
+
+var (
+	computeSystemResources = []string{
+		"zones",
+		"cloudregions",
+		"serverskus",
+		"cachedimages",
+		"dynamicschedtags",
+		"baremetalagents",
+		"schedpolicies",
+		"dnsrecords",
+		"metadatas",
+		"loadbalancerclusters",
+		"loadbalanceragents",
+		"isolated-devices",
+		"reservedips",
+	}
+	computeDomainResources = []string{
+		"cloudaccounts",
+		"cloudproviders",
+		"recyclebins",
+		// migrate system resources to domain resources
+		"hosts",
+		"vpcs",
+		"storages",
+		"wires",
+		"globalvpcs",
+		"route_tables",
+		"networkinterfaces",
+		"natgateways",
+		"natsentries",
+		"natdentries",
+	}
+	computeUserResources = []string{
+		"keypairs",
+	}
+)
+
+func init() {
+	common_policy.RegisterSystemResources(api.SERVICE_TYPE, computeSystemResources)
+	common_policy.RegisterDomainResources(api.SERVICE_TYPE, computeDomainResources)
+	common_policy.RegisterUserResources(api.SERVICE_TYPE, computeUserResources)
+}

--- a/pkg/compute/service/service.go
+++ b/pkg/compute/service/service.go
@@ -34,6 +34,7 @@ import (
 	_ "yunion.io/x/onecloud/pkg/compute/hostdrivers"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/compute/options"
+	_ "yunion.io/x/onecloud/pkg/compute/policy"
 	_ "yunion.io/x/onecloud/pkg/compute/regiondrivers"
 	_ "yunion.io/x/onecloud/pkg/compute/storagedrivers"
 	_ "yunion.io/x/onecloud/pkg/compute/tasks"

--- a/pkg/httperrors/general_test.go
+++ b/pkg/httperrors/general_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package httperrors
 
 import (

--- a/pkg/image/policy/defaults.go
+++ b/pkg/image/policy/defaults.go
@@ -15,87 +15,71 @@
 package policy
 
 import (
+	api "yunion.io/x/onecloud/pkg/apis/image"
+	common_policy "yunion.io/x/onecloud/pkg/cloudcommon/policy"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
+)
+
+const (
+	PolicyActionPerform = common_policy.PolicyActionPerform
+	PolicyActionGet     = common_policy.PolicyActionGet
+	PolicyActionList    = common_policy.PolicyActionList
 )
 
 var (
 	predefinedDefaultPolicies = []rbacutils.SRbacPolicy{
 		{
 			Auth:  true,
-			Scope: rbacutils.ScopeSystem,
-			Rules: []rbacutils.SRbacRule{
-				{
-					Resource: "tasks",
-					Action:   PolicyActionPerform,
-					Result:   rbacutils.Allow,
-				},
-				{
-					Service:  "yunionagent",
-					Resource: "notices",
-					Action:   PolicyActionList,
-					Result:   rbacutils.Allow,
-				},
-				{
-					Service:  "yunionagent",
-					Resource: "readmarks",
-					Action:   PolicyActionList,
-					Result:   rbacutils.Allow,
-				},
-				{
-					Service:  "yunionagent",
-					Resource: "readmarks",
-					Action:   PolicyActionCreate,
-					Result:   rbacutils.Allow,
-				},
-			},
-		},
-		{
-			Auth:  true,
 			Scope: rbacutils.ScopeProject,
 			Rules: []rbacutils.SRbacRule{
 				{
-					Resource: "tasks",
-					Action:   PolicyActionPerform,
+					Service:  api.SERVICE_TYPE,
+					Resource: "image_quotas",
+					Action:   PolicyActionGet,
 					Result:   rbacutils.Allow,
 				},
 				{
-					// usages for any services
-					// Service:  "compute",
-					Resource: "usages",
+					Service:  api.SERVICE_TYPE,
+					Resource: "image_quotas",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "images",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "images",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "guestimages",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "guestimages",
 					Action:   PolicyActionGet,
 					Result:   rbacutils.Allow,
 				},
 			},
 		},
 		{
-			// meta服务 dbinstance_skus列表不需要认证
+			// for anonymous update torrent status
 			Auth:  false,
 			Scope: rbacutils.ScopeSystem,
 			Rules: []rbacutils.SRbacRule{
 				{
-					Service:  "yunionmeta",
-					Resource: "dbinstance_skus",
-					Action:   PolicyActionGet,
-					Result:   rbacutils.Allow,
-				},
-				{
-					Service:  "yunionmeta",
-					Resource: "dbinstance_skus",
-					Action:   PolicyActionList,
-					Result:   rbacutils.Allow,
-				},
-			},
-		},
-		{
-			// for domain
-			Auth:  true,
-			Scope: rbacutils.ScopeDomain,
-			Rules: []rbacutils.SRbacRule{
-				{
-					// usages for any services
-					// Service:  "compute",
-					Resource: "usages",
-					Action:   PolicyActionGet,
+					Service:  api.SERVICE_TYPE,
+					Resource: "images",
+					Action:   PolicyActionPerform,
+					Extra:    []string{"update-torrent-status"},
 					Result:   rbacutils.Allow,
 				},
 			},
@@ -103,6 +87,6 @@ var (
 	}
 )
 
-func AppendDefaultPolicies(policies []rbacutils.SRbacPolicy) {
-	predefinedDefaultPolicies = append(predefinedDefaultPolicies, policies...)
+func init() {
+	common_policy.AppendDefaultPolicies(predefinedDefaultPolicies)
 }

--- a/pkg/image/policy/doc.go
+++ b/pkg/image/policy/doc.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package policy // import "yunion.io/x/onecloud/pkg/image/policy"

--- a/pkg/image/policy/resources.go
+++ b/pkg/image/policy/resources.go
@@ -12,4 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package policy
+
+import (
+	api "yunion.io/x/onecloud/pkg/apis/image"
+	common_policy "yunion.io/x/onecloud/pkg/cloudcommon/policy"
+)
+
+var (
+	imageSystemResources = []string{}
+	imageDomainResources = []string{}
+	imageUserResources   = []string{}
+)
+
+func init() {
+	common_policy.RegisterSystemResources(api.SERVICE_TYPE, imageSystemResources)
+	common_policy.RegisterDomainResources(api.SERVICE_TYPE, imageDomainResources)
+	common_policy.RegisterUserResources(api.SERVICE_TYPE, imageUserResources)
+}

--- a/pkg/image/service/service.go
+++ b/pkg/image/service/service.go
@@ -32,6 +32,7 @@ import (
 	"yunion.io/x/onecloud/pkg/hostman/hostdeployer/deployclient"
 	"yunion.io/x/onecloud/pkg/image/models"
 	"yunion.io/x/onecloud/pkg/image/options"
+	_ "yunion.io/x/onecloud/pkg/image/policy"
 	_ "yunion.io/x/onecloud/pkg/image/tasks"
 	"yunion.io/x/onecloud/pkg/image/torrent"
 	"yunion.io/x/onecloud/pkg/util/fileutils2"

--- a/pkg/keystone/policy/defaults.go
+++ b/pkg/keystone/policy/defaults.go
@@ -1,0 +1,157 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	api "yunion.io/x/onecloud/pkg/apis/identity"
+	common_policy "yunion.io/x/onecloud/pkg/cloudcommon/policy"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
+)
+
+const (
+	PolicyActionGet    = common_policy.PolicyActionGet
+	PolicyActionList   = common_policy.PolicyActionList
+	PolicyActionCreate = common_policy.PolicyActionCreate
+	PolicyActionUpdate = common_policy.PolicyActionUpdate
+	PolicyActionDelete = common_policy.PolicyActionDelete
+)
+
+var (
+	predefinedDefaultPolicies = []rbacutils.SRbacPolicy{
+		{
+			Auth:  true,
+			Scope: rbacutils.ScopeSystem,
+			Rules: []rbacutils.SRbacRule{
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "services",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "services",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+			},
+		},
+		{
+			Auth:  true,
+			Scope: rbacutils.ScopeUser,
+			Rules: []rbacutils.SRbacRule{
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "credentials",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "credentials",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "credentials",
+					Action:   PolicyActionCreate,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "credentials",
+					Action:   PolicyActionUpdate,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "credentials",
+					Action:   PolicyActionDelete,
+					Result:   rbacutils.Allow,
+				},
+			},
+		},
+		{
+			Auth:  true,
+			Scope: rbacutils.ScopeProject,
+			Rules: []rbacutils.SRbacRule{
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "users",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "groups",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+			},
+		},
+		{
+			// for domain
+			Auth:  true,
+			Scope: rbacutils.ScopeDomain,
+			Rules: []rbacutils.SRbacRule{
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "domains",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+			},
+		},
+		{
+			// for policies administration
+			Auth:     true,
+			Scope:    rbacutils.ScopeSystem,
+			DomainId: api.DEFAULT_DOMAIN_ID,
+			Projects: []string{api.SystemAdminProject},
+			Roles:    []string{api.SystemAdminRole},
+			Rules: []rbacutils.SRbacRule{
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "policies",
+					Action:   PolicyActionCreate,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "policies",
+					Action:   PolicyActionUpdate,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "policies",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "policies",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+			},
+		},
+	}
+)
+
+func init() {
+	common_policy.AppendDefaultPolicies(predefinedDefaultPolicies)
+}

--- a/pkg/keystone/policy/doc.go
+++ b/pkg/keystone/policy/doc.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package policy // import "yunion.io/x/onecloud/pkg/keystone/policy"

--- a/pkg/keystone/policy/resources.go
+++ b/pkg/keystone/policy/resources.go
@@ -1,0 +1,45 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	api "yunion.io/x/onecloud/pkg/apis/identity"
+	common_policy "yunion.io/x/onecloud/pkg/cloudcommon/policy"
+)
+
+var (
+	identitySystemResources = []string{
+		"identity_providers",
+		"domains",
+		"services",
+		"endpoints",
+	}
+	identityDomainResources = []string{
+		"users",
+		"groups",
+		"projects",
+		"roles",
+		"policies",
+	}
+	identityUserResources = []string{
+		"credentials",
+	}
+)
+
+func init() {
+	common_policy.RegisterSystemResources(api.SERVICE_TYPE, identitySystemResources)
+	common_policy.RegisterDomainResources(api.SERVICE_TYPE, identityDomainResources)
+	common_policy.RegisterUserResources(api.SERVICE_TYPE, identityUserResources)
+}

--- a/pkg/keystone/service/service.go
+++ b/pkg/keystone/service/service.go
@@ -34,6 +34,7 @@ import (
 	_ "yunion.io/x/onecloud/pkg/keystone/driver/sql"
 	"yunion.io/x/onecloud/pkg/keystone/models"
 	"yunion.io/x/onecloud/pkg/keystone/options"
+	_ "yunion.io/x/onecloud/pkg/keystone/policy"
 	_ "yunion.io/x/onecloud/pkg/keystone/tasks"
 	"yunion.io/x/onecloud/pkg/keystone/tokens"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"

--- a/pkg/logger/policy/defaults.go
+++ b/pkg/logger/policy/defaults.go
@@ -1,0 +1,53 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	api "yunion.io/x/onecloud/pkg/apis/logger"
+	common_policy "yunion.io/x/onecloud/pkg/cloudcommon/policy"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
+)
+
+const (
+	PolicyActionGet  = common_policy.PolicyActionGet
+	PolicyActionList = common_policy.PolicyActionList
+)
+
+var (
+	predefinedDefaultPolicies = []rbacutils.SRbacPolicy{
+		{
+			Auth:  true,
+			Scope: rbacutils.ScopeProject,
+			Rules: []rbacutils.SRbacRule{
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "actions",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "actions",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+			},
+		},
+	}
+)
+
+func init() {
+	common_policy.AppendDefaultPolicies(predefinedDefaultPolicies)
+}

--- a/pkg/logger/policy/doc.go
+++ b/pkg/logger/policy/doc.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package policy // import "yunion.io/x/onecloud/pkg/logger/policy"

--- a/pkg/logger/policy/resources.go
+++ b/pkg/logger/policy/resources.go
@@ -12,4 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package policy
+
+import (
+	api "yunion.io/x/onecloud/pkg/apis/logger"
+	common_policy "yunion.io/x/onecloud/pkg/cloudcommon/policy"
+)
+
+var (
+	loggerSystemResources = []string{}
+	loggerDomainResources = []string{}
+	loggerUserResources   = []string{}
+)
+
+func init() {
+	common_policy.RegisterSystemResources(api.SERVICE_TYPE, loggerSystemResources)
+	common_policy.RegisterDomainResources(api.SERVICE_TYPE, loggerDomainResources)
+	common_policy.RegisterUserResources(api.SERVICE_TYPE, loggerUserResources)
+}

--- a/pkg/logger/service/service.go
+++ b/pkg/logger/service/service.go
@@ -21,6 +21,7 @@ import (
 
 	"yunion.io/x/log"
 
+	api "yunion.io/x/onecloud/pkg/apis/logger"
 	"yunion.io/x/onecloud/pkg/cloudcommon"
 	app_common "yunion.io/x/onecloud/pkg/cloudcommon/app"
 	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
@@ -28,10 +29,7 @@ import (
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
 	"yunion.io/x/onecloud/pkg/logger/models"
 	"yunion.io/x/onecloud/pkg/logger/options"
-)
-
-const (
-	SERVICE_TYPE = "log"
+	_ "yunion.io/x/onecloud/pkg/logger/policy"
 )
 
 func StartService() {
@@ -42,7 +40,7 @@ func StartService() {
 	baseOpts := &opts.BaseOptions
 	commonOpts := &opts.CommonOptions
 	dbOpts := &opts.DBOptions
-	common_options.ParseOptions(opts, os.Args, "log.conf", SERVICE_TYPE)
+	common_options.ParseOptions(opts, os.Args, "log.conf", api.SERVICE_TYPE)
 
 	app_common.InitAuth(commonOpts, func() {
 		log.Infof("Auth complete!!")

--- a/pkg/mcclient/modules/mod_bill_tasks.go
+++ b/pkg/mcclient/modules/mod_bill_tasks.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package modules
 
 import "yunion.io/x/onecloud/pkg/mcclient/modulebase"

--- a/pkg/multicloud/loader/proxyfunc_test.go
+++ b/pkg/multicloud/loader/proxyfunc_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package loader
 
 import (

--- a/pkg/notify/policy/defaults.go
+++ b/pkg/notify/policy/defaults.go
@@ -1,0 +1,68 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	api "yunion.io/x/onecloud/pkg/apis/notify"
+	common_policy "yunion.io/x/onecloud/pkg/cloudcommon/policy"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
+)
+
+const (
+	PolicyActionGet    = common_policy.PolicyActionGet
+	PolicyActionList   = common_policy.PolicyActionList
+	PolicyActionCreate = common_policy.PolicyActionCreate
+	PolicyActionUpdate = common_policy.PolicyActionUpdate
+	PolicyActionDelete = common_policy.PolicyActionDelete
+)
+
+var (
+	predefinedDefaultPolicies = []rbacutils.SRbacPolicy{
+		{
+			Auth:  true,
+			Scope: rbacutils.ScopeUser,
+			Rules: []rbacutils.SRbacRule{
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "contacts",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "contacts",
+					Action:   PolicyActionCreate,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "contacts",
+					Action:   PolicyActionUpdate,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "contacts",
+					Action:   PolicyActionDelete,
+					Result:   rbacutils.Allow,
+				},
+			},
+		},
+	}
+)
+
+func init() {
+	common_policy.AppendDefaultPolicies(predefinedDefaultPolicies)
+}

--- a/pkg/notify/policy/doc.go
+++ b/pkg/notify/policy/doc.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package policy // import "yunion.io/x/onecloud/pkg/notify/policy"

--- a/pkg/notify/policy/resources.go
+++ b/pkg/notify/policy/resources.go
@@ -12,4 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package policy
+
+import (
+	api "yunion.io/x/onecloud/pkg/apis/notify"
+	common_policy "yunion.io/x/onecloud/pkg/cloudcommon/policy"
+)
+
+var (
+	notifySystemResources = []string{
+		"configs",
+	}
+	notifyDomainResources = []string{}
+	notifyUserResources   = []string{
+		"contacts",
+	}
+)
+
+func init() {
+	common_policy.RegisterSystemResources(api.SERVICE_TYPE, notifySystemResources)
+	common_policy.RegisterDomainResources(api.SERVICE_TYPE, notifyDomainResources)
+	common_policy.RegisterUserResources(api.SERVICE_TYPE, notifyUserResources)
+}

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -33,6 +33,7 @@ import (
 	"yunion.io/x/onecloud/pkg/notify/cache"
 	"yunion.io/x/onecloud/pkg/notify/models"
 	"yunion.io/x/onecloud/pkg/notify/options"
+	_ "yunion.io/x/onecloud/pkg/notify/policy"
 	"yunion.io/x/onecloud/pkg/notify/rpc"
 )
 

--- a/pkg/yunionconf/policy/defaults.go
+++ b/pkg/yunionconf/policy/defaults.go
@@ -1,0 +1,67 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	api "yunion.io/x/onecloud/pkg/apis/yunionconf"
+	common_policy "yunion.io/x/onecloud/pkg/cloudcommon/policy"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
+)
+
+const (
+	PolicyActionGet    = common_policy.PolicyActionGet
+	PolicyActionList   = common_policy.PolicyActionList
+	PolicyActionCreate = common_policy.PolicyActionCreate
+	PolicyActionUpdate = common_policy.PolicyActionUpdate
+)
+
+var (
+	predefinedDefaultPolicies = []rbacutils.SRbacPolicy{
+		{
+			Auth:  true,
+			Scope: rbacutils.ScopeUser,
+			Rules: []rbacutils.SRbacRule{
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "parameters",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "parameters",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "parameters",
+					Action:   PolicyActionCreate,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "parameters",
+					Action:   PolicyActionUpdate,
+					Result:   rbacutils.Allow,
+				},
+			},
+		},
+	}
+)
+
+func init() {
+	common_policy.AppendDefaultPolicies(predefinedDefaultPolicies)
+}

--- a/pkg/yunionconf/policy/doc.go
+++ b/pkg/yunionconf/policy/doc.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package policy // import "yunion.io/x/onecloud/pkg/yunionconf/policy"

--- a/pkg/yunionconf/policy/resources.go
+++ b/pkg/yunionconf/policy/resources.go
@@ -12,4 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package proxy // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
+package policy
+
+import (
+	api "yunion.io/x/onecloud/pkg/apis/yunionconf"
+	common_policy "yunion.io/x/onecloud/pkg/cloudcommon/policy"
+)
+
+var (
+	yunionconfSystemResources = []string{}
+	yunionconfDomainResources = []string{}
+	yunionconfUserResources   = []string{
+		"parameters",
+	}
+)
+
+func init() {
+	common_policy.RegisterSystemResources(api.SERVICE_TYPE, yunionconfSystemResources)
+	common_policy.RegisterDomainResources(api.SERVICE_TYPE, yunionconfDomainResources)
+	common_policy.RegisterUserResources(api.SERVICE_TYPE, yunionconfUserResources)
+}

--- a/pkg/yunionconf/service/service.go
+++ b/pkg/yunionconf/service/service.go
@@ -21,6 +21,7 @@ import (
 
 	"yunion.io/x/log"
 
+	api "yunion.io/x/onecloud/pkg/apis/yunionconf"
 	"yunion.io/x/onecloud/pkg/cloudcommon"
 	app_common "yunion.io/x/onecloud/pkg/cloudcommon/app"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
@@ -28,6 +29,7 @@ import (
 	"yunion.io/x/onecloud/pkg/yunionconf"
 	"yunion.io/x/onecloud/pkg/yunionconf/models"
 	"yunion.io/x/onecloud/pkg/yunionconf/options"
+	_ "yunion.io/x/onecloud/pkg/yunionconf/policy"
 )
 
 func StartService() {
@@ -36,7 +38,7 @@ func StartService() {
 	baseOpts := &options.Options.BaseOptions
 	commonOpts := &options.Options.CommonOptions
 	dbOpts := &options.Options.DBOptions
-	common_options.ParseOptions(opts, os.Args, "yunionconf.conf", "yunionconf")
+	common_options.ParseOptions(opts, os.Args, "yunionconf.conf", api.SERVICE_TYPE)
 	app_common.InitAuth(commonOpts, func() {
 		log.Infof("Auth complete!!")
 	})


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：把预定义policy放到各个服务自己管理，目前只把onecloud的处理了，其他服务等合并和再处理

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/area util

/cc @yousong @zexi 