### PR TITLE
Automated cherry pick of #5995: lblistener: fix updating lblistener without backend_group field

### DIFF
--- a/pkg/compute/models/loadbalancerlisteners.go
+++ b/pkg/compute/models/loadbalancerlisteners.go
@@ -354,7 +354,7 @@ func (lblis *SLoadbalancerListener) StartLoadBalancerListenerSyncstatusTask(ctx 
 func (lblis *SLoadbalancerListener) ValidateUpdateData(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
 	ownerId := lblis.GetOwnerId()
 	backendGroupV := validators.NewModelIdOrNameValidator("backend_group", "loadbalancerbackendgroup", ownerId)
-	backendGroupV.AllowEmpty(true).Optional(true)
+	backendGroupV.AllowEmpty(true).Default(lblis.BackendGroupId)
 	if err := backendGroupV.Validate(data); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry pick of #5995 on release/3.0.

#5995: lblistener: fix updating lblistener without backend_group field