### PR TITLE
fix: cloud-account-usage vpc/storage not accurate

### DIFF
--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -947,7 +947,10 @@ func (manager *SStorageManager) totalCapacityQ(
 		q = q.Filter(sqlchemy.In(storages.Field("id"), subq.SubQuery()))
 	}
 
-	q = CloudProviderFilter(q, storages.Field("manager_id"), providers, brands, cloudEnv)
+	if len(rangeObjs) > 0 || len(providers) > 0 || len(brands) > 0 || cloudEnv != "" {
+		q = CloudProviderFilter(q, storages.Field("manager_id"), providers, brands, cloudEnv)
+		q = RangeObjectsFilter(q, rangeObjs, nil, storages.Field("zone_id"), storages.Field("manager_id"))
+	}
 
 	q = q.Distinct()
 

--- a/pkg/compute/usages/handler.go
+++ b/pkg/compute/usages/handler.go
@@ -240,7 +240,7 @@ func getSystemGeneralUsage(userCred mcclient.IIdentityProvider, rangeObjs []db.I
 	count.Add("all.cpu_commit_rate.running", runningCpuCmtRate)
 
 	count.Include(
-		VpcUsage("", providers, brands, cloudEnv, nil, rbacutils.ScopeSystem),
+		VpcUsage("", providers, brands, cloudEnv, nil, rbacutils.ScopeSystem, rangeObjs),
 
 		HostAllUsage("", userCred, rbacutils.ScopeSystem, rangeObjs, hostTypes, []string{api.HostResourceTypeShared}, providers, brands, cloudEnv),
 		HostAllUsage("prepaid_pool", userCred, rbacutils.ScopeSystem, rangeObjs, hostTypes, []string{api.HostResourceTypePrepaidRecycle}, providers, brands, cloudEnv),
@@ -328,7 +328,7 @@ func getDomainGeneralUsage(scope rbacutils.TRbacScope, cred mcclient.IIdentityPr
 	count.Add("domain.cpu_commit_rate.running", runningCpuCmtRate)
 
 	count.Include(
-		VpcUsage("domain", providers, brands, cloudEnv, cred, rbacutils.ScopeDomain),
+		VpcUsage("domain", providers, brands, cloudEnv, cred, rbacutils.ScopeDomain, rangeObjs),
 
 		HostAllUsage("", cred, rbacutils.ScopeDomain, rangeObjs, hostTypes, []string{api.HostResourceTypeShared}, providers, brands, cloudEnv),
 		HostAllUsage("prepaid_pool", cred, rbacutils.ScopeDomain, rangeObjs, hostTypes, []string{api.HostResourceTypePrepaidRecycle}, providers, brands, cloudEnv),
@@ -492,10 +492,11 @@ func ZoneUsage(rangeObjs []db.IStandaloneModel, providers []string, brands []str
 	return count
 }
 
-func VpcUsage(prefix string, providers []string, brands []string, cloudEnv string, ownerId mcclient.IIdentityProvider, scope rbacutils.TRbacScope) Usage {
+func VpcUsage(prefix string, providers []string, brands []string, cloudEnv string, ownerId mcclient.IIdentityProvider, scope rbacutils.TRbacScope, rangeObjs []db.IStandaloneModel) Usage {
 	q := models.VpcManager.Query()
-	if len(providers) > 0 || len(brands) > 0 || len(cloudEnv) > 0 {
+	if len(rangeObjs) > 0 || len(providers) > 0 || len(brands) > 0 || len(cloudEnv) > 0 {
 		q = models.CloudProviderFilter(q, q.Field("manager_id"), providers, brands, cloudEnv)
+		q = models.RangeObjectsFilter(q, rangeObjs, nil, nil, q.Field("manager_id"))
 	}
 	if scope == rbacutils.ScopeDomain {
 		q = q.Equals("domain_id", ownerId.GetProjectDomainId())


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：cloud-account-usage #vpc不正确

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area region