### PR TITLE
fix: proxysetting attributes should be domain-settable

### DIFF
--- a/pkg/cloudcommon/db/proxy/proxysetting.go
+++ b/pkg/cloudcommon/db/proxy/proxysetting.go
@@ -56,9 +56,9 @@ func init() {
 type SProxySetting struct {
 	db.SInfrasResourceBase
 
-	HTTPProxy  string `create:"admin_optional" list:"admin" update:"admin"`
-	HTTPSProxy string `create:"admin_optional" list:"admin" update:"admin"`
-	NoProxy    string `create:"admin_optional" list:"admin" update:"admin"`
+	HTTPProxy  string `create:"domain_optional" list:"domain" update:"domain"`
+	HTTPSProxy string `create:"domain_optional" list:"domain" update:"domain"`
+	NoProxy    string `create:"domain_optional" list:"domain" update:"domain"`
 }
 
 func (man *SProxySettingManager) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data proxyapi.ProxySettingCreateInput) (proxyapi.ProxySettingCreateInput, error) {

--- a/pkg/mcclient/modules/mod_proxysettings.go
+++ b/pkg/mcclient/modules/mod_proxysettings.go
@@ -34,6 +34,8 @@ func init() {
 			"http_proxy",
 			"https_proxy",
 			"no_proxy",
+			"is_public",
+			"public_scope",
 		},
 		[]string{})}
 	registerCompute(&ProxySettings)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：1. proxysetting在域权限下无法设置相关属性 2. DIRECT默认全局共享

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @yousong 
/area region