### PR TITLE
Fix/esxi

### DIFF
--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1187,6 +1187,9 @@ func (manager *SGuestManager) validateCreateData(
 				rootDiskConfig.SizeMb = sysMinDiskMB
 			}
 		}
+		if len(rootDiskConfig.Driver) == 0 {
+			rootDiskConfig.Driver = osProf.DiskDriver
+		}
 		log.Debugf("ROOT DISK: %#v", rootDiskConfig)
 		input.Disks[0] = rootDiskConfig
 		//data.Set("disk.0", jsonutils.Marshal(rootDiskConfig))

--- a/pkg/hostman/storageman/storage_agent.go
+++ b/pkg/hostman/storageman/storage_agent.go
@@ -286,10 +286,11 @@ func (as *SAgentStorage) AgentDeployGuest(ctx context.Context, data interface{})
 		DiskPath:  rootPath,
 		GuestDesc: &guestDesc,
 		DeployInfo: &deployapi.DeployInfo{
-			PublicKey: &key,
-			Deploys:   deployArray,
-			Password:  passwd,
-			IsInit:    init,
+			PublicKey:               &key,
+			Deploys:                 deployArray,
+			Password:                passwd,
+			IsInit:                  init,
+			WindowsDefaultAdminUser: true,
 		},
 		VddkInfo: &vddkInfo,
 	})

--- a/pkg/hostman/storageman/storage_agent.go
+++ b/pkg/hostman/storageman/storage_agent.go
@@ -151,9 +151,14 @@ func (as *SAgentStorage) agentCreateGuest(ctx context.Context, data *jsonutils.J
 	if err != nil {
 		return errors.Wrapf(err, "%s: fail to unmarshal to esxi.SCreateVMParam", hostutils.ParamsError)
 	}
-	_, err = host.CreateVM2(ctx, ds, createParam)
+	vm, err := host.CreateVM2(ctx, ds, createParam)
 	if err != nil {
 		return errors.Wrap(err, "SHost.CreateVM2")
+	}
+	name, _ := descDict.GetString("name")
+	err = as.tryRenameVm(ctx, vm, name)
+	if err != nil {
+		return errors.Wrapf(err, "RenameVm name '%s'", name)
 	}
 	return nil
 }

--- a/pkg/hostman/storageman/storage_agent.go
+++ b/pkg/hostman/storageman/storage_agent.go
@@ -197,6 +197,7 @@ func (as *SAgentStorage) AgentDeployGuest(ctx context.Context, data interface{})
 		if err != nil {
 			return nil, errors.Wrap(err, "agentRebuildRoot")
 		}
+		init = true
 	}
 
 	var (

--- a/pkg/multicloud/esxi/devtools.go
+++ b/pkg/multicloud/esxi/devtools.go
@@ -125,6 +125,17 @@ func NewCDROMDev(path string, key, ctlKey int32) types.BaseVirtualDevice {
 	return &device
 }
 
+func NewUSBController(key *int32) types.BaseVirtualDevice {
+	device := types.VirtualUSBController{}
+	device.DeviceInfo = &types.Description{
+		Label: "USB controller",
+	}
+	if key != nil {
+		device.Key = *key
+	}
+	return &device
+}
+
 func NewVNICDev(host *SHost, mac, driver string, vlanId int32, key, ctlKey, index int32) (types.BaseVirtualDevice, error) {
 	desc := types.Description{Label: fmt.Sprintf("Network adapter %d", index+1), Summary: "VM Network"}
 

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -692,9 +692,10 @@ func (self *SHost) CreateVM2(ctx context.Context, ds *SDatastore, params SCreate
 func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreateVMParam) (*SVirtualMachine, error) {
 	deviceChange := make([]types.BaseVirtualDeviceConfigSpec, 0, 5)
 
-	// name first
-	if len(params.Name) == 0 {
-		params.Name = params.Uuid
+	// uuid first
+	name := params.Name
+	if len(params.Uuid) != 0 {
+		name = params.Uuid
 	}
 	datastorePath := fmt.Sprintf("[%s] ", ds.GetRelName())
 
@@ -718,7 +719,7 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 	}
 
 	spec := types.VirtualMachineConfigSpec{
-		Name:     params.Name,
+		Name:     name,
 		Version:  version,
 		Uuid:     params.Uuid,
 		GuestId:  guestId,
@@ -862,8 +863,7 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 	return NewVirtualMachine(self.manager, &moVM, self.datacenter), nil
 }
 
-func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SDatastore,
-	params SCreateVMParam) (*SVirtualMachine, error) {
+func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SDatastore, params SCreateVMParam) (*SVirtualMachine, error) {
 	ovm := from.getVmObj()
 
 	deviceChange := make([]types.BaseVirtualDeviceConfigSpec, 0, 5)
@@ -1008,11 +1008,13 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SData
 		Location: relocateSpec,
 	}
 
-	if len(params.Name) == 0 {
-		params.Name = params.Uuid
+	// uuid first
+	name := params.Name
+	if len(params.Uuid) != 0 {
+		name = params.Uuid
 	}
 	spec := types.VirtualMachineConfigSpec{
-		Name:     params.Name,
+		Name:     name,
 		Uuid:     params.Uuid,
 		NumCPUs:  int32(params.Cpu),
 		MemoryMB: int64(params.Mem),

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -802,6 +802,10 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 		deviceChange = append(deviceChange, spec)
 	}
 
+	// add usb to support mouse
+	usbController := addDevSpec(NewUSBController(nil))
+	deviceChange = append(deviceChange, usbController)
+
 	nics := params.Nics
 	for _, nic := range nics {
 		index, _ := nic.Int("index")

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -795,7 +795,8 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 			index = ideIdx % 2
 			ideIdx += 1
 		}
-		log.Debugf("size: %d, image path: %s, uuid: %s, index: %d, ctrlKey: %d", size, imagePath, uuid, index, ctrlKey)
+		log.Debugf("size: %d, image path: %s, uuid: %s, index: %d, ctrlKey: %d, driver: %s.", size, imagePath, uuid,
+			index, ctrlKey, disk.Driver)
 		spec := addDevSpec(NewDiskDev(size, imagePath, uuid, int32(index), 2000, int32(ctrlKey)))
 		spec.FileOperation = "create"
 		deviceChange = append(deviceChange, spec)

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -1326,13 +1326,14 @@ func (host *SHost) findVlanDVPG(vlanId int32) (*SDistributedVirtualPortgroup, er
 			if dvpg.ContainHost(host) {
 				return dvpg, nil
 			}
+			msg := "Find dvpg with correct vlan but it didn't contain this host"
+			log.Debugf(msg)
 			// add host to dvg
-			log.Debugf("Find dvpg with correct vlan but it didn't contain this host")
-			err := dvpg.AddHostToDVS(host)
-			if err != nil {
-				return nil, errors.Wrapf(err, "dvpg %s add host to dvs error", dvpg.GetName())
-			}
-			return dvpg, nil
+			// err := dvpg.AddHostToDVS(host)
+			// if err != nil {
+			//     return nil, errors.Wrapf(err, "dvpg %s add host to dvs error", dvpg.GetName())
+			// }
+			continue
 		}
 	}
 	return nil, nil

--- a/pkg/multicloud/esxi/vdisk.go
+++ b/pkg/multicloud/esxi/vdisk.go
@@ -270,7 +270,10 @@ func (disk *SVirtualDisk) GetDriver() string {
 	controller := disk.vm.getVdev(disk.getControllerKey())
 	name := controller.GetDriver()
 	name = strings.Replace(name, "controller", "", -1)
-	return driverMap[name]
+	if driver, ok := driverMap[name]; ok {
+		return driver
+	}
+	return name
 }
 
 func (disk *SVirtualDisk) GetCacheMode() string {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 重装系统的时候将 IsInit 置为 false，以禁用可能的cloud-init服务。
2. 如果满足 vlan 条件的 DVPG 中没有对应的 host，跳过而不是将 host 加入到 对应的 DVS 中
3. Set default value if rootdisk's driver is empty when creating guest in region.
4. Set 'WindowsDefaultAdminUser' as true when deploy vm. 'WindowsDefaultAdminUser' means that the default admin account is 'Administrator' when deploy windows vm. 
5. Fix GetDriver and add driver log for vdisk.
6. 创建机器时默认增加一个usb设备以支持在vnc访问机器时可以使用鼠标
7. 修复了创建同名机器失败的bug

其中第3条依赖于 [PR](https://github.com/yunionio/pkg/pull/61)
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2
- release/3.1
- release/3.0

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->
/area esxiagent
/cc @wanyaoqi @swordqiu @zexi 