### PR TITLE
[3.1] cloudaccounts: update: make proxy_setting optional

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -318,7 +318,7 @@ func (self *SCloudaccount) ValidateUpdateData(ctx context.Context, userCred mccl
 		"proxy_setting",
 		proxy.ProxySettingManager.Keyword(),
 		userCred,
-	)
+	).Optional(true)
 	if err := v.Validate(data); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
cloudaccounts: update: make proxy_setting optional
```

**是否需要 backport 到之前的 release 分支**:

NONE, 仅3.1需要

/area region
/cc @swordqiu 