### PR TITLE
fix: fail to sync share state for on-premise storages

### DIFF
--- a/pkg/compute/models/cloudproviderregions.go
+++ b/pkg/compute/models/cloudproviderregions.go
@@ -380,14 +380,14 @@ func (self *SCloudproviderregion) DoSync(ctx context.Context, userCred mcclient.
 		return err
 	}
 
-	log.Debugf("need to do deep sync ... %v", syncRange.DeepSync)
 	if !syncRange.DeepSync {
+		log.Debugf("no need to do deep sync, check...")
 		intval := self.getSyncIntervalSeconds(nil)
 		if self.LastDeepSyncAt.IsZero() || time.Now().Sub(self.LastDeepSyncAt) > time.Hour*24 || (time.Now().Sub(self.LastDeepSyncAt) > time.Duration(intval)*time.Second*8 && rand.Float32() < 0.5) {
 			syncRange.DeepSync = true
 		}
 	}
-	log.Debugf("no need to do deep sync ... %v", syncRange.DeepSync)
+	log.Debugf("need to do deep sync? ... %v", syncRange.DeepSync)
 
 	if localRegion.isManaged() {
 		remoteRegion, err := driver.GetIRegionById(localRegion.ExternalId)

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -1823,7 +1823,7 @@ func (self *SHost) SyncHostStorages(ctx context.Context, userCred mcclient.Token
 
 	for i := 0; i < len(commondb); i += 1 {
 		log.Infof("host %s is still connected with %s, to update ...", self.Id, commondb[i].Id)
-		err := self.syncWithCloudHostStorage(ctx, userCred, &commondb[i], commonext[i])
+		err := self.syncWithCloudHostStorage(ctx, userCred, &commondb[i], commonext[i], provider)
 		if err != nil {
 			syncResult.UpdateError(err)
 		} else {
@@ -1859,7 +1859,7 @@ func (self *SHost) syncRemoveCloudHostStorage(ctx context.Context, userCred mccl
 	return err
 }
 
-func (self *SHost) syncWithCloudHostStorage(ctx context.Context, userCred mcclient.TokenCredential, localStorage *SStorage, extStorage cloudprovider.ICloudStorage) error {
+func (self *SHost) syncWithCloudHostStorage(ctx context.Context, userCred mcclient.TokenCredential, localStorage *SStorage, extStorage cloudprovider.ICloudStorage, provider *SCloudprovider) error {
 	// do nothing
 	hs := self.GetHoststorageOfId(localStorage.Id)
 	err := hs.syncWithCloudHostStorage(userCred, extStorage)
@@ -1867,7 +1867,7 @@ func (self *SHost) syncWithCloudHostStorage(ctx context.Context, userCred mcclie
 		return err
 	}
 	s := hs.GetStorage()
-	err = s.syncWithCloudStorage(ctx, userCred, extStorage, nil)
+	err = s.syncWithCloudStorage(ctx, userCred, extStorage, provider)
 	return err
 }
 

--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -775,6 +775,7 @@ func (self *SStorage) syncWithCloudStorage(ctx context.Context, userCred mcclien
 	})
 	if err != nil {
 		log.Errorf("syncWithCloudZone error %s", err)
+		return err
 	}
 
 	if provider != nil {
@@ -783,7 +784,7 @@ func (self *SStorage) syncWithCloudStorage(ctx context.Context, userCred mcclien
 	}
 
 	db.OpsLog.LogSyncUpdate(self, diff, userCred)
-	return err
+	return nil
 }
 
 func (manager *SStorageManager) newFromCloudStorage(ctx context.Context, userCred mcclient.TokenCredential, extStorage cloudprovider.ICloudStorage, provider *SCloudprovider, zone *SZone) (*SStorage, error) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：未能正确同步on-premise存储的共享状态

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area region

/hold