### PR TITLE
Automated cherry pick of #5927: remove aws invalid backendgroup

### DIFF
--- a/pkg/compute/models/loadbalancerawscachedlbbg.go
+++ b/pkg/compute/models/loadbalancerawscachedlbbg.go
@@ -234,14 +234,8 @@ func (man *SAwsCachedLbbgManager) SyncLoadbalancerBackendgroups(ctx context.Cont
 	}
 	for i := 0; i < len(commondb); i++ {
 		var elb *SLoadbalancer
-		elbIds := commonext[i].GetLoadbalancerId()
-		if err != nil {
-			syncResult.UpdateError(err)
-			continue
-		}
-
 		elbId := commonext[i].GetLoadbalancerId()
-		if len(elbIds) > 0 {
+		if len(elbId) > 0 {
 			ielb, err := db.FetchByExternalId(LoadbalancerManager, elbId)
 			if err == nil {
 				elb = ielb.(*SLoadbalancer)
@@ -249,10 +243,8 @@ func (man *SAwsCachedLbbgManager) SyncLoadbalancerBackendgroups(ctx context.Cont
 		}
 
 		if elb == nil {
-			elb = &SLoadbalancer{}
-			elb.Id = ""
-			elb.CloudregionId = region.GetId()
-			elb.ManagerId = provider.GetId()
+			log.Debugf("Aws.SyncLoadbalancerBackendgroups skiped external backendgroup %s", elbId)
+			continue
 		}
 
 		err = commondb[i].SyncWithCloudLoadbalancerBackendgroup(ctx, userCred, elb, commonext[i], provider.GetOwnerId())
@@ -269,23 +261,18 @@ func (man *SAwsCachedLbbgManager) SyncLoadbalancerBackendgroups(ctx context.Cont
 	for i := 0; i < len(added); i++ {
 		var elb *SLoadbalancer
 		elbId := added[i].GetLoadbalancerId()
-		if err != nil {
-			syncResult.AddError(err)
-			continue
-		}
-
 		if len(elbId) > 0 {
 			elb, err = LoadbalancerManager.FetchByExternalId(provider.GetId(), elbId)
 			if err != nil {
 				log.Debugf("awsCachedLbbgManager.SyncLoadbalancerBackendgroups %s", err)
+				syncResult.AddError(err)
+				continue
 			}
 		}
 
 		if elb == nil {
-			elb = &SLoadbalancer{}
-			elb.Id = ""
-			elb.CloudregionId = region.GetId()
-			elb.ManagerId = provider.GetId()
+			log.Debugf("Aws.SyncLoadbalancerBackendgroups skiped external backendgroup %s", elbId)
+			continue
 		}
 
 		new, err := man.newFromCloudLoadbalancerBackendgroup(ctx, userCred, elb, added[i], syncOwnerId)

--- a/pkg/compute/models/loadbalancerbackendgroups.go
+++ b/pkg/compute/models/loadbalancerbackendgroups.go
@@ -939,12 +939,29 @@ func (man *SLoadbalancerBackendGroupManager) initBackendGroupType() error {
 }
 
 func (man *SLoadbalancerBackendGroupManager) InitializeData() error {
-	if err := man.initBackendGroupType(); err != nil {
-		return err
+	q := man.Query().IsNullOrEmpty("loadbalancer_id")
+	lbbgs := make([]SLoadbalancerBackendGroup, 0)
+	err := db.FetchModelObjects(man, q, &lbbgs)
+	if err != nil {
+		return errors.Wrap(err, "SLoadbalancerBackendGroupManager.InitializeData")
 	}
-	return man.initBackendGroupRegion()
+
+	for i := range lbbgs {
+		lbbg := lbbgs[i]
+		_, err = db.UpdateWithLock(context.Background(), &lbbg, func() error {
+			lbbg.MarkDelete()
+			return nil
+		})
+		if err != nil {
+			return errors.Wrap(err, "SLoadbalancerBackendGroupManager.InitializeData.MarkDelete")
+		}
+	}
+
+	log.Debugf("SLoadbalancerBackendGroupManager.InitializeData removed %d invalid loadbalancer backendgroup.", len(lbbgs))
+	return nil
 }
 
+/*
 func (manager *SLoadbalancerBackendGroupManager) initBackendGroupRegion() error {
 	groups := []SLoadbalancerBackendGroup{}
 	q := manager.Query()
@@ -966,7 +983,7 @@ func (manager *SLoadbalancerBackendGroupManager) initBackendGroupRegion() error 
 		}
 	}
 	return nil
-}
+}*/
 
 func (manager *SLoadbalancerBackendGroupManager) GetResourceCount() ([]db.SProjectResourceCount, error) {
 	virts := manager.Query().IsFalse("pending_deleted")


### PR DESCRIPTION
Cherry pick of #5927 on release/2.13.

#5927: remove aws invalid backendgroup