### PR TITLE
feature: add API to retrieve resource's change owner candidate domains

### DIFF
--- a/cmd/climc/shell/hosts.go
+++ b/cmd/climc/shell/hosts.go
@@ -752,4 +752,16 @@ func init() {
 		printObject(result)
 		return nil
 	})
+
+	type HostChangeOwnerCandidateDomainsOptions struct {
+		ID string `help:"ID or name of host"`
+	}
+	R(&HostChangeOwnerCandidateDomainsOptions{}, "host-change-owner-candidate-domains", "Get change owner candidate domain list", func(s *mcclient.ClientSession, args *HostChangeOwnerCandidateDomainsOptions) error {
+		result, err := modules.Hosts.GetSpecific(s, args.ID, "change-owner-candidate-domains", nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
 }

--- a/pkg/apis/compute/cloudprovider.go
+++ b/pkg/apis/compute/cloudprovider.go
@@ -247,3 +247,7 @@ type CloudproviderUpdateInput struct {
 
 type CloudproviderCreateInput struct {
 }
+
+type ChangeOwnerCandidateDomainsOutput struct {
+	Candidates []apis.SharedDomain `json:"candidates"`
+}

--- a/pkg/keystone/models/domains.go
+++ b/pkg/keystone/models/domains.go
@@ -225,6 +225,9 @@ func (domain *SDomain) CustomizeCreate(ctx context.Context, userCred mcclient.To
 	// domain.ParentId = api.KeystoneDomainRoot
 	domain.DomainId = api.KeystoneDomainRoot
 	domain.IsDomain = tristate.True
+	if len(domain.Displayname) == 0 {
+		domain.Displayname = domain.Name
+	}
 	return domain.SStandaloneResourceBase.CustomizeCreate(ctx, userCred, ownerId, query, data)
 }
 

--- a/pkg/keystone/models/projects.go
+++ b/pkg/keystone/models/projects.go
@@ -283,6 +283,9 @@ func (manager *SProjectManager) QueryDistinctExtraField(q *sqlchemy.SQuery, fiel
 func (model *SProject) CustomizeCreate(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data jsonutils.JSONObject) error {
 	model.ParentId = ownerId.GetProjectDomainId()
 	model.IsDomain = tristate.False
+	if len(model.Displayname) == 0 {
+		model.Displayname = model.Name
+	}
 	return model.SIdentityBaseResource.CustomizeCreate(ctx, userCred, ownerId, query, data)
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：增加change-owner-candiate-domains接口，提供changeowner的待选domain列表

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 

/area region