### PR TITLE
Automated cherry pick of #5890: fix: policy details should carry updated_at and created_at fields

### DIFF
--- a/pkg/mcclient/modules/mod_policies.go
+++ b/pkg/mcclient/modules/mod_policies.go
@@ -30,7 +30,7 @@ var Policies SPolicyManager
 
 func policyReadFilter(session *mcclient.ClientSession, s jsonutils.JSONObject, query jsonutils.JSONObject) (jsonutils.JSONObject, error) {
 	ss := s.(*jsonutils.JSONDict)
-	ret := ss.CopyIncludes("id", "type", "enabled", "domain_id", "domain", "project_domain", "can_update", "can_delete", "is_public", "description", "delete_fail_reason", "update_fail_reason", "public_scope", "shared_domains")
+	ret := ss.CopyIncludes("id", "type", "enabled", "domain_id", "domain", "project_domain", "can_update", "can_delete", "is_public", "description", "delete_fail_reason", "update_fail_reason", "public_scope", "shared_domains", "created_at", "updated_at")
 	blobJson, _ := ss.Get("blob")
 	if blobJson != nil {
 		policy := rbacutils.SRbacPolicy{}


### PR DESCRIPTION
Cherry pick of #5890 on release/3.2.

#5890: fix: policy details should carry updated_at and created_at fields