### PR TITLE
Hotfix/qj server list provider filter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -130,7 +130,7 @@ require (
 	yunion.io/x/executor v0.0.0-20200227030256-a18417815e74
 	yunion.io/x/jsonutils v0.0.0-20200330063846-589d9924bb8b
 	yunion.io/x/log v0.0.0-20200313080802-57a4ce5966b3
-	yunion.io/x/pkg v0.0.0-20200403115157-880d716ed624
+	yunion.io/x/pkg v0.0.0-20200414143921-085f89a6e1e9
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 	yunion.io/x/sqlchemy v0.0.0-20200312002602-1177cd8fbc57
 	yunion.io/x/structarg v0.0.0-20190809075558-115bed041de3

--- a/go.mod
+++ b/go.mod
@@ -130,7 +130,7 @@ require (
 	yunion.io/x/executor v0.0.0-20200227030256-a18417815e74
 	yunion.io/x/jsonutils v0.0.0-20200415132054-2bf8a5e94501
 	yunion.io/x/log v0.0.0-20200313080802-57a4ce5966b3
-	yunion.io/x/pkg v0.0.0-20200415124010-2c7da30b998f
+	yunion.io/x/pkg v0.0.0-20200416145704-22c189971435
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 	yunion.io/x/sqlchemy v0.0.0-20200312002602-1177cd8fbc57
 	yunion.io/x/structarg v0.0.0-20190809075558-115bed041de3

--- a/go.mod
+++ b/go.mod
@@ -128,9 +128,9 @@ require (
 	k8s.io/cluster-bootstrap v0.17.3
 	k8s.io/kubernetes v1.16.0
 	yunion.io/x/executor v0.0.0-20200227030256-a18417815e74
-	yunion.io/x/jsonutils v0.0.0-20200330063846-589d9924bb8b
+	yunion.io/x/jsonutils v0.0.0-20200415132054-2bf8a5e94501
 	yunion.io/x/log v0.0.0-20200313080802-57a4ce5966b3
-	yunion.io/x/pkg v0.0.0-20200414143921-085f89a6e1e9
+	yunion.io/x/pkg v0.0.0-20200415124010-2c7da30b998f
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 	yunion.io/x/sqlchemy v0.0.0-20200312002602-1177cd8fbc57
 	yunion.io/x/structarg v0.0.0-20190809075558-115bed041de3

--- a/go.sum
+++ b/go.sum
@@ -1106,8 +1106,8 @@ vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj
 yunion.io/x/executor v0.0.0-20200227030256-a18417815e74 h1:A15C6VdVRWvmQ9pAJHrUs9yan5qKlYH7uaRxHg1kRbk=
 yunion.io/x/executor v0.0.0-20200227030256-a18417815e74/go.mod h1:Uxuou9WQIeJXNpy7t2fPLL0BYLvLiMvGQwY7Qc6aSws=
 yunion.io/x/jsonutils v0.0.0-20190625054549-a964e1e8a051/go.mod h1:4N0/RVzsYL3kH3WE/H1BjUQdFiWu50JGCFQuuy+Z634=
-yunion.io/x/jsonutils v0.0.0-20200330063846-589d9924bb8b h1:mt0TOKRk76yeH0whJfmKsceXBuudXLjvoj8NKGTqpEU=
-yunion.io/x/jsonutils v0.0.0-20200330063846-589d9924bb8b/go.mod h1:T7kxQJR13+t7z0TuT+Wzd7MTxBOk2H9c0pO1ONQSv90=
+yunion.io/x/jsonutils v0.0.0-20200415132054-2bf8a5e94501 h1:i1r9XvbdxH3FgTCLmTaRi3MzQqhiQimXJRlUOPgrxnU=
+yunion.io/x/jsonutils v0.0.0-20200415132054-2bf8a5e94501/go.mod h1:T7kxQJR13+t7z0TuT+Wzd7MTxBOk2H9c0pO1ONQSv90=
 yunion.io/x/log v0.0.0-20190514041436-04ce53b17c6b/go.mod h1:+gauLs73omeJAPlsXcevLsJLKixV+sR/E7WSYTSx1fE=
 yunion.io/x/log v0.0.0-20190629062853-9f6483a7103d h1:59zrDL7Ft+hDukguJRmLr/Gdu/9V75x+yX99ovZwfaA=
 yunion.io/x/log v0.0.0-20190629062853-9f6483a7103d/go.mod h1:LC6f/4FozL0iaAbnFt2eDX9jlsyo3WiOUPm03d7+U4U=
@@ -1116,8 +1116,8 @@ yunion.io/x/log v0.0.0-20200313080802-57a4ce5966b3/go.mod h1:LC6f/4FozL0iaAbnFt2
 yunion.io/x/pkg v0.0.0-20190620104149-945c25821dbf/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/pkg v0.0.0-20190628082551-f4033ba2ea30/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/pkg v0.0.0-20200302034534-fdf44d54b070/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
-yunion.io/x/pkg v0.0.0-20200414143921-085f89a6e1e9 h1:baz7ZPSEPXG24d30B1a8CuYXvG7reykwCW2nzdTTs3s=
-yunion.io/x/pkg v0.0.0-20200414143921-085f89a6e1e9/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
+yunion.io/x/pkg v0.0.0-20200415124010-2c7da30b998f h1:7aKKuquYIFESmLnti3ea0IhGMZ1K1JnP/1XeJg59bmA=
+yunion.io/x/pkg v0.0.0-20200415124010-2c7da30b998f/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8J50Cise/HCylsOJngmo=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e/go.mod h1:0iFKpOs1y4lbCxeOmq3Xx/0AcQoewVPwj62eRluioEo=
 yunion.io/x/sqlchemy v0.0.0-20200312002602-1177cd8fbc57 h1:KtQAuLJ00RSUVqkiRmJ1DiDABiw0U3xxXnzD3lGavaY=

--- a/go.sum
+++ b/go.sum
@@ -1116,8 +1116,8 @@ yunion.io/x/log v0.0.0-20200313080802-57a4ce5966b3/go.mod h1:LC6f/4FozL0iaAbnFt2
 yunion.io/x/pkg v0.0.0-20190620104149-945c25821dbf/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/pkg v0.0.0-20190628082551-f4033ba2ea30/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/pkg v0.0.0-20200302034534-fdf44d54b070/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
-yunion.io/x/pkg v0.0.0-20200415124010-2c7da30b998f h1:7aKKuquYIFESmLnti3ea0IhGMZ1K1JnP/1XeJg59bmA=
-yunion.io/x/pkg v0.0.0-20200415124010-2c7da30b998f/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
+yunion.io/x/pkg v0.0.0-20200416145704-22c189971435 h1:Fwf1rjdl+Qmw9BNxQN7wi2lQpYVExV7eBLifd0emHaI=
+yunion.io/x/pkg v0.0.0-20200416145704-22c189971435/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8J50Cise/HCylsOJngmo=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e/go.mod h1:0iFKpOs1y4lbCxeOmq3Xx/0AcQoewVPwj62eRluioEo=
 yunion.io/x/sqlchemy v0.0.0-20200312002602-1177cd8fbc57 h1:KtQAuLJ00RSUVqkiRmJ1DiDABiw0U3xxXnzD3lGavaY=

--- a/go.sum
+++ b/go.sum
@@ -1116,8 +1116,8 @@ yunion.io/x/log v0.0.0-20200313080802-57a4ce5966b3/go.mod h1:LC6f/4FozL0iaAbnFt2
 yunion.io/x/pkg v0.0.0-20190620104149-945c25821dbf/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/pkg v0.0.0-20190628082551-f4033ba2ea30/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/pkg v0.0.0-20200302034534-fdf44d54b070/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
-yunion.io/x/pkg v0.0.0-20200403115157-880d716ed624 h1:yPayJlTJHOP0vKY6ovliZyTwJY9RvdWEF+QDqnxt/iw=
-yunion.io/x/pkg v0.0.0-20200403115157-880d716ed624/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
+yunion.io/x/pkg v0.0.0-20200414143921-085f89a6e1e9 h1:baz7ZPSEPXG24d30B1a8CuYXvG7reykwCW2nzdTTs3s=
+yunion.io/x/pkg v0.0.0-20200414143921-085f89a6e1e9/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8J50Cise/HCylsOJngmo=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e/go.mod h1:0iFKpOs1y4lbCxeOmq3Xx/0AcQoewVPwj62eRluioEo=
 yunion.io/x/sqlchemy v0.0.0-20200312002602-1177cd8fbc57 h1:KtQAuLJ00RSUVqkiRmJ1DiDABiw0U3xxXnzD3lGavaY=

--- a/pkg/apis/cloudcommon/proxy/proxy.go
+++ b/pkg/apis/cloudcommon/proxy/proxy.go
@@ -53,7 +53,11 @@ func (ps *SProxySetting) IsZero() bool {
 
 type ProxySettingResourceInput struct {
 	// 代理配置
-	ProxySettingId string `json:"proxy_setting_id"`
+	ProxySetting string `json:"proxy_setting"`
+
+	// swagger:ignore
+	// Deprecated
+	// ProxySettingId string `json:"proxy_setting_id" "yunion:deprecated-by":"proxy_setting"`
 }
 
 type ProxySettingTestInput struct {

--- a/pkg/apis/compute/api.go
+++ b/pkg/apis/compute/api.go
@@ -285,7 +285,7 @@ type ServerConfigs struct {
 	// swagger:ignore
 	// Deprecated
 	// alias for InstanceType
-	Sku string `json:"sku" deprecated-by:"instance_type"`
+	Sku string `json:"sku" "yunion:deprecated-by":"instance_type"`
 
 	// 虚拟机高可用(创建备机)
 	// default: false
@@ -358,11 +358,12 @@ type ServerCreateInput struct {
 	UserData string `json:"user_data"`
 
 	// swagger:ignore
-	Keypair string `json:"keypair" deprecated-by:"keypair_id"`
+	// Deprecated
+	KeypairId string `json:"keypair_id" "yunion:deprecated-by":"keypair"`
 
 	// 秘钥对Id
 	// required: false
-	KeypairId string `json:"keypair_id"`
+	Keypair string `json:"keypair"`
 
 	// 密码
 	// 要求: 密码长度 >= 20, 至少包含一个数字一个小写字母一个大小字母及特殊字符~`!@#$%^&*()-_=+[]{}|:';\",./<>?中的一个

--- a/pkg/apis/compute/cachedloadbalancercertificate.go
+++ b/pkg/apis/compute/cachedloadbalancercertificate.go
@@ -43,7 +43,7 @@ type LoadbalancerCertificateResourceInput struct {
 
 	// swagger:ignore
 	// Deprecated
-	CertificateId string `json:"certificate_id" deprecated-by:"certificate"`
+	CertificateId string `json:"certificate_id" "yunion:deprecated-by":"certificate"`
 }
 
 type LoadbalancerCertificateFilterListInput struct {

--- a/pkg/apis/compute/cloudaccount.go
+++ b/pkg/apis/compute/cloudaccount.go
@@ -66,7 +66,7 @@ type CloudenvResourceListInput struct {
 	Providers []string `json:"providers"`
 	// swagger:ignore
 	// Deprecated
-	Provider []string `json:"provider" deprecated-by:"providers"`
+	Provider []string `json:"provider" "yunion:deprecated-by":"providers"`
 
 	// 列出指定云平台品牌的资源，一般来说brand和provider相同，除了以上支持的provider之外，还支持以下band
 	//
@@ -77,7 +77,7 @@ type CloudenvResourceListInput struct {
 	Brands []string `json:"brands"`
 	// swagger:ignore
 	// Deprecated
-	Brand []string `json:"brand" deprecated-by:"brands"`
+	Brand []string `json:"brand" "yunion:deprecated-by":"brands"`
 
 	// 列出指定云环境的资源，支持云环境如下：
 	//

--- a/pkg/apis/compute/cloudprovider.go
+++ b/pkg/apis/compute/cloudprovider.go
@@ -147,15 +147,15 @@ type CloudproviderResourceInput struct {
 	// swagger:ignore
 	// Deprecated
 	// description: this param will be deprecate at 3.0
-	Manager string `json:"manager" deprecated-by:"cloudprovider"`
+	Manager string `json:"manager" "yunion:deprecated-by":"cloudprovider"`
 	// swagger:ignore
 	// Deprecated
 	// description: this param will be deprecate at 3.0
-	ManagerId string `json:"manager_id" deprecated-by:"cloudprovider"`
+	ManagerId string `json:"manager_id" "yunion:deprecated-by":"cloudprovider"`
 	// swagger:ignore
 	// Deprecated
 	// description: this param will be deprecate at 3.0
-	CloudproviderId string `json:"cloudprovider_id" deprecated-by:"cloudprovider"`
+	CloudproviderId string `json:"cloudprovider_id" "yunion:deprecated-by":"cloudprovider"`
 }
 
 type ManagedResourceListInput struct {
@@ -169,15 +169,15 @@ type ManagedResourceListInput struct {
 	// swagger:ignore
 	// Deprecated
 	// description: this param will be deprecate at 3.0
-	CloudaccountId string `json:"cloudaccount_id" deprecated-by:"cloudaccount"`
+	CloudaccountId string `json:"cloudaccount_id" "yunion:deprecated-by":"cloudaccount"`
 	// swagger:ignore
 	// Deprecated
 	// description: this param will be deprecate at 3.0
-	Account string `json:"account" deprecated-by:"cloudaccount"`
+	Account string `json:"account" "yunion:deprecated-by":"cloudaccount"`
 	// swagger:ignore
 	// Deprecated
 	// description: this param will be deprecate at 3.0
-	AccountId string `json:"account_id" deprecated-by:"cloudaccount"`
+	AccountId string `json:"account_id" "yunion:deprecated-by":"cloudaccount"`
 
 	// 过滤资源，是否为非OneCloud内置私有云管理的资源
 	// default: false

--- a/pkg/apis/compute/dbinstance.go
+++ b/pkg/apis/compute/dbinstance.go
@@ -306,7 +306,7 @@ type DBInstanceResourceInput struct {
 
 	// swagger:ignore
 	// Deprecated
-	DBInstanceId string `json:"dbinstance_id" deprecated-by:"dbinstance"`
+	DBInstanceId string `json:"dbinstance_id" "yunion:deprecated-by":"dbinstance"`
 }
 
 type DBInstanceFilterListInputBase struct {

--- a/pkg/apis/compute/disk.go
+++ b/pkg/apis/compute/disk.go
@@ -88,7 +88,7 @@ type SnapshotPolicyResourceInput struct {
 	// swagger:ignore
 	// Deprecated
 	// filter disk by snapshotpolicy_id
-	SnapshotpolicyId string `json:"snapshotpolicy_id" deprecated-by:"snapshotpolicy"`
+	SnapshotpolicyId string `json:"snapshotpolicy_id" "yunion:deprecated-by":"snapshotpolicy"`
 }
 
 type SnapshotPolicyFilterListInput struct {
@@ -113,7 +113,7 @@ type DiskListInput struct {
 	// swagger:ignore
 	// Deprecated
 	// filter by disk type
-	Type string `json:"type" deprecated-by:"disk_type"`
+	Type string `json:"type" "yunion:deprecated-by":"disk_type"`
 	// 过滤指定disk_type的磁盘列表，可能的值为：sys, data, swap. volume
 	//
 	// | disk_type值 | 说明 |
@@ -137,13 +137,13 @@ type DiskListInput struct {
 	Template string `json:"template"`
 	// swagger:ignore
 	// Deprecated
-	TemplateId string `json:"template_id" deprecated-by:"template"`
+	TemplateId string `json:"template_id" "yunion:deprecated-by":"template"`
 
 	// 快照
 	Snapshot string `json:"snapshot"`
 	// swagger:ignore
 	// Deprecated
-	SnapshotId string `json:"snapshot_id" deprecated-by:"snapshot"`
+	SnapshotId string `json:"snapshot_id" "yunion:deprecated-by":"snapshot"`
 }
 
 type DiskResourceInput struct {
@@ -152,7 +152,7 @@ type DiskResourceInput struct {
 	// swagger:ignore
 	// Deprecated
 	// filter by disk_id
-	DiskId string `json:"disk_id" deprecated-by:"disk"`
+	DiskId string `json:"disk_id" "yunion:deprecated-by":"disk"`
 }
 
 type DiskFilterListInputBase struct {

--- a/pkg/apis/compute/elasticcache.go
+++ b/pkg/apis/compute/elasticcache.go
@@ -53,7 +53,7 @@ type ELasticcacheResourceInput struct {
 
 	// swagger:ignore
 	// Deprecated
-	ElasticcacheId string `json:"elasticcache_id" deprecated-by:"elasticcache"`
+	ElasticcacheId string `json:"elasticcache_id" "yunion:deprecated-by":"elasticcache"`
 }
 
 type ElasticcacheFilterListInput struct {

--- a/pkg/apis/compute/geo_input.go
+++ b/pkg/apis/compute/geo_input.go
@@ -24,15 +24,15 @@ type CloudregionResourceInput struct {
 	// swagger:ignore
 	// Deprecated
 	// description: this param will be deprecate at 3.0
-	CloudregionId string `json:"cloudregion_id" deprecated-by:"cloudregion"`
+	CloudregionId string `json:"cloudregion_id" "yunion:deprecated-by":"cloudregion"`
 	// swagger:ignore
 	// Deprecated
 	// description: this param will be deprecate at 3.0
-	Region string `json:"region" deprecated-by:"cloudregion"`
+	Region string `json:"region" "yunion:deprecated-by":"cloudregion"`
 	// swagger:ignore
 	// Deprecated
 	// description: this param will be deprecate at 3.0
-	RegionId string `json:"region_id" deprecated-by:"cloudregion"`
+	RegionId string `json:"region_id" "yunion:deprecated-by":"cloudregion"`
 }
 
 type RegionalFilterListInput struct {
@@ -117,5 +117,5 @@ type ZoneResourceInput struct {
 
 	// swagger:ignore
 	// Deprecated
-	ZoneId string `json:"zone_id" deprecated-by:"zone"`
+	ZoneId string `json:"zone_id" "yunion:deprecated-by":"zone"`
 }

--- a/pkg/apis/compute/globalvpc.go
+++ b/pkg/apis/compute/globalvpc.go
@@ -39,7 +39,7 @@ type GlobalVpcResourceInput struct {
 
 	// swagger:ignore
 	// Deprecated
-	GlobalvpcId string `json:"globalvpc_id" deprecated-by:"globalvpc"`
+	GlobalvpcId string `json:"globalvpc_id" "yunion:deprecated-by":"globalvpc"`
 }
 
 type GlobalVpcResourceListInput struct {

--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -262,15 +262,15 @@ type ServerResourceInput struct {
 	// swagger:ignore
 	// Deprecated
 	// Filter by guest Id
-	ServerId string `json:"server_id" deprecated-by:"server"`
+	ServerId string `json:"server_id" "yunion:deprecated-by":"server"`
 	// swagger:ignore
 	// Deprecated
 	// Filter by guest Id
-	Guest string `json:"guest" deprecated-by:"server"`
+	Guest string `json:"guest" "yunion:deprecated-by":"server"`
 	// swagger:ignore
 	// Deprecated
 	// Filter by guest Id
-	GuestId string `json:"guest_id" deprecated-by:"server"`
+	GuestId string `json:"guest_id" "yunion:deprecated-by":"server"`
 }
 
 type ServerFilterListInput struct {

--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -30,7 +30,7 @@ type ServerListInput struct {
 
 	HostFilterListInput
 
-	NetworkFilterListInput
+	NetworkFilterListInput `"yunion:ambiguous-prefix":"vpc_"`
 
 	billing.BillingResourceListInput
 

--- a/pkg/apis/compute/host.go
+++ b/pkg/apis/compute/host.go
@@ -217,7 +217,7 @@ type HostResourceInput struct {
 	// swagger:ignore
 	// Deprecated
 	// filter by host_id
-	HostId string `json:"host_id" deprecated-by:"host"`
+	HostId string `json:"host_id" "yunion:deprecated-by":"host"`
 }
 
 type HostRegisterMetadata struct {

--- a/pkg/apis/compute/hostjoin.go
+++ b/pkg/apis/compute/hostjoin.go
@@ -21,7 +21,7 @@ type HostJointResourceDetailsBase struct {
 	Host string `json:"host"`
 	// 裸金属服务器名称
 	// Deprecated
-	Baremetal string `json:"baremetal" deprecated-by:"host"`
+	Baremetal string `json:"baremetal" "yunion:deprecated-by":"host"`
 }
 
 type HostJointResourceDetails struct {

--- a/pkg/apis/compute/input.go
+++ b/pkg/apis/compute/input.go
@@ -150,7 +150,7 @@ type GuestTemplateFilterListInput struct {
 	GuestTemplate string `json:"guest_template"`
 	// swagger:ignore
 	// Deprecated
-	GuestTemplateId string `json:"guest_template_id" deprecated-by:"guest_template"`
+	GuestTemplateId string `json:"guest_template_id" "yunion:deprecated-by":"guest_template"`
 }
 
 type ServiceCatalogListInput struct {

--- a/pkg/apis/compute/instance_group.go
+++ b/pkg/apis/compute/instance_group.go
@@ -50,7 +50,7 @@ type GroupResourceInput struct {
 	// swagger:ignore
 	// Deprecated
 	// Filter by instance group Id
-	GroupId string `json:"group_id" deprecated-by:"group"`
+	GroupId string `json:"group_id" "yunion:deprecated-by":"group"`
 }
 
 type GroupFilterListInput struct {

--- a/pkg/apis/compute/loadbalancer.go
+++ b/pkg/apis/compute/loadbalancer.go
@@ -202,7 +202,7 @@ type LoadbalancerResourceInput struct {
 
 	// swagger:ignore
 	// Deprecated
-	LoadbalancerId string `json:"loadbalancer_id" deprecated-by:"loadbalancer"`
+	LoadbalancerId string `json:"loadbalancer_id" "yunion:deprecated-by":"loadbalancer"`
 }
 
 type LoadbalancerFilterListInput struct {

--- a/pkg/apis/compute/loadbalancerbackendgroup.go
+++ b/pkg/apis/compute/loadbalancerbackendgroup.go
@@ -39,7 +39,7 @@ type LoadbalancerBackendGroupResourceInput struct {
 
 	// swagger:ignore
 	// Deprecated
-	BackendGroupId string `json:"backend_group_id" deprecated-by:"backend_group"`
+	BackendGroupId string `json:"backend_group_id" "yunion:deprecated-by":"backend_group"`
 }
 
 type LoadbalancerBackendGroupFilterListInput struct {

--- a/pkg/apis/compute/loadbalancercluster.go
+++ b/pkg/apis/compute/loadbalancercluster.go
@@ -45,7 +45,7 @@ type LoadbalancerClusterResourceInput struct {
 
 	// swagger:ignore
 	// Deprecated
-	ClusterId string `json:"cluster_id" deprecated-by:"cluster"`
+	ClusterId string `json:"cluster_id" "yunion:deprecated-by":"cluster"`
 }
 
 type LoadbalancerClusterFilterListInput struct {

--- a/pkg/apis/compute/loadbalancerlistener.go
+++ b/pkg/apis/compute/loadbalancerlistener.go
@@ -45,7 +45,7 @@ type LoadbalancerListenerResourceInput struct {
 	// 负载均衡监听器ID
 	// swagger:ignore
 	// Deprecated
-	ListenerId string `json:"listener_id" deprecated-by:"listener"`
+	ListenerId string `json:"listener_id" "yunion:deprecated-by":"listener"`
 }
 
 type LoadbalancerListenerFilterListInput struct {

--- a/pkg/apis/compute/natgateway.go
+++ b/pkg/apis/compute/natgateway.go
@@ -89,7 +89,7 @@ type NatGatewayResourceInput struct {
 
 	// swagger:ignore
 	// Deprecated
-	NatgatewayId string `json:"natgateway_id" deprecated-by:"natgateway"`
+	NatgatewayId string `json:"natgateway_id" "yunion:deprecated-by":"natgateway"`
 }
 
 type NatGatewayFilterListInput struct {

--- a/pkg/apis/compute/network.go
+++ b/pkg/apis/compute/network.go
@@ -24,7 +24,7 @@ type WireResourceInput struct {
 	// swagger:ignore
 	// Deprecated
 	// fitler by wire id
-	WireId string `json:"wire_id" deprecated-by:"wire"`
+	WireId string `json:"wire_id" "yunion:deprecated-by":"wire"`
 }
 
 type WireFilterListBase struct {
@@ -47,7 +47,7 @@ type NetworkResourceInput struct {
 	// swagger:ignore
 	// Deprecated
 	// filter by networkId
-	NetworkId string `json:"network_id" deprecated-by:"network"`
+	NetworkId string `json:"network_id" "yunion:deprecated-by":"network"`
 }
 
 type NetworkFilterListBase struct {

--- a/pkg/apis/compute/schedtag.go
+++ b/pkg/apis/compute/schedtag.go
@@ -45,7 +45,7 @@ type SchedtagResourceInput struct {
 	// swagger:ignore
 	// Deprecated
 	// filter by schedtag_id
-	SchedtagId string `json:"schedtag_id" deprecated-by:"schedtag"`
+	SchedtagId string `json:"schedtag_id" "yunion:deprecated-by":"schedtag"`
 }
 
 type SchedtagFilterListInput struct {
@@ -69,7 +69,7 @@ type SchedtagListInput struct {
 	// swagger:ignore
 	// Deprecated
 	// filter by type, alias for resource_type
-	Type string `json:"type" deprecated-by:"resource_type"`
+	Type string `json:"type" "yunion:deprecated-by":"resource_type"`
 
 	DefaultStrategy []string `json:"default_strategy"`
 }

--- a/pkg/apis/compute/secgroup.go
+++ b/pkg/apis/compute/secgroup.go
@@ -178,7 +178,7 @@ type SecgroupResourceInput struct {
 	// swagger:ignore
 	// Deprecated
 	// filter by secgroup_id
-	SecgroupId string `json:"secgroup_id" deprecated-by:"secgroup"`
+	SecgroupId string `json:"secgroup_id" "yunion:deprecated-by":"secgroup"`
 }
 
 type SecgroupFilterListInput struct {

--- a/pkg/apis/compute/storage_const.go
+++ b/pkg/apis/compute/storage_const.go
@@ -144,7 +144,7 @@ type StorageResourceInput struct {
 	// swagger:ignore
 	// Deprecated
 	// filter by storage_id
-	StorageId string `json:"storage_id" deprecated-by:"storage"`
+	StorageId string `json:"storage_id" "yunion:deprecated-by":"storage"`
 }
 
 type StorageFilterListInputBase struct {

--- a/pkg/apis/compute/storagecachedimage.go
+++ b/pkg/apis/compute/storagecachedimage.go
@@ -48,13 +48,13 @@ type StoragecachedimageListInput struct {
 	Storagecache string `json:"storagecache"`
 	// Deprecated
 	// swagger:ignore
-	StoragecacheId string `json:"storagecache_id" deprecated-by:"storagecache"`
+	StoragecacheId string `json:"storagecache_id" "yunion:deprecated-by":"storagecache"`
 
 	// 以镜像缓存过滤
 	Cachedimage string `json:"cachedimage"`
 	// Deprecated
 	// swagger:ignore
-	CachedimageId string `json:"cachedimage_id" deprecated-by:"cachedimage_id"`
+	CachedimageId string `json:"cachedimage_id" "yunion:deprecated-by":"cachedimage"`
 
 	// 镜像状态
 	Status []string `json:"status"`

--- a/pkg/apis/compute/vpc.go
+++ b/pkg/apis/compute/vpc.go
@@ -80,7 +80,7 @@ type VpcResourceInput struct {
 	// swagger:ignore
 	// Deprecated
 	// filter by vpc Id
-	VpcId string `json:"vpc_id" deprecated-by:"vpc"`
+	VpcId string `json:"vpc_id" "yunion:deprecated-by":"vpc"`
 }
 
 type VpcFilterListInputBase struct {

--- a/pkg/apis/identity/identityprovider.go
+++ b/pkg/apis/identity/identityprovider.go
@@ -68,10 +68,10 @@ type IdentityProviderCreateInput struct {
 	Template string `json:"template"`
 
 	// 默认导入用户和组的域
-	TargetDomainId string `json:"target_domain_id"`
+	TargetDomain string `json:"target_domain"`
 	// swagger:ignore
 	// Deprecated
-	TargetDomain string `json:"target_domain" "yunion:deprecated-by":"target_domain_id"`
+	TargetDomainId string `json:"target_domain_id" "yunion:deprecated-by":"target_domain"`
 
 	// 新建域的时候是否自动新建第一个项目
 	AutoCreateProject *bool `json:"auto_create_project"`

--- a/pkg/apis/identity/input.go
+++ b/pkg/apis/identity/input.go
@@ -48,22 +48,22 @@ type ProjectFilterListInput struct {
 	ProjectDomain string `json:"project_domain"`
 	// swagger:ignore
 	// Deprecated
-	ProjectDomainId string `json:"project_domain_id" deprecated-by:"project-domain"`
+	ProjectDomainId string `json:"project_domain_id" "yunion:deprecated-by":"project-domain"`
 
 	// 以项目（ID或Name）过滤列表结果
 	Project string `json:"project"`
 	// swagger:ignore
 	// Deprecated
 	// filter by project_id
-	ProjectId string `json:"project_id" deprecated-by:"project"`
+	ProjectId string `json:"project_id" "yunion:deprecated-by":"project"`
 	// swagger:ignore
 	// Deprecated
 	// filter by tenant
-	Tenant string `json:"tenant" deprecated-by:"project"`
+	Tenant string `json:"tenant" "yunion:deprecated-by":"project"`
 	// swagger:ignore
 	// Deprecated
 	// filter by tenant_id
-	TenantId string `json:"tenant_id" deprecated-by:"project"`
+	TenantId string `json:"tenant_id" "yunion:deprecated-by":"project"`
 }
 
 type UserFilterListInput struct {
@@ -78,7 +78,7 @@ type UserFilterListInput struct {
 	// swagger:ignore
 	// Deprecated
 	// filter by user_id
-	UserId string `json:"user_id" deprecated-by:"user"`
+	UserId string `json:"user_id" "yunion:deprecated-by":"user"`
 }
 
 type GroupFilterListInput struct {
@@ -93,7 +93,7 @@ type GroupFilterListInput struct {
 	// swagger:ignore
 	// Deprecated
 	// filter by group_id
-	GroupId string `json:"group_id" deprecated-by:"group"`
+	GroupId string `json:"group_id" "yunion:deprecated-by":"group"`
 }
 
 type RoleFilterListInput struct {
@@ -108,7 +108,7 @@ type RoleFilterListInput struct {
 	// swagger:ignore
 	// Deprecated
 	// filter by role_id
-	RoleId string `json:"role_id" deprecated-by:"role"`
+	RoleId string `json:"role_id" "yunion:deprecated-by":"role"`
 }
 
 type ServiceFilterListInput struct {
@@ -120,7 +120,7 @@ type ServiceFilterListInput struct {
 	// swagger:ignore
 	// Deprecated
 	// filter by service_id
-	ServiceId string `json:"service_id" deprecated-by:"service"`
+	ServiceId string `json:"service_id" "yunion:deprecated-by":"service"`
 
 	// 以服务名称排序
 	OrderByService string `json:"order_by_service"`
@@ -320,7 +320,7 @@ type RegionFilterListInput struct {
 	Region string `json:"region"`
 	// swagger:ignore
 	// Deprecated
-	RegionId string `json:"region_id" deprecated-by:"region"`
+	RegionId string `json:"region_id" "yunion:deprecated-by":"region"`
 }
 
 type RegionListInput struct {

--- a/pkg/apis/input.go
+++ b/pkg/apis/input.go
@@ -21,15 +21,15 @@ type DomainizedResourceInput struct {
 
 	// swagger:ignore
 	// Deprecated
-	Domain string `json:"domain" deprecated-by:"project_domain"`
+	Domain string `json:"domain" "yunion:deprecated-by":"project_domain"`
 	// swagger:ignore
 	// Deprecated
 	// Project domain Id filter, alias for project_domain
-	ProjectDomainId string `json:"project_domain_id" deprecated-by:"project_domain"`
+	ProjectDomainId string `json:"project_domain_id" "yunion:deprecated-by":"project_domain"`
 	// swagger:ignore
 	// Deprecated
 	// Domain Id filter, alias for project_domain
-	DomainId string `json:"domain_id" deprecated-by:"project_domain"`
+	DomainId string `json:"domain_id" "yunion:deprecated-by":"project_domain"`
 }
 
 type ProjectizedResourceInput struct {
@@ -39,15 +39,15 @@ type ProjectizedResourceInput struct {
 	// swagger:ignore
 	// Deprecated
 	// Filter by project_id, alias for project
-	ProjectId string `json:"project_id" deprecated-by:"project"`
+	ProjectId string `json:"project_id" "yunion:deprecated-by":"project"`
 	// swagger:ignore
 	// Deprecated
 	// Filter by tenant ID or Name, alias for project
-	Tenant string `json:"tenant" deprecated-by:"project"`
+	Tenant string `json:"tenant" "yunion:deprecated-by":"project"`
 	// swagger:ignore
 	// Deprecated
 	// Filter by tenant_id, alias for project
-	TenantId string `json:"tenant_id" deprecated-by:"project"`
+	TenantId string `json:"tenant_id" "yunion:deprecated-by":"project"`
 }
 
 type DomainizedResourceCreateInput struct {

--- a/pkg/apis/list.go
+++ b/pkg/apis/list.go
@@ -50,7 +50,7 @@ type ProjectizedResourceListInput struct {
 	OrderByProject string `json:"order_by_project"`
 	// swagger:ignore
 	// Deprecated
-	OrderByTenant string `json:"order_by_tenant" deprecated-by:"order_by_project"`
+	OrderByTenant string `json:"order_by_tenant" "yunion:deprecated-by":"order_by_project"`
 }
 
 type UserResourceListInput struct {
@@ -59,7 +59,7 @@ type UserResourceListInput struct {
 	// swagger:ignore
 	// Deprecated
 	// Filter by userId
-	UserId string `json:"user_id" deprecated-by:"user"`
+	UserId string `json:"user_id" "yunion:deprecated-by":"user"`
 }
 
 type ModelBaseListInput struct {

--- a/pkg/apis/output.go
+++ b/pkg/apis/output.go
@@ -133,11 +133,11 @@ type ProjectizedResourceInfo struct {
 
 	// 资源归属项目的ID(向后兼容别名）
 	// Deprecated
-	TenantId string `json:"project_id" deprecated-by:"tenant_id"`
+	TenantId string `json:"project_id" "yunion:deprecated-by":"tenant_id"`
 
 	// 资源归属项目的名称（向后兼容别名）
 	// Deprecated
-	Tenant string `json:"project" deprecated-by:"tenant"`
+	Tenant string `json:"project" "yunion:deprecated-by":"tenant"`
 }
 
 type ScopedResourceBaseInfo struct {

--- a/pkg/cloudcommon/cmdline/helper.go
+++ b/pkg/cloudcommon/cmdline/helper.go
@@ -402,7 +402,7 @@ func FetchServerCreateInputByJSON(obj jsonutils.JSONObject) (*compute.ServerCrea
 		input.InstanceType = skuName
 	}
 	if keypair := jsonutils.GetAnyString(obj, []string{"keypair", "keypair_id"}); keypair != "" {
-		input.KeypairId = keypair
+		input.Keypair = keypair
 	}
 	if secgroup := jsonutils.GetAnyString(obj, []string{"secgroup", "secgroup_id", "secgrp_id"}); len(secgroup) != 0 {
 		input.SecgroupId = secgroup

--- a/pkg/cloudcommon/db/proxy/proxysetting.go
+++ b/pkg/cloudcommon/db/proxy/proxysetting.go
@@ -227,14 +227,14 @@ func RegisterReferrer(man db.IModelManager) {
 }
 
 func ValidateProxySettingResourceInput(userCred mcclient.TokenCredential, input proxyapi.ProxySettingResourceInput) (*SProxySetting, proxyapi.ProxySettingResourceInput, error) {
-	m, err := ProxySettingManager.FetchByIdOrName(userCred, input.ProxySettingId)
+	m, err := ProxySettingManager.FetchByIdOrName(userCred, input.ProxySetting)
 	if err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
-			return nil, input, errors.Wrapf(httperrors.ErrResourceNotFound, "%s %s", ProxySettingManager.Keyword(), input.ProxySettingId)
+			return nil, input, errors.Wrapf(httperrors.ErrResourceNotFound, "%s %s", ProxySettingManager.Keyword(), input.ProxySetting)
 		} else {
 			return nil, input, errors.Wrapf(err, "ProxySettingManager.FetchByIdOrName")
 		}
 	}
-	input.ProxySettingId = m.GetId()
+	input.ProxySetting = m.GetId()
 	return m.(*SProxySetting), input, nil
 }

--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -297,7 +297,7 @@ func (self *SCloudaccount) ValidateUpdateData(
 		input.Options = optionsJson
 	}
 
-	if len(input.ProxySettingId) > 0 {
+	if len(input.ProxySetting) > 0 {
 		var proxySetting *proxy.SProxySetting
 		proxySetting, input.ProxySettingResourceInput, err = proxy.ValidateProxySettingResourceInput(userCred, input.ProxySettingResourceInput)
 		if err != nil {
@@ -391,8 +391,8 @@ func (manager *SCloudaccountManager) ValidateCreateData(
 
 	var proxyFunc httputils.TransportProxyFunc
 	{
-		if input.ProxySettingId == "" {
-			input.ProxySettingId = proxyapi.ProxySettingId_DIRECT
+		if input.ProxySetting == "" {
+			input.ProxySetting = proxyapi.ProxySettingId_DIRECT
 		}
 		var proxySetting *proxy.SProxySetting
 		proxySetting, input.ProxySettingResourceInput, err = proxy.ValidateProxySettingResourceInput(userCred, input.ProxySettingResourceInput)

--- a/pkg/compute/models/guest_template.go
+++ b/pkg/compute/models/guest_template.go
@@ -366,8 +366,8 @@ func (gt *SGuestTemplate) getMoreDetails(ctx context.Context, userCred mcclient.
 	configInfo.Disks = disks
 
 	// keypair
-	if len(input.KeypairId) > 0 {
-		model, err := KeypairManager.FetchById(input.KeypairId)
+	if len(input.Keypair) > 0 {
+		model, err := KeypairManager.FetchByIdOrName(userCred, input.Keypair)
 		if err == nil {
 			keypair := model.(*SKeypair)
 			configInfo.Keypair = keypair.GetName()
@@ -482,7 +482,7 @@ func (gt *SGuestTemplate) PerformPublic(
 
 	// check for below private resource in the guest template
 	privateResource := map[string]int{
-		"keypair":           len(input.KeypairId),
+		"keypair":           len(input.Keypair),
 		"instance group":    len(input.InstanceGroupIds),
 		"instance snapshot": len(input.InstanceSnapshotId),
 	}

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1272,13 +1272,13 @@ func (manager *SGuestManager) validateCreateData(
 		input.IsolatedDevices[idx] = devConfig
 	}
 
-	keypairId := input.KeypairId
+	keypairId := input.Keypair
 	if len(keypairId) > 0 {
 		keypairObj, err := KeypairManager.FetchByIdOrName(userCred, keypairId)
 		if err != nil {
 			return nil, httperrors.NewResourceNotFoundError("Keypair %s not found", keypairId)
 		}
-		input.KeypairId = keypairObj.GetId()
+		input.Keypair = keypairObj.GetId()
 	}
 
 	secGrpIds := []string{}
@@ -4880,7 +4880,7 @@ func (self *SGuest) ToCreateInput(userCred mcclient.TokenCredential) *api.Server
 	userInput.ShutdownBehavior = genInput.ShutdownBehavior
 	userInput.IsSystem = genInput.IsSystem
 	userInput.SecgroupId = genInput.SecgroupId
-	userInput.KeypairId = genInput.KeypairId
+	userInput.Keypair = genInput.Keypair
 	userInput.EipBw = genInput.EipBw
 	userInput.EipChargeType = genInput.EipChargeType
 	// cloned server should belongs to the project creating it
@@ -4942,7 +4942,7 @@ func (self *SGuest) toCreateInput() *api.ServerCreateInput {
 	r.IsolatedDevices = self.ToIsolatedDevicesConfig()
 
 	if keypair := self.getKeypair(); keypair != nil {
-		r.KeypairId = keypair.Id
+		r.Keypair = keypair.Id
 	}
 	if host := self.GetHost(); host != nil {
 		r.ResourceType = host.ResourceType

--- a/pkg/compute/models/instance_snapshots.go
+++ b/pkg/compute/models/instance_snapshots.go
@@ -315,7 +315,7 @@ func (self *SInstanceSnapshot) ToInstanceCreateInput(
 		sourceInput.VcpuCount = serverConfig.Ncpu
 	}
 	if len(self.KeypairId) > 0 {
-		sourceInput.KeypairId = self.KeypairId
+		sourceInput.Keypair = self.KeypairId
 	}
 	if self.SecGroups != nil {
 		secGroups := make([]string, 0)

--- a/pkg/keystone/models/identity_provider.go
+++ b/pkg/keystone/models/identity_provider.go
@@ -304,7 +304,7 @@ func (manager *SIdentityProviderManager) ValidateCreateData(
 		}
 	}
 
-	targetDomainStr := input.TargetDomainId
+	targetDomainStr := input.TargetDomain
 	if len(targetDomainStr) > 0 {
 		domain, err := DomainManager.FetchDomainById(targetDomainStr)
 		if err != nil {
@@ -314,7 +314,7 @@ func (manager *SIdentityProviderManager) ValidateCreateData(
 				return input, httperrors.NewGeneralError(err)
 			}
 		}
-		input.TargetDomainId = domain.Id
+		input.TargetDomain = domain.Id
 	}
 
 	var err error

--- a/pkg/mcclient/options/servers.go
+++ b/pkg/mcclient/options/servers.go
@@ -61,6 +61,8 @@ type ServerListOptions struct {
 	ScalingGroup string `help:"ScalingGroup's id or name'"`
 
 	BaseListOptions
+
+	VpcProvider string `help:"filter by vpc's provider" json:"vpc_provider"`
 }
 
 type ServerIdOptions struct {

--- a/pkg/mcclient/options/servers.go
+++ b/pkg/mcclient/options/servers.go
@@ -376,7 +376,7 @@ func (opts *ServerCreateOptionalOptions) OptionalParams() (*computeapi.ServerCre
 	params := &computeapi.ServerCreateInput{
 		ServerConfigs:      config,
 		VcpuCount:          opts.VcpuCount,
-		KeypairId:          opts.Keypair,
+		Keypair:            opts.Keypair,
 		Password:           opts.Password,
 		Cdrom:              opts.Iso,
 		Vga:                opts.Vga,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1019,7 +1019,7 @@ yunion.io/x/jsonutils
 # yunion.io/x/log v0.0.0-20200313080802-57a4ce5966b3
 yunion.io/x/log
 yunion.io/x/log/hooks
-# yunion.io/x/pkg v0.0.0-20200415124010-2c7da30b998f
+# yunion.io/x/pkg v0.0.0-20200416145704-22c189971435
 yunion.io/x/pkg/errors
 yunion.io/x/pkg/gotypes
 yunion.io/x/pkg/prettytable

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1014,12 +1014,12 @@ sigs.k8s.io/yaml
 yunion.io/x/executor/apis
 yunion.io/x/executor/client
 yunion.io/x/executor/server
-# yunion.io/x/jsonutils v0.0.0-20200330063846-589d9924bb8b
+# yunion.io/x/jsonutils v0.0.0-20200415132054-2bf8a5e94501
 yunion.io/x/jsonutils
 # yunion.io/x/log v0.0.0-20200313080802-57a4ce5966b3
 yunion.io/x/log
 yunion.io/x/log/hooks
-# yunion.io/x/pkg v0.0.0-20200403115157-880d716ed624
+# yunion.io/x/pkg v0.0.0-20200415124010-2c7da30b998f
 yunion.io/x/pkg/errors
 yunion.io/x/pkg/gotypes
 yunion.io/x/pkg/prettytable

--- a/vendor/yunion.io/x/jsonutils/consts.go
+++ b/vendor/yunion.io/x/jsonutils/consts.go
@@ -14,6 +14,10 @@
 
 package jsonutils
 
+import (
+	"yunion.io/x/pkg/util/reflectutils"
+)
+
 const (
-	TAG_DEPRECATED_BY = "deprecated-by"
+	TAG_DEPRECATED_BY = reflectutils.TAG_DEPRECATED_BY
 )

--- a/vendor/yunion.io/x/pkg/prettytable/prettytable.go
+++ b/vendor/yunion.io/x/pkg/prettytable/prettytable.go
@@ -16,11 +16,8 @@ package prettytable
 
 import (
 	"bytes"
-	"os"
 	"strings"
 	"unicode"
-
-	"golang.org/x/sys/unix"
 )
 
 type AlignmentType uint8
@@ -54,15 +51,6 @@ func NewPrettyTable(fields []string) *PrettyTable {
 		pt.columns = append(pt.columns, col)
 	}
 	return &pt
-}
-
-func termWidth() (int, error) {
-	fd := int(os.Stdout.Fd())
-	wsz, err := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)
-	if err != nil {
-		return -1, err
-	}
-	return int(wsz.Col), nil
 }
 
 func rowLine(buf *bytes.Buffer, widths []int) {

--- a/vendor/yunion.io/x/pkg/prettytable/termwidth_unix.go
+++ b/vendor/yunion.io/x/pkg/prettytable/termwidth_unix.go
@@ -1,5 +1,5 @@
 // Copyright 2019 Yunion
-//
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,31 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package yunionconf
+// +build !windows
+
+package prettytable
 
 import (
-	"yunion.io/x/onecloud/pkg/apis"
+	"os"
+
+	"golang.org/x/sys/unix"
 )
 
-type ParameterListInput struct {
-	apis.ResourceBaseListInput
-
-	NamespaceId string `json:"namespace_id"`
-
-	// 服务名称或ID
-	Service string `json:"service"`
-
-	// Deprecated
-	// swagger:ignore
-	ServiceId string `json:"service_id" "yunion:deprecated-by":"service"`
-
-	// 用户名称或ID
-	User string `json:"user"`
-
-	// Deprecated
-	// swagger:ignore
-	UserId string `json:"user_id" "yunion:deprecated-by":"user"`
-
-	// filter by name
-	Name []string `json:"name"`
+func termWidth() (int, error) {
+	fd := int(os.Stdout.Fd())
+	wsz, err := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)
+	if err != nil {
+		return -1, err
+	}
+	return int(wsz.Col), nil
 }

--- a/vendor/yunion.io/x/pkg/prettytable/termwidth_windows.go
+++ b/vendor/yunion.io/x/pkg/prettytable/termwidth_windows.go
@@ -1,5 +1,5 @@
 // Copyright 2019 Yunion
-//
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,31 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package yunionconf
+// +build windows
+
+package prettytable
 
 import (
-	"yunion.io/x/onecloud/pkg/apis"
+	"os"
+
+	"golang.org/x/sys/windows"
 )
 
-type ParameterListInput struct {
-	apis.ResourceBaseListInput
-
-	NamespaceId string `json:"namespace_id"`
-
-	// 服务名称或ID
-	Service string `json:"service"`
-
-	// Deprecated
-	// swagger:ignore
-	ServiceId string `json:"service_id" "yunion:deprecated-by":"service"`
-
-	// 用户名称或ID
-	User string `json:"user"`
-
-	// Deprecated
-	// swagger:ignore
-	UserId string `json:"user_id" "yunion:deprecated-by":"user"`
-
-	// filter by name
-	Name []string `json:"name"`
+func termWidth() (int, error) {
+	var (
+		h    = windows.Handle(os.Stdout.Fd())
+		info windows.ConsoleScreenBufferInfo
+	)
+	if err := windows.GetConsoleScreenBufferInfo(h, &info); err != nil {
+		return -1, err
+	}
+	return int(info.Size.X), nil
 }

--- a/vendor/yunion.io/x/pkg/util/reflectutils/ambiguous.go
+++ b/vendor/yunion.io/x/pkg/util/reflectutils/ambiguous.go
@@ -1,0 +1,57 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reflectutils
+
+import (
+	"fmt"
+)
+
+const (
+	TAG_AMBIGUOUS_PREFIX  = "yunion:ambiguous-prefix"
+	TAG_DEPRECATED_BY     = "yunion:deprecated-by"
+	TAG_OLD_DEPRECATED_BY = "deprecated-by"
+)
+
+func expandAmbiguousPrefix(fields SStructFieldValueSet) SStructFieldValueSet {
+	keyIndexMap := make(map[string][]int)
+	for i := range fields {
+		if fields[i].Info.Ignore {
+			continue
+		}
+		key := fields[i].Info.MarshalName()
+		values, ok := keyIndexMap[key]
+		if !ok {
+			values = make([]int, 0, 2)
+		}
+		keyIndexMap[key] = append(values, i)
+	}
+	for _, indexes := range keyIndexMap {
+		if len(indexes) > 1 {
+			// ambiguous found
+			for _, idx := range indexes {
+				if amPrefix, ok := fields[idx].Info.Tags[TAG_AMBIGUOUS_PREFIX]; ok {
+					fields[idx].Info.Name = fmt.Sprintf("%s%s", amPrefix, fields[idx].Info.Name)
+					if depBy, ok := fields[idx].Info.Tags[TAG_DEPRECATED_BY]; ok {
+						fields[idx].Info.Tags[TAG_DEPRECATED_BY] = fmt.Sprintf("%s%s", amPrefix, depBy)
+					}
+					if depBy, ok := fields[idx].Info.Tags[TAG_OLD_DEPRECATED_BY]; ok {
+						fields[idx].Info.Tags[TAG_OLD_DEPRECATED_BY] = fmt.Sprintf("%s%s", amPrefix, depBy)
+					}
+				}
+			}
+		}
+	}
+	return fields
+}

--- a/vendor/yunion.io/x/pkg/util/reflectutils/jsonfield.go
+++ b/vendor/yunion.io/x/pkg/util/reflectutils/jsonfield.go
@@ -257,27 +257,18 @@ func fetchStructFieldValueSet(dataValue reflect.Value, allocatePtr bool, tags ma
 }
 
 func (fields SStructFieldValueSet) GetStructFieldIndex(name string) int {
-	for i := range fields {
-		if fields[i].Info.Ignore {
-			continue
-		}
-		if fields[i].Info.MarshalName() == name {
-			return i
-		}
-		/*if utils.CamelSplit(jsonInfo.FieldName, "_") == utils.CamelSplit(name, "_") {
-			return i
-		}
-		if jsonInfo.FieldName == name {
-			return i
-		}
-		if jsonInfo.FieldName == utils.Capitalize(name) {
-			return i
-		}*/
+	indexes := fields.GetStructFieldIndexes(name)
+	if len(indexes) > 0 {
+		return indexes[0]
 	}
 	return -1
 }
 
 func (fields SStructFieldValueSet) GetStructFieldIndexes(name string) []int {
+	return fields.GetStructFieldIndexes2(name, false)
+}
+
+func (fields SStructFieldValueSet) GetStructFieldIndexes2(name string, strictMode bool) []int {
 	ret := make([]int, 0)
 	for i := range fields {
 		if fields[i].Info.Ignore {
@@ -287,18 +278,20 @@ func (fields SStructFieldValueSet) GetStructFieldIndexes(name string) []int {
 			ret = append(ret, i)
 			continue
 		}
-		/*if utils.CamelSplit(jsonInfo.FieldName, "_") == utils.CamelSplit(name, "_") {
-			ret = append(ret, i)
-			continue
+		if !strictMode {
+			if utils.CamelSplit(fields[i].Info.FieldName, "_") == utils.CamelSplit(name, "_") {
+				ret = append(ret, i)
+				continue
+			}
+			if fields[i].Info.FieldName == name {
+				ret = append(ret, i)
+				continue
+			}
+			if fields[i].Info.FieldName == utils.Capitalize(name) {
+				ret = append(ret, i)
+				continue
+			}
 		}
-		if jsonInfo.FieldName == name {
-			ret = append(ret, i)
-			continue
-		}
-		if jsonInfo.FieldName == utils.Capitalize(name) {
-			ret = append(ret, i)
-			continue
-		}*/
 	}
 	return ret
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：主机列表过滤参数结构化后，嵌入两次ManagedResourceListInput，一个用于host过滤（HostResourceListInput），一个用于vpc过滤(NetworkResourceListInput)，当提供provider=VMware时，则会先对host进行provider过滤，再对vpc进行provider过滤。当provider=VMware时，vpc过滤结果为空，host返回vmware的宿主机，最后导致结果为空。现增加yunion:ambiguous-prefix的tag，当两个struct的field名称重复时，如果有这个tag，则在名称前加上这个前缀。设置vpc的ManagedResourceListInput的ambiguous-prefix为vpc_这样，过滤参数为provider=VMware时，只有host过滤器生效。过滤参数为vpc_provider=VMware是，只有vpc过滤器生效。

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @yousong  @zexi 

/area region