### PR TITLE
disks: reword error message on bad DiskConfig struct

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -1611,7 +1611,7 @@ func parseDiskInfo(ctx context.Context, userCred mcclient.TokenCredential, info 
 	// 	diskConfig.SizeMb = options.Options.DefaultDiskSize // MB
 	// else
 	if len(info.ImageId) == 0 && info.SizeMb == 0 {
-		return nil, httperrors.NewInputParameterError("Diskinfo not contains either imageID or size")
+		return nil, httperrors.NewInputParameterError("Diskinfo index %d: both imageID and size are absent", info.Index)
 	}
 	return info, nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
disks: reword error message on bad DiskConfig struct
```

- [x] 冒烟测试

**是否需要 backport 到之前的 release 分支**:

- release/2.13

/area region
/cc @swordqiu @zexi @wanyaoqi 
