### PR TITLE
fix: disable delete standard image

### DIFF
--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -694,6 +694,9 @@ func (self *SImage) ValidateDeleteCondition(ctx context.Context) error {
 	if self.IsGuestImage.IsTrue() {
 		return httperrors.NewForbiddenError("image is the part of guest image")
 	}
+	if self.IsStandard.IsTrue() {
+		return httperrors.NewForbiddenError("image is standard")
+	}
 	// if self.IsShared() {
 	// 	return httperrors.NewForbiddenError("image is shared")
 	// }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：禁止删除标准镜像

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area glance

/hold