### PR TITLE
fix: domain resources' field tags should changed to domain tags

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -89,99 +89,99 @@ type SHost struct {
 	SBillingResourceBase
 
 	// 机架
-	Rack string `width:"16" charset:"ascii" nullable:"true" get:"admin" update:"admin" create:"admin_optional"`
+	Rack string `width:"16" charset:"ascii" nullable:"true" get:"domain" update:"domain" create:"domain_optional"`
 	// 机位
-	Slots string `width:"16" charset:"ascii" nullable:"true" get:"admin" update:"admin" create:"admin_optional"`
+	Slots string `width:"16" charset:"ascii" nullable:"true" get:"domain" update:"domain" create:"domain_optional"`
 
 	// 管理口MAC
-	AccessMac string `width:"32" charset:"ascii" nullable:"false" index:"true" list:"admin" update:"admin"`
+	AccessMac string `width:"32" charset:"ascii" nullable:"false" index:"true" list:"domain" update:"domain"`
 
 	// 管理口Ip地址
-	AccessIp string `width:"16" charset:"ascii" nullable:"true" list:"admin"`
+	AccessIp string `width:"16" charset:"ascii" nullable:"true" list:"domain"`
 
 	// 管理地址
-	ManagerUri string `width:"256" charset:"ascii" nullable:"true" list:"admin" update:"admin" create:"admin_optional"`
+	ManagerUri string `width:"256" charset:"ascii" nullable:"true" list:"domain" update:"domain" create:"domain"`
 
 	// 系统信息
-	SysInfo jsonutils.JSONObject `nullable:"true" search:"admin" list:"admin" update:"admin" create:"admin_optional"`
+	SysInfo jsonutils.JSONObject `nullable:"true" search:"domain" list:"domain" update:"domain" create:"domain_optional"`
 	// 物理机序列号信息
-	SN string `width:"128" charset:"ascii" nullable:"true" list:"admin" update:"admin" create:"admin_optional"`
+	SN string `width:"128" charset:"ascii" nullable:"true" list:"domain" update:"domain" create:"domain_optional"`
 
 	// CPU核数
-	CpuCount int `nullable:"true" list:"admin" update:"admin" create:"admin_optional"`
+	CpuCount int `nullable:"true" list:"domain" update:"domain" create:"domain_optional"`
 	// 物理CPU颗数
-	NodeCount int8 `nullable:"true" list:"admin" update:"admin" create:"admin_optional"`
+	NodeCount int8 `nullable:"true" list:"domain" update:"domain" create:"domain_optional"`
 	// CPU描述信息
-	CpuDesc string `width:"64" charset:"ascii" nullable:"true" get:"admin" update:"admin" create:"admin_optional"`
+	CpuDesc string `width:"64" charset:"ascii" nullable:"true" get:"domain" update:"domain" create:"domain_optional"`
 	// CPU频率
-	CpuMhz int `nullable:"true" get:"admin" update:"admin" create:"admin_optional"`
+	CpuMhz int `nullable:"true" get:"domain" update:"domain" create:"domain_optional"`
 	// CPU缓存大小,单位KB
-	CpuCache int `nullable:"true" get:"admin" update:"admin" create:"admin_optional"`
+	CpuCache int `nullable:"true" get:"domain" update:"domain" create:"domain_optional"`
 	// 预留CPU大小
-	CpuReserved int `nullable:"true" default:"0" list:"admin" update:"admin" create:"admin_optional"`
+	CpuReserved int `nullable:"true" default:"0" list:"domain" update:"domain" create:"domain_optional"`
 	// CPU超分比
-	CpuCmtbound float32 `nullable:"true" default:"8" list:"admin" update:"admin" create:"admin_optional"`
+	CpuCmtbound float32 `nullable:"true" default:"8" list:"domain" update:"domain" create:"domain_optional"`
 	// CPUMicrocode
-	CpuMicrocode string `width:"64" charset:"ascii" nullable:"true" get:"admin" update:"admin" create:"admin_optional"`
+	CpuMicrocode string `width:"64" charset:"ascii" nullable:"true" get:"domain" update:"domain" create:"domain_optional"`
 	// CPU架构
-	CpuArchitecture string `width:"16" charset:"ascii" nullable:"true" get:"user" update:"admin" create:"admin_optional"`
+	CpuArchitecture string `width:"16" charset:"ascii" nullable:"true" get:"domain" update:"domain" create:"domain_optional"`
 
 	// 内存大小,单位Mb
-	MemSize int `nullable:"true" list:"admin" update:"admin" create:"admin_optional"`
+	MemSize int `nullable:"true" list:"domain" update:"domain" create:"domain_optional"`
 	// 预留内存大小
-	MemReserved int `nullable:"true" default:"0" list:"admin" update:"admin" create:"admin_optional"`
+	MemReserved int `nullable:"true" default:"0" list:"domain" update:"domain" create:"domain_optional"`
 	// 内存超分比
-	MemCmtbound float32 `nullable:"true" default:"1" list:"admin" update:"admin" create:"admin_optional"`
+	MemCmtbound float32 `nullable:"true" default:"1" list:"domain" update:"domain" create:"domain_optional"`
 
 	// 存储大小,单位Mb
-	StorageSize int `nullable:"true" list:"admin" update:"admin" create:"admin_optional"`
+	StorageSize int `nullable:"true" list:"domain" update:"domain" create:"domain_optional"`
 	// 存储类型
-	StorageType string `width:"20" charset:"ascii" nullable:"true" list:"admin" update:"admin" create:"admin_optional"`
+	StorageType string `width:"20" charset:"ascii" nullable:"true" list:"domain" update:"domain" create:"domain_optional"`
 	// 存储驱动类型
-	StorageDriver string `width:"20" charset:"ascii" nullable:"true" get:"admin" update:"admin" create:"admin_optional"`
+	StorageDriver string `width:"20" charset:"ascii" nullable:"true" get:"domain" update:"domain" create:"domain_optional"`
 	// 存储详情
-	StorageInfo jsonutils.JSONObject `nullable:"true" get:"admin" update:"admin" create:"admin_optional"`
+	StorageInfo jsonutils.JSONObject `nullable:"true" get:"domain" update:"domain" create:"domain_optional"`
 
 	// IPMI地址
-	IpmiIp string `width:"16" charset:"ascii" nullable:"true" list:"admin"`
+	IpmiIp string `width:"16" charset:"ascii" nullable:"true" list:"domain"`
 
 	// IPMI详情
-	IpmiInfo jsonutils.JSONObject `nullable:"true" get:"admin" update:"admin" create:"admin_optional"`
+	IpmiInfo jsonutils.JSONObject `nullable:"true" get:"domain" update:"domain" create:"domain_optional"`
 
 	// 宿主机状态
 	// example: online
-	HostStatus string `width:"16" charset:"ascii" nullable:"false" default:"offline" list:"admin"`
+	HostStatus string `width:"16" charset:"ascii" nullable:"false" default:"offline" list:"domain"`
 
 	// 宿主机类型
-	HostType string `width:"36" charset:"ascii" nullable:"false" list:"admin" update:"admin" create:"admin_required"`
+	HostType string `width:"36" charset:"ascii" nullable:"false" list:"domain" update:"domain" create:"domain_required"`
 
 	// host服务软件版本
-	Version string `width:"64" charset:"ascii" list:"admin" update:"admin" create:"admin_optional"`
+	Version string `width:"64" charset:"ascii" list:"domain" update:"domain" create:"domain_optional"`
 	// OVN软件版本
-	OvnVersion string `width:"64" charset:"ascii" list:"admin" update:"admin" create:"admin_optional"`
+	OvnVersion string `width:"64" charset:"ascii" list:"domain" update:"domain" create:"domain_optional"`
 
-	IsBaremetal bool `nullable:"true" default:"false" list:"admin" update:"admin" create:"admin_optional"`
+	IsBaremetal bool `nullable:"true" default:"false" list:"domain" update:"domain" create:"domain_optional"`
 
 	// 是否处于维护状态
-	IsMaintenance bool `nullable:"true" default:"false" list:"admin"`
+	IsMaintenance bool `nullable:"true" default:"false" list:"domain"`
 
 	LastPingAt time.Time ``
 
-	ResourceType string `width:"36" charset:"ascii" nullable:"false" list:"admin" update:"admin" create:"admin_optional" default:"shared"`
+	ResourceType string `width:"36" charset:"ascii" nullable:"false" list:"domain" update:"domain" create:"domain_optional" default:"shared"`
 
-	RealExternalId string `width:"256" charset:"utf8" get:"admin"`
+	RealExternalId string `width:"256" charset:"utf8" get:"domain"`
 
 	// 是否为导入的宿主机
-	IsImport bool `nullable:"true" default:"false" list:"admin" create:"admin_optional"`
+	IsImport bool `nullable:"true" default:"false" list:"domain" create:"domain_optional"`
 
 	// 是否允许PXE启动
-	EnablePxeBoot tristate.TriState `nullable:"false" default:"true" list:"admin" create:"admin_optional" update:"admin"`
+	EnablePxeBoot tristate.TriState `nullable:"false" default:"true" list:"domain" create:"domain_optional" update:"domain"`
 
 	// 主机UUID
-	Uuid string `width:"64" nullable:"true" list:"admin" update:"admin" create:"admin_optional"`
+	Uuid string `width:"64" nullable:"true" list:"domain" update:"domain" create:"domain_optional"`
 
 	// 主机启动模式, 可能值位PXE和ISO
-	BootMode string `width:"8" nullable:"true" list:"admin" update:"admin" create:"admin_optional"`
+	BootMode string `width:"8" nullable:"true" list:"domain" update:"domain" create:"domain_optional"`
 }
 
 func (manager *SHostManager) GetContextManagers() [][]db.IModelManager {

--- a/pkg/compute/models/isolated_devices.go
+++ b/pkg/compute/models/isolated_devices.go
@@ -75,25 +75,25 @@ func init() {
 
 type SIsolatedDevice struct {
 	db.SStandaloneResourceBase
-	SHostResourceBase `width:"36" charset:"ascii" nullable:"false" default:"" index:"true" list:"admin" create:"admin_required"`
+	SHostResourceBase `width:"36" charset:"ascii" nullable:"false" default:"" index:"true" list:"domain" create:"domain_required"`
 
 	// 宿主机Id
-	// HostId string `width:"36" charset:"ascii" nullable:"false" default:"" index:"true" list:"admin" create:"admin_required"`
+	// HostId string `width:"36" charset:"ascii" nullable:"false" default:"" index:"true" list:"domain" create:"domain_required"`
 
 	// # PCI / GPU-HPC / GPU-VGA / USB / NIC
 	// 设备类型
-	DevType string `width:"16" charset:"ascii" nullable:"false" default:"" index:"true" list:"admin" create:"admin_required" update:"admin"`
+	DevType string `width:"16" charset:"ascii" nullable:"false" default:"" index:"true" list:"domain" create:"domain_required" update:"domain"`
 
 	// # Specific device name read from lspci command, e.g. `Tesla K40m` ...
-	Model string `width:"32" charset:"ascii" nullable:"false" default:"" index:"true" list:"admin" create:"admin_required" update:"admin"`
+	Model string `width:"32" charset:"ascii" nullable:"false" default:"" index:"true" list:"domain" create:"domain_required" update:"domain"`
 
 	// 云主机Id
-	GuestId string `width:"36" charset:"ascii" nullable:"true" index:"true" list:"admin"`
+	GuestId string `width:"36" charset:"ascii" nullable:"true" index:"true" list:"domain"`
 
 	// # pci address of `Bus:Device.Function` format, or usb bus address of `bus.addr`
-	Addr string `width:"16" charset:"ascii" nullable:"true" list:"admin" update:"admin" create:"admin_optional"`
+	Addr string `width:"16" charset:"ascii" nullable:"true" list:"domain" update:"domain" create:"domain_optional"`
 
-	VendorDeviceId string `width:"16" charset:"ascii" nullable:"true" list:"admin" create:"admin_optional"`
+	VendorDeviceId string `width:"16" charset:"ascii" nullable:"true" list:"domain" create:"domain_optional"`
 }
 
 func (manager *SIsolatedDeviceManager) AllowListItems(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {

--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -64,39 +64,39 @@ func init() {
 }
 
 type SStorage struct {
-	db.SEnabledStatusInfrasResourceBase `"status->default":"offline" "status->update":"admin" "enabled->default":"true"`
+	db.SEnabledStatusInfrasResourceBase `"status->default":"offline" "status->update":"domain" "enabled->default":"true"`
 	db.SExternalizedResourceBase
 
 	SManagedResourceBase
 	SZoneResourceBase
 
 	// 容量大小,单位Mb
-	Capacity int64 `nullable:"false" list:"admin" update:"admin" create:"admin_required"`
+	Capacity int64 `nullable:"false" list:"domain" update:"domain" create:"domain_required"`
 	// 预留容量大小
-	Reserved int64 `nullable:"true" default:"0" list:"admin" update:"admin"`
+	Reserved int64 `nullable:"true" default:"0" list:"domain" update:"domain"`
 	// 存储类型
 	// example: local
-	StorageType string `width:"32" charset:"ascii" nullable:"false" list:"user" create:"admin_required"`
+	StorageType string `width:"32" charset:"ascii" nullable:"false" list:"user" create:"domain_required"`
 	// 介质类型
 	// example: ssd
-	MediumType string `width:"32" charset:"ascii" nullable:"false" list:"user" update:"admin" create:"admin_required"`
+	MediumType string `width:"32" charset:"ascii" nullable:"false" list:"user" update:"domain" create:"domain_required"`
 	// 超售比
-	Cmtbound float32 `nullable:"true" default:"1" list:"admin" update:"admin"`
+	Cmtbound float32 `nullable:"true" default:"1" list:"domain" update:"domain"`
 	// 存储配置信息
-	StorageConf jsonutils.JSONObject `nullable:"true" get:"admin" list:"admin" update:"admin"`
+	StorageConf jsonutils.JSONObject `nullable:"true" get:"domain" list:"domain" update:"domain"`
 
 	// 存储缓存Id
-	StoragecacheId string `width:"36" charset:"ascii" nullable:"true" list:"admin" get:"admin" update:"admin" create:"optional"`
+	StoragecacheId string `width:"36" charset:"ascii" nullable:"true" list:"domain" get:"domain" update:"domain" create:"domain_optional"`
 
 	// 是否启用
 	// Enabled tristate.TriState `nullable:"false" default:"true" list:"user" create:"optional"`
 	// 状态
-	// Status string `width:"36" charset:"ascii" nullable:"false" default:"offline" update:"admin" list:"user" create:"optional"`
+	// Status string `width:"36" charset:"ascii" nullable:"false" default:"offline" update:"domain" list:"user" create:"optional"`
 
 	// indicating whether system disk can be allocated in this storage
 	// 是否可以用作系统盘存储
 	// example: true
-	IsSysDiskStore tristate.TriState `nullable:"false" default:"true" list:"user" create:"optional" update:"admin"`
+	IsSysDiskStore tristate.TriState `nullable:"false" default:"true" list:"user" create:"optional" update:"domain"`
 }
 
 func (manager *SStorageManager) GetContextManagers() [][]db.IModelManager {

--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -68,20 +68,20 @@ type SVpc struct {
 
 	SManagedResourceBase
 
-	SCloudregionResourceBase `width:"36" charset:"ascii" nullable:"false" list:"domain" create:"admin_required" default:"default"`
+	SCloudregionResourceBase `width:"36" charset:"ascii" nullable:"false" list:"domain" create:"domain_required" default:"default"`
 
 	SGlobalVpcResourceBase `width:"36" charset:"ascii" list:"user" json:"globalvpc_id"`
 
 	// 是否是默认VPC
 	// example: true
-	IsDefault bool `default:"false" list:"admin" create:"admin_optional"`
+	IsDefault bool `default:"false" list:"domain" create:"domain_optional"`
 
 	// CIDR地址段
 	// example: 192.168.222.0/24
-	CidrBlock string `charset:"ascii" nullable:"true" list:"admin" create:"admin_required"`
+	CidrBlock string `charset:"ascii" nullable:"true" list:"domain" create:"domain_required"`
 
 	// 区域Id
-	// CloudregionId string `width:"36" charset:"ascii" nullable:"false" list:"domain" create:"admin_required" default:"default"`
+	// CloudregionId string `width:"36" charset:"ascii" nullable:"false" list:"domain" create:"domain_required" default:"default"`
 
 	// 全局VPC Id
 	// GlobalvpcId string `width:"36" charset:"ascii" list:"user" json:"globalvpc_id"`

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -65,22 +65,22 @@ type SWire struct {
 	db.SInfrasResourceBase
 	db.SExternalizedResourceBase
 
-	SVpcResourceBase  `wdith:"36" charset:"ascii" nullable:"false" list:"admin" create:"admin_required"`
-	SZoneResourceBase `width:"36" charset:"ascii" nullable:"true" list:"admin" create:"admin_required"`
+	SVpcResourceBase  `wdith:"36" charset:"ascii" nullable:"false" list:"domain" create:"domain_required"`
+	SZoneResourceBase `width:"36" charset:"ascii" nullable:"true" list:"domain" create:"domain_required"`
 
 	// 带宽大小, 单位Mbps
 	// example: 1000
-	Bandwidth int `list:"admin" update:"admin" nullable:"false" create:"admin_required" json:"bandwidth"`
+	Bandwidth int `list:"domain" update:"domain" nullable:"false" create:"domain_required" json:"bandwidth"`
 	// MTU
 	// example: 1500
-	Mtu int `list:"admin" update:"admin" nullable:"false" create:"admin_optional" default:"1500" json:"mtu"`
+	Mtu int `list:"domain" update:"domain" nullable:"false" create:"domain_optional" default:"1500" json:"mtu"`
 	// swagger:ignore
-	ScheduleRank int `list:"admin" update:"admin" json:"schedule_rank"`
+	ScheduleRank int `list:"domain" update:"domain" json:"schedule_rank"`
 
 	// 可用区Id
-	// ZoneId string `width:"36" charset:"ascii" nullable:"true" list:"admin" create:"admin_required"`
+	// ZoneId string `width:"36" charset:"ascii" nullable:"true" list:"domain" create:"domain_required"`
 	// VPC Id
-	// VpcId string `wdith:"36" charset:"ascii" nullable:"false" list:"admin" create:"admin_required"`
+	// VpcId string `wdith:"36" charset:"ascii" nullable:"false" list:"domain" create:"domain_required"`
 }
 
 func (manager *SWireManager) GetContextManagers() [][]db.IModelManager {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：系统资源改为域资源后，tag里的限制也需要从admin改为domain

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/area region
/cc @zexi @yousong 