### PR TITLE
region: lbagents: default to using public type endpoint of influxdb

### DIFF
--- a/pkg/compute/models/buckets.go
+++ b/pkg/compute/models/buckets.go
@@ -31,6 +31,7 @@ import (
 	"yunion.io/x/sqlchemy"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	identity_apis "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
@@ -548,7 +549,8 @@ func joinPath(ep, path string) string {
 }
 
 func (bucket *SBucket) getMoreDetails(out api.BucketDetails) api.BucketDetails {
-	s3gwUrl, _ := auth.GetServiceURL("s3gateway", options.Options.Region, "", "public")
+	s3gwUrl, _ := auth.GetServiceURL("s3gateway", options.Options.Region, "", identity_apis.EndpointInterfacePublic)
+
 	if len(s3gwUrl) > 0 {
 		accessUrls := make([]cloudprovider.SBucketAccessUrl, 0)
 		if bucket.AccessUrls != nil {

--- a/pkg/compute/models/loadbalanceragents.go
+++ b/pkg/compute/models/loadbalanceragents.go
@@ -31,6 +31,7 @@ import (
 
 	"yunion.io/x/onecloud/pkg/apis"
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	identity_apis "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/validators"
 	"yunion.io/x/onecloud/pkg/compute/options"
@@ -250,7 +251,8 @@ func (p *SLoadbalancerAgentParamsTelegraf) Validate(data *jsonutils.JSONDict) er
 func (p *SLoadbalancerAgentParamsTelegraf) initDefault(data *jsonutils.JSONDict) {
 	if p.InfluxDbOutputUrl == "" {
 		baseOpts := &options.Options
-		u, _ := auth.GetServiceURL("influxdb", baseOpts.Region, "", "")
+		u, _ := auth.GetServiceURL("influxdb", baseOpts.Region, "",
+			identity_apis.EndpointInterfacePublic)
 		p.InfluxDbOutputUrl = u
 	}
 	if p.HaproxyInputInterval == 0 {

--- a/pkg/image/torrent/torrent.go
+++ b/pkg/image/torrent/torrent.go
@@ -21,6 +21,7 @@ import (
 
 	"yunion.io/x/log"
 
+	identity_apis "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/image/options"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
@@ -80,7 +81,7 @@ func SeedTorrent(torrentpath string, imageId, format string) error {
 }
 
 func seedTorrent(torrentpath string, imageId, format string) error {
-	url, err := auth.GetServiceURL("image", options.Options.Region, "", "public")
+	url, err := auth.GetServiceURL("image", options.Options.Region, "", identity_apis.EndpointInterfacePublic)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
region: buckets: use identity_apis.EndpointInterfacePublic
image: use identity_apis.EndpointInterfacePublic
region: lbagents: default to using public type endpoint of influxdb
```

**是否需要 backport 到之前的 release 分支**:

- release/2.13

/area region
/area image
/cc @swordqiu @wanyaoqi @zexi 