### PR TITLE
Automated cherry pick of #6347: scheduler: set schedtag default strategy if input empty

### DIFF
--- a/pkg/scheduler/algorithm/predicates/schedtag_helper.go
+++ b/pkg/scheduler/algorithm/predicates/schedtag_helper.go
@@ -123,6 +123,16 @@ func GetRequestSchedtags(reqTags []*computeapi.SchedtagConfig, allTags []models.
 
 	appendedTagIds := make(map[string]int)
 
+	for _, reqTag := range reqTags {
+		for _, dbTag := range allTags {
+			if reqTag.Id == dbTag.Id || reqTag.Id == dbTag.Name {
+				if reqTag.Strategy == "" {
+					reqTag.Strategy = dbTag.DefaultStrategy
+				}
+			}
+		}
+	}
+
 	appendTagByStrategy := func(tag *computeapi.SchedtagConfig, defaultWeight int) {
 		if tag.Weight <= 0 {
 			tag.Weight = defaultWeight


### PR DESCRIPTION
Cherry pick of #6347 on release/3.1.

#6347: scheduler: set schedtag default strategy if input empty