### PR TITLE
cloudcommon: allow create:"domain" tag

### DIFF
--- a/pkg/cloudcommon/db/models.go
+++ b/pkg/cloudcommon/db/models.go
@@ -46,7 +46,15 @@ func RegisterModelManager(modelMan IModelManager) {
 
 func mustCheckModelManager(modelMan IModelManager) {
 	allowedTags := map[string][]string{
-		"create": {"required", "optional", "domain_required", "domain_optional", "admin_required", "admin_optional"},
+		"create": {
+			"required",
+			"optional",
+			"domain",
+			"domain_required",
+			"domain_optional",
+			"admin_required",
+			"admin_optional",
+		},
 		"search": {"user", "domain", "admin"},
 		"get":    {"user", "domain", "admin"},
 		"list":   {"user", "domain", "admin"},


### PR DESCRIPTION


**这个 PR 实现什么功能/修复什么问题**:

```
Fixes panic: model manager hosts: column manager_uri has invalid tag
create:"domain", expecting [required optional domain_required
domain_optional admin_required admin_optional]
```

- [x] 冒烟测试

**是否需要 backport 到之前的 release 分支**:


- release/3.2

/cc @swordqiu @zexi 
/area region