### PR TITLE
vpcagent: fend off non-onecloud-vpc guest nics

### DIFF
--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -263,6 +263,8 @@ func (manager *SGuestnetworkManager) newGuestNetwork(
 			return nil, fmt.Errorf("cannot find vpc of network %s(%s)", network.Id, network.Name)
 		} else if vpc.Id != api.DEFAULT_VPC_ID && vpc.GetProviderName() == api.CLOUD_PROVIDER_ONECLOUD {
 			var err error
+			GuestnetworkManager.lockAllocMappedAddr(ctx)
+			defer GuestnetworkManager.unlockAllocMappedAddr(ctx)
 			gn.MappedIpAddr, err = GuestnetworkManager.allocMappedIpAddr(ctx)
 			if err != nil {
 				return nil, err

--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -440,6 +440,24 @@ func (self *SGuestnetwork) getJsonDescHostwire(network *SNetwork, hostwire *SHos
 }
 
 func (self *SGuestnetwork) getJsonDescOneCloudVpc(network *SNetwork) *jsonutils.JSONDict {
+	if self.MappedIpAddr == "" {
+		var (
+			err  error
+			addr string
+		)
+		addr, err = GuestnetworkManager.allocMappedIpAddr(context.TODO())
+		if err != nil {
+			log.Errorf("getJsonDescOneCloudVpc: row %d: alloc mapped ipaddr: %v", self.RowId, err)
+		} else {
+			if _, err := db.Update(self, func() error {
+				self.MappedIpAddr = addr
+				return nil
+			}); err != nil {
+				log.Errorf("getJsonDescOneCloudVpc: row %d: db update mapped addr: %v", self.RowId, err)
+				self.MappedIpAddr = ""
+			}
+		}
+	}
 	vpc := network.GetVpc()
 
 	vpcDesc := jsonutils.NewDict()

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -3685,18 +3685,14 @@ func (self *SGuest) GetJsonDescAtHypervisor(ctx context.Context, host *SHost) *j
 
 	// nics, domain
 	jsonNics := make([]jsonutils.JSONObject, 0)
-
 	nics, _ := self.GetNetworks("")
-
 	domain := options.Options.DNSDomain
-	if nics != nil && len(nics) > 0 {
-		for _, nic := range nics {
-			nicDesc := nic.getJsonDescAtHost(host)
-			jsonNics = append(jsonNics, nicDesc)
-			nicDomain, _ := nicDesc.GetString("domain")
-			if len(nicDomain) > 0 && len(domain) == 0 {
-				domain = nicDomain
-			}
+	for _, nic := range nics {
+		nicDesc := nic.getJsonDescAtHost(host)
+		jsonNics = append(jsonNics, nicDesc)
+		nicDomain, _ := nicDesc.GetString("domain")
+		if len(nicDomain) > 0 && len(domain) == 0 {
+			domain = nicDomain
 		}
 	}
 	desc.Add(jsonutils.NewArray(jsonNics...), "nics")

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -3127,6 +3127,8 @@ func (self *SHost) PostUpdate(ctx context.Context, userCred mcclient.TokenCreden
 	}
 
 	if self.OvnVersion != "" && self.OvnMappedIpAddr == "" {
+		HostManager.lockAllocOvnMappedIpAddr(ctx)
+		defer HostManager.unlockAllocOvnMappedIpAddr(ctx)
 		addr, err := HostManager.allocOvnMappedIpAddr(ctx)
 		if err != nil {
 			log.Errorf("host %s(%s): alloc vpc mapped addr: %v",

--- a/pkg/compute/models/vpcs_mapped_address.go
+++ b/pkg/compute/models/vpcs_mapped_address.go
@@ -12,19 +12,23 @@ import (
 
 const (
 	errMappedIpExhausted = errors.Error("mapped ip exhaused")
+
+	LOCK_CLASS_guestnetworks_mapped_addr = "guestnetworks-mapped-addr"
+	LOCK_OBJ_guestnetworks_mapped_addr   = "the-addr"
+
+	LOCK_CLASS_hosts_mapped_addr = "hosts-mapped-addr"
+	LOCK_OBJ_hosts_mapped_addr   = "the-addr"
 )
 
-func (man *SGuestnetworkManager) allocMappedIpAddr(ctx context.Context) (string, error) {
-	const (
-		LOCK_CLASS = "guestnetworks-mapped-addr"
-		LOCK_OBJ   = "the-addr"
-	)
-	lockman.LockRawObject(ctx, LOCK_CLASS, LOCK_OBJ)
-	defer lockman.ReleaseRawObject(ctx, LOCK_CLASS, LOCK_OBJ)
-	return man.allocMappedIpAddr_(ctx)
+func (man *SGuestnetworkManager) lockAllocMappedAddr(ctx context.Context) {
+	lockman.LockRawObject(ctx, LOCK_CLASS_guestnetworks_mapped_addr, LOCK_OBJ_guestnetworks_mapped_addr)
 }
 
-func (man *SGuestnetworkManager) allocMappedIpAddr_(ctx context.Context) (string, error) {
+func (man *SGuestnetworkManager) unlockAllocMappedAddr(ctx context.Context) {
+	defer lockman.ReleaseRawObject(ctx, LOCK_CLASS_guestnetworks_mapped_addr, LOCK_OBJ_guestnetworks_mapped_addr)
+}
+
+func (man *SGuestnetworkManager) allocMappedIpAddr(ctx context.Context) (string, error) {
 	var (
 		used []string
 		ip   string
@@ -53,17 +57,15 @@ func (man *SGuestnetworkManager) allocMappedIpAddr_(ctx context.Context) (string
 	return "", errors.Wrap(errMappedIpExhausted, "guests")
 }
 
-func (man *SHostManager) allocOvnMappedIpAddr(ctx context.Context) (string, error) {
-	const (
-		LOCK_CLASS = "hosts-vpc-mapped-addr"
-		LOCK_OBJ   = "the-addr"
-	)
-	lockman.LockRawObject(ctx, LOCK_CLASS, LOCK_OBJ)
-	defer lockman.ReleaseRawObject(ctx, LOCK_CLASS, LOCK_OBJ)
-	return man.allocOvnMappedIpAddr_(ctx)
+func (man *SHostManager) lockAllocOvnMappedIpAddr(ctx context.Context) {
+	lockman.LockRawObject(ctx, LOCK_CLASS_hosts_mapped_addr, LOCK_OBJ_hosts_mapped_addr)
 }
 
-func (man *SHostManager) allocOvnMappedIpAddr_(ctx context.Context) (string, error) {
+func (man *SHostManager) unlockAllocOvnMappedIpAddr(ctx context.Context) {
+	lockman.ReleaseRawObject(ctx, LOCK_CLASS_hosts_mapped_addr, LOCK_OBJ_hosts_mapped_addr)
+}
+
+func (man *SHostManager) allocOvnMappedIpAddr(ctx context.Context) (string, error) {
 	var (
 		used []string
 		ip   string

--- a/pkg/compute/models/vpcs_mapped_address.go
+++ b/pkg/compute/models/vpcs_mapped_address.go
@@ -44,7 +44,7 @@ func (man *SGuestnetworkManager) allocMappedIpAddr_(ctx context.Context) (string
 
 	sip := api.VpcMappedIPStart()
 	eip := api.VpcMappedIPEnd()
-	for i := sip; i <= eip; i++ {
+	for i := eip; i >= sip; i-- {
 		s := i.String()
 		if !utils.IsInStringArray(s, used) {
 			return s, nil

--- a/pkg/hostman/host_services.go
+++ b/pkg/hostman/host_services.go
@@ -15,15 +15,12 @@
 package hostman
 
 import (
-	"os"
-
 	execlient "yunion.io/x/executor/client"
 	"yunion.io/x/log"
 
 	"yunion.io/x/onecloud/pkg/appsrv"
 	app_common "yunion.io/x/onecloud/pkg/cloudcommon/app"
 	"yunion.io/x/onecloud/pkg/cloudcommon/cronman"
-	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
 	"yunion.io/x/onecloud/pkg/cloudcommon/service"
 	"yunion.io/x/onecloud/pkg/hostman/downloader"
 	"yunion.io/x/onecloud/pkg/hostman/guestman"
@@ -48,16 +45,7 @@ type SHostService struct {
 }
 
 func (host *SHostService) InitService() {
-	common_options.ParseOptions(&options.HostOptions, os.Args, "host.conf", "host")
-	if len(options.HostOptions.CommonConfigFile) > 0 {
-		baseOpt := options.HostOptions.BaseOptions.BaseOptions
-		commonCfg := new(common_options.CommonOptions)
-		commonCfg.Config = options.HostOptions.CommonConfigFile
-		common_options.ParseOptions(commonCfg, []string{"host"}, "common.conf", "host")
-		options.HostOptions.CommonOptions = *commonCfg
-		// keep base options
-		options.HostOptions.BaseOptions.BaseOptions = baseOpt
-	}
+	options.Init()
 	isRoot := sysutils.IsRootPermission()
 	if !isRoot {
 		log.Fatalf("host service must running with root permissions")

--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -14,7 +14,11 @@
 
 package options
 
-import common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
+import (
+	"os"
+
+	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
+)
 
 type SHostOptions struct {
 	common_options.CommonOptions
@@ -120,4 +124,25 @@ type SHostOptions struct {
 	OvnMappedBridge      string `help:"name of bridge for mapped traffic management" default:"mapped" default:"$HOST_OVN_MAPPED_BRIDGE|brmapped"`
 }
 
-var HostOptions SHostOptions
+var (
+	HostOptions SHostOptions
+)
+
+func Parse() (hostOpts SHostOptions) {
+	common_options.ParseOptions(&hostOpts, os.Args, "host.conf", "host")
+	if len(hostOpts.CommonConfigFile) > 0 {
+		commonCfg := &common_options.CommonOptions{}
+		commonCfg.Config = hostOpts.CommonConfigFile
+		common_options.ParseOptions(commonCfg, []string{os.Args[0]}, "common.conf", "host")
+
+		baseOpt := hostOpts.BaseOptions.BaseOptions
+		hostOpts.CommonOptions = *commonCfg
+		// keep base options
+		hostOpts.BaseOptions.BaseOptions = baseOpt
+	}
+	return hostOpts
+}
+
+func Init() {
+	HostOptions = Parse()
+}

--- a/pkg/vpcagent/models/modelset.go
+++ b/pkg/vpcagent/models/modelset.go
@@ -216,9 +216,11 @@ func (set Guestnetworks) joinGuests(subEntries Guests) bool {
 		gId := gn.GuestId
 		g, ok := subEntries[gId]
 		if !ok {
-			log.Warningf("guestnetwork %d(%s,%s) guest id %s not found",
-				gn.Index, gn.NetworkId, gn.IpAddr, gId)
-			correct = false
+			if gn.Network != nil && gn.Network.Vpc != nil {
+				log.Warningf("guestnetwork %d(net:%s,ip:%s) guest id %s not found",
+					gn.RowId, gn.NetworkId, gn.IpAddr, gId)
+				correct = false
+			}
 			continue
 		}
 		gn.Guest = g


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
guestnetworks: try allocation of mapped addr on sync
region: vpcs_mapped_address: fix locking
region: vpcs_mapped_address: alloc guestnic mapped addr backwards
guests: simplify code
hostman: options: pack up a Parse() func
vpcagent: fend off non-onecloud-vpc guest nics
```

**是否需要 backport 到之前的 release 分支**:


- release/3.2

/area vpcagent
/cc @swordqiu @zexi @wanyaoqi 