### PR TITLE
fix: decouple climc and webconsole, make climc windows buildable

### DIFF
--- a/cmd/climc/shell/webconsole.go
+++ b/cmd/climc/shell/webconsole.go
@@ -22,11 +22,11 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/utils"
 
+	webconsole_api "yunion.io/x/onecloud/pkg/apis/webconsole"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	o "yunion.io/x/onecloud/pkg/mcclient/options"
 	"yunion.io/x/onecloud/pkg/webconsole/command"
-	"yunion.io/x/onecloud/pkg/webconsole/session"
 )
 
 const (
@@ -61,8 +61,8 @@ func init() {
 		}
 		protocol := query.Get("protocol")
 		if !utils.IsInStringArray(protocol, []string{
-			command.PROTOCOL_TTY, session.VNC,
-			session.SPICE, session.WMKS,
+			command.PROTOCOL_TTY, webconsole_api.VNC,
+			webconsole_api.SPICE, webconsole_api.WMKS,
 		}) {
 			fmt.Println(connParams)
 			return nil

--- a/pkg/apis/webconsole/consts.go
+++ b/pkg/apis/webconsole/consts.go
@@ -18,3 +18,15 @@ const (
 	SERVICE_TYPE    = "webconsole"
 	SERVICE_VERSION = ""
 )
+
+const (
+	VNC       = "vnc"
+	ALIYUN    = "aliyun"
+	QCLOUD    = "qcloud"
+	OPENSTACK = "openstack"
+	SPICE     = "spice"
+	WMKS      = "wmks"
+	VMRC      = "vmrc"
+	ZSTACK    = "zstack"
+	CTYUN     = "ctyun"
+)

--- a/pkg/webconsole/session/remote_console.go
+++ b/pkg/webconsole/session/remote_console.go
@@ -19,20 +19,21 @@ import (
 	"net/url"
 	"os/exec"
 
+	api "yunion.io/x/onecloud/pkg/apis/webconsole"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 )
 
 const (
-	VNC       = "vnc"
-	ALIYUN    = "aliyun"
-	QCLOUD    = "qcloud"
-	OPENSTACK = "openstack"
-	SPICE     = "spice"
-	WMKS      = "wmks"
-	VMRC      = "vmrc"
-	ZSTACK    = "zstack"
-	CTYUN     = "ctyun"
+	VNC       = api.VNC
+	ALIYUN    = api.ALIYUN
+	QCLOUD    = api.QCLOUD
+	OPENSTACK = api.OPENSTACK
+	SPICE     = api.SPICE
+	WMKS      = api.WMKS
+	VMRC      = api.VMRC
+	ZSTACK    = api.ZSTACK
+	CTYUN     = api.CTYUN
 )
 
 type RemoteConsoleInfo struct {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：climc不依赖webconsole/session

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 

/area climc