### PR TITLE
fix: update README api docs url to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Please refers to [install & deployment](https://docs.yunion.io/docs/setup/) (cur
 
 - [Yunion OneCloud Documents](https://docs.yunion.io/)
 
-- [Swagger API](https://docs.yunion.cn/api/)
+- [Swagger API](https://docs.yunion.cn/apiv2/)
 
 ## Architecture
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：README.md的API文档链接改为v2

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area util