### PR TITLE
fix: keystone username duplicate error should return 409

### DIFF
--- a/pkg/keystone/tokens/handlers.go
+++ b/pkg/keystone/tokens/handlers.go
@@ -85,7 +85,9 @@ func authenticateTokensV3(ctx context.Context, w http.ResponseWriter, r *http.Re
 	token, err := AuthenticateV3(ctx, input)
 	if err != nil {
 		switch errors.Cause(err) {
-		case sqlchemy.ErrDuplicateEntry, httperrors.ErrTooManyAttempts:
+		case sqlchemy.ErrDuplicateEntry:
+			httperrors.ConflictError(w, "duplicate username")
+		case httperrors.ErrTooManyAttempts:
 			httperrors.GeneralServerError(w, err)
 		default:
 			httperrors.UnauthorizedError(w, "unauthorized %s", err)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：在多个域有重复用户名，登录时需要返回409

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area keystone