### PR TITLE
fix: 1. allow share proxysetting 2. claim proxsetting as domain resource

### DIFF
--- a/cmd/climc/shell/proxysettings.go
+++ b/cmd/climc/shell/proxysettings.go
@@ -15,6 +15,8 @@
 package shell
 
 import (
+	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/mcclient/options"
@@ -76,6 +78,24 @@ func init() {
 			return err
 		}
 		printObject(proxysetting)
+		return nil
+	})
+	R(&options.ProxySettingPublicOptions{}, "proxysetting-public", "Make proxysetting public", func(s *mcclient.ClientSession, opts *options.ProxySettingPublicOptions) error {
+		params := jsonutils.Marshal(opts)
+		result, err := modules.ProxySettings.PerformAction(s, opts.ID, "public", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+	R(&options.ProxySettingPrivateOptions{}, "proxysetting-private", "Make proxysetting private", func(s *mcclient.ClientSession, opts *options.ProxySettingPrivateOptions) error {
+		params := jsonutils.Marshal(opts)
+		result, err := modules.ProxySettings.PerformAction(s, opts.ID, "private", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
 		return nil
 	})
 }

--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -307,11 +307,12 @@ func (self *SCloudaccount) ValidateUpdateData(
 		if proxySetting != nil {
 			// updated proxy setting, so do the check
 			proxyFunc := proxySetting.HttpTransportProxyFunc()
+			secret, _ := self.getPassword()
 			_, err := cloudprovider.IsValidCloudAccount(cloudprovider.ProviderConfig{
 				Vendor:    self.Provider,
 				URL:       self.AccessUrl,
 				Account:   self.Account,
-				Secret:    self.Secret,
+				Secret:    secret,
 				ProxyFunc: proxyFunc,
 			})
 			if err != nil {

--- a/pkg/compute/policy/resources.go
+++ b/pkg/compute/policy/resources.go
@@ -52,6 +52,7 @@ var (
 		"natsentries",
 		"natdentries",
 		"policy_assignments",
+		"proxysettings",
 	}
 	computeUserResources = []string{
 		"keypairs",

--- a/pkg/mcclient/options/cloudaccounts.go
+++ b/pkg/mcclient/options/cloudaccounts.go
@@ -83,6 +83,8 @@ type SCloudAccountCreateBaseOptions struct {
 	SyncIntervalSeconds int `help:"Interval to synchronize if auto sync is enable" metavar:"SECONDS"`
 
 	ProjectDomain string `help:"domain for this account"`
+
+	ProxySettingId string `help:"proxy setting id or name" json:"proxy_setting_id"`
 }
 
 type SVMwareCloudAccountCreateOptions struct {
@@ -229,7 +231,7 @@ type SCloudAccountUpdateBaseOptions struct {
 
 	SyncIntervalSeconds int    `help:"auto synchornize interval in seconds"`
 	AutoCreateProject   *bool  `help:"automatically create local project for new remote project"`
-	ProxySetting        string `help:"proxy setting name or id"`
+	ProxySettingId      string `help:"proxy setting name or id" json:"proxy_setting_id"`
 
 	Desc string `help:"Description" json:"description" token:"desc"`
 }

--- a/pkg/mcclient/options/proxysettings.go
+++ b/pkg/mcclient/options/proxysettings.go
@@ -46,3 +46,13 @@ type ProxySettingTestOptions struct {
 type ProxySettingListOptions struct {
 	BaseListOptions
 }
+
+type ProxySettingPublicOptions struct {
+	ProxySettingGetOptions
+	Scope        string   `json:"scope" help:"share scope" choices:"domain|system"`
+	SharedDomain []string `json:"share"`
+}
+
+type ProxySettingPrivateOptions struct {
+	ProxySettingGetOptions
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：1. proxyseting作为域资源 2. proxy setting 共享的climc命令 3. 创建和更新cloudaccount proxysetting的命令

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @yousong 

/area region