### PR TITLE
feature: keystone lock user returns ErrTooManyAttempts

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -288,7 +288,7 @@ func (h *AuthHandlers) doCredentialLogin(ctx context.Context, req *http.Request,
 	if err != nil {
 		switch httperr := err.(type) {
 		case *httputils.JSONClientError:
-			if httperr.Code == 409 {
+			if httperr.Code == 409 || httperr.Code == 429 {
 				return nil, err
 			}
 		}

--- a/pkg/httperrors/consts.go
+++ b/pkg/httperrors/consts.go
@@ -80,6 +80,9 @@ const (
 	ErrNoBalancePermission = errors.Error("NoBalancePermission")
 
 	ErrTooLarge = errors.Error("TooLargeEntity")
+
+	ErrTooManyAttempts = errors.Error("TooManyFailedAttempts")
+	ErrTooManyRequests = errors.Error("TooManyRequests")
 )
 
 var (
@@ -149,6 +152,9 @@ var (
 		ErrNoProject:         403,
 
 		ErrTooLarge: 413,
+
+		ErrTooManyAttempts: 429,
+		ErrTooManyRequests: 429,
 	}
 )
 

--- a/pkg/keystone/driver/sql/sql.go
+++ b/pkg/keystone/driver/sql/sql.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 
 	api "yunion.io/x/onecloud/pkg/apis/identity"
+	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/keystone/driver"
 	"yunion.io/x/onecloud/pkg/keystone/models"
 	o "yunion.io/x/onecloud/pkg/keystone/options"
@@ -58,7 +59,8 @@ func (sql *SSQLDriver) Authenticate(ctx context.Context, ident mcclient.SAuthent
 	if err != nil {
 		localUser.SaveFailedAuth()
 		if o.Options.PasswordErrorLockCount > 0 && localUser.FailedAuthCount > o.Options.PasswordErrorLockCount {
-			models.UserManager.LockUser(usrExt.Id)
+			models.UserManager.LockUser(usrExt.Id, "too many failed auth attempts")
+			return nil, errors.Wrap(httperrors.ErrTooManyAttempts, "user locked")
 		}
 		return nil, errors.Wrap(err, "usrExt.VerifyPassword")
 	}

--- a/pkg/keystone/models/users.go
+++ b/pkg/keystone/models/users.go
@@ -952,20 +952,21 @@ func leaveProjects(ident db.IModel, isUser bool, ctx context.Context, userCred m
 	return nil
 }
 
-func (manager *SUserManager) LockUser(uid string) error {
+func (manager *SUserManager) LockUser(uid string, reason string) error {
 	usrObj, err := manager.FetchById(uid)
 	if err != nil {
 		return errors.Wrapf(err, "manager.FetchById %s", uid)
 	}
 	usr := usrObj.(*SUser)
-	diff, err := db.Update(usr, func() error {
+	_, err = db.Update(usr, func() error {
 		usr.Enabled = tristate.False
 		return nil
 	})
 	if err != nil {
 		return errors.Wrap(err, "Update")
 	}
-	db.OpsLog.LogEvent(usr, db.ACT_UPDATE, diff, GetDefaultAdminCred())
+	db.OpsLog.LogEvent(usr, db.ACT_DISABLE, reason, GetDefaultAdminCred())
+	logclient.AddSimpleActionLog(usr, logclient.ACT_DISABLE, reason, GetDefaultAdminCred(), false)
 	return nil
 }
 

--- a/pkg/keystone/tokens/handlers.go
+++ b/pkg/keystone/tokens/handlers.go
@@ -84,9 +84,10 @@ func authenticateTokensV3(ctx context.Context, w http.ResponseWriter, r *http.Re
 	input.Auth.Context = FetchAuthContext(input.Auth.Context, r)
 	token, err := AuthenticateV3(ctx, input)
 	if err != nil {
-		if errors.Cause(err) == sqlchemy.ErrDuplicateEntry {
-			httperrors.ConflictError(w, "duplicate username")
-		} else {
+		switch errors.Cause(err) {
+		case sqlchemy.ErrDuplicateEntry, httperrors.ErrTooManyAttempts:
+			httperrors.GeneralServerError(w, err)
+		default:
 			httperrors.UnauthorizedError(w, "unauthorized %s", err)
 		}
 		return


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：keystone用户密码重试lock后，返回429的错误

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi @yousong 

/area keystone

/hold