### PR TITLE
fix: service-config-show shows service's own config

### DIFF
--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -88,7 +88,7 @@ type BaseOptions struct {
 
 	DomainizedNamespace bool `help:"turn on global name space, default is on" default:"false" json:"domainized_namespace,allowfalse"`
 
-	ApiServer string `help:"URL to access frontend webconsole" default:"http://webconsole.yunion.io"`
+	ApiServer string `help:"URL to access frontend webconsole"`
 
 	structarg.BaseOptions
 }

--- a/pkg/keystone/models/identity_provider.go
+++ b/pkg/keystone/models/identity_provider.go
@@ -203,7 +203,7 @@ func (self *SIdentityProvider) AllowGetDetailsConfig(ctx context.Context, userCr
 }
 
 func (self *SIdentityProvider) GetDetailsConfig(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (jsonutils.JSONObject, error) {
-	conf, err := GetConfigs(self, false)
+	conf, err := GetConfigs(self, false, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/keystone/models/services.go
+++ b/pkg/keystone/models/services.go
@@ -160,7 +160,15 @@ func (service *SService) AllowGetDetailsConfig(ctx context.Context, userCred mcc
 }
 
 func (service *SService) GetDetailsConfig(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (jsonutils.JSONObject, error) {
-	conf, err := GetConfigs(service, false)
+	var whiteList, blackList map[string][]string
+	if service.isCommonService() {
+		// whitelist common options
+		whiteList = api.CommonWhitelistOptionMap
+	} else {
+		// blacklist common options
+		blackList = api.CommonWhitelistOptionMap
+	}
+	conf, err := GetConfigs(service, false, whiteList, blackList)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/keystone/models/syncworker.go
+++ b/pkg/keystone/models/syncworker.go
@@ -44,7 +44,7 @@ func submitIdpSyncTask(ctx context.Context, userCred mcclient.TokenCredential, i
 		idp.SetSyncStatus(ctx, userCred, api.IdentitySyncStatusSyncing)
 		defer idp.SetSyncStatus(ctx, userCred, api.IdentitySyncStatusIdle)
 
-		conf, err := GetConfigs(idp, true)
+		conf, err := GetConfigs(idp, true, nil, nil)
 		if err != nil {
 			log.Errorf("GetConfig for idp %s fail %s", idp.Name, err)
 			idp.MarkDisconnected(ctx, userCred)

--- a/pkg/keystone/tokens/auth.go
+++ b/pkg/keystone/tokens/auth.go
@@ -150,7 +150,7 @@ func authUserByIdentity(ctx context.Context, ident mcclient.SAuthenticationIdent
 		return nil, errors.Error(fmt.Sprintf("invalid idp status %s", idp.Status))
 	}
 
-	conf, err := models.GetConfigs(idp, true)
+	conf, err := models.GetConfigs(idp, true, nil, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "GetConfig")
 	}
@@ -184,7 +184,7 @@ func authUserByCASV3(ctx context.Context, input mcclient.SAuthenticationInputV3)
 		return nil, errors.Error("more than 1 cas identity providers?")
 	}
 	idp := &idps[0]
-	conf, err := models.GetConfigs(idp, true)
+	conf, err := models.GetConfigs(idp, true, nil, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "idp.GetConfig")
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：service-config-show/edit只展示和修改该服务本身的配置，不包含common的配置项。common的配置项通过common展示和修改。

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area keystone