### PR TITLE
Automated cherry pick of #6302: vpcagent: ignore possible external subnets

### DIFF
--- a/pkg/vpcagent/models/modelset.go
+++ b/pkg/vpcagent/models/modelset.go
@@ -66,9 +66,12 @@ func (ms Vpcs) joinNetworks(subEntries Networks) bool {
 		}
 		m, ok := ms[id]
 		if !ok {
+			// let it go.  By the time the subnet has externalId or
+			// managerId set, we will not receive updates from them
+			// anymore
 			log.Warningf("network %s(%s): vpc id %s not found",
 				subEntry.Name, subEntry.Id, id)
-			correct = false
+			delete(subEntries, subId)
 			continue
 		}
 		if _, ok := m.Networks[subId]; ok {


### PR DESCRIPTION
Cherry pick of #6302 on release/3.2.

#6302: vpcagent: ignore possible external subnets