### PR TITLE
region: lbagent: vrrp.advert_int must be the same inside cluster

### DIFF
--- a/pkg/compute/models/loadbalanceragents.go
+++ b/pkg/compute/models/loadbalanceragents.go
@@ -151,6 +151,9 @@ func (p *SLoadbalancerAgentParamsVrrp) validatePeer(pp *SLoadbalancerAgentParams
 	if p.VirtualRouterId != pp.VirtualRouterId {
 		return fmt.Errorf("vrrp virtual_router_id of peer lbagents must be the same: %d != %d", p.VirtualRouterId, pp.VirtualRouterId)
 	}
+	if p.AdvertInt != pp.AdvertInt {
+		return fmt.Errorf("vrrp advert_int of peer lbagents must be the same: %d != %d", p.AdvertInt, pp.AdvertInt)
+	}
 	if p.Preempt != pp.Preempt {
 		return fmt.Errorf("vrrp preempt property of peer lbagents must be the same: %v != %v", p.Preempt, pp.Preempt)
 	}
@@ -165,6 +168,9 @@ func (p *SLoadbalancerAgentParamsVrrp) needsUpdatePeer(pp *SLoadbalancerAgentPar
 	if p.VirtualRouterId != pp.VirtualRouterId {
 		return true
 	}
+	if p.AdvertInt != pp.AdvertInt {
+		return true
+	}
 	if p.Preempt != pp.Preempt {
 		return true
 	}
@@ -176,6 +182,7 @@ func (p *SLoadbalancerAgentParamsVrrp) needsUpdatePeer(pp *SLoadbalancerAgentPar
 
 func (p *SLoadbalancerAgentParamsVrrp) updateBy(pp *SLoadbalancerAgentParamsVrrp) {
 	p.VirtualRouterId = pp.VirtualRouterId
+	p.AdvertInt = pp.AdvertInt
 	p.Preempt = pp.Preempt
 	p.Pass = pp.Pass
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
region: lbagent: vrrp.advert_int must be the same inside cluster
```

- [x] 冒烟测试

**是否需要 backport 到之前的 release 分支**:

- release/2.13

/area region
/cc @zexi @swordqiu @ioito 