### PR TITLE
Automated cherry pick of #6386: vpcagent: ovn: cmp: generate clean args in a single batch

### DIFF
--- a/pkg/vpcagent/ovn/cmp.go
+++ b/pkg/vpcagent/ovn/cmp.go
@@ -36,7 +36,7 @@ func cmp(db *ovnutil.OVNNorthbound, ocver string, irows ...ovnutil.IRow) (bool, 
 	if len(irowsFound) == len(irows) {
 		return true, nil
 	}
-	args := ovnutil.OvnNbctlArgsDestroy(irowsFound)
-	args = append(args, ovnutil.OvnNbctlArgsDestroy(irowsDiff)...)
+	irowsCleanup := append(irowsFound, irowsDiff...)
+	args := ovnutil.OvnNbctlArgsDestroy(irowsCleanup)
 	return false, args
 }

--- a/pkg/vpcagent/ovnutil/ovn_nbctl.go
+++ b/pkg/vpcagent/ovnutil/ovn_nbctl.go
@@ -151,18 +151,26 @@ func OvnNbctlArgsDestroy(irows []IRow) []string {
 	})
 	var args []string
 	for _, irow := range irows {
+		var newArgs []string
 		switch irow.(type) {
 		case *LogicalSwitchPort:
-			args = append(args, "--", "--if-exists", "lsp-del", irow.OvnUuid())
+			newArgs = []string{"--", "--if-exists", "lsp-del", irow.OvnUuid()}
 		case *LogicalRouterPort:
-			args = append(args, "--", "--if-exists", "lrp-del", irow.OvnUuid())
+			newArgs = []string{"--", "--if-exists", "lrp-del", irow.OvnUuid()}
 		case *LogicalRouterStaticRoute:
 			// find out vpc id/logical router from external_ids
 		default:
 			if !irow.OvnIsRoot() {
 				panic(irow.OvnTableName())
 			}
-			args = append(args, "--", "--if-exists", "destroy", irow.OvnTableName(), irow.OvnUuid())
+			newArgs = []string{"--", "--if-exists", "destroy", irow.OvnTableName(), irow.OvnUuid()}
+		}
+		if len(newArgs) > 0 {
+			if irow.OvnIsRoot() {
+				args = append(args, newArgs...)
+			} else {
+				args = append(newArgs, args...)
+			}
 		}
 	}
 	return args


### PR DESCRIPTION
Cherry pick of #6386 on release/3.2.

#6386: vpcagent: ovn: cmp: generate clean args in a single batch