### PR TITLE
vpcagent: ignore possible external subnets

### DIFF
--- a/pkg/vpcagent/models/modelset.go
+++ b/pkg/vpcagent/models/modelset.go
@@ -66,9 +66,12 @@ func (ms Vpcs) joinNetworks(subEntries Networks) bool {
 		}
 		m, ok := ms[id]
 		if !ok {
+			// let it go.  By the time the subnet has externalId or
+			// managerId set, we will not receive updates from them
+			// anymore
 			log.Warningf("network %s(%s): vpc id %s not found",
 				subEntry.Name, subEntry.Id, id)
-			correct = false
+			delete(subEntries, subId)
 			continue
 		}
 		if _, ok := m.Networks[subId]; ok {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
vpcagent: ignore possible external subnets
```

**是否需要 backport 到之前的 release 分支**:

- release/3.1

/area vpcagent
/cc @swordqiu @zexi @ioito @tb365 