### PR TITLE
fix: dns name pattern revisited

### DIFF
--- a/pkg/cloudcommon/db/namevalidator.go
+++ b/pkg/cloudcommon/db/namevalidator.go
@@ -115,7 +115,7 @@ func GenerateName2(manager IModelManager, ownerId mcclient.IIdentityProvider, hi
 }
 
 var (
-	dnsNameREG = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]*$`)
+	dnsNameREG = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 )
 
 type SDnsNameValidatorManager struct{}

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -69,7 +69,6 @@ type SGuestManager struct {
 	db.SVirtualResourceBaseManager
 	db.SExternalizedResourceBaseManager
 	SDeletePreventableResourceBaseManager
-	db.SDnsNameValidatorManager
 
 	SHostResourceBaseManager
 	SBillingResourceBaseManager
@@ -5227,4 +5226,15 @@ func (guest *SGuest) GetUsages() []db.IUsage {
 		&usage,
 		&regionUsage,
 	}
+}
+
+var (
+	serverNameREG = regexp.MustCompile(`^[a-z$][a-z0-9-${}.]*$`)
+)
+
+func (manager *SGuestManager) ValidateName(name string) error {
+	if serverNameREG.MatchString(name) {
+		return nil
+	}
+	return httperrors.NewInputParameterError("name starts with letter, and contains letter, number and - only")
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：1. dns模式的名字检查不允许大写字母（影响host名字检查）2.  虚拟机名字检查除了匹配dns模式，还允许变量例如${zone}-${host}

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi  

/area region