### PR TITLE
fix: increase apigateway default worker count to 32

### DIFF
--- a/pkg/apigateway/options/options.go
+++ b/pkg/apigateway/options/options.go
@@ -29,7 +29,7 @@ type GatewayOptions struct {
 
 	SqlitePath string `help:"sqlite db path" default:"/etc/yunion/data/yunionapi.db"`
 
-	common_options.CommonOptions
+	common_options.CommonOptions `"request_worker_count->default":"32"`
 }
 
 var (

--- a/pkg/apigateway/service/service.go
+++ b/pkg/apigateway/service/service.go
@@ -44,6 +44,10 @@ func StartService() {
 
 	common_options.StartOptionManager(opts, opts.ConfigSyncPeriodSeconds, api.SERVICE_TYPE, api.SERVICE_VERSION, options.OnOptionsChange)
 
+	if commonOpts.RequestWorkerCount < 32 {
+		commonOpts.RequestWorkerCount = 32
+	}
+
 	if opts.DisableModuleApiVersion {
 		mcclient.DisableApiVersionByModule()
 	}

--- a/pkg/cloudcommon/app/app.go
+++ b/pkg/cloudcommon/app/app.go
@@ -28,6 +28,7 @@ import (
 
 func InitApp(options *common_options.BaseOptions, dbAccess bool) *appsrv.Application {
 	// cache := appsrv.NewCache(options.AuthTokenCacheSize)
+	log.Infof("RequestWorkerCount: %d", options.RequestWorkerCount)
 	app := appsrv.NewApplication(options.ApplicationID, options.RequestWorkerCount, dbAccess)
 	app.CORSAllowHosts(options.CorsHosts)
 

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -58,7 +58,7 @@ type BaseOptions struct {
 	TempPath  string   `help:"Path for store temp file, at least 40G space" default:"/opt/yunion/tmp"`
 
 	ApplicationID      string `help:"Application ID"`
-	RequestWorkerCount int    `default:"4" help:"Request worker thread count, default is 4"`
+	RequestWorkerCount int    `default:"8" help:"Request worker thread count, default is 8"`
 
 	EnableSsl   bool   `help:"Enable https"`
 	SslCaCerts  string `help:"ssl certificate ca root file, separating ca and cert file is not encouraged" alias:"ca-file"`


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：将apigatway的缺省worker数量调高到32，其他服务的缺省worker数量调高到8

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi @yousong 

/area apigateway