### PR TITLE
build: fix "mod" target on darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ dep:
 	@$(MAKE) mod
 
 mod:
-	go get $(patsubst %,%@master,$(shell GO111MODULE=on go mod edit -print  | sed -n -e 's|.*\(yunion.io/x/[a-z].*\) v.*|\1|p'))
+	go get -d $(patsubst %,%@master,$(shell GO111MODULE=on go mod edit -print  | sed -n -e 's|.*\(yunion.io/x/[a-z].*\) v.*|\1|p'))
 	go mod tidy
 	go mod vendor -v
 


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:

```
We do not need to build and install binaries when updating modules

	go get: cannot install cross-compiled binaries when GOBIN is set
```

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

NONE

/area util
/cc @zexi @zhaoxiangchun 