### PR TITLE
fix: host agent list use baremetalagents model

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -718,7 +718,7 @@ func isHostAgentExists(s *mcclient.ClientSession) (bool, error) {
 	params.Add(jsonutils.NewString("system"), "scope")
 	params.Add(jsonutils.NewInt(1), "limit")
 	params.Add(jsonutils.JSONFalse, "details")
-	agents, err := modules.Baremetalagents.List(s, params)
+	agents, err := modules.Hosts.List(s, params)
 	if err != nil {
 		return false, errors.Wrap(err, "modules.LoadbalancerAgents.List")
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：hostAgent列表拉取用了baremetalAgent

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area apigateway
