### PR TITLE
feature: make webconsole's api_server option common

### DIFF
--- a/pkg/apis/identity/consts.go
+++ b/pkg/apis/identity/consts.go
@@ -96,6 +96,7 @@ var (
 			"non_default_domain_projects",
 			"time_zone",
 			"domainized_namespace",
+			"api_server",
 		},
 	}
 

--- a/pkg/apis/webconsole/consts.go
+++ b/pkg/apis/webconsole/consts.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package notify
+package webconsole
 
 const (
-	SERVICE_TYPE    = "notify"
+	SERVICE_TYPE    = "webconsole"
 	SERVICE_VERSION = ""
 )

--- a/pkg/apis/webconsole/doc.go
+++ b/pkg/apis/webconsole/doc.go
@@ -12,9 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package notify
-
-const (
-	SERVICE_TYPE    = "notify"
-	SERVICE_VERSION = ""
-)
+package webconsole // import "yunion.io/x/onecloud/pkg/apis/webconsole"

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -88,6 +88,8 @@ type BaseOptions struct {
 
 	DomainizedNamespace bool `help:"turn on global name space, default is on" default:"false" json:"global_namespace,allowfalse"`
 
+	ApiServer string `help:"URL to access frontend webconsole" default:"http://webconsole.yunion.io"`
+
 	structarg.BaseOptions
 }
 

--- a/pkg/notify/models/mod_template.go
+++ b/pkg/notify/models/mod_template.go
@@ -34,6 +34,7 @@ import (
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/notify/options"
 	"yunion.io/x/onecloud/pkg/notify/rpc/apis"
+	"yunion.io/x/onecloud/pkg/util/httputils"
 )
 
 type STemplateManager struct {
@@ -72,6 +73,9 @@ type STemplate struct {
 }
 
 func (tm *STemplateManager) GetEmailUrl() string {
+	if len(options.Options.ApiServer) > 0 && len(options.Options.VerifyEmailUrlPath) > 0 {
+		return httputils.JoinPath(options.Options.ApiServer, options.Options.VerifyEmailUrlPath)
+	}
 	return options.Options.VerifyEmailUrl
 }
 

--- a/pkg/notify/options/options.go
+++ b/pkg/notify/options/options.go
@@ -15,20 +15,39 @@
 package options
 
 import (
-	"yunion.io/x/onecloud/pkg/cloudcommon/options"
+	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
 )
 
 type NotifyOption struct {
-	options.CommonOptions
-	options.DBOptions
+	common_options.CommonOptions
+	common_options.DBOptions
 
-	DingtalkEnabled bool   `help:"Enable dingtalk"`
-	SocketFileDir   string `help:"Socket file directory" default:"/etc/yunion/notify"`
-	UpdateInterval  int    `help:"Update send services interval(unit:min)" default:"30"`
-	VerifyEmailUrl  string `help:"url of verify email"`
-	ReSendScope     int    `help:"Resend all messages that have not been sent successfully within ReSendScope
-seconds" default:"30"`
+	DingtalkEnabled    bool   `help:"Enable dingtalk"`
+	SocketFileDir      string `help:"Socket file directory" default:"/etc/yunion/notify"`
+	UpdateInterval     int    `help:"Update send services interval(unit:min)" default:"30"`
+	VerifyEmailUrlPath string `help:"url of verify email" json:"verify_email_url_path"`
+
+	// Deprecated
+	VerifyEmailUrl string `help:"url of verify email" json:"verify_email_url"`
+
+	ReSendScope int `help:"Resend all messages that have not been sent successfully within ReSendScope seconds" default:"30"`
+
 	InitNotificationScope int `help:"initialize data of notification with in InitNotificationScope hours" default:"100"`
 }
 
 var Options NotifyOption
+
+func OnOptionsChange(oldO, newO interface{}) bool {
+	oldOpts := oldO.(*NotifyOption)
+	newOpts := newO.(*NotifyOption)
+
+	if common_options.OnCommonOptionsChange(&oldOpts.CommonOptions, &newOpts.CommonOptions) {
+		return true
+	}
+
+	if oldOpts.SocketFileDir != newOpts.SocketFileDir {
+		return true
+	}
+
+	return false
+}

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -23,6 +23,7 @@ import (
 
 	"yunion.io/x/log"
 
+	api "yunion.io/x/onecloud/pkg/apis/notify"
 	"yunion.io/x/onecloud/pkg/cloudcommon"
 	"yunion.io/x/onecloud/pkg/cloudcommon/app"
 	"yunion.io/x/onecloud/pkg/cloudcommon/cronman"
@@ -41,12 +42,14 @@ func StartService() {
 	commonOpts := &options.Options.CommonOptions
 	dbOpts := &options.Options.DBOptions
 	baseOpts := &options.Options.BaseOptions
-	common_options.ParseOptions(opts, os.Args, "notify.conf", "notify")
+	common_options.ParseOptions(opts, os.Args, "notify.conf", api.SERVICE_TYPE)
 
 	// init auth
 	app.InitAuth(commonOpts, func() {
 		log.Infof("Auth complete!")
 	})
+
+	common_options.StartOptionManager(opts, opts.ConfigSyncPeriodSeconds, api.SERVICE_TYPE, api.SERVICE_VERSION, options.OnOptionsChange)
 
 	// init handler
 	applicaion := app.InitApp(baseOpts, true)

--- a/pkg/webconsole/options/options.go
+++ b/pkg/webconsole/options/options.go
@@ -23,10 +23,22 @@ var (
 type WebConsoleOptions struct {
 	common_options.CommonOptions
 
-	ApiServer       string `help:"API server url to handle websocket connection, usually with public access" default:"http://webconsole.yunion.io"`
+	//ApiServer       string `help:"API server url to handle websocket connection, usually with public access" default:"http://webconsole.yunion.io"`
+
 	KubectlPath     string `help:"kubectl binary path used to connect k8s cluster" default:"/usr/bin/kubectl"`
 	IpmitoolPath    string `help:"ipmitool binary path used to connect baremetal sol" default:"/usr/bin/ipmitool"`
 	SshToolPath     string `help:"sshtool binary path used to connect server sol" default:"/usr/bin/ssh"`
 	SshpassToolPath string `help:"sshpass tool binary path used to connect server sol" default:"/usr/bin/sshpass"`
 	EnableAutoLogin bool   `help:"allow webconsole to log in directly with the cloudroot public key" default:"false"`
+}
+
+func OnOptionsChange(oldO, newO interface{}) bool {
+	oldOpts := oldO.(*WebConsoleOptions)
+	newOpts := newO.(*WebConsoleOptions)
+
+	if common_options.OnCommonOptionsChange(&oldOpts.CommonOptions, &newOpts.CommonOptions) {
+		return true
+	}
+
+	return false
 }

--- a/pkg/webconsole/service/service.go
+++ b/pkg/webconsole/service/service.go
@@ -25,6 +25,7 @@ import (
 
 	"yunion.io/x/log"
 
+	api "yunion.io/x/onecloud/pkg/apis/webconsole"
 	app_common "yunion.io/x/onecloud/pkg/cloudcommon/app"
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
 	"yunion.io/x/onecloud/pkg/webconsole"
@@ -42,7 +43,7 @@ func StartService() {
 
 	opts := &o.Options
 	commonOpts := &o.Options.CommonOptions
-	common_options.ParseOptions(opts, os.Args, "webconsole.conf", "webconsole")
+	common_options.ParseOptions(opts, os.Args, "webconsole.conf", api.SERVICE_TYPE)
 
 	if opts.ApiServer == "" {
 		log.Fatalf("--api-server must specified")
@@ -59,6 +60,9 @@ func StartService() {
 	app_common.InitAuth(commonOpts, func() {
 		log.Infof("Auth complete")
 	})
+
+	common_options.StartOptionManager(opts, opts.ConfigSyncPeriodSeconds, api.SERVICE_TYPE, api.SERVICE_VERSION, o.OnOptionsChange)
+
 	start()
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：将webconsole, notify的options设置为可以service-config设置，并且api_server的配置放到common里，被服务共享

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi @yousong 

/area webconsole notify

/hold