### PR TITLE
fix: fail to fetch real client ip from httprequest

### DIFF
--- a/pkg/util/netutils2/http.go
+++ b/pkg/util/netutils2/http.go
@@ -20,16 +20,21 @@ import (
 )
 
 func GetHttpRequestIp(r *http.Request) string {
-	ipStr := r.Header.Get("X-Real-Ip")
-	if len(ipStr) == 0 {
-		ipStr = r.Header.Get("X-Forwarded-For")
-		if len(ipStr) == 0 {
-			ipStr = r.RemoteAddr
-			colonPos := strings.Index(ipStr, ":")
-			if colonPos > 0 {
-				ipStr = ipStr[:colonPos]
-			}
+	ipStr := r.Header.Get("X-Forwarded-For")
+	if len(ipStr) > 0 {
+		ipList := strings.Split(ipStr, ",")
+		if len(ipList) > 0 {
+			return ipList[0]
 		}
+	}
+	ipStr = r.Header.Get("X-Real-Ip")
+	if len(ipStr) > 0 {
+		return ipStr
+	}
+	ipStr = r.RemoteAddr
+	colonPos := strings.Index(ipStr, ":")
+	if colonPos > 0 {
+		ipStr = ipStr[:colonPos]
 	}
 	return ipStr
 }

--- a/pkg/util/netutils2/http_test.go
+++ b/pkg/util/netutils2/http_test.go
@@ -1,0 +1,76 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netutils2
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestGetHttpRequestIp(t *testing.T) {
+	cases := []struct {
+		request *http.Request
+		want    string
+	}{
+		{
+			request: &http.Request{
+				Header: map[string][]string{
+					"X-Forwarded-For": []string{
+						"10.168.26.232",
+					},
+				},
+				RemoteAddr: "10.168.26.2:32322",
+			},
+			want: "10.168.26.232",
+		},
+		{
+			request: &http.Request{
+				RemoteAddr: "192.168.222.23:35533",
+			},
+			want: "192.168.222.23",
+		},
+		{
+			request: &http.Request{
+				Header: map[string][]string{
+					"X-Real-Ip": []string{
+						"10.40.23.3",
+					},
+				},
+				RemoteAddr: "192.168.222.23:34343",
+			},
+			want: "10.40.23.3",
+		},
+		{
+			request: &http.Request{
+				Header: map[string][]string{
+					"X-Real-Ip": []string{
+						"10.40.23.3",
+					},
+					"X-Forwarded-For": []string{
+						"211.25.23.2, 10.34.3.1, 192.168.222.3",
+					},
+				},
+				RemoteAddr: "192.168.222.23:34343",
+			},
+			want: "211.25.23.2",
+		},
+	}
+	for _, c := range cases {
+		got := GetHttpRequestIp(c.request)
+		if got != c.want {
+			t.Errorf("got: %s want: %s", got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：GetHttpClientIp应该优先从X-Forwarded-For中查找客户端IP

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area apigateway