### PR TITLE
feature: make baremetal options managed by service config

### DIFF
--- a/pkg/apis/baremetal/consts.go
+++ b/pkg/apis/baremetal/consts.go
@@ -1,0 +1,20 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package baremetal
+
+const (
+	SERVICE_TYPE    = "baremetal"
+	SERVICE_VERSION = ""
+)

--- a/pkg/apis/baremetal/doc.go
+++ b/pkg/apis/baremetal/doc.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package baremetal // import "yunion.io/x/onecloud/pkg/apis/baremetal"

--- a/pkg/apis/identity/consts.go
+++ b/pkg/apis/identity/consts.go
@@ -102,6 +102,9 @@ var (
 
 	ServiceBlacklistOptionMap = map[string][]string{
 		"default": []string{
+			// ############################
+			// common blacklist options
+			// ############################
 			"help",
 			"version",
 			"config",
@@ -120,7 +123,9 @@ var (
 			"session_endpoint_type",
 			"admin_password",
 			"admin_project",
+			"admin_project_domain",
 			"admin_user",
+			"admin_domain",
 			"auth_url",
 			"enable_ssl",
 			"ssl_certfile",
@@ -130,6 +135,9 @@ var (
 			"is_slave_node",
 			"config_sync_period_seconds",
 
+			// ############################
+			// db blacklist options
+			// ############################
 			"sql_connection",
 			"auto_sync_table",
 			"exit_after_db_init",
@@ -147,9 +155,42 @@ var (
 			"etcd_cert",
 			"etcd_key",
 
+			// ############################
+			// keystone blacklist options
+			// ############################
 			"bootstrap_admin_user_password",
 			"reset_admin_user_password",
 			"fernet_key_repository",
+
+			// ############################
+			// baremetal blacklist options
+			// ############################
+			"listen_interface",
+			"access_address",
+			"listen_address",
+			"tftp_root",
+			// "AutoRegisterBaremetal",
+			"baremetals_path",
+			// "LinuxDefaultRootUser",
+			"ipmi_lan_port_shared",
+			"zone",
+			"dhcp_lease_time",
+			"dhcp_renewal_time",
+			"enable_general_guest_dhcp",
+			"force_dhcp_probe_ipmi",
+			"tftp_block_size_in_bytes",
+			"tftp_max_timeout_retries",
+			"lengthy_worker_count",
+			"short_worker_count",
+			// "default_ipmi_password",
+			// "default_strong_ipmi_password",
+			// "windows_default_admin_user",
+			"cache_path",
+			"enable_pxe_boot",
+			"boot_iso_path",
+			// "status_probe_interval_seconds",
+			// "log_fetch_interval_seconds",
+			// "send_metrics_interval_seconds",
 		},
 	}
 )

--- a/pkg/baremetal/options/options.go
+++ b/pkg/baremetal/options/options.go
@@ -55,3 +55,16 @@ type BaremetalOptions struct {
 var (
 	Options BaremetalOptions
 )
+
+func OnOptionsChange(oldO, newO interface{}) bool {
+	oldOpts := oldO.(*BaremetalOptions)
+	newOpts := newO.(*BaremetalOptions)
+
+	changed := false
+
+	if common_options.OnCommonOptionsChange(&oldOpts.CommonOptions, &newOpts.CommonOptions) {
+		changed = true
+	}
+
+	return changed
+}

--- a/pkg/baremetal/service/service.go
+++ b/pkg/baremetal/service/service.go
@@ -21,6 +21,7 @@ import (
 
 	"yunion.io/x/log"
 
+	api "yunion.io/x/onecloud/pkg/apis/baremetal"
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/baremetal"
 	"yunion.io/x/onecloud/pkg/baremetal/handler"
@@ -65,6 +66,8 @@ func (s *BaremetalService) StartService() {
 	fsdriver.Init(nil)
 	app := app_common.InitApp(&o.Options.BaseOptions, false)
 	handler.InitHandlers(app)
+
+	common_options.StartOptionManager(&o.Options, o.Options.ConfigSyncPeriodSeconds, api.SERVICE_TYPE, api.SERVICE_VERSION, o.OnOptionsChange)
 
 	s.startAgent(app)
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：baremetal的options由service config管理

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi @wanyaoqi 

/area baremetal keystone
