### PR TITLE
Automated cherry pick of #6365: fix(host-deployer): Remove 'IsInit' check in DeployYunionroot

### DIFF
--- a/pkg/hostman/guestfs/core.go
+++ b/pkg/hostman/guestfs/core.go
@@ -142,7 +142,7 @@ func DoDeployGuestFs(rootfs fsdriver.IRootFsDriver, guestDesc *deployapi.GuestDe
 		}
 	}
 
-	if err = rootfs.DeployYunionroot(partition, deployInfo.PublicKey, deployInfo.IsInit, deployInfo.EnableCloudInit); err != nil {
+	if err = rootfs.DeployYunionroot(partition, deployInfo.PublicKey, deployInfo.EnableCloudInit); err != nil {
 		return nil, fmt.Errorf("DeployYunionroot: %v", err)
 	}
 	if partition.SupportSerialPorts() {

--- a/pkg/hostman/guestfs/fsdriver/base.go
+++ b/pkg/hostman/guestfs/fsdriver/base.go
@@ -80,7 +80,7 @@ func (d *sGuestRootFsDriver) IsFsCaseInsensitive() bool {
 	return false
 }
 
-func (d *sGuestRootFsDriver) DeployYunionroot(rootfs IDiskPartition, pubkeys *deployapi.SSHKeys, isInit, enableCloudInit bool) error {
+func (d *sGuestRootFsDriver) DeployYunionroot(rootfs IDiskPartition, pubkeys *deployapi.SSHKeys, enableCloudInit bool) error {
 	return nil
 }
 

--- a/pkg/hostman/guestfs/fsdriver/interface.go
+++ b/pkg/hostman/guestfs/fsdriver/interface.go
@@ -73,7 +73,7 @@ type IRootFsDriver interface {
 	GetLoginAccount(IDiskPartition, bool, bool) string
 	DeployPublicKey(IDiskPartition, string, *deployapi.SSHKeys) error
 	ChangeUserPasswd(part IDiskPartition, account, gid, publicKey, password string) (string, error)
-	DeployYunionroot(rootFs IDiskPartition, pubkeys *deployapi.SSHKeys, isInit bool, enableCloudInit bool) error
+	DeployYunionroot(rootFs IDiskPartition, pubkeys *deployapi.SSHKeys, enableCloudInit bool) error
 	EnableSerialConsole(IDiskPartition, *jsonutils.JSONDict) error
 	DisableSerialConsole(IDiskPartition) error
 	CommitChanges(IDiskPartition) error

--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -139,9 +139,9 @@ func (l *sLinuxRootFs) DeployPublicKey(rootFs IDiskPartition, selUsr string, pub
 	return DeployAuthorizedKeys(rootFs, usrDir, pubkeys, false)
 }
 
-func (l *sLinuxRootFs) DeployYunionroot(rootFs IDiskPartition, pubkeys *deployapi.SSHKeys, isInit, enableCloudInit bool) error {
+func (l *sLinuxRootFs) DeployYunionroot(rootFs IDiskPartition, pubkeys *deployapi.SSHKeys, enableCloudInit bool) error {
 	l.DisableSelinux(rootFs)
-	if !enableCloudInit && isInit {
+	if !enableCloudInit {
 		l.DisableCloudinit(rootFs)
 	}
 	var yunionroot = YUNIONROOT_USER


### PR DESCRIPTION
Cherry pick of #6365 on release/2.13.

#6365: fix(host-deployer): Remove 'IsInit' check in DeployYunionroot