### PR TITLE
Automated cherry pick of #5906: fix: blacklist keystone reset admin password

### DIFF
--- a/pkg/apis/identity/consts.go
+++ b/pkg/apis/identity/consts.go
@@ -146,6 +146,10 @@ var (
 			"etcd_cacert",
 			"etcd_cert",
 			"etcd_key",
+
+			"bootstrap_admin_user_password",
+			"reset_admin_user_password",
+			"fernet_key_repository",
 		},
 	}
 )


### PR DESCRIPTION
Cherry pick of #5906 on release/3.2.

#5906: fix: blacklist keystone reset admin password