### PR TITLE
monitor: support support extra params in alertnotification joint object

### DIFF
--- a/pkg/apis/monitor/alertnotification.go
+++ b/pkg/apis/monitor/alertnotification.go
@@ -1,6 +1,10 @@
 package monitor
 
-import "yunion.io/x/onecloud/pkg/apis"
+import (
+	"yunion.io/x/jsonutils"
+
+	"yunion.io/x/onecloud/pkg/apis"
+)
 
 type AlertJointResourceBaseDetails struct {
 	apis.VirtualJointResourceBaseDetails
@@ -22,6 +26,7 @@ type AlertJointCreateInput struct {
 type AlertnotificationCreateInput struct {
 	AlertJointCreateInput
 
-	NotificationId string `json:"notification_id"`
-	UsedBy         string `json:"used_by"`
+	NotificationId string               `json:"notification_id"`
+	UsedBy         string               `json:"used_by"`
+	Params         jsonutils.JSONObject `json:"params"`
 }

--- a/pkg/monitor/alerting/interfaces.go
+++ b/pkg/monitor/alerting/interfaces.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"time"
 
+	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/apis/monitor"
 	"yunion.io/x/onecloud/pkg/monitor/models"
 	"yunion.io/x/onecloud/pkg/monitor/notifydrivers"
@@ -48,7 +50,7 @@ type Condition interface {
 type Notifier interface {
 	notifydrivers.Notifier
 
-	Notify(evalContext *EvalContext) error
+	Notify(evalContext *EvalContext, params jsonutils.JSONObject) error
 
 	// ShouldNotify checks this evaluation should send an alert notification
 	ShouldNotify(ctx context.Context, evalContext *EvalContext, notificationState *models.SAlertnotification) bool

--- a/pkg/monitor/alerting/notifier.go
+++ b/pkg/monitor/alerting/notifier.go
@@ -68,7 +68,7 @@ func (n *notificationService) sendAndMarkAsComplete(evalCtx *EvalContext, state 
 
 	log.Debugf("Sending notification, type %s, id %s", notifier.GetType(), notifier.GetNotifierId())
 
-	if err := notifier.Notify(evalCtx); err != nil {
+	if err := notifier.Notify(evalCtx, state.state.GetParams()); err != nil {
 		log.Errorf("failed to send notification %s: %v", notifier.GetNotifierId(), err)
 		return err
 	}

--- a/pkg/monitor/alerting/notifiers/dingding.go
+++ b/pkg/monitor/alerting/notifiers/dingding.go
@@ -86,7 +86,7 @@ func newDingdingNotifier(config alerting.NotificationConfig) (alerting.Notifier,
 	}, nil
 }
 
-func (dd *DingDingNotifier) Notify(ctx *alerting.EvalContext) error {
+func (dd *DingDingNotifier) Notify(ctx *alerting.EvalContext, _ jsonutils.JSONObject) error {
 	log.Infof("Sending alert notification to dingding")
 	// msgUrl, err := ctx.GetRuleURL()
 

--- a/pkg/monitor/alerting/notifiers/feishu.go
+++ b/pkg/monitor/alerting/notifiers/feishu.go
@@ -86,7 +86,7 @@ func newFeishuNotifier(config alerting.NotificationConfig) (alerting.Notifier, e
 	}, nil
 }
 
-func (fs *FeishuNotifier) Notify(ctx *alerting.EvalContext) error {
+func (fs *FeishuNotifier) Notify(ctx *alerting.EvalContext, _ jsonutils.JSONObject) error {
 	log.Infof("Sending alert notification to feishu")
 	errGrp := errgroup.Group{}
 	for _, cId := range fs.ChatIds {

--- a/pkg/monitor/alerting/notifiers/onecloud.go
+++ b/pkg/monitor/alerting/notifiers/onecloud.go
@@ -113,7 +113,7 @@ func GetNotifyTemplateConfig(ctx *alerting.EvalContext) monitor.NotificationTemp
 }
 
 // Notify sends the alert notification.
-func (oc *OneCloudNotifier) Notify(ctx *alerting.EvalContext) error {
+func (oc *OneCloudNotifier) Notify(ctx *alerting.EvalContext, _ jsonutils.JSONObject) error {
 	log.Infof("Sending alert notification %s to onecloud", ctx.GetRuleTitle())
 	config := GetNotifyTemplateConfig(ctx)
 	contentConfig := oc.buildContent(config)

--- a/pkg/monitor/models/alertnotification.go
+++ b/pkg/monitor/models/alertnotification.go
@@ -56,10 +56,11 @@ func init() {
 
 type SAlertnotification struct {
 	SAlertJointsBase
-	NotificationId string `width:"36" charset:"ascii" nullable:"false" list:"user" create:"required"`
-	State          string `nullable:"false" list:"user" create:"required"`
-	Index          int8   `nullable:"false" default:"0" list:"user" list:"user" update:"user"`
-	UsedBy         string `width:"36" charset:"ascii" nullable:"true" list:"user"`
+	NotificationId string               `width:"36" charset:"ascii" nullable:"false" list:"user" create:"required"`
+	State          string               `nullable:"false" list:"user" create:"required"`
+	Index          int8                 `nullable:"false" default:"0" list:"user" list:"user" update:"user"`
+	UsedBy         string               `width:"36" charset:"ascii" nullable:"true" list:"user"`
+	Params         jsonutils.JSONObject `nullable:"true" list:"user" update:"user"`
 }
 
 func (man *SAlertNotificationManager) GetSlaveFieldName() string {
@@ -214,4 +215,8 @@ func (state *SAlertnotification) setState(changeState monitor.AlertNotificationS
 
 func (state *SAlertnotification) GetState() monitor.AlertNotificationStateType {
 	return monitor.AlertNotificationStateType(state.State)
+}
+
+func (state *SAlertnotification) GetParams() jsonutils.JSONObject {
+	return state.Params
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

alert attach notification 的时候可以存 params

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->
- 3.1
/cc @rainzm 
/area monitor