### PR TITLE
fix: service config changes not effective

### DIFF
--- a/pkg/apigateway/options/options.go
+++ b/pkg/apigateway/options/options.go
@@ -40,9 +40,10 @@ func OnOptionsChange(oldO, newO interface{}) bool {
 	oldOpts := oldO.(*GatewayOptions)
 	newOpts := newO.(*GatewayOptions)
 
+	changed := false
 	if common_options.OnCommonOptionsChange(&oldOpts.CommonOptions, &newOpts.CommonOptions) {
-		return true
+		changed = true
 	}
 
-	return false
+	return changed
 }

--- a/pkg/cloudcommon/consts/consts.go
+++ b/pkg/cloudcommon/consts/consts.go
@@ -16,6 +16,8 @@ package consts
 
 import (
 	"time"
+
+	"yunion.io/x/log"
 )
 
 var (
@@ -60,6 +62,7 @@ func GetTenantCacheExpireSeconds() time.Duration {
 }
 
 func SetNonDefaultDomainProjects(val bool) {
+	log.Infof("set non_default_domain_projects to %v", val)
 	nonDefaultDomainProjects = val
 }
 

--- a/pkg/cloudcommon/options/changes.go
+++ b/pkg/cloudcommon/options/changes.go
@@ -22,30 +22,35 @@ func OnBaseOptionsChange(oOpts, nOpts interface{}) bool {
 	oldOpts := oOpts.(*BaseOptions)
 	newOpts := nOpts.(*BaseOptions)
 
+	changed := false
 	if oldOpts.RequestWorkerCount != newOpts.RequestWorkerCount {
-		return true
+		changed = true
 	}
 	if oldOpts.TimeZone != newOpts.TimeZone {
-		return true
+		changed = true
 	}
 	if oldOpts.EnableRbac != newOpts.EnableRbac {
-		return true
+		changed = true
 	}
 	if oldOpts.NonDefaultDomainProjects != newOpts.NonDefaultDomainProjects {
 		consts.SetNonDefaultDomainProjects(newOpts.NonDefaultDomainProjects)
+		changed = true
 	}
 	if oldOpts.DomainizedNamespace != newOpts.DomainizedNamespace {
 		consts.SetDomainizedNamespace(newOpts.DomainizedNamespace)
+		changed = true
 	}
-	return false
+	return changed
 }
 
 func OnCommonOptionsChange(oOpts, nOpts interface{}) bool {
 	oldOpts := oOpts.(*CommonOptions)
 	newOpts := nOpts.(*CommonOptions)
 
+	changed := false
 	if OnBaseOptionsChange(&oldOpts.BaseOptions, &newOpts.BaseOptions) {
-		return true
+		changed = true
 	}
-	return false
+
+	return changed
 }

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -158,8 +158,9 @@ func OnOptionsChange(oldO, newO interface{}) bool {
 	oldOpts := oldO.(*ComputeOptions)
 	newOpts := newO.(*ComputeOptions)
 
+	changed := false
 	if common_options.OnCommonOptionsChange(&oldOpts.CommonOptions, &newOpts.CommonOptions) {
-		return true
+		changed = true
 	}
-	return false
+	return changed
 }

--- a/pkg/image/options/options.go
+++ b/pkg/image/options/options.go
@@ -51,9 +51,10 @@ func OnOptionsChange(oldO, newO interface{}) bool {
 	oldOpts := oldO.(*SImageOptions)
 	newOpts := newO.(*SImageOptions)
 
+	changed := false
 	if common_options.OnCommonOptionsChange(&oldOpts.CommonOptions, &newOpts.CommonOptions) {
-		return true
+		changed = true
 	}
 
-	return false
+	return changed
 }

--- a/pkg/keystone/options/options.go
+++ b/pkg/keystone/options/options.go
@@ -59,9 +59,10 @@ func OnOptionsChange(oldOptions, newOptions interface{}) bool {
 	oldOpts := oldOptions.(*SKeystoneOptions)
 	newOpts := newOptions.(*SKeystoneOptions)
 
+	changed := false
 	if options.OnBaseOptionsChange(&oldOpts.BaseOptions, &newOpts.BaseOptions) {
-		return true
+		changed = true
 	}
 
-	return false
+	return changed
 }

--- a/pkg/notify/options/options.go
+++ b/pkg/notify/options/options.go
@@ -41,13 +41,15 @@ func OnOptionsChange(oldO, newO interface{}) bool {
 	oldOpts := oldO.(*NotifyOption)
 	newOpts := newO.(*NotifyOption)
 
+	changed := false
+
 	if common_options.OnCommonOptionsChange(&oldOpts.CommonOptions, &newOpts.CommonOptions) {
-		return true
+		changed = true
 	}
 
 	if oldOpts.SocketFileDir != newOpts.SocketFileDir {
-		return true
+		changed = true
 	}
 
-	return false
+	return changed
 }

--- a/pkg/webconsole/options/options.go
+++ b/pkg/webconsole/options/options.go
@@ -36,9 +36,10 @@ func OnOptionsChange(oldO, newO interface{}) bool {
 	oldOpts := oldO.(*WebConsoleOptions)
 	newOpts := newO.(*WebConsoleOptions)
 
+	changed := false
 	if common_options.OnCommonOptionsChange(&oldOpts.CommonOptions, &newOpts.CommonOptions) {
-		return true
+		changed = true
 	}
 
-	return false
+	return changed
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：service config变更没有生效，因为OnOptionChange遇到改变就返回，导致没有全部生效

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 

/area compute keystone image