### PR TITLE
fix(host): No tag when tag's value is empty

### DIFF
--- a/pkg/hostman/hostmetrics/hostmetrics.go
+++ b/pkg/hostman/hostmetrics/hostmetrics.go
@@ -232,7 +232,10 @@ func (s *SGuestMonitorCollector) toTelegrafReportData(data *jsonutils.JSONDict) 
 		for metrics, stat := range report.(*jsonutils.JSONDict).Value() {
 			tags := map[string]string{
 				"vm_id": guestId, "vm_name": vmName, "vm_ip": vmIp,
-				"is_vm": "true", "platform": "kvm", "vm_scaling_group_id": scalingGroupId,
+				"is_vm": "true", "platform": "kvm",
+			}
+			if len(scalingGroupId) > 0 {
+				tags["vm_scaling_group_id"] = scalingGroupId
 			}
 			if val, ok := stat.(*jsonutils.JSONDict); ok {
 				line := s.addTelegrafLine(metrics, tags, val)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

对于 'vm_scaling_group_id' 这个tag， 当tag的value为空时，去掉此tag
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/area host
/cc @wanyaoqi 