### PR TITLE
fix: delete idp also delete users/groups in target domain

### DIFF
--- a/pkg/keystone/models/identity_provider.go
+++ b/pkg/keystone/models/identity_provider.go
@@ -306,7 +306,7 @@ func (manager *SIdentityProviderManager) ValidateCreateData(
 
 	targetDomainStr := input.TargetDomain
 	if len(targetDomainStr) > 0 {
-		domain, err := DomainManager.FetchDomainById(targetDomainStr)
+		domain, err := DomainManager.FetchDomainByIdOrName(targetDomainStr)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				return input, httperrors.NewResourceNotFoundError2(DomainManager.Keyword(), targetDomainStr)
@@ -491,6 +491,10 @@ func (self *SIdentityProvider) GetUserCount() (int, error) {
 }
 
 func (self *SIdentityProvider) getNonlocalUserCount() (int, error) {
+	return self.getNonlocalUserQuery().CountWithError()
+}
+
+func (self *SIdentityProvider) getNonlocalUserQuery() *sqlchemy.SQuery {
 	users := UserManager.Query().SubQuery()
 	idmaps := IdmappingManager.Query().SubQuery()
 
@@ -501,7 +505,17 @@ func (self *SIdentityProvider) getNonlocalUserCount() (int, error) {
 	))
 	q = q.Filter(sqlchemy.Equals(idmaps.Field("domain_id"), self.Id))
 
-	return q.CountWithError()
+	return q
+}
+
+func (self *SIdentityProvider) getNonlocalUsers() ([]SUser, error) {
+	q := self.getNonlocalUserQuery()
+	users := make([]SUser, 0)
+	err := db.FetchModelObjects(UserManager, q, &users)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, errors.Wrap(err, "FetchModelObjects")
+	}
+	return users, nil
 }
 
 func (self *SIdentityProvider) getLocalUserCount() (int, error) {
@@ -519,6 +533,10 @@ func (self *SIdentityProvider) GetGroupCount() (int, error) {
 }
 
 func (self *SIdentityProvider) getNonlocalGroupCount() (int, error) {
+	return self.getNonlocalGroupQuery().CountWithError()
+}
+
+func (self *SIdentityProvider) getNonlocalGroupQuery() *sqlchemy.SQuery {
 	groups := GroupManager.Query().SubQuery()
 	idmaps := IdmappingManager.Query().SubQuery()
 
@@ -529,7 +547,17 @@ func (self *SIdentityProvider) getNonlocalGroupCount() (int, error) {
 	))
 	q = q.Filter(sqlchemy.Equals(idmaps.Field("domain_id"), self.Id))
 
-	return q.CountWithError()
+	return q
+}
+
+func (self *SIdentityProvider) getNonlocalGroups() ([]SGroup, error) {
+	q := self.getNonlocalGroupQuery()
+	groups := make([]SGroup, 0)
+	err := db.FetchModelObjects(GroupManager, q, &groups)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, errors.Wrap(err, "FetchModelObjects")
+	}
+	return groups, nil
 }
 
 func (self *SIdentityProvider) getLocalGroupCount() (int, error) {
@@ -607,6 +635,9 @@ func (self *SIdentityProvider) ValidateDeleteCondition(ctx context.Context) erro
 	if self.Driver == api.IdentityDriverSQL {
 		return httperrors.NewForbiddenError("cannot delete default SQL identity provider")
 	}
+	if self.Enabled.IsTrue() {
+		return httperrors.NewInvalidStatusError("cannot delete enabled idp")
+	}
 	prjCnt, err := self.GetProjectCount()
 	if err != nil {
 		return httperrors.NewGeneralError(err)
@@ -656,6 +687,45 @@ func (ident *SIdentityProvider) deleteConfigs(ctx context.Context, userCred mccl
 }
 
 func (self *SIdentityProvider) Purge(ctx context.Context, userCred mcclient.TokenCredential) error {
+	// delete users
+	users, err := self.getNonlocalUsers()
+	if err != nil {
+		return errors.Wrap(err, "getNonlocalUsers")
+	}
+	for i := range users {
+		err = users[i].UnlinkIdp(self.Id)
+		if err != nil {
+			return errors.Wrap(err, "users[i].UnlinkIdp")
+		}
+		err = users[i].ValidateDeleteCondition(ctx)
+		if err != nil {
+			return errors.Wrap(err, "users[i].ValidateDeleteCondition")
+		}
+		err = users[i].Delete(ctx, userCred)
+		if err != nil {
+			return errors.Wrap(err, "delete users[i]")
+		}
+	}
+	// delete groups
+	groups, err := self.getNonlocalGroups()
+	if err != nil {
+		return errors.Wrap(err, "getNonlocalGroups")
+	}
+	for i := range groups {
+		err = groups[i].UnlinkIdp(self.Id)
+		if err != nil {
+			return errors.Wrap(err, "groups[i].UnlinkIdp")
+		}
+		err = groups[i].ValidateDeleteCondition(ctx)
+		if err != nil {
+			return errors.Wrap(err, "groups[i].ValidateDeleteCondition")
+		}
+		err = groups[i].Delete(ctx, userCred)
+		if err != nil {
+			return errors.Wrap(err, "delete groups[i]")
+		}
+	}
+	// delete domains
 	domains, err := self.getDomains()
 	if err != nil {
 		return errors.Wrap(err, "getDomains")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：当idp设置了targetdomain后，删除idp不会清除idp导入的用户

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/area keystone
/cc @zexi @yousong 