### PR TITLE
fix: create cloudaccount with disabled state

### DIFF
--- a/pkg/apis/input.go
+++ b/pkg/apis/input.go
@@ -88,6 +88,17 @@ type EnabledBaseResourceCreateInput struct {
 	// 该资源是否被管理员*人为*启用或者禁用
 	// required: false
 	Enabled *bool `json:"enabled"`
+
+	// 该资源是否被管理员*人为*禁用, 和enabled互斥
+	// required: false
+	Disabled *bool `json:"disabled"`
+}
+
+func (input *EnabledBaseResourceCreateInput) AfterUnmarshal() {
+	if input.Disabled != nil && input.Enabled == nil {
+		enabled := !(*input.Disabled)
+		input.Enabled = &enabled
+	}
 }
 
 type StatusBaseResourceCreateInput struct {

--- a/pkg/mcclient/options/cloudaccounts.go
+++ b/pkg/mcclient/options/cloudaccounts.go
@@ -85,6 +85,8 @@ type SCloudAccountCreateBaseOptions struct {
 	Project       string `help:"project for this account"`
 	ProjectDomain string `help:"domain for this account"`
 
+	Disabled *bool `help:"create cloud account with disabled status"`
+
 	ProxySetting string `help:"proxy setting id or name" json:"proxy_setting"`
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：允许创建初始状态为disabled的cloudaccount

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/area region
/cc @zexi @tb365 
/hold