### PR TITLE
fix: worker may block by worker_chan

### DIFF
--- a/pkg/appsrv/response.go
+++ b/pkg/appsrv/response.go
@@ -100,7 +100,12 @@ func (w *responseWriterChannel) wait(ctx context.Context, workerChan chan *SWork
 	stop := false
 	for !stop {
 		select {
-		case worker = <-workerChan:
+		case curWorker, more := <-workerChan:
+			if more {
+				worker = curWorker
+			} else {
+				// ignore, worker is responsible for close the channel
+			}
 		case <-ctx.Done():
 			// ctx deadline reached, timeout
 			if worker != nil {

--- a/pkg/appsrv/workers.go
+++ b/pkg/appsrv/workers.go
@@ -83,6 +83,9 @@ func (worker *SWorker) run() {
 			task := req.(*sWorkerTask)
 			if task.worker != nil {
 				task.worker <- worker
+				// worker channel is buffered
+				// close the worker channel
+				close(task.worker)
 			}
 			execCallback(task)
 		} else {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：worker可能会block在workers.go:85的地方，可能原因是这个时候，worker_chan已经没有consumer了，所以这里把worker_chan设置为容量为1的buffered channel。避免阻塞写。

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi @yousong 

/area util
