### PR TITLE
Automated cherry pick of #5785: fix: 避免aliyun access key不可用时返回NotFoundError错误

### DIFF
--- a/pkg/multicloud/aliyun/aliyun.go
+++ b/pkg/multicloud/aliyun/aliyun.go
@@ -119,6 +119,13 @@ func jsonRequest(client *sdk.Client, domain, apiVersion, apiName string, params 
 		resp, err := _jsonRequest(client, domain, apiVersion, apiName, params)
 		retry := false
 		if err != nil {
+			for _, code := range []string{
+				"InvalidAccessKeyId.NotFound",
+			} {
+				if strings.Contains(err.Error(), code) {
+					return nil, err
+				}
+			}
 			for _, code := range []string{"404 Not Found"} {
 				if strings.Contains(err.Error(), code) {
 					return nil, cloudprovider.ErrNotFound


### PR DESCRIPTION
Cherry pick of #5785 on release/3.1.

#5785: fix: 避免aliyun access key不可用时返回NotFoundError错误