### PR TITLE
Automated cherry pick of #5652: proxysetting: forbid deletion of DIRECT setting

### DIFF
--- a/pkg/apis/cloudcommon/proxy/proxy.go
+++ b/pkg/apis/cloudcommon/proxy/proxy.go
@@ -13,20 +13,16 @@ const (
 type ProxySettingCreateInput struct {
 	apis.StandaloneResourceCreateInput
 
-	HttpProxy  string
-	HttpsProxy string
-	NoProxy    string
+	ProxySetting
 }
 
 type ProxySettingUpdateInput struct {
-	HttpProxy  string
-	HttpsProxy string
-	NoProxy    string
-
 	// 资源名称
 	Name string `json:"name"`
 	// 资源描述
 	Description string `json:"description"`
+
+	ProxySetting
 }
 
 // String implements ISerializable interface

--- a/pkg/apis/cloudcommon/proxy/setting.go
+++ b/pkg/apis/cloudcommon/proxy/setting.go
@@ -1,0 +1,111 @@
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"yunion.io/x/pkg/errors"
+)
+
+type ProxySetting struct {
+	HttpProxy  string
+	HttpsProxy string
+	NoProxy    string
+}
+
+func (v *ProxySetting) Sanitize() error {
+	v.HttpProxy = strings.TrimSpace(v.HttpProxy)
+	if u, err := parseProxy(v.HttpProxy); err != nil {
+		return errors.Wrap(err, "invalid https_proxy url")
+	} else {
+		v.HttpProxy = u.String()
+	}
+
+	v.HttpsProxy = strings.TrimSpace(v.HttpsProxy)
+	if u, err := parseProxy(v.HttpsProxy); err != nil {
+		return errors.Wrap(err, "invalid http_proxy url")
+	} else {
+		v.HttpsProxy = u.String()
+	}
+
+	if noProxy, err := parseNoProxy(v.NoProxy); err == nil {
+		v.NoProxy = strings.Join(noProxy, ",")
+	} else {
+		return errors.Wrap(err, "invalid no_proxy")
+	}
+	return nil
+}
+
+func parseProxy(proxy string) (*url.URL, error) {
+	if proxy == "" {
+		return nil, nil
+	}
+
+	proxyURL, err := url.Parse(proxy)
+	if err != nil ||
+		(proxyURL.Scheme != "http" &&
+			proxyURL.Scheme != "https" &&
+			proxyURL.Scheme != "socks5") {
+		// proxy was bogus. Try prepending "http://" to it and
+		// see if that parses correctly. If not, we fall
+		// through and complain about the original one.
+		if proxyURL, err := url.Parse("http://" + proxy); err == nil {
+			return proxyURL, nil
+		}
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid proxy address %q", proxy)
+	}
+	return proxyURL, nil
+}
+
+func parseNoProxy(noProxy string) ([]string, error) {
+	var r []string
+	for _, p := range strings.Split(noProxy, ",") {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if len(p) == 0 {
+			continue
+		}
+
+		if p == "*" {
+			r = append(r, p)
+			// let it go
+			//return r, nil
+		}
+
+		// IPv4/CIDR, IPv6/CIDR
+		if _, _, err := net.ParseCIDR(p); err == nil {
+			r = append(r, p)
+			continue
+		}
+
+		// IPv4:port, [IPv6]:port
+		phost, _, err := net.SplitHostPort(p)
+		if err == nil {
+			if len(phost) == 0 {
+				// There is no host part, likely the entry is malformed; ignore.
+				return nil, fmt.Errorf("host part must not be empty: %s", p)
+			}
+			if phost[0] == '[' && phost[len(phost)-1] == ']' {
+				phost = phost[1 : len(phost)-1]
+			}
+		} else {
+			phost = p
+		}
+		// IPv4, IPv6
+		if pip := net.ParseIP(phost); pip != nil {
+			r = append(r, p)
+			continue
+		}
+
+		if len(phost) == 0 {
+			// There is no host part, likely the entry is malformed; ignore.
+			continue
+		}
+
+		r = append(r, p)
+	}
+	return r, nil
+}

--- a/pkg/apis/compute/cloudaccount.go
+++ b/pkg/apis/compute/cloudaccount.go
@@ -19,6 +19,7 @@ import (
 	"yunion.io/x/pkg/utils"
 
 	"yunion.io/x/onecloud/pkg/apis"
+	proxyapi "yunion.io/x/onecloud/pkg/apis/cloudcommon/proxy"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/httperrors"
 )
@@ -180,4 +181,6 @@ type CloudaccountDetail struct {
 	// 存储缓存数量
 	// example: 10
 	StoragecacheCount int `json:"storagecache_count,allowempty"`
+
+	ProxySetting proxyapi.SProxySetting `json:"proxy_setting"`
 }

--- a/pkg/cloudcommon/db/proxy/proxysetting.go
+++ b/pkg/cloudcommon/db/proxy/proxysetting.go
@@ -74,6 +74,9 @@ func (ps *SProxySetting) HttpTransportProxyFunc() httputils.TransportProxyFunc {
 }
 
 func (ps *SProxySetting) ValidateDeleteCondition(ctx context.Context) error {
+	if ps.Id == proxyapi.ProxySettingId_DIRECT {
+		return httperrors.NewConflictError("DIRECT setting cannot be deleted")
+	}
 	for _, man := range referrersMen {
 		t := man.TableSpec().Instance()
 		n, err := t.Query().

--- a/pkg/cloudcommon/db/proxy/proxysetting.go
+++ b/pkg/cloudcommon/db/proxy/proxysetting.go
@@ -46,6 +46,9 @@ type SProxySetting struct {
 }
 
 func (man *SProxySettingManager) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data proxyapi.ProxySettingCreateInput) (proxyapi.ProxySettingCreateInput, error) {
+	if err := data.ProxySetting.Sanitize(); err != nil {
+		return data, httperrors.NewInputParameterError("%s", err)
+	}
 	return data, nil
 }
 
@@ -57,6 +60,9 @@ func (ps *SProxySetting) CustomizeCreate(ctx context.Context, userCred mcclient.
 func (ps *SProxySetting) ValidateUpdateData(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data proxyapi.ProxySettingUpdateInput) (proxyapi.ProxySettingUpdateInput, error) {
 	if ps.Id == proxyapi.ProxySettingId_DIRECT {
 		return data, httperrors.NewConflictError("DIRECT setting cannot be changed")
+	}
+	if err := data.ProxySetting.Sanitize(); err != nil {
+		return data, httperrors.NewInputParameterError("%s", err)
 	}
 	return data, nil
 }


### PR DESCRIPTION
Cherry pick of #5652 on release/3.1.

#5652: proxysetting: forbid deletion of DIRECT setting

以下commit实现的功能在3.1中已经有了，因此未backport

```
cloudproviders: provide proxysetting id, name
```