### PR TITLE
fix: role/policy missing FilterByOwner implementation

### DIFF
--- a/pkg/keystone/models/policies.go
+++ b/pkg/keystone/models/policies.go
@@ -326,3 +326,7 @@ func (policy *SPolicy) GetUsages() []db.IUsage {
 		&usage,
 	}
 }
+
+func (manager *SPolicyManager) FilterByOwner(q *sqlchemy.SQuery, owner mcclient.IIdentityProvider, scope rbacutils.TRbacScope) *sqlchemy.SQuery {
+	return db.SharableManagerFilterByOwner(manager, q, owner, scope)
+}

--- a/pkg/keystone/models/roles.go
+++ b/pkg/keystone/models/roles.go
@@ -31,6 +31,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/policy"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
 	"yunion.io/x/onecloud/pkg/util/stringutils2"
 )
 
@@ -509,4 +510,8 @@ func (role *SRole) PostCreate(
 	if err != nil {
 		log.Errorf("CancelPendingUsage fail %s", err)
 	}
+}
+
+func (manager *SRoleManager) FilterByOwner(q *sqlchemy.SQuery, owner mcclient.IIdentityProvider, scope rbacutils.TRbacScope) *sqlchemy.SQuery {
+	return db.SharableManagerFilterByOwner(manager, q, owner, scope)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正: role/polocy没有实现FilterByOwner，导致无法查看共享的资源

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
None

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area keystone