### PR TITLE
Automated cherry pick of #6394: fix: xxx-agent should generally use scope=system to list resources

### DIFF
--- a/pkg/baremetal/manager.go
+++ b/pkg/baremetal/manager.go
@@ -377,6 +377,7 @@ func (m *SBaremetalManager) fetchIpmiIp(sshCli *ssh.Client) (string, error) {
 func (m *SBaremetalManager) checkNetworkFromIp(ip string) (string, error) {
 	params := jsonutils.NewDict()
 	params.Set("ip", jsonutils.NewString(ip))
+	params.Set("scope", jsonutils.NewString("system"))
 	params.Set("is_on_premise", jsonutils.JSONTrue)
 	res, err := modules.Networks.List(m.GetClientSession(), params)
 	if err != nil {
@@ -403,6 +404,7 @@ func (m *SBaremetalManager) verifyMacAddr(sshCli *ssh.Client) (error, bool) {
 	for _, nic := range nicinfo {
 		if len(nic.Mac) > 0 {
 			params.Set("any_mac", jsonutils.NewString(nic.Mac.String()))
+			params.Set("scope", jsonutils.NewString("system"))
 			res, err := modules.Hosts.List(m.GetClientSession(), params)
 			if err != nil {
 				return fmt.Errorf("Get hosts info failed: %s", err), false
@@ -1038,6 +1040,7 @@ func (b *SBaremetalInstance) getSyslinuxPath(filename string, isTftp bool) strin
 func (b *SBaremetalInstance) findAccessNetwork(accessIp string) (*types.SNetworkConfig, error) {
 	params := jsonutils.NewDict()
 	params.Add(jsonutils.NewString(accessIp), "ip")
+	params.Add(jsonutils.NewString("system"), "scope")
 	params.Add(jsonutils.JSONTrue, "is_on_premise")
 	session := b.manager.GetClientSession()
 	ret, err := modules.Networks.List(session, params)

--- a/pkg/baremetal/pxe/dhcp.go
+++ b/pkg/baremetal/pxe/dhcp.go
@@ -272,6 +272,7 @@ func (req *dhcpRequest) findNetworkConf(session *mcclient.ClientSession, filterU
 		params.Add(jsonutils.JSONTrue, "filter_any")
 	}
 	params.Add(jsonutils.JSONTrue, "is_on_premise")
+	params.Add(jsonutils.NewString("system"), "scope")
 	ret, err := modules.Networks.List(session, params)
 	if err != nil {
 		return nil, err
@@ -299,6 +300,7 @@ func (req *dhcpRequest) findNetworkConf(session *mcclient.ClientSession, filterU
 func (req *dhcpRequest) findBaremetalsByUuid(session *mcclient.ClientSession) (*modulebase.ListResult, error) {
 	params := jsonutils.NewDict()
 	params.Add(jsonutils.NewString(req.ClientGuid), "uuid")
+	params.Add(jsonutils.NewString("system"), "scope")
 	ret, err := modules.Hosts.List(session, params)
 	if err != nil {
 		return nil, err

--- a/pkg/baremetal/tasks/baseprepare.go
+++ b/pkg/baremetal/tasks/baseprepare.go
@@ -559,6 +559,7 @@ type ipmiIPConfig struct {
 func (task *sBaremetalPrepareTask) getIPMIIPConfig(ipAddr string) (*ipmiIPConfig, error) {
 	params := jsonutils.NewDict()
 	params.Add(jsonutils.NewString(ipAddr), "ip")
+	params.Add(jsonutils.NewString("system"), "scope")
 	params.Add(jsonutils.JSONTrue, "is_on_premise")
 	listRet, err := modules.Networks.List(task.getClientSession(), params)
 	if err != nil {

--- a/pkg/baremetal/tasks/bm_register.go
+++ b/pkg/baremetal/tasks/bm_register.go
@@ -185,6 +185,7 @@ func (s *sBaremetalRegisterTask) UpdateBaremetal() (string, error) {
 
 	params := jsonutils.NewDict()
 	params.Set("any_mac", jsonutils.NewString(accessMacAddr.String()))
+	params.Set("scope", jsonutils.NewString("system"))
 	res, err := modules.Hosts.List(s.BmManager.GetClientSession(), params)
 	if err != nil {
 		return "", fmt.Errorf("Fetch baremetal failed %s", err)

--- a/pkg/cloudcommon/agent/agent.go
+++ b/pkg/cloudcommon/agent/agent.go
@@ -202,6 +202,7 @@ func (agent *SBaseAgent) getZoneByIP(session *mcclient.ClientSession) (jsonutils
 	}
 	params.Add(jsonutils.NewString(listenIP.String()), "ip")
 	params.Add(jsonutils.JSONTrue, "is_on_premise")
+	params.Add(jsonutils.NewString("system"), "scope")
 	networks, err := modules.Networks.List(session, params)
 	if err != nil {
 		return nil, err

--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -128,7 +128,7 @@ func (m *SGuestManager) Bootstrap() {
 func (m *SGuestManager) VerifyExistingGuests(pendingDelete bool) {
 	params := jsonutils.NewDict()
 	params.Set("limit", jsonutils.NewInt(0))
-	params.Set("admin", jsonutils.JSONTrue)
+	params.Set("scope", jsonutils.NewString("system"))
 	params.Set("system", jsonutils.JSONTrue)
 	params.Set("host", jsonutils.NewString(m.host.GetHostId()))
 	params.Set("pending_delete", jsonutils.NewBool(pendingDelete))

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -782,6 +782,7 @@ func (h *SHostInfo) fetchAccessNetworkInfo() {
 	params := jsonutils.NewDict()
 	params.Set("ip", jsonutils.NewString(masterIp))
 	params.Set("is_on_premise", jsonutils.JSONTrue)
+	params.Set("scope", jsonutils.NewString("system"))
 	params.Set("limit", jsonutils.NewInt(0))
 	// use default vpc
 	params.Set("vpc", jsonutils.NewString(api.DEFAULT_VPC_ID))
@@ -1106,6 +1107,7 @@ func (h *SHostInfo) uploadNetworkInfo() {
 				kwargs := jsonutils.NewDict()
 				kwargs.Set("ip", jsonutils.NewString(nic.Ip))
 				kwargs.Set("is_on_premise", jsonutils.JSONTrue)
+				kwargs.Set("scope", jsonutils.NewString("system"))
 				kwargs.Set("limit", jsonutils.NewInt(0))
 
 				wireInfo, err := hostutils.GetWireOfIp(context.Background(), kwargs)
@@ -1319,6 +1321,7 @@ func (h *SHostInfo) getIsolatedDevices() {
 	params.Set("details", jsonutils.JSONTrue)
 	params.Set("limit", jsonutils.NewInt(0))
 	params.Set("host", jsonutils.NewString(h.GetHostId()))
+	params.Set("scope", jsonutils.NewString("system"))
 	res, err := modules.IsolatedDevices.List(h.GetSession(), params)
 	if err != nil {
 		h.onFail(fmt.Sprintf("getIsolatedDevices: %v", err))
@@ -1372,7 +1375,7 @@ func (h *SHostInfo) deployAdminAuthorizedKeys() {
 	}
 
 	query := jsonutils.NewDict()
-	query.Add(jsonutils.JSONTrue, "admin")
+	query.Add(jsonutils.NewString("system"), "scope")
 	ret, err := modules.Sshkeypairs.List(h.GetSession(), query)
 	if err != nil {
 		onErr("Get admin sshkey: %v", err)


### PR DESCRIPTION
Cherry pick of #6394 on release/3.2.

#6394: fix: xxx-agent should generally use scope=system to list resources