### PR TITLE
Automated cherry pick of #5740: region: lbagents: fix returning error when glob has no match

### DIFF
--- a/pkg/compute/models/loadbalanceragents_deploy.go
+++ b/pkg/compute/models/loadbalanceragents_deploy.go
@@ -159,7 +159,7 @@ func (lbagent *SLoadbalancerAgent) deploy(ctx context.Context, userCred mcclient
 				return nil, errors.WithMessagef(err, "glob error %s", pattern)
 			}
 			if len(matches) == 0 {
-				return nil, errors.WithMessagef(err, "glob nomatch %s", pattern)
+				return nil, errors.Errorf("no match for %q", pattern)
 			}
 			path := matches[len(matches)-1]
 			name := filepath.Base(path)


### PR DESCRIPTION
Cherry pick of #5740 on release/3.0.

#5740: region: lbagents: fix returning error when glob has no match