### PR TITLE
fix: cloudaccount usage region/zone count not accurate

### DIFF
--- a/pkg/compute/usages/handler.go
+++ b/pkg/compute/usages/handler.go
@@ -465,7 +465,7 @@ func ReportGeneralUsage(
 func RegionUsage(rangeObjs []db.IStandaloneModel, providers []string, brands []string, cloudEnv string) Usage {
 	q := models.CloudregionManager.Query()
 
-	if len(providers) > 0 || len(brands) > 0 || len(cloudEnv) > 0 {
+	if len(rangeObjs) > 0 || len(providers) > 0 || len(brands) > 0 || len(cloudEnv) > 0 {
 		subq := models.VpcManager.Query("cloudregion_id")
 		subq = models.CloudProviderFilter(subq, subq.Field("manager_id"), providers, brands, cloudEnv)
 		subq = models.RangeObjectsFilter(subq, rangeObjs, nil, nil, subq.Field("manager_id"))
@@ -480,7 +480,7 @@ func RegionUsage(rangeObjs []db.IStandaloneModel, providers []string, brands []s
 func ZoneUsage(rangeObjs []db.IStandaloneModel, providers []string, brands []string, cloudEnv string) Usage {
 	q := models.ZoneManager.Query()
 
-	if len(providers) > 0 || len(brands) > 0 || len(cloudEnv) > 0 {
+	if len(rangeObjs) > 0 || len(providers) > 0 || len(brands) > 0 || len(cloudEnv) > 0 {
 		subq := models.HostManager.Query("zone_id")
 		subq = models.CloudProviderFilter(subq, subq.Field("manager_id"), providers, brands, cloudEnv)
 		subq = models.RangeObjectsFilter(subq, rangeObjs, nil, nil, subq.Field("manager_id"))


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：cloud-account-usage的region、zone数量不对

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area region