### PR TITLE
lblistener: fix updating lblistener without backend_group field

### DIFF
--- a/pkg/compute/models/loadbalancerlisteners.go
+++ b/pkg/compute/models/loadbalancerlisteners.go
@@ -424,7 +424,7 @@ func (lblis *SLoadbalancerListener) StartLoadBalancerListenerSyncstatusTask(ctx 
 func (lblis *SLoadbalancerListener) ValidateUpdateData(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
 	ownerId := lblis.GetOwnerId()
 	backendGroupV := validators.NewModelIdOrNameValidator("backend_group", "loadbalancerbackendgroup", ownerId)
-	backendGroupV.AllowEmpty(true).Optional(true)
+	backendGroupV.AllowEmpty(true).Default(lblis.BackendGroupId)
 	if err := backendGroupV.Validate(data); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


**这个 PR 实现什么功能/修复什么问题**:

Fixes dd01610931c8 ("lblistener: allow setting http/https listener
backendgroup to empty")


- [x] 冒烟测试
- [x] 测试case编写

**是否需要 backport 到之前的 release 分支**:

- release/3.0

/area region
/cc @ioito @tb365 @swordqiu @zexi 
