### PR TITLE
Automated cherry pick of #6219: fix: 1. vpc, cloudprovider should not violate the sharing limit of cloud account 2. sharing mode of host and attached local storage should be consistent. 3. cannot change owner of shared resource

### DIFF
--- a/cmd/climc/shell/cloudaccounts.go
+++ b/cmd/climc/shell/cloudaccounts.go
@@ -1037,4 +1037,12 @@ func init() {
 		return nil
 	})
 
+	R(&CloudaccountShowOptions{}, "cloud-account-change-owner-candidate-domains", "Show candiate domains of a cloud account changing project", func(s *mcclient.ClientSession, args *CloudaccountShowOptions) error {
+		result, err := modules.Cloudaccounts.GetSpecific(s, args.ID, "change-owner-candidate-domains", nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
 }

--- a/cmd/climc/shell/cloudproviders.go
+++ b/cmd/climc/shell/cloudproviders.go
@@ -245,4 +245,13 @@ func init() {
 		printObject(result)
 		return nil
 	})
+
+	R(&CloudproviderShowOptions{}, "cloud-provider-change-owner-candidate-domains", "Show candiate domains of a cloud provider  changing owner", func(s *mcclient.ClientSession, args *CloudproviderShowOptions) error {
+		result, err := modules.Cloudproviders.GetSpecific(s, args.ID, "change-owner-candidate-domains", nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
 }

--- a/cmd/climc/shell/globalvpcs.go
+++ b/cmd/climc/shell/globalvpcs.go
@@ -15,6 +15,8 @@
 package shell
 
 import (
+	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/mcclient/options"
@@ -42,6 +44,34 @@ func init() {
 	}
 	R(&GlobalVpcShowOptions{}, "global-vpc-show", "Show details of a global vpc", func(s *mcclient.ClientSession, args *GlobalVpcShowOptions) error {
 		result, err := modules.GlobalVpcs.GetById(s, args.ID, nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
+	type GlobalVpcPublicOptions struct {
+		ID            string   `help:"ID or name of global vpc" json:"-"`
+		Scope         string   `help:"sharing scope" choices:"system|domain"`
+		SharedDomains []string `help:"share to domains"`
+	}
+	R(&GlobalVpcPublicOptions{}, "global-vpc-public", "Make global vpc public", func(s *mcclient.ClientSession, args *GlobalVpcPublicOptions) error {
+		params := jsonutils.Marshal(args)
+		result, err := modules.GlobalVpcs.PerformAction(s, args.ID, "public", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
+	type GlobalVpcPrivateOptions struct {
+		ID string `help:"ID or name of global vpc" json:"-"`
+	}
+	R(&GlobalVpcPrivateOptions{}, "global-vpc-private", "Make global vpc private", func(s *mcclient.ClientSession, args *GlobalVpcPrivateOptions) error {
+		params := jsonutils.Marshal(args)
+		result, err := modules.GlobalVpcs.PerformAction(s, args.ID, "private", params)
 		if err != nil {
 			return err
 		}

--- a/cmd/climc/shell/storages.go
+++ b/cmd/climc/shell/storages.go
@@ -215,4 +215,49 @@ func init() {
 		printObject(storage)
 		return nil
 	})
+
+	type StorageChangeOwnerOptions struct {
+		ID            string `help:"ID or name of storage" json:"-"`
+		ProjectDomain string `json:"project_domain" help:"target domain"`
+	}
+	R(&StorageChangeOwnerOptions{}, "storage-change-owner", "Change owner domain of storage", func(s *mcclient.ClientSession, args *StorageChangeOwnerOptions) error {
+		if len(args.ProjectDomain) == 0 {
+			return fmt.Errorf("empty project_domain")
+		}
+		params := jsonutils.Marshal(args)
+		ret, err := modules.Storages.PerformAction(s, args.ID, "change-owner", params)
+		if err != nil {
+			return err
+		}
+		printObject(ret)
+		return nil
+	})
+
+	type StoragePublicOptions struct {
+		ID            string   `help:"ID or name of storage" json:"-"`
+		Scope         string   `help:"sharing scope" choices:"system|domain"`
+		SharedDomains []string `help:"share to domains"`
+	}
+	R(&StoragePublicOptions{}, "storage-public", "Make a storage public", func(s *mcclient.ClientSession, args *StoragePublicOptions) error {
+		params := jsonutils.Marshal(args)
+		result, err := modules.Storages.PerformAction(s, args.ID, "public", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
+	type StoragePrivateOptions struct {
+		ID string `help:"ID or name of storage" json:"-"`
+	}
+	R(&StoragePrivateOptions{}, "storage-private", "Make a storage private", func(s *mcclient.ClientSession, args *StoragePrivateOptions) error {
+		params := jsonutils.Marshal(args)
+		result, err := modules.Storages.PerformAction(s, args.ID, "private", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
 }

--- a/cmd/climc/shell/vpcs.go
+++ b/cmd/climc/shell/vpcs.go
@@ -15,6 +15,8 @@
 package shell
 
 import (
+	"fmt"
+
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -216,6 +218,23 @@ func init() {
 			return err
 		}
 		printObject(result)
+		return nil
+	})
+
+	type VpcChangeOwnerOptions struct {
+		ID            string `help:"ID or name of vpc" json:"-"`
+		ProjectDomain string `json:"project_domain" help:"target domain"`
+	}
+	R(&VpcChangeOwnerOptions{}, "vpc-change-owner", "Change owner domain of vpc", func(s *mcclient.ClientSession, args *VpcChangeOwnerOptions) error {
+		if len(args.ProjectDomain) == 0 {
+			return fmt.Errorf("empty project_domain")
+		}
+		params := jsonutils.Marshal(args)
+		ret, err := modules.Vpcs.PerformAction(s, args.ID, "change-owner", params)
+		if err != nil {
+			return err
+		}
+		printObject(ret)
 		return nil
 	})
 }

--- a/pkg/cloudcommon/db/domainresource.go
+++ b/pkg/cloudcommon/db/domainresource.go
@@ -133,6 +133,10 @@ func (model *SDomainLevelResourceBase) AllowPerformChangeOwner(ctx context.Conte
 }
 
 func (model *SDomainLevelResourceBase) PerformChangeOwner(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformChangeDomainOwnerInput) (jsonutils.JSONObject, error) {
+	if model.GetIStandaloneModel().IsShared() {
+		return nil, errors.Wrap(httperrors.ErrForbidden, "cannot change owner of shared resource")
+	}
+
 	manager := model.GetModelManager()
 
 	data := jsonutils.Marshal(input)

--- a/pkg/cloudcommon/db/infraresource.go
+++ b/pkg/cloudcommon/db/infraresource.go
@@ -266,9 +266,9 @@ func (model *SInfrasResourceBase) GetRequiredSharedDomainIds() []string {
 	return []string{model.DomainId}
 }
 
-func (model *SInfrasResourceBase) ValidateDeleteCondition(ctx context.Context) error {
+/*func (model *SInfrasResourceBase) ValidateDeleteCondition(ctx context.Context) error {
 	if model.IsShared() {
 		return httperrors.NewForbiddenError("%s %s is shared", model.Keyword(), model.Name)
 	}
 	return model.SDomainLevelResourceBase.ValidateDeleteCondition(ctx)
-}
+}*/

--- a/pkg/cloudcommon/db/sharablevirtual.go
+++ b/pkg/cloudcommon/db/sharablevirtual.go
@@ -253,9 +253,9 @@ func (model *SSharableVirtualResourceBase) GetRequiredSharedDomainIds() []string
 	return []string{model.DomainId}
 }
 
-func (model *SSharableVirtualResourceBase) ValidateDeleteCondition(ctx context.Context) error {
+/*func (model *SSharableVirtualResourceBase) ValidateDeleteCondition(ctx context.Context) error {
 	if model.IsShared() {
 		return httperrors.NewForbiddenError("%s %s is shared", model.Keyword(), model.Name)
 	}
 	return model.SVirtualResourceBase.ValidateDeleteCondition(ctx)
-}
+}*/

--- a/pkg/cloudcommon/db/virtualresource.go
+++ b/pkg/cloudcommon/db/virtualresource.go
@@ -258,6 +258,10 @@ func (model *SVirtualResourceBase) AllowPerformChangeOwner(ctx context.Context, 
 }
 
 func (model *SVirtualResourceBase) PerformChangeOwner(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformChangeProjectOwnerInput) (jsonutils.JSONObject, error) {
+	if model.GetIStandaloneModel().IsShared() {
+		return nil, errors.Wrap(httperrors.ErrForbidden, "cannot change owner of shared resource")
+	}
+
 	manager := model.GetModelManager()
 
 	data := jsonutils.Marshal(input)

--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -1054,7 +1054,7 @@ func (self *SManagedVirtualizedGuestDriver) chooseHostStorage(
 	if len(storageIds) != 0 {
 		return models.StorageManager.FetchStorageById(storageIds[0])
 	}
-	storages := host.GetAttachedStorages("")
+	storages := host.GetAttachedEnabledHostStorages(nil)
 	for i := 0; i < len(storages); i += 1 {
 		if storages[i].StorageType == backend {
 			return &storages[i]

--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -580,7 +580,7 @@ func (disk *SDisk) SetStorageByHost(hostId string, diskConfig *api.DiskConfig, s
 		storage = host.GetLeastUsedStorage(backend)
 	} else {
 		// unlimited pulic cloud storages
-		storages := host.GetAttachedStorages("")
+		storages := host.GetAttachedEnabledHostStorages(nil)
 		for _, s := range storages {
 			if s.StorageType == backend {
 				tmpS := s

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -2567,7 +2567,7 @@ func (net *SNetwork) PerformStatus(ctx context.Context, userCred mcclient.TokenC
 
 func (net *SNetwork) GetChangeOwnerCandidateDomainIds() []string {
 	candidates := [][]string{
-		net.SSharableVirtualResourceBase.GetChangeOwnerCandidateDomainIds(),
+		db.ISharableChangeOwnerCandidateDomainIds(net),
 	}
 	wire := net.GetWire()
 	if wire != nil {

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -2566,11 +2566,13 @@ func (net *SNetwork) PerformStatus(ctx context.Context, userCred mcclient.TokenC
 }
 
 func (net *SNetwork) GetChangeOwnerCandidateDomainIds() []string {
-	candidates := [][]string{
-		db.ISharableChangeOwnerCandidateDomainIds(net),
-	}
+	candidates := [][]string{}
 	wire := net.GetWire()
 	if wire != nil {
+		vpc := wire.GetVpc()
+		if vpc != nil {
+			candidates = append(candidates, vpc.GetChangeOwnerCandidateDomainIds())
+		}
 		candidates = append(candidates, db.ISharableChangeOwnerCandidateDomainIds(wire))
 	}
 	return db.ISharableMergeChangeOwnerCandidateDomainIds(net, candidates...)

--- a/pkg/compute/models/purge.go
+++ b/pkg/compute/models/purge.go
@@ -94,7 +94,7 @@ func (host *SHost) purge(ctx context.Context, userCred mcclient.TokenCredential)
 	}
 
 	// clean all disks on locally attached storages
-	storages := host._getAttachedStorages(tristate.None, tristate.None, api.STORAGE_LOCAL)
+	storages := host._getAttachedStorages(tristate.None, tristate.None, api.HOST_STORAGE_LOCAL_TYPES)
 	for i := range storages {
 		err := storages[i].purgeDisks(ctx, userCred)
 		if err != nil {

--- a/pkg/compute/models/secgroups.go
+++ b/pkg/compute/models/secgroups.go
@@ -819,6 +819,7 @@ func (manager *SSecurityGroupManager) InitializeData() error {
 		secGrp.DomainId = auth.AdminCredential().GetProjectDomainId()
 		// secGrp.IsEmulated = false
 		secGrp.IsPublic = true
+		secGrp.PublicScope = string(rbacutils.ScopeSystem)
 		err = manager.TableSpec().Insert(secGrp)
 		if err != nil {
 			log.Errorf("Insert default secgroup failed!!! %s", err)

--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -1458,6 +1458,21 @@ func (self *SStorage) StartDeleteRbdDisks(ctx context.Context, userCred mcclient
 	return nil
 }
 
+func (storage *SStorage) PerformChangeOwner(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformChangeDomainOwnerInput) (jsonutils.JSONObject, error) {
+	// not allow to perform public for locally connected storage
+	if storage.IsLocal() {
+		hosts := storage.GetAttachedHosts()
+		if len(hosts) > 0 {
+			return nil, errors.Wrap(httperrors.ErrForbidden, "not allow to change owner for local storage")
+		}
+	}
+	return storage.performChangeOwnerInternal(ctx, userCred, query, input)
+}
+
+func (storage *SStorage) performChangeOwnerInternal(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformChangeDomainOwnerInput) (jsonutils.JSONObject, error) {
+	return storage.SEnabledStatusInfrasResourceBase.PerformChangeOwner(ctx, userCred, query, input)
+}
+
 func (storage *SStorage) PerformPublic(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPublicDomainInput) (jsonutils.JSONObject, error) {
 	// not allow to perform public for locally connected storage
 	if storage.IsLocal() {

--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -573,6 +573,7 @@ func (manager *SVpcManager) InitializeData() error {
 			defVpc.Description = "Default VPC"
 			defVpc.Status = api.VPC_STATUS_AVAILABLE
 			defVpc.IsDefault = true
+			defVpc.IsPublic = true
 			defVpc.PublicScope = string(rbacutils.ScopeSystem)
 			err = manager.TableSpec().Insert(&defVpc)
 			if err != nil {
@@ -1093,12 +1094,13 @@ func (manager *SVpcManager) totalCount(
 
 func (vpc *SVpc) GetChangeOwnerCandidateDomainIds() []string {
 	candidates := [][]string{
-		db.ISharableChangeOwnerCandidateDomainIds(vpc),
+		vpc.SManagedResourceBase.GetChangeOwnerCandidateDomainIds(),
 	}
 	globalVpc, _ := vpc.GetGlobalVpc()
 	if globalVpc != nil {
 		candidates = append(candidates, db.ISharableChangeOwnerCandidateDomainIds(globalVpc))
 	}
+	log.Debugf("Candidate: %s", candidates)
 	return db.ISharableMergeChangeOwnerCandidateDomainIds(vpc, candidates...)
 }
 

--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -1093,7 +1093,7 @@ func (manager *SVpcManager) totalCount(
 
 func (vpc *SVpc) GetChangeOwnerCandidateDomainIds() []string {
 	candidates := [][]string{
-		vpc.SEnabledStatusInfrasResourceBase.GetChangeOwnerCandidateDomainIds(),
+		db.ISharableChangeOwnerCandidateDomainIds(vpc),
 	}
 	globalVpc, _ := vpc.GetGlobalVpc()
 	if globalVpc != nil {

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -1012,7 +1012,7 @@ func (model *SWire) CustomizeCreate(ctx context.Context, userCred mcclient.Token
 
 func (wire *SWire) GetChangeOwnerCandidateDomainIds() []string {
 	candidates := [][]string{
-		wire.SInfrasResourceBase.GetChangeOwnerCandidateDomainIds(),
+		db.ISharableChangeOwnerCandidateDomainIds(wire),
 	}
 	vpc := wire.GetVpc()
 	if vpc != nil {

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -1011,12 +1011,12 @@ func (model *SWire) CustomizeCreate(ctx context.Context, userCred mcclient.Token
 }
 
 func (wire *SWire) GetChangeOwnerCandidateDomainIds() []string {
-	candidates := [][]string{
-		db.ISharableChangeOwnerCandidateDomainIds(wire),
-	}
+	candidates := [][]string{}
 	vpc := wire.GetVpc()
 	if vpc != nil {
-		candidates = append(candidates, db.ISharableChangeOwnerCandidateDomainIds(vpc))
+		candidates = append(candidates,
+			vpc.GetChangeOwnerCandidateDomainIds(),
+			db.ISharableChangeOwnerCandidateDomainIds(vpc))
 	}
 	return db.ISharableMergeChangeOwnerCandidateDomainIds(wire, candidates...)
 }

--- a/pkg/mcclient/modules/mod_vpcs.go
+++ b/pkg/mcclient/modules/mod_vpcs.go
@@ -22,7 +22,7 @@ var (
 
 func init() {
 	Vpcs = NewComputeManager("vpc", "vpcs",
-		[]string{"ID", "Name", "Enabled", "Status", "Cloudregion_Id", "Is_default", "Cidr_Block", "Region", "Public_Scope"},
+		[]string{"ID", "Name", "Enabled", "Status", "Cloudregion_Id", "Is_default", "Cidr_Block", "Region", "Public_Scope", "Domain_Id", "Domain"},
 		[]string{})
 
 	registerCompute(&Vpcs)


### PR DESCRIPTION
Cherry pick of #6219 on release/3.2.

#6219: fix: 1. vpc, cloudprovider should not violate the sharing limit of cloud account 2. sharing mode of host and attached local storage should be consistent. 3. cannot change owner of shared resource