### PR TITLE
fix(host-deployer): Remove 'IsInit' check in DeployYunionroot

### DIFF
--- a/pkg/hostman/guestfs/core.go
+++ b/pkg/hostman/guestfs/core.go
@@ -146,7 +146,7 @@ func DoDeployGuestFs(rootfs fsdriver.IRootFsDriver, guestDesc *deployapi.GuestDe
 		}
 	}
 
-	if err = rootfs.DeployYunionroot(partition, deployInfo.PublicKey, deployInfo.IsInit, deployInfo.EnableCloudInit); err != nil {
+	if err = rootfs.DeployYunionroot(partition, deployInfo.PublicKey, deployInfo.EnableCloudInit); err != nil {
 		return nil, fmt.Errorf("DeployYunionroot: %v", err)
 	}
 	if partition.SupportSerialPorts() {

--- a/pkg/hostman/guestfs/fsdriver/base.go
+++ b/pkg/hostman/guestfs/fsdriver/base.go
@@ -80,7 +80,7 @@ func (d *sGuestRootFsDriver) IsFsCaseInsensitive() bool {
 	return false
 }
 
-func (d *sGuestRootFsDriver) DeployYunionroot(rootfs IDiskPartition, pubkeys *deployapi.SSHKeys, isInit, enableCloudInit bool) error {
+func (d *sGuestRootFsDriver) DeployYunionroot(rootfs IDiskPartition, pubkeys *deployapi.SSHKeys, enableCloudInit bool) error {
 	return nil
 }
 

--- a/pkg/hostman/guestfs/fsdriver/interface.go
+++ b/pkg/hostman/guestfs/fsdriver/interface.go
@@ -73,7 +73,7 @@ type IRootFsDriver interface {
 	GetLoginAccount(IDiskPartition, string, bool, bool) (string, error)
 	DeployPublicKey(IDiskPartition, string, *deployapi.SSHKeys) error
 	ChangeUserPasswd(part IDiskPartition, account, gid, publicKey, password string) (string, error)
-	DeployYunionroot(rootFs IDiskPartition, pubkeys *deployapi.SSHKeys, isInit bool, enableCloudInit bool) error
+	DeployYunionroot(rootFs IDiskPartition, pubkeys *deployapi.SSHKeys, enableCloudInit bool) error
 	EnableSerialConsole(IDiskPartition, *jsonutils.JSONDict) error
 	DisableSerialConsole(IDiskPartition) error
 	CommitChanges(IDiskPartition) error

--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -148,9 +148,9 @@ func (l *sLinuxRootFs) DeployPublicKey(rootFs IDiskPartition, selUsr string, pub
 	return DeployAuthorizedKeys(rootFs, usrDir, pubkeys, false)
 }
 
-func (l *sLinuxRootFs) DeployYunionroot(rootFs IDiskPartition, pubkeys *deployapi.SSHKeys, isInit, enableCloudInit bool) error {
+func (l *sLinuxRootFs) DeployYunionroot(rootFs IDiskPartition, pubkeys *deployapi.SSHKeys, enableCloudInit bool) error {
 	l.DisableSelinux(rootFs)
-	if !enableCloudInit && isInit {
+	if !enableCloudInit {
 		l.DisableCloudinit(rootFs)
 	}
 	var yunionroot = YUNIONROOT_USER


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

vmware  重装系统，如果镜像中有cloud-init, 'IsInit' check 会使cloud-init运行，从而覆盖 网卡配置文件，导致ip无效。

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

release/3.2
release/3.1
release/3.0
release/2.13
release/2.12
release/2.11
release/2.10.0

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/area host-deployer
/cc @swordqiu @zexi @wanyaoqi 