### PR TITLE
fix: default value of is_domain field is not consistent between projects and domains

### DIFF
--- a/pkg/keystone/models/domains.go
+++ b/pkg/keystone/models/domains.go
@@ -61,7 +61,7 @@ type SDomain struct {
 	Extra *jsonutils.JSONDict `nullable:"true"`
 
 	Enabled  tristate.TriState `nullable:"false" default:"true" list:"admin" update:"admin" create:"admin_optional"`
-	IsDomain tristate.TriState `default:"true" nullable:"false"`
+	IsDomain tristate.TriState `default:"false" nullable:"false"`
 
 	// IdpId string `token:"parent_id" width:"64" charset:"ascii" index:"true" list:"admin"`
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：projects和domains的is_domain字段缺省值不一致（两个model共享table）

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area keystone