### PR TITLE
climc: support zsh completion

### DIFF
--- a/cmd/climc/climc.go
+++ b/cmd/climc/climc.go
@@ -49,7 +49,7 @@ type BaseOptions struct {
 	CertFile string `default:"$YUNION_CERT_FILE" help:"certificate file"`
 	KeyFile  string `default:"$YUNION_KEY_FILE" help:"private key file"`
 
-	Completion     string `default:"" help:"Generate climc auto complete script" choices:"bash"`
+	Completion     string `default:"" help:"Generate climc auto complete script" choices:"bash|zsh"`
 	UseCachedToken bool   `default:"$YUNION_USE_CACHED_TOKEN|false" help:"Use cached token"`
 
 	OsUsername string `default:"$OS_USERNAME" help:"Username, defaults to env[OS_USERNAME]"`
@@ -73,9 +73,13 @@ type BaseOptions struct {
 }
 
 func getSubcommandsParser() (*structarg.ArgumentParser, error) {
+	var (
+		prog = "climc"
+		desc = `Command-line interface to the API server.`
+	)
 	parse, e := structarg.NewArgumentParser(&BaseOptions{},
-		"climc",
-		`Command-line interface to the API server.`,
+		prog,
+		desc,
 		`See "climc help COMMAND" for help on a specific command.`)
 	if e != nil {
 		return nil, e
@@ -96,26 +100,28 @@ func getSubcommandsParser() (*structarg.ArgumentParser, error) {
 			return nil
 		}
 	})
+
+	promptRootCmd := promputils.InitRootCmd(prog, desc, parse.GetOptArgs(), parse.GetPosArgs())
 	for _, v := range shell.CommandTable {
 		_par, e := subcmd.AddSubParser(v.Options, v.Command, v.Desc, v.Callback)
 
 		if e != nil {
 			return nil, e
 		}
-		promputils.AppendCommand(v.Command, v.Desc)
+		promputils.AppendCommand(promptRootCmd, v.Command, v.Desc)
 		cmd := v.Command
 
 		for _, v := range _par.GetOptArgs() {
 			text := v.String()
 			text = strings.TrimLeft(text, "[<")
 			text = strings.TrimRight(text, "]>")
-			promputils.AppendOpt(cmd, text, v.HelpString(""))
+			promputils.AppendOpt(cmd, text, v.HelpString(""), v)
 		}
 		for _, v := range _par.GetPosArgs() {
 			text := v.String()
 			text = strings.TrimLeft(text, "[<")
 			text = strings.TrimRight(text, "]>")
-			promputils.AppendPos(cmd, text, v.HelpString(""))
+			promputils.AppendPos(cmd, text, v.HelpString(""), v)
 		}
 	}
 	return parse, nil
@@ -270,7 +276,7 @@ func main() {
 	options := parser.Options().(*BaseOptions)
 
 	if len(options.Completion) > 0 {
-		completeScript := promputils.GenerateAutoCompleteCmds(options.Completion)
+		completeScript := promputils.GenerateAutoCompleteCmds(promputils.GetRootCmd(), options.Completion)
 		if len(completeScript) > 0 {
 			fmt.Printf("%s", completeScript)
 		}

--- a/cmd/climc/promputils/complete_zsh.go
+++ b/cmd/climc/promputils/complete_zsh.go
@@ -1,0 +1,162 @@
+package promputils
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/template"
+
+	"yunion.io/x/structarg"
+)
+
+// ref: https://github.com/spf13/cobra/blob/master/zsh_completions.go
+
+var (
+	zshCompFuncMap = template.FuncMap{
+		"genZshFuncName":              zshCompGenFuncName,
+		"extractFlags":                zshCompExtractFlag,
+		"genFlagEntryForZshArguments": zshCompGenFlagEntryForArguments,
+		"extractArgsCompletions":      zshCompExtractArgumentCompletionHintsForRendering,
+	}
+	zshCompletionText = `
+{{/* should accept Command (that contains subcommands) as parameter */}}
+{{define "argumentsC" -}}
+{{ $cmdPath := genZshFuncName .}}
+function {{$cmdPath}} {
+	local -a commands
+	_arguments -C \{{- range extractFlags .}}
+	  {{genFlagEntryForZshArguments .}} \{{- end}}
+	  "1: :->cmnds" \
+	  "*::arg:->args"
+
+	case $state in
+	cmnds)
+	  commands=({{range .SubCmds}}
+		"{{.Name}}:{{.Desc}}"{{end}}
+	  )
+	  _describe "command" commands
+	  ;;
+	esac
+
+	case "$words[1]" in {{- range .SubCmds}}
+	{{.Name}})
+	  {{$cmdPath}}_{{.Name}}
+	  ;;{{end}}
+	esac
+}
+{{range .SubCmds}}
+{{template "selectCmdTemplate" .}}
+{{- end}}
+{{- end}}
+
+{{/* should accept Command without subcommands as parameter */}}
+{{define "arguments" -}}
+function {{genZshFuncName .}} {
+{{"  _arguments"}}{{range extractFlags .}} \
+     {{genFlagEntryForZshArguments . -}}
+{{end}}{{range extractArgsCompletions .}} \
+     {{.}}{{end}}
+}
+{{end}}
+
+{{/* dispatcher for commands with or without subcommands */}}
+{{define "selectCmdTemplate" -}}
+{{if .SubCmds}}{{template "argumentsC" .}}{{else}}{{template "arguments" .}}{{end}}
+{{- end}}
+
+{{/* template entry point */}}
+{{define "Main" -}}
+#compdef _{{.Name}} {{.Name}}
+
+{{template "selectCmdTemplate" .}}
+compdef _{{.Name}} {{.Name}}
+{{end}}
+`
+)
+
+func zshCompGenFuncName(c *Cmd) string {
+	if c.ParentCmd != nil {
+		return zshCompGenFuncName(c.ParentCmd) + "_" + c.Name
+	}
+	return "_" + c.Name
+}
+
+func zshCompExtractFlag(c *Cmd) []structarg.Argument {
+	return c.GetArguments()
+}
+
+func zshCompGenFlagEntryForArguments(f structarg.Argument) string {
+	// not process positional argument and single command
+	if f.IsPositional() {
+		return ""
+	}
+	if f.ShortToken() == "" {
+		return zshCompGenFlagEntryForSingleOptionFlag(f)
+	}
+	return zshCompGenFlagEntryForMultiOptionFlag(f)
+}
+
+func zshCompGenFlagEntryForSingleOptionFlag(f structarg.Argument) string {
+	var option, multiMark, extras string
+	if f.IsMulti() {
+		multiMark = "*"
+	}
+
+	option = "--" + f.Token()
+	extras = zshCompGenFlagEntryExtras(f)
+	return fmt.Sprintf(`'%s%s[%s]%s'`, multiMark, option, zshCompQuoteFlagDescription(f.HelpString("")), extras)
+}
+
+func zshCompGenFlagEntryForMultiOptionFlag(f structarg.Argument) string {
+	var options, parenMultiMark, curlyMultiMark, extras string
+	if f.IsMulti() {
+		parenMultiMark = "*"
+		curlyMultiMark = "\\*"
+	}
+
+	options = fmt.Sprintf(`'(%s-%s %s--%s)'{%s-%s,%s--%s}`,
+		parenMultiMark, f.ShortToken(), parenMultiMark, f.Token(), curlyMultiMark, f.ShortToken(), curlyMultiMark, f.Token())
+	extras = zshCompGenFlagEntryExtras(f)
+
+	return fmt.Sprintf(`%s'[%s]%s'`, options, zshCompQuoteFlagDescription(f.HelpString("")), extras)
+}
+
+func zshCompGenFlagEntryExtras(f structarg.Argument) string {
+	if !f.NeedData() {
+		return ""
+	}
+	// allow options for flag
+	extras := ":"
+
+	switch arg := f.(type) {
+	case *structarg.SingleArgument:
+		// process choices
+		var words []string
+		for _, w := range arg.Choices() {
+			words = append(words, fmt.Sprintf("%q", w))
+		}
+		if len(words) != 0 {
+			extras = fmt.Sprintf("%s :(%s)", extras, strings.Join(words, " "))
+		}
+	}
+	return extras
+}
+
+func zshCompQuoteFlagDescription(s string) string {
+	s = strings.Replace(s, "'", `'\''`, -1)
+	s = strings.Replace(s, "[", `\[`, -1)
+	s = strings.Replace(s, "]", `\]`, -1)
+	return s
+}
+
+func zshCompExtractArgumentCompletionHintsForRendering(c *Cmd) []string {
+	return nil
+}
+
+func (c *Cmd) GenZshCompletion(w io.Writer) error {
+	tmpl, err := template.New("Main").Funcs(zshCompFuncMap).Parse(zshCompletionText)
+	if err != nil {
+		return fmt.Errorf("error creating zsh completion template: %v", err)
+	}
+	return tmpl.Execute(w, c.Root())
+}

--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ require (
 	yunion.io/x/pkg v0.0.0-20200416145704-22c189971435
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 	yunion.io/x/sqlchemy v0.0.0-20200312002602-1177cd8fbc57
-	yunion.io/x/structarg v0.0.0-20190809075558-115bed041de3
+	yunion.io/x/structarg v0.0.0-20200423163001-168d0687be7e
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -1122,5 +1122,5 @@ yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e/go.mod h1:0iFKpOs1y4lbCxeOmq3Xx/0AcQoewVPwj62eRluioEo=
 yunion.io/x/sqlchemy v0.0.0-20200312002602-1177cd8fbc57 h1:KtQAuLJ00RSUVqkiRmJ1DiDABiw0U3xxXnzD3lGavaY=
 yunion.io/x/sqlchemy v0.0.0-20200312002602-1177cd8fbc57/go.mod h1:FTdwPdGhMgh4E+UFXc9klI1Ok34fMuybTT+jLhOaIjI=
-yunion.io/x/structarg v0.0.0-20190809075558-115bed041de3 h1:bfC8EhXYvyGYldRWlzxiCM39Zfj3s3+zham9mW2h2LE=
-yunion.io/x/structarg v0.0.0-20190809075558-115bed041de3/go.mod h1:EP6NSv2C0zzqBDTKumv8hPWLb3XvgMZDHQRfyuOrQng=
+yunion.io/x/structarg v0.0.0-20200423163001-168d0687be7e h1:pctCe/EPel3F1B83pJ2q9b34Umd1NdbLW1Yd+Lzur2s=
+yunion.io/x/structarg v0.0.0-20200423163001-168d0687be7e/go.mod h1:EP6NSv2C0zzqBDTKumv8hPWLb3XvgMZDHQRfyuOrQng=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1053,5 +1053,5 @@ yunion.io/x/pkg/utils
 yunion.io/x/s3cli
 # yunion.io/x/sqlchemy v0.0.0-20200312002602-1177cd8fbc57
 yunion.io/x/sqlchemy
-# yunion.io/x/structarg v0.0.0-20190809075558-115bed041de3
+# yunion.io/x/structarg v0.0.0-20200423163001-168d0687be7e
 yunion.io/x/structarg

--- a/vendor/yunion.io/x/structarg/structarg.go
+++ b/vendor/yunion.io/x/structarg/structarg.go
@@ -535,6 +535,10 @@ func (this *SingleArgument) InChoices(val string) bool {
 	}
 }
 
+func (this *SingleArgument) Choices() []string {
+	return this.choices
+}
+
 func (this *SingleArgument) SetValue(val string) error {
 	if !this.InChoices(val) {
 		return this.choicesErr(val)


### PR DESCRIPTION

![2020-04-24_01-28_1](https://user-images.githubusercontent.com/10767027/80130676-91d91600-85cb-11ea-8f61-baa0ead276e7.png)
![2020-04-24_01-28](https://user-images.githubusercontent.com/10767027/80130679-93a2d980-85cb-11ea-9122-e92cfa0f47b3.png)

**这个 PR 实现什么功能/修复什么问题**:

实现 climc zsh 的补全, 用法:

```bash
$ source <(climc --completion zsh)
$ climc <TAB><TAB>
```

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->
NONE
/cc @swordqiu @wanyaoqi @yousong @rainzm @ioito 