### PR TITLE
Automated cherry pick of #5659: host session use internal endpoint

### DIFF
--- a/pkg/hostman/hostutils/hostutils.go
+++ b/pkg/hostman/hostutils/hostutils.go
@@ -53,15 +53,15 @@ type IHost interface {
 }
 
 func GetComputeSession(ctx context.Context) *mcclient.ClientSession {
-	return auth.GetAdminSessionWithPublic(ctx, options.HostOptions.Region, "v2")
+	return auth.GetAdminSessionWithInternal(ctx, options.HostOptions.Region, "v2")
 }
 
 func GetK8sSession(ctx context.Context) *mcclient.ClientSession {
-	return auth.GetAdminSessionWithPublic(ctx, options.HostOptions.Region, "")
+	return auth.GetAdminSessionWithInternal(ctx, options.HostOptions.Region, "")
 }
 
 func GetImageSession(ctx context.Context, zone string) *mcclient.ClientSession {
-	return auth.AdminSessionWithPublic(ctx, options.HostOptions.Region, zone, "v1")
+	return auth.AdminSessionWithInternal(ctx, options.HostOptions.Region, zone, "v1")
 }
 
 func TaskFailed(ctx context.Context, reason string) {

--- a/pkg/mcclient/auth/auth.go
+++ b/pkg/mcclient/auth/auth.go
@@ -356,6 +356,11 @@ func GetAdminSessionWithPublic(ctx context.Context, region string,
 	return GetSessionWithPublic(ctx, manager.adminCredential, region, apiVersion)
 }
 
+func GetAdminSessionWithInternal(
+	ctx context.Context, region string, apiVersion string) *mcclient.ClientSession {
+	return GetSessionWithInternal(ctx, manager.adminCredential, region, apiVersion)
+}
+
 func GetSession(ctx context.Context, token mcclient.TokenCredential, region string, apiVersion string) *mcclient.ClientSession {
 	if len(globalEndpointType) != 0 {
 		return getSessionByType(ctx, token, region, apiVersion, globalEndpointType)


### PR DESCRIPTION
Cherry pick of #5659 on release/3.1.

#5659: host session use internal endpoint