### PR TITLE
fix: 1. parameter duplicate error due to missing name filter 2.infras_quota setKeys error

### DIFF
--- a/pkg/apis/yunionconf/input.go
+++ b/pkg/apis/yunionconf/input.go
@@ -36,4 +36,7 @@ type ParameterListInput struct {
 	// Deprecated
 	// swagger:ignore
 	UserId string `json:"user_id" deprecated-by:"user"`
+
+	// filter by name
+	Name []string `json:"name"`
 }

--- a/pkg/compute/models/infrasquota.go
+++ b/pkg/compute/models/infrasquota.go
@@ -70,18 +70,18 @@ func init() {
 type SInfrasQuota struct {
 	quotas.SQuotaBase
 
-	quotas.SRegionalCloudResourceKeys
+	quotas.SDomainRegionalCloudResourceKeys
 
 	Host int `default:"-1" allow_zero:"true" json:"host"`
 	Vpc  int `default:"-1" allow_zero:"true" json:"vpc"`
 }
 
 func (self *SInfrasQuota) GetKeys() quotas.IQuotaKeys {
-	return self.SRegionalCloudResourceKeys
+	return self.SDomainRegionalCloudResourceKeys
 }
 
 func (self *SInfrasQuota) SetKeys(keys quotas.IQuotaKeys) {
-	self.SRegionalCloudResourceKeys = keys.(quotas.SRegionalCloudResourceKeys)
+	self.SDomainRegionalCloudResourceKeys = keys.(quotas.SDomainRegionalCloudResourceKeys)
 }
 
 func (self *SInfrasQuota) FetchSystemQuota() {
@@ -106,7 +106,7 @@ func (self *SInfrasQuota) FetchSystemQuota() {
 }
 
 func (self *SInfrasQuota) FetchUsage(ctx context.Context) error {
-	regionKeys := self.SRegionalCloudResourceKeys
+	regionKeys := self.SDomainRegionalCloudResourceKeys
 
 	scope := regionKeys.Scope()
 	ownerId := regionKeys.OwnerId()

--- a/pkg/yunionconf/models/parameters.go
+++ b/pkg/yunionconf/models/parameters.go
@@ -256,6 +256,9 @@ func (manager *SParameterManager) ListItemFilter(
 	if err != nil {
 		return nil, errors.Wrap(err, "SResourceBaseManager.ListItemFilter")
 	}
+	if len(query.Name) > 0 {
+		q = q.In("name", query.Name)
+	}
 	if db.IsAdminAllowList(userCred, manager) {
 		if id := query.NamespaceId; len(id) > 0 {
 			q = q.Equals("namespace_id", id)
@@ -371,4 +374,8 @@ func (model *SParameter) GetOwnerId() mcclient.IIdentityProvider {
 
 	owner := db.SOwnerId{UserId: model.NamespaceId}
 	return &owner
+}
+
+func (manager *SParameterManager) FetchOwnerId(ctx context.Context, data jsonutils.JSONObject) (mcclient.IIdentityProvider, error) {
+	return db.FetchUserInfo(ctx, data)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：1. 参数化缺少name过滤器导致参数重名错误 2. infras_quota setKeys类型转换panic

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/area region yunionconf

/cc @zexi 