### PR TITLE
fix: change-owner-candidate-domains not implemented for some resources

### DIFF
--- a/cmd/climc/shell/compute/disks.go
+++ b/cmd/climc/shell/compute/disks.go
@@ -291,4 +291,14 @@ func init() {
 		printObject(srv)
 		return nil
 	})
+
+	R(&DiskDetailOptions{}, "disk-change-owner-candidate-domains", "Get change owner candidate domain list", func(s *mcclient.ClientSession, args *DiskDetailOptions) error {
+		result, err := modules.Disks.GetSpecific(s, args.ID, "change-owner-candidate-domains", nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
 }

--- a/cmd/climc/shell/compute/loadbalancers.go
+++ b/cmd/climc/shell/compute/loadbalancers.go
@@ -99,4 +99,13 @@ func init() {
 		return nil
 	})
 
+	R(&options.LoadbalancerGetOptions{}, "lb-change-owner-candidate-domains", "Get change owner candidate domain list", func(s *mcclient.ClientSession, args *options.LoadbalancerGetOptions) error {
+		result, err := modules.Loadbalancers.GetSpecific(s, args.ID, "change-owner-candidate-domains", nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
 }

--- a/cmd/climc/shell/compute/servers.go
+++ b/cmd/climc/shell/compute/servers.go
@@ -1350,4 +1350,14 @@ func init() {
 		printObject(result)
 		return nil
 	})
+
+	R(&options.ServerShowOptions{}, "server-change-owner-candidate-domains", "Get change owner candidate domain list", func(s *mcclient.ClientSession, args *options.ServerShowOptions) error {
+		result, err := modules.Servers.GetSpecific(s, args.ID, "change-owner-candidate-domains", nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
 }

--- a/pkg/cloudcommon/db/sharablebase.go
+++ b/pkg/cloudcommon/db/sharablebase.go
@@ -168,7 +168,9 @@ func SharableManagerValidateCreateData(
 			input.IsPublic = &isPublic
 			reqScope = rbacutils.ScopeDomain
 		} else if input.IsPublic != nil && *input.IsPublic {
-			return input, errors.Wrap(httperrors.ErrNotSupported, "domain level resource can be shared to system ONLY")
+			// return input, errors.Wrap(httperrors.ErrNotSupported, "project level resource can be shared to domain or system ONLY")
+			input.IsPublic = nil
+			input.PublicScope = string(rbacutils.ScopeNone)
 		} else {
 			input.IsPublic = nil
 			input.PublicScope = string(rbacutils.ScopeNone)
@@ -178,7 +180,9 @@ func SharableManagerValidateCreateData(
 			input.IsPublic = &isPublic
 			reqScope = rbacutils.ScopeSystem
 		} else if input.IsPublic != nil && *input.IsPublic {
-			return input, errors.Wrap(httperrors.ErrNotSupported, "domain level resource can be shared to system ONLY")
+			// return input, errors.Wrap(httperrors.ErrNotSupported, "domain level resource can be shared to system ONLY")
+			input.IsPublic = nil
+			input.PublicScope = string(rbacutils.ScopeNone)
 		} else {
 			input.IsPublic = nil
 			input.PublicScope = string(rbacutils.ScopeNone)

--- a/pkg/compute/models/dbinstance_backups.go
+++ b/pkg/compute/models/dbinstance_backups.go
@@ -578,3 +578,7 @@ func (manager *SDBInstanceBackupManager) ListItemExportKeys(ctx context.Context,
 	}
 	return q, nil
 }
+
+func (self *SDBInstanceBackup) GetChangeOwnerCandidateDomainIds() []string {
+	return self.SManagedResourceBase.GetChangeOwnerCandidateDomainIds()
+}

--- a/pkg/compute/models/dbinstanceresource.go
+++ b/pkg/compute/models/dbinstanceresource.go
@@ -264,3 +264,11 @@ func (manager *SDBInstanceResourceBaseManager) GetExportKeys() []string {
 	keys = append(keys, manager.SVpcResourceBaseManager.GetExportKeys()...)
 	return keys
 }
+
+func (self *SDBInstanceResourceBase) GetChangeOwnerCandidateDomainIds() []string {
+	dbinst, _ := self.GetDBInstance()
+	if dbinst != nil {
+		return dbinst.GetChangeOwnerCandidateDomainIds()
+	}
+	return nil
+}

--- a/pkg/compute/models/diskresource.go
+++ b/pkg/compute/models/diskresource.go
@@ -252,3 +252,11 @@ func (manager *SDiskResourceBaseManager) GetExportKeys() []string {
 	keys = append(keys, manager.SStorageResourceBaseManager.GetExportKeys()...)
 	return keys
 }
+
+func (self *SDiskResourceBase) GetChangeOwnerCandidateDomainIds() []string {
+	disk := self.GetDisk()
+	if disk != nil {
+		return disk.GetChangeOwnerCandidateDomainIds()
+	}
+	return nil
+}

--- a/pkg/compute/models/elasticcacheresource.go
+++ b/pkg/compute/models/elasticcacheresource.go
@@ -302,3 +302,11 @@ func (manager *SElasticcacheResourceBaseManager) GetExportKeys() []string {
 	keys = append(keys, "zone")
 	return keys
 }
+
+func (self *SElasticcacheResourceBase) GetChangeOwnerCandidateDomainIds() []string {
+	cache, _ := self.GetElasticcache()
+	if cache != nil {
+		return cache.GetChangeOwnerCandidateDomainIds()
+	}
+	return nil
+}

--- a/pkg/compute/models/guestresource.go
+++ b/pkg/compute/models/guestresource.go
@@ -251,3 +251,11 @@ func (manager *SGuestResourceBaseManager) GetExportKeys() []string {
 	keys = append(keys, manager.SHostResourceBaseManager.GetExportKeys()...)
 	return keys
 }
+
+func (self *SGuestResourceBase) GetChangeOwnerCandidateDomainIds() []string {
+	guest := self.GetGuest()
+	if guest != nil {
+		return guest.GetChangeOwnerCandidateDomainIds()
+	}
+	return nil
+}

--- a/pkg/compute/models/hostresource.go
+++ b/pkg/compute/models/hostresource.go
@@ -54,6 +54,15 @@ func ValidateHostResourceInput(userCred mcclient.TokenCredential, input api.Host
 	return hostObj.(*SHost), input, nil
 }
 
+func (self *SHostResourceBase) GetHost() *SHost {
+	obj, err := HostManager.FetchById(self.HostId)
+	if err != nil {
+		log.Errorf("fail to get host by id %s: %s", self.HostId, err)
+		return nil
+	}
+	return obj.(*SHost)
+}
+
 func (manager *SHostResourceBaseManager) getHostIdFieldName() string {
 	if len(manager.hostIdFieldName) > 0 {
 		return manager.hostIdFieldName
@@ -278,4 +287,12 @@ func (manager *SHostResourceBaseManager) GetExportKeys() []string {
 	keys = append(keys, manager.SZoneResourceBaseManager.GetExportKeys()...)
 	keys = append(keys, manager.SManagedResourceBaseManager.GetExportKeys()...)
 	return keys
+}
+
+func (model *SHostResourceBase) GetChangeOwnerCandidateDomainIds() []string {
+	host := model.GetHost()
+	if host != nil {
+		return host.GetChangeOwnerCandidateDomainIds()
+	}
+	return nil
 }

--- a/pkg/compute/models/loadbalancerresource.go
+++ b/pkg/compute/models/loadbalancerresource.go
@@ -344,3 +344,11 @@ func (manager *SLoadbalancerResourceBaseManager) GetExportKeys() []string {
 	keys = append(keys, "vpc")
 	return keys
 }
+
+func (self *SLoadbalancerResourceBase) GetChangeOwnerCandidateDomainIds() []string {
+	lb := self.GetLoadbalancer()
+	if lb != nil {
+		return lb.GetChangeOwnerCandidateDomainIds()
+	}
+	return nil
+}

--- a/pkg/compute/models/loadbalancers.go
+++ b/pkg/compute/models/loadbalancers.go
@@ -1137,3 +1137,7 @@ func (manager *SLoadbalancerManager) ListItemExportKeys(ctx context.Context,
 	}
 	return q, nil
 }
+
+func (self *SLoadbalancer) GetChangeOwnerCandidateDomainIds() []string {
+	return self.SManagedResourceBase.GetChangeOwnerCandidateDomainIds()
+}

--- a/pkg/compute/models/natgatewayresource.go
+++ b/pkg/compute/models/natgatewayresource.go
@@ -220,3 +220,11 @@ func (manager *SNatgatewayResourceBaseManager) FilterByParentId(q *sqlchemy.SQue
 	return q
 }
 */
+
+func (self *SNatgatewayResourceBase) GetChangeOwnerCandidateDomainIds() []string {
+	nat, _ := self.GetNatgateway()
+	if nat != nil {
+		return nat.GetChangeOwnerCandidateDomainIds()
+	}
+	return nil
+}

--- a/pkg/compute/models/networkresource.go
+++ b/pkg/compute/models/networkresource.go
@@ -260,3 +260,11 @@ func (manager *SNetworkResourceBaseManager) GetExportKeys() []string {
 	keys = append(keys, manager.SWireResourceBaseManager.GetExportKeys()...)
 	return keys
 }
+
+func (self *SNetworkResourceBase) GetChangeOwnerCandidateDomainIds() []string {
+	network := self.GetNetwork()
+	if network != nil {
+		return network.GetChangeOwnerCandidateDomainIds()
+	}
+	return nil
+}

--- a/pkg/compute/models/storageresource.go
+++ b/pkg/compute/models/storageresource.go
@@ -53,6 +53,15 @@ func ValidateStorageResourceInput(userCred mcclient.TokenCredential, query api.S
 	return storageObj.(*SStorage), query, nil
 }
 
+func (self *SStorageResourceBase) GetStorage() *SStorage {
+	obj, err := StorageManager.FetchById(self.StorageId)
+	if err != nil {
+		log.Errorf("fail to fetch storage by id: %s: %s", self.StorageId, err)
+		return nil
+	}
+	return obj.(*SStorage)
+}
+
 func (self *SStorageResourceBase) GetExtraDetails(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) api.StorageResourceInfo {
 	return api.StorageResourceInfo{}
 }
@@ -267,4 +276,12 @@ func (manager *SStorageResourceBaseManager) GetExportKeys() []string {
 	keys = append(keys, manager.SZoneResourceBaseManager.GetExportKeys()...)
 	keys = append(keys, manager.SManagedResourceBaseManager.GetExportKeys()...)
 	return keys
+}
+
+func (model *SStorageResourceBase) GetChangeOwnerCandidateDomainIds() []string {
+	storage := model.GetStorage()
+	if storage != nil {
+		return storage.GetChangeOwnerCandidateDomainIds()
+	}
+	return nil
 }

--- a/pkg/compute/models/vpcresource.go
+++ b/pkg/compute/models/vpcresource.go
@@ -310,3 +310,11 @@ func (manager *SVpcResourceBaseManager) GetExportKeys() []string {
 	keys = append(keys, manager.SCloudregionResourceBaseManager.GetExportKeys()...)
 	return keys
 }
+
+func (self *SVpcResourceBase) GetChangeOwnerCandidateDomainIds() []string {
+	vpc := self.GetVpc()
+	if vpc != nil {
+		return vpc.GetChangeOwnerCandidateDomainIds()
+	}
+	return nil
+}

--- a/pkg/compute/models/wireresource.go
+++ b/pkg/compute/models/wireresource.go
@@ -305,3 +305,11 @@ func (manager *SWireResourceBaseManager) GetExportKeys() []string {
 	keys = append(keys, manager.SVpcResourceBaseManager.GetExportKeys()...)
 	return keys
 }
+
+func (self *SWireResourceBase) GetChangeOwnerCandidateDomainIds() []string {
+	wire := self.GetWire()
+	if wire != nil {
+		return wire.GetChangeOwnerCandidateDomainIds()
+	}
+	return nil
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：部分资源的 GetChangeOwnerCandidateDomainids未实现

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area region
/hold