### PR TITLE
Automated cherry pick of #6073: fix/notify: remove 'v2' from email verify url

### DIFF
--- a/pkg/notify/models/mod_template.go
+++ b/pkg/notify/models/mod_template.go
@@ -73,7 +73,7 @@ type STemplate struct {
 }
 
 const (
-	verifyUrlPath = "/v2/email-verification/id/{0}/token/{1}?region=%s"
+	verifyUrlPath = "/email-verification/id/{0}/token/{1}?region=%s"
 )
 
 func (tm *STemplateManager) GetEmailUrl() string {


### PR DESCRIPTION
Cherry pick of #6073 on release/3.2.

#6073: fix/notify: remove 'v2' from email verify url