### PR TITLE
cloudcommon: resourcebase: allow list fields "deleted"

### DIFF
--- a/pkg/cloudcommon/db/resourcebase.go
+++ b/pkg/cloudcommon/db/resourcebase.go
@@ -39,9 +39,9 @@ type SResourceBase struct {
 	// 资源被更新次数
 	UpdateVersion int `default:"0" nullable:"false" auto_version:"true" list:"user" json:"update_version"`
 	// 资源删除时间
-	DeletedAt time.Time `json:"deleted_at"`
+	DeletedAt time.Time `json:"deleted_at" list:"admin"`
 	// 资源是否被删除
-	Deleted bool `nullable:"false" default:"false" json:"deleted"`
+	Deleted bool `nullable:"false" default:"false" json:"deleted" list:"admin"`
 }
 
 type SResourceBaseManager struct {

--- a/pkg/cloudcommon/db/resourcebase_test.go
+++ b/pkg/cloudcommon/db/resourcebase_test.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"testing"
+
+	"yunion.io/x/pkg/utils"
+
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
+)
+
+type omniToken struct {
+	mcclient.SSimpleToken
+}
+
+func (tk *omniToken) IsAllow(scope rbacutils.TRbacScope, service string, resource string, action string, extra ...string) bool {
+	return true
+}
+
+func TestListFields(t *testing.T) {
+	man := NewResourceBaseManager(
+		&SResourceBase{},
+		"tbl",
+		"keyword",
+		"keywords",
+	)
+	userCred := &omniToken{}
+	inc, exc := listFields(&man, userCred)
+	for _, fn := range []string{"deleted", "deleted_at"} {
+		if !utils.IsInStringArray(fn, inc) {
+			t.Errorf("resourcebase: field %q not included", fn)
+		}
+		if utils.IsInStringArray(fn, exc) {
+			t.Errorf("resourcebase: field %q excluded", fn)
+		}
+	}
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
cloudcommon: resourcebase: allow list fields "deleted"
```

- [x] 冒烟测试

**是否需要 backport 到之前的 release 分支**:

NONE

/area region
/cc @swordqiu @zexi 
