### PR TITLE
fix: GetOnPremiseNetworkOfIP should return underlay networks

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -771,10 +771,11 @@ func (manager *SNetworkManager) GetOnPremiseNetworkOfIP(ipAddr string, serverTyp
 	}
 	q := manager.Query()
 	wires := WireManager.Query().SubQuery()
-	vpcs := VpcManager.Query().SubQuery()
+	// vpcs := VpcManager.Query().SubQuery()
 	q = q.Join(wires, sqlchemy.Equals(q.Field("wire_id"), wires.Field("id")))
-	q = q.Join(vpcs, sqlchemy.Equals(wires.Field("vpc_id"), vpcs.Field("id")))
-	q = q.Filter(sqlchemy.IsNullOrEmpty(vpcs.Field("manager_id")))
+	// q = q.Join(vpcs, sqlchemy.Equals(wires.Field("vpc_id"), vpcs.Field("id")))
+	// q = q.Filter(sqlchemy.IsNullOrEmpty(vpcs.Field("manager_id")))
+	q = q.Filter(sqlchemy.Equals(wires.Field("vpc_id"), api.DEFAULT_VPC_ID))
 	if len(serverType) > 0 {
 		q = q.Filter(sqlchemy.Equals(q.Field("server_type"), serverType))
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：GetOnPRemsieNetworkOfIP应该只返回underlay的IP网络

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @yousong 
/area region