### PR TITLE
fix: proxysetting_id => proxysetting revisited on 3.1

### DIFF
--- a/pkg/apis/cloudcommon/proxy/proxy.go
+++ b/pkg/apis/cloudcommon/proxy/proxy.go
@@ -42,7 +42,11 @@ func (ps *SProxySetting) IsZero() bool {
 
 type ProxySettingResourceInput struct {
 	// 代理配置
-	ProxySettingId string `json:"proxy_setting_id"`
+	ProxySetting string `json:"proxy_setting"`
+
+	// swagger:ignore
+	// Deprecated
+	ProxySettingId string `json:"proxy_setting_id" "yunion:deprecated-by":"proxy_setting"`
 }
 
 type ProxySettingTestInput struct {

--- a/pkg/cloudcommon/db/proxy/proxysetting.go
+++ b/pkg/cloudcommon/db/proxy/proxysetting.go
@@ -205,14 +205,14 @@ func RegisterReferrer(man db.IModelManager) {
 }
 
 func ValidateProxySettingResourceInput(userCred mcclient.TokenCredential, input proxyapi.ProxySettingResourceInput) (*SProxySetting, proxyapi.ProxySettingResourceInput, error) {
-	m, err := ProxySettingManager.FetchByIdOrName(userCred, input.ProxySettingId)
+	m, err := ProxySettingManager.FetchByIdOrName(userCred, input.ProxySetting)
 	if err != nil {
 		if errors.Cause(err) == sql.ErrNoRows {
-			return nil, input, errors.Wrapf(httperrors.ErrResourceNotFound, "%s %s", ProxySettingManager.Keyword(), input.ProxySettingId)
+			return nil, input, errors.Wrapf(httperrors.ErrResourceNotFound, "%s %s", ProxySettingManager.Keyword(), input.ProxySetting)
 		} else {
 			return nil, input, errors.Wrapf(err, "ProxySettingManager.FetchByIdOrName")
 		}
 	}
-	input.ProxySettingId = m.GetId()
+	input.ProxySetting = m.GetId()
 	return m.(*SProxySetting), input, nil
 }

--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -401,8 +401,8 @@ func (manager *SCloudaccountManager) ValidateCreateData(ctx context.Context, use
 
 	var proxyFunc httputils.TransportProxyFunc
 	{
-		if input.ProxySettingId == "" {
-			input.ProxySettingId = proxyapi.ProxySettingId_DIRECT
+		if input.ProxySetting == "" {
+			input.ProxySetting = proxyapi.ProxySettingId_DIRECT
 		}
 		var proxySetting *proxy.SProxySetting
 		proxySetting, input.ProxySettingResourceInput, err = proxy.ValidateProxySettingResourceInput(userCred, input.ProxySettingResourceInput)

--- a/pkg/mcclient/options/cloudaccounts.go
+++ b/pkg/mcclient/options/cloudaccounts.go
@@ -84,7 +84,7 @@ type SCloudAccountCreateBaseOptions struct {
 
 	ProjectDomain string `help:"domain for this account"`
 
-	ProxySettingId string `help:"proxy setting id or name" json:"proxy_setting_id"`
+	ProxySetting string `help:"proxy setting id or name" json:"proxy_setting"`
 }
 
 type SVMwareCloudAccountCreateOptions struct {
@@ -231,7 +231,7 @@ type SCloudAccountUpdateBaseOptions struct {
 
 	SyncIntervalSeconds int    `help:"auto synchornize interval in seconds"`
 	AutoCreateProject   *bool  `help:"automatically create local project for new remote project"`
-	ProxySettingId      string `help:"proxy setting name or id" json:"proxy_setting_id"`
+	ProxySetting        string `help:"proxy setting name or id" json:"proxy_setting"`
 
 	Desc string `help:"Description" json:"description" token:"desc"`
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：proxysetting_id再次改为proxysetting， backport to 3.1

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @yousong 

/area region