### PR TITLE
fix: sync resource's share state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BUILD_SCRIPT := $(ROOT_DIR)/build/build.sh
 ifeq ($(ONECLOUD_CI_BUILD),)
 	GIT_COMMIT := $(shell git rev-parse --short HEAD)
 	GIT_BRANCH := $(shell git name-rev --name-only HEAD)
-	GIT_VERSION := $(shell git describe --tags --abbrev=14 $(GIT_COMMIT)^{commit})
+	GIT_VERSION := $(shell git describe --always --tags --abbrev=14 $(GIT_COMMIT)^{commit})
 	GIT_TREE_STATE := $(shell s=`git status --porcelain 2>/dev/null`; if [ -z "$$s" ]; then echo "clean"; else echo "dirty"; fi)
 	BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 else

--- a/cmd/climc/shell/hosts.go
+++ b/cmd/climc/shell/hosts.go
@@ -725,10 +725,9 @@ func init() {
 	})
 
 	type HostPublicOptions struct {
-		ID             string   `help:"ID or name of host" json:"-"`
-		Scope          string   `help:"sharing scope" choices:"system|domain|project"`
-		SharedProjects []string `help:"Share to prjects"`
-		SharedDomains  []string `help:"share to domains"`
+		ID            string   `help:"ID or name of host" json:"-"`
+		Scope         string   `help:"sharing scope" choices:"system|domain"`
+		SharedDomains []string `help:"share to domains"`
 	}
 	R(&HostPublicOptions{}, "host-public", "Make a host public", func(s *mcclient.ClientSession, args *HostPublicOptions) error {
 		params := jsonutils.Marshal(args)

--- a/cmd/climc/shell/networks.go
+++ b/cmd/climc/shell/networks.go
@@ -185,10 +185,7 @@ func init() {
 		SharedDomains  []string `help:"share to domains"`
 	}
 	R(&NetworkShareOptions{}, "network-public", "Make a network public", func(s *mcclient.ClientSession, args *NetworkShareOptions) error {
-		params, err := options.StructToParams(args)
-		if err != nil {
-			return err
-		}
+		params := jsonutils.Marshal(args)
 		result, err := modules.Networks.PerformAction(s, args.ID, "public", params)
 		if err != nil {
 			return err
@@ -393,6 +390,15 @@ func init() {
 	R(&NetworkStatusOptions{}, "network-status", "Set on-premise network status", func(s *mcclient.ClientSession, args *NetworkStatusOptions) error {
 		params := jsonutils.Marshal(args)
 		result, err := modules.Networks.PerformAction(s, args.NETWORK, "status", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
+	R(&NetworkIdOptions{}, "network-change-owner-candidate-domains", "Show candiate domains of a network for changing owner", func(s *mcclient.ClientSession, args *NetworkIdOptions) error {
+		result, err := modules.Networks.GetSpecific(s, args.ID, "change-owner-candidate-domains", nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/climc/shell/policies.go
+++ b/cmd/climc/shell/policies.go
@@ -136,11 +136,14 @@ func init() {
 	R(&PolicyPatchOptions{}, "policy-patch", "Patch policy", updateFunc)
 	R(&PolicyPatchOptions{}, "policy-update", "Update policy", updateFunc)
 
-	type PolicyPerformOptions struct {
-		ID string `help:"ID of policy to update"`
+	type PolicyPublicOptions struct {
+		ID            string   `help:"ID of policy to update" json:"-"`
+		Scope         string   `help:"sharing scope" choices:"system|domain"`
+		SharedDomains []string `help:"share to domains"`
 	}
-	R(&PolicyPerformOptions{}, "policy-public", "Mark a policy public", func(s *mcclient.ClientSession, args *PolicyPerformOptions) error {
-		result, err := modules.Policies.PerformAction(s, args.ID, "public", nil)
+	R(&PolicyPublicOptions{}, "policy-public", "Mark a policy public", func(s *mcclient.ClientSession, args *PolicyPublicOptions) error {
+		params := jsonutils.Marshal(args)
+		result, err := modules.Policies.PerformAction(s, args.ID, "public", params)
 		if err != nil {
 			return err
 		}
@@ -148,7 +151,10 @@ func init() {
 		return nil
 	})
 
-	R(&PolicyPerformOptions{}, "policy-private", "Mark a policy private", func(s *mcclient.ClientSession, args *PolicyPerformOptions) error {
+	type PolicyPrivateOptions struct {
+		ID string `help:"ID of policy to update" json:"-"`
+	}
+	R(&PolicyPrivateOptions{}, "policy-private", "Mark a policy private", func(s *mcclient.ClientSession, args *PolicyPrivateOptions) error {
 		result, err := modules.Policies.PerformAction(s, args.ID, "private", nil)
 		if err != nil {
 			return err
@@ -184,11 +190,7 @@ func init() {
 		if err != nil {
 			return err
 		}
-		yaml, err := result.GetString("policy")
-		if err != nil {
-			return err
-		}
-		fmt.Println(yaml)
+		printObject(result)
 		return nil
 	})
 

--- a/cmd/climc/shell/vpcs.go
+++ b/cmd/climc/shell/vpcs.go
@@ -178,4 +178,40 @@ func init() {
 		return nil
 	})
 
+	type VpcPublicOptions struct {
+		ID            string   `help:"ID or name of vpc" json:"-"`
+		Scope         string   `help:"sharing scope" choices:"system|domain"`
+		SharedDomains []string `help:"share to domains"`
+	}
+	R(&VpcPublicOptions{}, "vpc-public", "Make vpc public", func(s *mcclient.ClientSession, args *VpcPublicOptions) error {
+		params := jsonutils.Marshal(args)
+		result, err := modules.Vpcs.PerformAction(s, args.ID, "public", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
+	type VpcPrivateOptions struct {
+		ID string `help:"ID or name of vpc" json:"-"`
+	}
+	R(&VpcPrivateOptions{}, "vpc-private", "Make vpc private", func(s *mcclient.ClientSession, args *VpcPrivateOptions) error {
+		params := jsonutils.Marshal(args)
+		result, err := modules.Vpcs.PerformAction(s, args.ID, "private", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
+	R(&VpcShowOptions{}, "vpc-change-owner-candidate-domains", "Show candiate domains of a vpc for changing owner", func(s *mcclient.ClientSession, args *VpcShowOptions) error {
+		result, err := modules.Vpcs.GetSpecific(s, args.ID, "change-owner-candidate-domains", nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
 }

--- a/cmd/climc/shell/wires.go
+++ b/cmd/climc/shell/wires.go
@@ -132,4 +132,41 @@ func init() {
 		printObject(result)
 		return nil
 	})
+
+	type WirePublicOptions struct {
+		ID            string   `help:"ID or name of wire" json:"-"`
+		Scope         string   `help:"sharing scope" choices:"system|domain"`
+		SharedDomains []string `help:"share to domains"`
+	}
+	R(&WirePublicOptions{}, "wire-public", "Make wire public", func(s *mcclient.ClientSession, args *WirePublicOptions) error {
+		params := jsonutils.Marshal(args)
+		result, err := modules.Wires.PerformAction(s, args.ID, "public", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
+	type WirePrivateOptions struct {
+		ID string `help:"ID or name of wire" json:"-"`
+	}
+	R(&WirePrivateOptions{}, "wire-private", "Make wire private", func(s *mcclient.ClientSession, args *WirePrivateOptions) error {
+		params := jsonutils.Marshal(args)
+		result, err := modules.Wires.PerformAction(s, args.ID, "private", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
+	R(&WireShowOptions{}, "wire-change-owner-candidate-domains", "Show candiate domains of a wire for changing owner", func(s *mcclient.ClientSession, args *WireShowOptions) error {
+		result, err := modules.Wires.GetSpecific(s, args.ID, "change-owner-candidate-domains", nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
 }

--- a/pkg/apis/compute/bucket.go
+++ b/pkg/apis/compute/bucket.go
@@ -43,7 +43,7 @@ const (
 )
 
 type BucketCreateInput struct {
-	apis.VirtualResourceCreateInput
+	apis.SharableVirtualResourceCreateInput
 	CloudregionResourceInput
 	CloudproviderResourceInput
 
@@ -51,7 +51,7 @@ type BucketCreateInput struct {
 }
 
 type BucketDetails struct {
-	apis.VirtualResourceDetails
+	apis.SharableVirtualResourceDetails
 	ManagedResourceInfo
 	CloudregionResourceInfo
 
@@ -98,7 +98,7 @@ func (input *BucketMetadataInput) Validate() error {
 }
 
 type BucketListInput struct {
-	apis.VirtualResourceListInput
+	apis.SharableVirtualResourceListInput
 	apis.ExternalizedResourceBaseListInput
 
 	ManagedResourceListInput
@@ -118,5 +118,5 @@ type BucketSyncstatusInput struct {
 }
 
 type BucketUpdateInput struct {
-	apis.VirtualResourceBaseUpdateInput
+	apis.SharableVirtualResourceBaseUpdateInput
 }

--- a/pkg/apis/compute/cloudprovider.go
+++ b/pkg/apis/compute/cloudprovider.go
@@ -247,7 +247,3 @@ type CloudproviderUpdateInput struct {
 
 type CloudproviderCreateInput struct {
 }
-
-type ChangeOwnerCandidateDomainsOutput struct {
-	Candidates []apis.SharedDomain `json:"candidates"`
-}

--- a/pkg/apis/identity/input.go
+++ b/pkg/apis/identity/input.go
@@ -438,6 +438,7 @@ type GroupCreateInput struct {
 
 type PolicyCreateInput struct {
 	EnabledIdentityBaseResourceCreateInput
+	apis.SharableResourceBaseCreateInput
 
 	Type string `json:"type"`
 
@@ -446,4 +447,6 @@ type PolicyCreateInput struct {
 
 type RoleCreateInput struct {
 	IdentityBaseResourceCreateInput
+
+	apis.SharableResourceBaseCreateInput
 }

--- a/pkg/apis/identity/policy.go
+++ b/pkg/apis/identity/policy.go
@@ -14,8 +14,11 @@
 
 package identity
 
+import "yunion.io/x/onecloud/pkg/apis"
+
 type PolicyDetails struct {
 	EnabledIdentityBaseResourceDetails
+	apis.SharableResourceBaseInfo
 
 	SPolicy
 }

--- a/pkg/apis/identity/role.go
+++ b/pkg/apis/identity/role.go
@@ -14,8 +14,11 @@
 
 package identity
 
+import "yunion.io/x/onecloud/pkg/apis"
+
 type RoleDetails struct {
 	IdentityBaseResourceDetails
+	apis.SharableResourceBaseInfo
 
 	SRole
 

--- a/pkg/apis/input.go
+++ b/pkg/apis/input.go
@@ -59,16 +59,20 @@ type ProjectizedResourceCreateInput struct {
 	ProjectizedResourceInput
 }
 
-type SharableVirtualResourceCreateInput struct {
-	VirtualResourceCreateInput
-
-	// description: indicate the resource is a public resource
+type SharableResourceBaseCreateInput struct {
+	// 是否共享
 	// required: false
 	IsPublic *bool `json:"is_public"`
 
-	// description: indicate the shared scope for a public resource, which can be domain or system or none
+	// 共享范围
 	// required: false
 	PublicScope string `json:"public_scope"`
+}
+
+type SharableVirtualResourceCreateInput struct {
+	VirtualResourceCreateInput
+
+	SharableResourceBaseCreateInput
 }
 
 type VirtualResourceCreateInput struct {
@@ -207,6 +211,8 @@ type PerformDisableInput struct {
 
 type InfrasResourceBaseCreateInput struct {
 	DomainLevelResourceCreateInput
+
+	SharableResourceBaseCreateInput
 }
 
 type StatusInfrasResourceBaseCreateInput struct {

--- a/pkg/apis/output.go
+++ b/pkg/apis/output.go
@@ -156,3 +156,7 @@ type StatusInfrasResourceBaseDetails struct {
 type EnabledStatusInfrasResourceBaseDetails struct {
 	StatusInfrasResourceBaseDetails
 }
+
+type ChangeOwnerCandidateDomainsOutput struct {
+	Candidates []SharedDomain `json:"candidates"`
+}

--- a/pkg/cloudcommon/db/domain.go
+++ b/pkg/cloudcommon/db/domain.go
@@ -69,6 +69,12 @@ func (model *SDomainizedResourceBase) GetOwnerId() mcclient.IIdentityProvider {
 	return &owner
 }
 
+// returns candiate domain Id list that the resource can change owner to
+// nil or empty means any domain
+func (model *SDomainizedResourceBase) GetChangeOwnerCandidateDomainIds() []string {
+	return nil
+}
+
 func ValidateCreateDomainId(domainId string) error {
 	if !consts.GetNonDefaultDomainProjects() && domainId != identity.DEFAULT_DOMAIN_ID {
 		return httperrors.NewForbiddenError("project in non-default domain is prohibited")

--- a/pkg/cloudcommon/db/domain.go
+++ b/pkg/cloudcommon/db/domain.go
@@ -146,7 +146,7 @@ func (manager *SDomainizedResourceBaseManager) FetchCustomizeColumns(
 				domainIds = stringutils2.Append(domainIds, base.DomainId)
 			}
 		}
-		domains := FetchProjects(domainIds, true)
+		domains := DefaultProjectsFetcher(ctx, domainIds, true)
 		if domains != nil {
 			for i := range objs {
 				var base *SDomainizedResourceBase

--- a/pkg/cloudcommon/db/domainresource.go
+++ b/pkg/cloudcommon/db/domainresource.go
@@ -17,11 +17,10 @@ package db
 import (
 	"context"
 
-	"yunion.io/x/pkg/utils"
-
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/utils"
 	"yunion.io/x/sqlchemy"
 
 	"yunion.io/x/onecloud/pkg/apis"

--- a/pkg/cloudcommon/db/fetch.go
+++ b/pkg/cloudcommon/db/fetch.go
@@ -246,7 +246,7 @@ func FetchProjectInfo(ctx context.Context, data jsonutils.JSONObject) (mcclient.
 	tenantId, key := jsonutils.GetAnyString2(data, []string{"project", "project_id", "tenant", "tenant_id"})
 	if len(tenantId) > 0 {
 		data.(*jsonutils.JSONDict).Remove(key)
-		t, err := TenantCacheManager.FetchTenantByIdOrName(ctx, tenantId)
+		t, err := DefaultProjectFetcher(ctx, tenantId)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				return nil, httperrors.NewResourceNotFoundError2("project", tenantId)
@@ -271,7 +271,7 @@ func FetchDomainInfo(ctx context.Context, data jsonutils.JSONObject) (mcclient.I
 	domainId, key := jsonutils.GetAnyString2(data, []string{"domain_id", "project_domain", "project_domain_id"})
 	if len(domainId) > 0 {
 		data.(*jsonutils.JSONDict).Remove(key)
-		domain, err := TenantCacheManager.FetchDomainByIdOrName(ctx, domainId)
+		domain, err := DefaultDomainFetcher(ctx, domainId)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				return nil, httperrors.NewResourceNotFoundError2("domain", domainId)

--- a/pkg/cloudcommon/db/infraresource.go
+++ b/pkg/cloudcommon/db/infraresource.go
@@ -214,19 +214,26 @@ func (model *SInfrasResourceBase) Delete(ctx context.Context, userCred mcclient.
 }
 
 func (model *SInfrasResourceBase) SyncShareState(ctx context.Context, userCred mcclient.TokenCredential, shareInfo apis.SAccountShareInfo) {
-	if model.PublicScope != string(apis.OWNER_SOURCE_LOCAL) {
+	if model.PublicSrc != string(apis.OWNER_SOURCE_LOCAL) {
 		diff, _ := Update(model, func() error {
+			model.PublicSrc = string(apis.OWNER_SOURCE_CLOUD)
 			switch shareInfo.ShareMode {
 			case compute.CLOUD_ACCOUNT_SHARE_MODE_ACCOUNT_DOMAIN:
 				model.IsPublic = false
 				model.PublicScope = string(rbacutils.ScopeNone)
+				SharedResourceManager.shareToTarget(ctx, userCred, model.GetIInfrasModel(), SharedTargetProject, nil, nil, nil)
+				SharedResourceManager.shareToTarget(ctx, userCred, model.GetIInfrasModel(), SharedTargetDomain, nil, nil, nil)
 			case compute.CLOUD_ACCOUNT_SHARE_MODE_PROVIDER_DOMAIN:
 				model.IsPublic = false
 				model.PublicScope = string(rbacutils.ScopeNone)
+				SharedResourceManager.shareToTarget(ctx, userCred, model.GetIInfrasModel(), SharedTargetProject, nil, nil, nil)
+				SharedResourceManager.shareToTarget(ctx, userCred, model.GetIInfrasModel(), SharedTargetDomain, nil, nil, nil)
 			case compute.CLOUD_ACCOUNT_SHARE_MODE_SYSTEM:
 				if shareInfo.IsPublic && shareInfo.PublicScope == rbacutils.ScopeSystem {
 					model.IsPublic = true
 					model.PublicScope = string(rbacutils.ScopeSystem)
+					SharedResourceManager.shareToTarget(ctx, userCred, model.GetIInfrasModel(), SharedTargetProject, nil, nil, nil)
+					SharedResourceManager.shareToTarget(ctx, userCred, model.GetIInfrasModel(), SharedTargetDomain, nil, nil, nil)
 				} else if len(shareInfo.SharedDomains) > 0 {
 					model.IsPublic = true
 					model.PublicScope = string(rbacutils.ScopeDomain)

--- a/pkg/cloudcommon/db/infraresource.go
+++ b/pkg/cloudcommon/db/infraresource.go
@@ -47,7 +47,7 @@ func NewInfrasResourceBaseManager(
 
 type SInfrasResourceBase struct {
 	SDomainLevelResourceBase
-	SSharableBaseResource
+	SSharableBaseResource `"is_public=>create":"domain_optional" "public_scope=>create":"domain_optional"`
 }
 
 func (manager *SInfrasResourceBaseManager) GetIInfrasModelManager() IInfrasModelManager {
@@ -75,7 +75,7 @@ func (model *SInfrasResourceBase) AllowPerformPublic(ctx context.Context, userCr
 }
 
 func (model *SInfrasResourceBase) PerformPublic(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPublicInput) (jsonutils.JSONObject, error) {
-	err := SharablePerformPublic(model, ctx, userCred, input)
+	err := SharablePerformPublic(model.GetIInfrasModel(), ctx, userCred, input)
 	if err != nil {
 		return nil, errors.Wrap(err, "SharablePerformPublic")
 	}
@@ -87,7 +87,7 @@ func (model *SInfrasResourceBase) AllowPerformPrivate(ctx context.Context, userC
 }
 
 func (model *SInfrasResourceBase) PerformPrivate(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPrivateInput) (jsonutils.JSONObject, error) {
-	err := SharablePerformPrivate(model, ctx, userCred)
+	err := SharablePerformPrivate(model.GetIInfrasModel(), ctx, userCred)
 	if err != nil {
 		return nil, errors.Wrap(err, "SharablePerformPrivate")
 	}
@@ -230,13 +230,13 @@ func (model *SInfrasResourceBase) SyncShareState(ctx context.Context, userCred m
 				} else if len(shareInfo.SharedDomains) > 0 {
 					model.IsPublic = true
 					model.PublicScope = string(rbacutils.ScopeDomain)
-					SharedResourceManager.shareToTarget(ctx, userCred, model.GetIInfrasModel(), SharedTargetProject, nil)
-					SharedResourceManager.shareToTarget(ctx, userCred, model.GetIInfrasModel(), SharedTargetDomain, shareInfo.SharedDomains)
+					SharedResourceManager.shareToTarget(ctx, userCred, model.GetIInfrasModel(), SharedTargetProject, nil, nil, nil)
+					SharedResourceManager.shareToTarget(ctx, userCred, model.GetIInfrasModel(), SharedTargetDomain, shareInfo.SharedDomains, nil, nil)
 				} else {
 					model.IsPublic = false
 					model.PublicScope = string(rbacutils.ScopeNone)
-					SharedResourceManager.shareToTarget(ctx, userCred, model.GetIInfrasModel(), SharedTargetProject, nil)
-					SharedResourceManager.shareToTarget(ctx, userCred, model.GetIInfrasModel(), SharedTargetDomain, nil)
+					SharedResourceManager.shareToTarget(ctx, userCred, model.GetIInfrasModel(), SharedTargetProject, nil, nil, nil)
+					SharedResourceManager.shareToTarget(ctx, userCred, model.GetIInfrasModel(), SharedTargetDomain, nil, nil, nil)
 				}
 			}
 			return nil
@@ -245,4 +245,12 @@ func (model *SInfrasResourceBase) SyncShareState(ctx context.Context, userCred m
 			OpsLog.LogEvent(model, ACT_SYNC_SHARE, diff, userCred)
 		}
 	}
+}
+
+func (model *SInfrasResourceBase) GetSharableTargetDomainIds() []string {
+	return model.GetIInfrasModel().GetChangeOwnerCandidateDomainIds()
+}
+
+func (model *SInfrasResourceBase) GetRequiredSharedDomainIds() []string {
+	return []string{model.DomainId}
 }

--- a/pkg/cloudcommon/db/interface.go
+++ b/pkg/cloudcommon/db/interface.go
@@ -295,6 +295,8 @@ type IDomainLevelModel interface {
 	SyncCloudDomainId(userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider)
 
 	GetIDomainLevelModel() IDomainLevelModel
+
+	IOwnerResourceBaseModel
 }
 
 type IInfrasModelManager interface {
@@ -308,7 +310,6 @@ type IInfrasModel interface {
 	ISharableBase
 
 	GetIInfrasModel() IInfrasModel
-	GetSharedDomains() []string
 }
 
 type IVirtualModelManager interface {
@@ -328,6 +329,8 @@ type IVirtualModel interface {
 	SyncCloudProjectId(userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider)
 
 	GetIVirtualModel() IVirtualModel
+
+	IOwnerResourceBaseModel
 }
 
 type ISharableVirtualModelManager interface {
@@ -342,7 +345,6 @@ type ISharableVirtualModel interface {
 
 	GetISharableVirtualModel() ISharableVirtualModel
 	GetSharedProjects() []string
-	GetSharedDomains() []string
 }
 
 type IAdminSharableVirtualModelManager interface {

--- a/pkg/cloudcommon/db/managed.go
+++ b/pkg/cloudcommon/db/managed.go
@@ -15,8 +15,9 @@
 package db
 
 import (
-	"yunion.io/x/onecloud/pkg/apis"
 	"yunion.io/x/pkg/errors"
+
+	"yunion.io/x/onecloud/pkg/apis"
 )
 
 type IOwnerResourceBaseModel interface {

--- a/pkg/cloudcommon/db/opslog.go
+++ b/pkg/cloudcommon/db/opslog.go
@@ -480,7 +480,7 @@ func (manager *SOpsLogManager) ListItemFilter(
 	projStrs := jsonutils.GetQueryStringArray(query, "project")
 	if len(projStrs) > 0 {
 		for i := range projStrs {
-			projObj, err := TenantCacheManager.FetchTenantByIdOrName(ctx, projStrs[i])
+			projObj, err := DefaultProjectFetcher(ctx, projStrs[i])
 			if err != nil {
 				if err == sql.ErrNoRows {
 					return nil, httperrors.NewResourceNotFoundError2("project", projStrs[i])

--- a/pkg/cloudcommon/db/project.go
+++ b/pkg/cloudcommon/db/project.go
@@ -143,7 +143,7 @@ func (manager *SProjectizedResourceBaseManager) FetchCustomizeColumns(
 				projectIds = stringutils2.Append(projectIds, base.ProjectId)
 			}
 		}
-		projects := FetchProjects(projectIds, false)
+		projects := DefaultProjectsFetcher(ctx, projectIds, false)
 		if projects != nil {
 			for i := range objs {
 				var base *SProjectizedResourceBase
@@ -164,7 +164,7 @@ func (manager *SProjectizedResourceBaseManager) FetchCustomizeColumns(
 	return ret
 }
 
-func FetchProjects(projectIds []string, isDomain bool) map[string]STenant {
+func fetchProjects(ctx context.Context, projectIds []string, isDomain bool) map[string]STenant {
 	deadline := time.Now().UTC().Add(-consts.GetTenantCacheExpireSeconds())
 	q := TenantCacheManager.Query().In("id", projectIds).GT("last_check", deadline)
 	if isDomain {
@@ -181,7 +181,6 @@ func FetchProjects(projectIds []string, isDomain bool) map[string]STenant {
 	for i := range projects {
 		ret[projects[i].Id] = projects[i]
 	}
-	ctx := context.Background()
 	for _, pid := range projectIds {
 		if _, ok := ret[pid]; !ok {
 			// not found

--- a/pkg/cloudcommon/db/quotas/register.go
+++ b/pkg/cloudcommon/db/quotas/register.go
@@ -85,7 +85,6 @@ func cancelUsage(ctx context.Context, userCred mcclient.TokenCredential, usage I
 	if err != nil {
 		log.Errorf("cancelUsage %s fail: %s", jsonutils.Marshal(usage), err)
 	}
-	log.Infof("cancelUsage %s", jsonutils.Marshal(usage))
 }
 
 func GetQuotaCount(ctx context.Context, request IQuota, pendingKeys IQuotaKeys) (int, error) {

--- a/pkg/cloudcommon/db/scoperesource.go
+++ b/pkg/cloudcommon/db/scoperesource.go
@@ -151,7 +151,7 @@ func (m *SScopedResourceBaseManager) PerformSetScope(
 	domainId := jsonutils.GetAnyString(data, []string{"domain_id", "domain", "project_domain_id", "project_domain"})
 	projectId := jsonutils.GetAnyString(data, []string{"project_id", "project"})
 	if projectId != "" {
-		project, err := TenantCacheManager.FetchTenantByIdOrName(ctx, projectId)
+		project, err := DefaultProjectFetcher(ctx, projectId)
 		if err != nil {
 			return nil, err
 		}
@@ -159,7 +159,7 @@ func (m *SScopedResourceBaseManager) PerformSetScope(
 		domainId = project.GetDomainId()
 	}
 	if domainId != "" {
-		domain, err := TenantCacheManager.FetchDomainByIdOrName(ctx, domainId)
+		domain, err := DefaultDomainFetcher(ctx, domainId)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cloudcommon/db/sharablebase_test.go
+++ b/pkg/cloudcommon/db/sharablebase_test.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestISharableMergeChangeOwnerCandidateDomainIds(t *testing.T) {
+	cases := []struct {
+		candidates [][]string
+		want       []string
+	}{
+		{
+			candidates: [][]string{
+				nil,
+				[]string{"abc"},
+				[]string{},
+				[]string{"abc", "bcd"},
+				[]string{"bcd"},
+			},
+			want: []string{"123"},
+		},
+		{
+			candidates: [][]string{
+				nil,
+				[]string{},
+			},
+			want: nil,
+		},
+	}
+	model := &SInfrasResourceBase{}
+	model.DomainId = "123"
+	for _, c := range cases {
+		got := ISharableMergeChangeOwnerCandidateDomainIds(model, c.candidates...)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("want: %s got %s", c.want, got)
+		}
+	}
+}
+
+func TestISharableMergeShareRequireDomainIds(t *testing.T) {
+	cases := []struct {
+		requires [][]string
+		want     []string
+	}{
+		{
+			requires: [][]string{
+				nil,
+				[]string{"abc"},
+			},
+			want: nil,
+		},
+		{
+			requires: [][]string{
+				{"abc"},
+				{"def"},
+				{"abc", "def"},
+			},
+			want: []string{"abc", "def"},
+		},
+	}
+	for _, c := range cases {
+		got := ISharableMergeShareRequireDomainIds(c.requires...)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("want: %s got %s", c.want, got)
+		}
+	}
+}

--- a/pkg/cloudcommon/db/sharablevirtual.go
+++ b/pkg/cloudcommon/db/sharablevirtual.go
@@ -31,7 +31,7 @@ import (
 
 type SSharableVirtualResourceBase struct {
 	SVirtualResourceBase
-	SSharableBaseResource
+	SSharableBaseResource `"is_public=>create":"optional" "public_scope=>create":"optional"`
 	// IsPublic    bool   `default:"false" nullable:"false" create:"domain_optional" list:"user" json:"is_public"`
 	// PublicScope string `width:"16" charset:"ascii" nullable:"false" default:"system" create:"domain_optional" list:"user" json:"public_scope"`
 }
@@ -70,7 +70,7 @@ func (model *SSharableVirtualResourceBase) AllowPerformPublic(ctx context.Contex
 }
 
 func (model *SSharableVirtualResourceBase) PerformPublic(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPublicInput) (jsonutils.JSONObject, error) {
-	err := SharablePerformPublic(model, ctx, userCred, input)
+	err := SharablePerformPublic(model.GetISharableVirtualModel(), ctx, userCred, input)
 	if err != nil {
 		return nil, errors.Wrap(err, "SharablePerformPublic")
 	}
@@ -82,7 +82,7 @@ func (model *SSharableVirtualResourceBase) AllowPerformPrivate(ctx context.Conte
 }
 
 func (model *SSharableVirtualResourceBase) PerformPrivate(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPrivateInput) (jsonutils.JSONObject, error) {
-	err := SharablePerformPrivate(model, ctx, userCred)
+	err := SharablePerformPrivate(model.GetISharableVirtualModel(), ctx, userCred)
 	if err != nil {
 		return nil, errors.Wrap(err, "SharablePerformPrivate")
 	}
@@ -222,8 +222,8 @@ func (model *SSharableVirtualResourceBase) SyncShareState(ctx context.Context, u
 					model.PublicScope = string(rbacutils.ScopeSystem)
 				} else {
 					model.PublicScope = string(rbacutils.ScopeDomain)
-					SharedResourceManager.shareToTarget(ctx, userCred, model.GetISharableVirtualModel(), SharedTargetProject, nil)
-					SharedResourceManager.shareToTarget(ctx, userCred, model.GetISharableVirtualModel(), SharedTargetDomain, shareInfo.SharedDomains)
+					SharedResourceManager.shareToTarget(ctx, userCred, model.GetISharableVirtualModel(), SharedTargetProject, nil, nil, nil)
+					SharedResourceManager.shareToTarget(ctx, userCred, model.GetISharableVirtualModel(), SharedTargetDomain, shareInfo.SharedDomains, nil, nil)
 				}
 			}
 			return nil
@@ -232,4 +232,12 @@ func (model *SSharableVirtualResourceBase) SyncShareState(ctx context.Context, u
 			OpsLog.LogEvent(model, ACT_SYNC_SHARE, diff, userCred)
 		}
 	}
+}
+
+func (model *SSharableVirtualResourceBase) GetSharableTargetDomainIds() []string {
+	return model.GetISharableVirtualModel().GetChangeOwnerCandidateDomainIds()
+}
+
+func (model *SSharableVirtualResourceBase) GetRequiredSharedDomainIds() []string {
+	return []string{model.DomainId}
 }

--- a/pkg/cloudcommon/db/sharablevirtual.go
+++ b/pkg/cloudcommon/db/sharablevirtual.go
@@ -207,19 +207,26 @@ func (model *SSharableVirtualResourceBase) Delete(ctx context.Context, userCred 
 }
 
 func (model *SSharableVirtualResourceBase) SyncShareState(ctx context.Context, userCred mcclient.TokenCredential, shareInfo apis.SAccountShareInfo) {
-	if model.PublicScope != string(apis.OWNER_SOURCE_LOCAL) {
+	if model.PublicSrc != string(apis.OWNER_SOURCE_LOCAL) {
 		diff, _ := Update(model, func() error {
+			model.PublicSrc = string(apis.OWNER_SOURCE_CLOUD)
 			switch shareInfo.ShareMode {
 			case compute.CLOUD_ACCOUNT_SHARE_MODE_ACCOUNT_DOMAIN:
 				model.IsPublic = true
 				model.PublicScope = string(rbacutils.ScopeDomain)
+				SharedResourceManager.shareToTarget(ctx, userCred, model.GetISharableVirtualModel(), SharedTargetProject, nil, nil, nil)
+				SharedResourceManager.shareToTarget(ctx, userCred, model.GetISharableVirtualModel(), SharedTargetDomain, nil, nil, nil)
 			case compute.CLOUD_ACCOUNT_SHARE_MODE_PROVIDER_DOMAIN:
 				model.IsPublic = true
 				model.PublicScope = string(rbacutils.ScopeDomain)
+				SharedResourceManager.shareToTarget(ctx, userCred, model.GetISharableVirtualModel(), SharedTargetProject, nil, nil, nil)
+				SharedResourceManager.shareToTarget(ctx, userCred, model.GetISharableVirtualModel(), SharedTargetDomain, nil, nil, nil)
 			case compute.CLOUD_ACCOUNT_SHARE_MODE_SYSTEM:
 				model.IsPublic = true
 				if shareInfo.IsPublic && shareInfo.PublicScope == rbacutils.ScopeSystem {
 					model.PublicScope = string(rbacutils.ScopeSystem)
+					SharedResourceManager.shareToTarget(ctx, userCred, model.GetISharableVirtualModel(), SharedTargetProject, nil, nil, nil)
+					SharedResourceManager.shareToTarget(ctx, userCred, model.GetISharableVirtualModel(), SharedTargetDomain, nil, nil, nil)
 				} else {
 					model.PublicScope = string(rbacutils.ScopeDomain)
 					SharedResourceManager.shareToTarget(ctx, userCred, model.GetISharableVirtualModel(), SharedTargetProject, nil, nil, nil)

--- a/pkg/cloudcommon/db/sharedresource.go
+++ b/pkg/cloudcommon/db/sharedresource.go
@@ -18,9 +18,8 @@ import (
 	"context"
 	"database/sql"
 
-	"yunion.io/x/pkg/utils"
-
 	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/utils"
 
 	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/cloudcommon/policy"
@@ -146,7 +145,7 @@ func (manager *SSharedResourceManager) shareToTarget(
 	for i := 0; i < len(targetIds); i++ {
 		switch targetType {
 		case SharedTargetProject:
-			tenant, err := TenantCacheManager.FetchTenantByIdOrName(ctx, targetIds[i])
+			tenant, err := DefaultProjectFetcher(ctx, targetIds[i])
 			if err != nil {
 				return nil, errors.Wrapf(err, "fetch tenant %s error", targetIds[i])
 			}
@@ -158,7 +157,7 @@ func (manager *SSharedResourceManager) shareToTarget(
 			}
 			newIds = stringutils2.Append(newIds, tenant.GetId())
 		case SharedTargetDomain:
-			domain, err := TenantCacheManager.FetchDomainByIdOrName(ctx, targetIds[i])
+			domain, err := DefaultDomainFetcher(ctx, targetIds[i])
 			if err != nil {
 				return nil, errors.Wrapf(err, "fetch domain %s error", targetIds[i])
 			}

--- a/pkg/cloudcommon/db/tenantcache.go
+++ b/pkg/cloudcommon/db/tenantcache.go
@@ -37,6 +37,12 @@ import (
 	"yunion.io/x/onecloud/pkg/util/stringutils2"
 )
 
+var (
+	DefaultProjectFetcher  func(ctx context.Context, id string) (*STenant, error)
+	DefaultDomainFetcher   func(ctx context.Context, id string) (*STenant, error)
+	DefaultProjectsFetcher func(ctx context.Context, idList []string, isDomain bool) map[string]STenant
+)
+
 type STenantCacheManager struct {
 	SKeystoneCacheObjectManager
 }
@@ -64,6 +70,10 @@ func init() {
 	// log.Debugf("Initialize tenant cache manager %s %s", TenantCacheManager.KeywordPlural(), TenantCacheManager)
 
 	TenantCacheManager.SetVirtualObject(TenantCacheManager)
+
+	DefaultProjectFetcher = TenantCacheManager.FetchTenantByIdOrName
+	DefaultDomainFetcher = TenantCacheManager.FetchDomainByIdOrName
+	DefaultProjectsFetcher = fetchProjects
 }
 
 func RegistUserCredCacheUpdater() {

--- a/pkg/compute/models/globalvpcs.go
+++ b/pkg/compute/models/globalvpcs.go
@@ -218,3 +218,15 @@ func (globalVpc *SGlobalVpc) GetUsages() []db.IUsage {
 		&usage,
 	}
 }
+
+func (globalVpc *SGlobalVpc) GetRequiredSharedDomainIds() []string {
+	vpcs, _ := globalVpc.GetVpcs()
+	if len(vpcs) == 0 {
+		return globalVpc.SEnabledStatusInfrasResourceBase.GetRequiredSharedDomainIds()
+	}
+	requires := make([][]string, len(vpcs))
+	for i := range vpcs {
+		requires[i] = db.ISharableChangeOwnerCandidateDomainIds(&vpcs[i])
+	}
+	return db.ISharableMergeShareRequireDomainIds(requires...)
+}

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -4998,3 +4998,27 @@ func (host *SHost) GetUsages() []db.IUsage {
 		&usage,
 	}
 }
+
+func (host *SHost) PerformPublic(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPublicInput) (jsonutils.JSONObject, error) {
+	// perform public for all connected local storage
+	storages := host.GetAttachedLocalStorages()
+	for i := range storages {
+		_, err := storages[i].PerformPublic(ctx, userCred, query, input)
+		if err != nil {
+			return nil, errors.Wrap(err, "storage.PerformPublic")
+		}
+	}
+	return host.SEnabledStatusInfrasResourceBase.PerformPublic(ctx, userCred, query, input)
+}
+
+func (host *SHost) PerformPrivate(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPrivateInput) (jsonutils.JSONObject, error) {
+	// perform private for all connected local storage
+	storages := host.GetAttachedLocalStorages()
+	for i := range storages {
+		_, err := storages[i].PerformPrivate(ctx, userCred, query, input)
+		if err != nil {
+			return nil, errors.Wrap(err, "storage.PerformPrivate")
+		}
+	}
+	return host.SEnabledStatusInfrasResourceBase.PerformPrivate(ctx, userCred, query, input)
+}

--- a/pkg/compute/models/managedresource.go
+++ b/pkg/compute/models/managedresource.go
@@ -348,15 +348,14 @@ func (manager *SManagedResourceBaseManager) GetOrderByFields(query api.ManagedRe
 	return []string{query.OrderByManager, query.OrderByAccount, query.OrderByProvider, query.OrderByBrand}
 }
 
-func (model *SManagedResourceBase) GetDetailsChangeOwnerCandidateDomains(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (api.ChangeOwnerCandidateDomainsOutput, error) {
-	output := api.ChangeOwnerCandidateDomainsOutput{}
+func (model *SManagedResourceBase) GetChangeOwnerCandidateDomainIds() []string {
 	provider := model.GetCloudprovider()
 	if provider == nil {
-		return output, nil
+		return nil
 	}
 	account := model.GetCloudaccount()
 	if account == nil {
-		return output, nil
+		return nil
 	}
 	var candidateIds []string
 	switch account.ShareMode {
@@ -370,19 +369,7 @@ func (model *SManagedResourceBase) GetDetailsChangeOwnerCandidateDomains(ctx con
 			candidateIds = append(candidateIds, account.DomainId)
 		}
 	}
-	domainMap := make(map[string]db.STenant)
-	err := db.FetchQueryObjectsByIds(db.TenantCacheManager.GetDomainQuery(), "id", candidateIds, &domainMap)
-	if err != nil {
-		return output, errors.Wrap(err, "FetchQueryObjectsByIds")
-	}
-	output.Candidates = make([]apis.SharedDomain, len(candidateIds))
-	for i := range candidateIds {
-		output.Candidates[i].Id = candidateIds[i]
-		if domain, ok := domainMap[candidateIds[i]]; ok {
-			output.Candidates[i].Name = domain.Name
-		}
-	}
-	return output, nil
+	return candidateIds
 }
 
 func _managedResourceFilterByDomain(managerIdFieldName string, q *sqlchemy.SQuery, query apis.DomainizedResourceListInput, filterField string, subqFunc func() *sqlchemy.SQuery) (*sqlchemy.SQuery, error) {

--- a/pkg/compute/models/managedresource.go
+++ b/pkg/compute/models/managedresource.go
@@ -245,7 +245,7 @@ func (manager *SManagedResourceBaseManager) FetchCustomizeColumns(
 		return nil
 	}
 
-	projects := db.FetchProjects(projectIds, false)
+	projects := db.DefaultProjectsFetcher(ctx, projectIds, false)
 
 	for i := range rows {
 		if account, ok := accounts[rows[i].AccountId]; ok {

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -2515,3 +2515,14 @@ func (net *SNetwork) PerformStatus(ctx context.Context, userCred mcclient.TokenC
 	}
 	return net.SSharableVirtualResourceBase.PerformStatus(ctx, userCred, query, input)
 }
+
+func (net *SNetwork) GetChangeOwnerCandidateDomainIds() []string {
+	candidates := [][]string{
+		net.SSharableVirtualResourceBase.GetChangeOwnerCandidateDomainIds(),
+	}
+	wire := net.GetWire()
+	if wire != nil {
+		candidates = append(candidates, db.ISharableChangeOwnerCandidateDomainIds(wire))
+	}
+	return db.ISharableMergeChangeOwnerCandidateDomainIds(net, candidates...)
+}

--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -378,7 +378,7 @@ func (manager *SVpcManager) SyncVPCs(ctx context.Context, userCred mcclient.Toke
 		}
 	}
 	for i := 0; i < len(commondb); i += 1 {
-		err = commondb[i].SyncWithCloudVpc(ctx, userCred, commonext[i], provider.GetOwnerId())
+		err = commondb[i].SyncWithCloudVpc(ctx, userCred, commonext[i], provider)
 		if err != nil {
 			syncResult.UpdateError(err)
 			continue
@@ -490,7 +490,7 @@ func (self *SVpc) SyncGlobalVpc(ctx context.Context, userCred mcclient.TokenCred
 	return nil
 }
 
-func (self *SVpc) SyncWithCloudVpc(ctx context.Context, userCred mcclient.TokenCredential, extVPC cloudprovider.ICloudVpc, syncOwnerId mcclient.IIdentityProvider) error {
+func (self *SVpc) SyncWithCloudVpc(ctx context.Context, userCred mcclient.TokenCredential, extVPC cloudprovider.ICloudVpc, provider *SCloudprovider) error {
 	diff, err := db.UpdateWithLock(ctx, self, func() error {
 		extVPC.Refresh()
 		// self.Name = extVPC.GetName()
@@ -507,8 +507,9 @@ func (self *SVpc) SyncWithCloudVpc(ctx context.Context, userCred mcclient.TokenC
 		return err
 	}
 
-	if syncOwnerId != nil {
-		SyncCloudDomain(userCred, self, syncOwnerId)
+	if provider != nil {
+		SyncCloudDomain(userCred, self, provider.GetOwnerId())
+		self.SyncShareState(ctx, userCred, provider.getAccountShareInfo())
 	}
 
 	db.OpsLog.LogSyncUpdate(self, diff, userCred)
@@ -541,6 +542,10 @@ func (manager *SVpcManager) newFromCloudVpc(ctx context.Context, userCred mcclie
 	}
 
 	SyncCloudDomain(userCred, &vpc, provider.GetOwnerId())
+
+	if provider != nil {
+		vpc.SyncShareState(ctx, userCred, provider.getAccountShareInfo())
+	}
 
 	db.OpsLog.LogEvent(&vpc, db.ACT_CREATE, vpc.GetShortDesc(ctx), userCred)
 

--- a/pkg/compute/policy/defaults.go
+++ b/pkg/compute/policy/defaults.go
@@ -269,6 +269,18 @@ var (
 					Action:   PolicyActionGet,
 					Result:   rbacutils.Allow,
 				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "proxysettings",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "proxysettings",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
 			},
 		},
 		{

--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -1354,6 +1354,9 @@ func (self *SImage) PerformMarkStandard(
 	query jsonutils.JSONObject,
 	data jsonutils.JSONObject,
 ) (jsonutils.JSONObject, error) {
+	if self.IsGuestImage.IsTrue() {
+		return nil, errors.Wrap(httperrors.ErrForbidden, "cannot mark standard to a guest image")
+	}
 	isStandard := jsonutils.QueryBoolean(data, "is_standard", false)
 	if !self.IsStandard.IsTrue() && isStandard {
 		input := apis.PerformPublicInput{

--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -1441,3 +1441,23 @@ func (img *SImage) GetUsages() []db.IUsage {
 		&usage,
 	}
 }
+
+func (img *SImage) PerformPublic(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPublicInput) (jsonutils.JSONObject, error) {
+	if img.IsStandard.IsTrue() {
+		return nil, errors.Wrap(httperrors.ErrForbidden, "cannot perform public for standard image")
+	}
+	if img.IsGuestImage.IsTrue() {
+		return nil, errors.Wrap(httperrors.ErrForbidden, "cannot perform public for guest image")
+	}
+	return img.SSharableVirtualResourceBase.PerformPublic(ctx, userCred, query, input)
+}
+
+func (img *SImage) PerformPrivate(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPrivateInput) (jsonutils.JSONObject, error) {
+	if img.IsStandard.IsTrue() {
+		return nil, errors.Wrap(httperrors.ErrForbidden, "cannot perform private for standard image")
+	}
+	if img.IsGuestImage.IsTrue() {
+		return nil, errors.Wrap(httperrors.ErrForbidden, "cannot perform private for guest image")
+	}
+	return img.SSharableVirtualResourceBase.PerformPrivate(ctx, userCred, query, input)
+}

--- a/pkg/keystone/models/credentials.go
+++ b/pkg/keystone/models/credentials.go
@@ -261,7 +261,7 @@ func (self *SCredential) GetOwnerId() mcclient.IIdentityProvider {
 func (manager *SCredentialManager) FetchOwnerId(ctx context.Context, data jsonutils.JSONObject) (mcclient.IIdentityProvider, error) {
 	userStr, key := jsonutils.GetAnyString2(data, []string{"user", "user_id"})
 	if len(userStr) > 0 {
-		domainOwner, err := fetchDomainInfo(data)
+		domainOwner, err := db.FetchDomainInfo(ctx, data)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/keystone/models/identitybase.go
+++ b/pkg/keystone/models/identitybase.go
@@ -16,16 +16,13 @@ package models
 
 import (
 	"context"
-	"database/sql"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/tristate"
-	"yunion.io/x/pkg/util/reflectutils"
 	"yunion.io/x/sqlchemy"
 
-	"yunion.io/x/onecloud/pkg/apis"
 	api "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/httperrors"
@@ -223,7 +220,7 @@ func (manager *SEnabledIdentityBaseResourceManager) QueryDistinctExtraField(q *s
 	return q, httperrors.ErrNotFound
 }
 
-func fetchDomainInfo(data jsonutils.JSONObject) (mcclient.IIdentityProvider, error) {
+/*func fetchDomainInfo(data jsonutils.JSONObject) (mcclient.IIdentityProvider, error) {
 	domainId, key := jsonutils.GetAnyString2(data, []string{"domain_id", "project_domain", "project_domain_id"})
 	if len(domainId) > 0 {
 		data.(*jsonutils.JSONDict).Remove(key)
@@ -243,7 +240,7 @@ func fetchDomainInfo(data jsonutils.JSONObject) (mcclient.IIdentityProvider, err
 
 func (manager *SIdentityBaseResourceManager) FetchOwnerId(ctx context.Context, data jsonutils.JSONObject) (mcclient.IIdentityProvider, error) {
 	return fetchDomainInfo(data)
-}
+}*/
 
 func (manager *SIdentityBaseResourceManager) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, input api.IdentityBaseResourceCreateInput) (api.IdentityBaseResourceCreateInput, error) {
 	domain, _ := DomainManager.FetchDomainById(ownerId.GetProjectDomainId())
@@ -319,21 +316,22 @@ func (manager *SIdentityBaseResourceManager) FetchCustomizeColumns(
 	rows := make([]api.IdentityBaseResourceDetails, len(objs))
 
 	stdRows := manager.SStandaloneResourceBaseManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields, isList)
+	domainRows := manager.SDomainizedResourceBaseManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields, isList)
 
-	domainIds := stringutils2.SSortedStrings{}
+	// domainIds := stringutils2.SSortedStrings{}
 	for i := range rows {
 		rows[i] = api.IdentityBaseResourceDetails{
 			StandaloneResourceDetails: stdRows[i],
-			DomainizedResourceInfo:    apis.DomainizedResourceInfo{},
+			DomainizedResourceInfo:    domainRows[i],
 		}
-		var base *SIdentityBaseResource
+		/*var base *SIdentityBaseResource
 		reflectutils.FindAnonymouStructPointer(objs[i], &base)
 		if base != nil && len(base.DomainId) > 0 && base.DomainId != api.KeystoneDomainRoot {
 			domainIds = stringutils2.Append(domainIds, base.DomainId)
-		}
+		}*/
 	}
 
-	if len(fields) == 0 || fields.Contains("project_domain") {
+	/*if len(fields) == 0 || fields.Contains("project_domain") {
 		domains := fetchDomain(domainIds)
 		if domains != nil {
 			for i := range rows {
@@ -346,7 +344,7 @@ func (manager *SIdentityBaseResourceManager) FetchCustomizeColumns(
 				}
 			}
 		}
-	}
+	}*/
 	return rows
 }
 
@@ -380,6 +378,7 @@ func (manager *SEnabledIdentityBaseResourceManager) FetchCustomizeColumns(
 	return rows
 }
 
+/*
 func fetchDomain(domainIds []string) map[string]SDomain {
 	q := DomainManager.Query().In("id", domainIds)
 	domains := make([]SDomain, 0)
@@ -392,7 +391,7 @@ func fetchDomain(domainIds []string) map[string]SDomain {
 		ret[domains[i].Id] = domains[i]
 	}
 	return ret
-}
+}*/
 
 func (model *SIdentityBaseResource) CustomizeCreate(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data jsonutils.JSONObject) error {
 	model.DomainId = ownerId.GetProjectDomainId()

--- a/pkg/keystone/models/identityquota.go
+++ b/pkg/keystone/models/identityquota.go
@@ -277,7 +277,7 @@ func (manager *SQuotaManager) FetchIdNames(ctx context.Context, idMap map[string
 }
 
 func (manager *SQuotaManager) FetchOwnerId(ctx context.Context, data jsonutils.JSONObject) (mcclient.IIdentityProvider, error) {
-	return fetchDomainInfo(data)
+	return db.FetchDomainInfo(ctx, data)
 }
 
 ///////////////////////////////////////////////////

--- a/pkg/keystone/models/policies.go
+++ b/pkg/keystone/models/policies.go
@@ -66,7 +66,7 @@ func init() {
 
 type SPolicy struct {
 	SEnabledIdentityBaseResource
-	db.SSharableBaseResource
+	db.SSharableBaseResource `"is_public=>create":"domain_optional" "public_scope=>create":"domain_optional"`
 
 	Type string               `width:"255" charset:"utf8" nullable:"false" list:"user" create:"domain_required" update:"domain"`
 	Blob jsonutils.JSONObject `nullable:"false" list:"user" create:"domain_required" update:"domain"`

--- a/pkg/keystone/models/policies.go
+++ b/pkg/keystone/models/policies.go
@@ -308,9 +308,11 @@ func (manager *SPolicyManager) FetchCustomizeColumns(
 ) []api.PolicyDetails {
 	rows := make([]api.PolicyDetails, len(objs))
 	identRows := manager.SEnabledIdentityBaseResourceManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields, isList)
+	shareRows := manager.SSharableBaseResourceManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields, isList)
 	for i := range rows {
 		rows[i] = api.PolicyDetails{
 			EnabledIdentityBaseResourceDetails: identRows[i],
+			SharableResourceBaseInfo:           shareRows[i],
 		}
 	}
 	return rows
@@ -329,4 +331,16 @@ func (policy *SPolicy) GetUsages() []db.IUsage {
 
 func (manager *SPolicyManager) FilterByOwner(q *sqlchemy.SQuery, owner mcclient.IIdentityProvider, scope rbacutils.TRbacScope) *sqlchemy.SQuery {
 	return db.SharableManagerFilterByOwner(manager, q, owner, scope)
+}
+
+func (policy *SPolicy) GetSharableTargetDomainIds() []string {
+	return nil
+}
+
+func (policy *SPolicy) GetRequiredSharedDomainIds() []string {
+	return []string{policy.DomainId}
+}
+
+func (policy *SPolicy) GetSharedDomains() []string {
+	return db.SharableGetSharedProjects(policy, db.SharedTargetDomain)
 }

--- a/pkg/keystone/models/roles.go
+++ b/pkg/keystone/models/roles.go
@@ -225,10 +225,12 @@ func (manager *SRoleManager) FetchCustomizeColumns(
 	rows := make([]api.RoleDetails, len(objs))
 
 	identRows := manager.SIdentityBaseResourceManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields, isList)
+	shareRows := manager.SSharableBaseResourceManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields, isList)
 
 	for i := range rows {
 		rows[i] = api.RoleDetails{
 			IdentityBaseResourceDetails: identRows[i],
+			SharableResourceBaseInfo:    shareRows[i],
 		}
 		role := objs[i].(*SRole)
 		rows[i].UserCount, _ = role.GetUserCount()
@@ -514,4 +516,16 @@ func (role *SRole) PostCreate(
 
 func (manager *SRoleManager) FilterByOwner(q *sqlchemy.SQuery, owner mcclient.IIdentityProvider, scope rbacutils.TRbacScope) *sqlchemy.SQuery {
 	return db.SharableManagerFilterByOwner(manager, q, owner, scope)
+}
+
+func (role *SRole) GetSharableTargetDomainIds() []string {
+	return nil
+}
+
+func (role *SRole) GetRequiredSharedDomainIds() []string {
+	return []string{role.DomainId}
+}
+
+func (role *SRole) GetSharedDomains() []string {
+	return db.SharableGetSharedProjects(role, db.SharedTargetDomain)
 }

--- a/pkg/keystone/models/roles.go
+++ b/pkg/keystone/models/roles.go
@@ -67,8 +67,8 @@ func init() {
 */
 
 type SRole struct {
-	SIdentityBaseResource `"name->update":""`
-	db.SSharableBaseResource
+	SIdentityBaseResource    `"name->update":""`
+	db.SSharableBaseResource `"is_public=>create":"domain_optional" "public_scope=>create":"domain_optional"`
 }
 
 func (manager *SRoleManager) GetContextManagers() [][]db.IModelManager {

--- a/pkg/keystone/service/override.go
+++ b/pkg/keystone/service/override.go
@@ -1,0 +1,107 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/golang-plus/uuid"
+
+	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+
+	api "yunion.io/x/onecloud/pkg/apis/identity"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/httperrors"
+	"yunion.io/x/onecloud/pkg/keystone/models"
+)
+
+func keystoneUUIDGenerator() string {
+	id, _ := uuid.NewV4()
+	return id.Format(uuid.StyleWithoutDash)
+}
+
+func keystoneProjectFetcher(ctx context.Context, idstr string) (*db.STenant, error) {
+	tenantObj, err := models.ProjectManager.FetchByIdOrName(nil, idstr)
+	if err != nil {
+		if errors.Cause(err) == sql.ErrNoRows {
+			return nil, errors.Wrapf(httperrors.ErrResourceNotFound, "tenant %s", idstr)
+		} else {
+			return nil, errors.Wrap(err, "models.ProjectManager.FetchByIdOrName")
+		}
+	}
+	ret := project2Tenant(tenantObj.(*models.SProject))
+	return &ret, nil
+}
+
+func keystoneDomainFetcher(ctx context.Context, idstr string) (*db.STenant, error) {
+	domainObj, err := models.DomainManager.FetchByIdOrName(nil, idstr)
+	if err != nil {
+		if errors.Cause(err) == sql.ErrNoRows {
+			return nil, errors.Wrapf(httperrors.ErrResourceNotFound, "domain %s", idstr)
+		} else {
+			return nil, errors.Wrap(err, "models.DomainManager.FetchByIdOrName")
+		}
+	}
+	ret := domain2Tenant(domainObj.(*models.SDomain))
+	return &ret, nil
+}
+
+func project2Tenant(tenant *models.SProject) db.STenant {
+	ret := db.STenant{}
+	ret.Id = tenant.Id
+	ret.Name = tenant.Name
+	ret.DomainId = tenant.DomainId
+	ret.Domain = tenant.GetDomain().Name
+	return ret
+}
+
+func domain2Tenant(domain *models.SDomain) db.STenant {
+	ret := db.STenant{}
+	ret.Id = domain.Id
+	ret.Name = domain.Name
+	ret.DomainId = api.KeystoneDomainRoot
+	ret.Domain = api.KeystoneDomainRoot
+	return ret
+}
+
+func keystoneProjectsFetcher(ctx context.Context, idList []string, isDomain bool) map[string]db.STenant {
+	if isDomain {
+		domains := make(map[string]models.SDomain)
+		err := db.FetchStandaloneObjectsByIds(models.DomainManager, idList, &domains)
+		if err != nil {
+			log.Errorf("FetchStandaloneObjectsByIds for domain fail %s", err)
+			return nil
+		}
+		ret := make(map[string]db.STenant)
+		for id, domain := range domains {
+			ret[id] = domain2Tenant(&domain)
+		}
+		return ret
+	} else {
+		projects := make(map[string]models.SProject)
+		err := db.FetchStandaloneObjectsByIds(models.ProjectManager, idList, &projects)
+		if err != nil {
+			log.Errorf("FetchStandaloneObjectsByIds for project fail %s", err)
+			return nil
+		}
+		ret := make(map[string]db.STenant)
+		for id, project := range projects {
+			ret[id] = project2Tenant(&project)
+		}
+		return ret
+	}
+}

--- a/pkg/keystone/service/service.go
+++ b/pkg/keystone/service/service.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/golang-plus/uuid"
 
 	api "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/cloudcommon"
@@ -41,14 +40,12 @@ import (
 	"yunion.io/x/onecloud/pkg/util/logclient"
 )
 
-func keystoneUUIDGenerator() string {
-	id, _ := uuid.NewV4()
-	return id.Format(uuid.StyleWithoutDash)
-}
-
 func StartService() {
 	auth.DefaultTokenVerifier = tokens.FernetTokenVerifier
 	db.DefaultUUIDGenerator = keystoneUUIDGenerator
+	db.DefaultProjectFetcher = keystoneProjectFetcher
+	db.DefaultDomainFetcher = keystoneDomainFetcher
+	db.DefaultProjectsFetcher = keystoneProjectsFetcher
 	policy.DefaultPolicyFetcher = localPolicyFetcher
 	logclient.DefaultSessionGenerator = models.GetDefaultClientSession
 	cronman.DefaultAdminSessionGenerator = models.GetDefaultAdminCred

--- a/pkg/mcclient/modules/mod_buckets.go
+++ b/pkg/mcclient/modules/mod_buckets.go
@@ -73,7 +73,7 @@ func init() {
 		NewComputeManager("bucket", "buckets",
 			[]string{"ID", "Name", "Storage_Class",
 				"Status", "location", "acl",
-				"region", "manager_id",
+				"region", "manager_id", "public_scope",
 			},
 			[]string{}),
 	}

--- a/pkg/mcclient/modules/mod_cloudaccounts.go
+++ b/pkg/mcclient/modules/mod_cloudaccounts.go
@@ -28,7 +28,8 @@ func init() {
 			"guest_count", "project_domain", "domain_id",
 			"Provider", "Brand",
 			"Enable_Auto_Sync", "Sync_Interval_Seconds",
-			"Share_Mode"},
+			"Share_Mode", "is_public", "public_scope",
+		},
 		[]string{})
 
 	registerCompute(&Cloudaccounts)

--- a/pkg/mcclient/modules/mod_globalvpcs.go
+++ b/pkg/mcclient/modules/mod_globalvpcs.go
@@ -29,7 +29,7 @@ var (
 func init() {
 	GlobalVpcs = GlobalVpcManager{NewComputeManager("globalvpc", "globalvpcs",
 		[]string{},
-		[]string{"ID", "Name", "Description", "Status", "Enabled"})}
+		[]string{"ID", "Name", "Description", "Status", "Enabled", "public_scope"})}
 
 	registerCompute(&GlobalVpcs)
 }

--- a/pkg/mcclient/modules/mod_hosts.go
+++ b/pkg/mcclient/modules/mod_hosts.go
@@ -185,6 +185,7 @@ func init() {
 			"storage_size",
 			"expired_at",
 			"domain_id", "project_domain",
+			"public_scope",
 		},
 		[]string{})}
 	registerCompute(&Hosts)

--- a/pkg/mcclient/modules/mod_policies.go
+++ b/pkg/mcclient/modules/mod_policies.go
@@ -30,7 +30,7 @@ var Policies SPolicyManager
 
 func policyReadFilter(session *mcclient.ClientSession, s jsonutils.JSONObject, query jsonutils.JSONObject) (jsonutils.JSONObject, error) {
 	ss := s.(*jsonutils.JSONDict)
-	ret := ss.CopyIncludes("id", "type", "enabled", "domain_id", "domain", "project_domain", "can_update", "can_delete", "is_public", "description", "delete_fail_reason", "update_fail_reason")
+	ret := ss.CopyIncludes("id", "type", "enabled", "domain_id", "domain", "project_domain", "can_update", "can_delete", "is_public", "description", "delete_fail_reason", "update_fail_reason", "public_scope", "shared_domains")
 	blobJson, _ := ss.Get("blob")
 	if blobJson != nil {
 		policy := rbacutils.SRbacPolicy{}
@@ -82,7 +82,7 @@ func policyWriteFilter(session *mcclient.ClientSession, s jsonutils.JSONObject, 
 		ret.Add(blobJson, "blob")
 	}
 	for _, k := range []string{
-		"type", "enabled", "domain", "domain_id", "project_domain", "description",
+		"type", "enabled", "domain", "domain_id", "project_domain", "description", "is_public", "public_scope", "shared_domains",
 	} {
 		if s.Contains(k) {
 			val, err := s.Get(k)

--- a/pkg/mcclient/modules/mod_storages.go
+++ b/pkg/mcclient/modules/mod_storages.go
@@ -22,7 +22,7 @@ var (
 
 func init() {
 	Storages = NewComputeManager("storage", "storages",
-		[]string{"ID", "Name", "Capacity", "Status", "Used_capacity", "Waste_capacity", "Free_capacity", "Storage_type", "Medium_type", "Virtual_capacity", "commit_bound", "commit_rate", "Enabled"},
+		[]string{"ID", "Name", "Capacity", "Status", "Used_capacity", "Waste_capacity", "Free_capacity", "Storage_type", "Medium_type", "Virtual_capacity", "commit_bound", "commit_rate", "Enabled", "public_scope"},
 		[]string{})
 
 	registerCompute(&Storages)

--- a/pkg/mcclient/modules/mod_vpcs.go
+++ b/pkg/mcclient/modules/mod_vpcs.go
@@ -22,7 +22,7 @@ var (
 
 func init() {
 	Vpcs = NewComputeManager("vpc", "vpcs",
-		[]string{"ID", "Name", "Enabled", "Status", "Cloudregion_Id", "Is_default", "Cidr_Block", "Region"},
+		[]string{"ID", "Name", "Enabled", "Status", "Cloudregion_Id", "Is_default", "Cidr_Block", "Region", "Public_Scope"},
 		[]string{})
 
 	registerCompute(&Vpcs)

--- a/pkg/mcclient/modules/mod_wires.go
+++ b/pkg/mcclient/modules/mod_wires.go
@@ -23,7 +23,7 @@ var (
 func init() {
 	Wires = NewComputeManager("wire", "wires",
 		[]string{"ID", "Name", "Bandwidth", "Zone_ID",
-			"Zone", "Networks", "VPC", "VPC_ID"},
+			"Zone", "Networks", "VPC", "VPC_ID", "public_scope"},
 		[]string{})
 
 	registerCompute(&Wires)

--- a/pkg/util/stringutils2/sortedstrings.go
+++ b/pkg/util/stringutils2/sortedstrings.go
@@ -161,3 +161,21 @@ func Merge(a, b SSortedStrings) SSortedStrings {
 	}
 	return SSortedStrings(ret)
 }
+
+func Intersect(a, b SSortedStrings) SSortedStrings {
+	ret := make([]string, 0)
+	i := 0
+	j := 0
+	for i < len(a) && j < len(b) {
+		if a[i] == b[j] {
+			ret = append(ret, a[i])
+			i += 1
+			j += 1
+		} else if a[i] < b[j] {
+			i += 1
+		} else if a[i] > b[j] {
+			j += 1
+		}
+	}
+	return SSortedStrings(ret)
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：
1. 更改云账号的共享范围后，需要同步修改归属资源的共享范围
2. 增加一些共享相关的climc命令
3. vpc, wire, network的change owner和共享的级联检查
4. keystone和其他服务FetchProjectInfo和FetchDomainInfo的统一
5. host和关联本地存储共享范围统一，不允许单独对本地存储进行共享设置
6. 不允许对标准镜像和主机镜像进行共享范围的设置
7. 将bucket设置为允许共享的项目资源

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi @yousong 

/area region