### PR TITLE
fix: changes to request_work_count cause apigateway restart

### DIFF
--- a/pkg/apigateway/service/service.go
+++ b/pkg/apigateway/service/service.go
@@ -44,10 +44,6 @@ func StartService() {
 
 	common_options.StartOptionManager(opts, opts.ConfigSyncPeriodSeconds, api.SERVICE_TYPE, api.SERVICE_VERSION, options.OnOptionsChange)
 
-	if commonOpts.RequestWorkerCount < 32 {
-		commonOpts.RequestWorkerCount = 32
-	}
-
 	if opts.DisableModuleApiVersion {
 		mcclient.DisableApiVersionByModule()
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：默认将apigateway的request_worker_count修改会导致apigateway服务重启

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/area util

/cc @zexi 