### PR TITLE
fix: remove notify option VerifyEmailUrlPath

### DIFF
--- a/pkg/notify/models/mod_template.go
+++ b/pkg/notify/models/mod_template.go
@@ -72,9 +72,13 @@ type STemplate struct {
 	Content      string `length:"text" nullable:"false" create:"required" get:"user" list:"user" update:"user"`
 }
 
+const (
+	verifyUrlPath = "/v2/email-verification/id/{0}/token/{1}?region=%s"
+)
+
 func (tm *STemplateManager) GetEmailUrl() string {
-	if len(options.Options.ApiServer) > 0 && len(options.Options.VerifyEmailUrlPath) > 0 {
-		return httputils.JoinPath(options.Options.ApiServer, options.Options.VerifyEmailUrlPath)
+	if len(options.Options.ApiServer) > 0 {
+		return httputils.JoinPath(options.Options.ApiServer, fmt.Sprintf(verifyUrlPath, options.Options.Region))
 	}
 	return options.Options.VerifyEmailUrl
 }

--- a/pkg/notify/options/options.go
+++ b/pkg/notify/options/options.go
@@ -22,10 +22,10 @@ type NotifyOption struct {
 	common_options.CommonOptions
 	common_options.DBOptions
 
-	DingtalkEnabled    bool   `help:"Enable dingtalk"`
-	SocketFileDir      string `help:"Socket file directory" default:"/etc/yunion/notify"`
-	UpdateInterval     int    `help:"Update send services interval(unit:min)" default:"30"`
-	VerifyEmailUrlPath string `help:"url of verify email" json:"verify_email_url_path"`
+	DingtalkEnabled bool   `help:"Enable dingtalk"`
+	SocketFileDir   string `help:"Socket file directory" default:"/etc/yunion/notify"`
+	UpdateInterval  int    `help:"Update send services interval(unit:min)" default:"30"`
+	// VerifyEmailUrlPath string `help:"url of verify email" json:"verify_email_url_path"`
 
 	// Deprecated
 	VerifyEmailUrl string `help:"url of verify email" json:"verify_email_url"`


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：不再使用notify的VerifyEmailUrlPath，该URL在代码中自动生成

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi @rainzm 
/area notify
