### PR TITLE
[WIP]Fix/esxi rebuild

### DIFF
--- a/cmd/climc/shell/identity/policies.go
+++ b/cmd/climc/shell/identity/policies.go
@@ -15,6 +15,7 @@
 package identity
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -363,7 +364,7 @@ func init() {
 			token = s.GetToken()
 		}
 
-		result, err := policy.PolicyManager.ExplainRpc(token, req, args.Name)
+		result, err := policy.ExplainRpc(context.Background(), token, req, args.Name)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -130,7 +130,7 @@ require (
 	yunion.io/x/jsonutils v0.0.0-20200415132054-2bf8a5e94501
 	yunion.io/x/log v0.0.0-20200313080802-57a4ce5966b3
 	yunion.io/x/ovsdb v0.0.0-20200512112253-a3601d1ee987
-	yunion.io/x/pkg v0.0.0-20200416145704-22c189971435
+	yunion.io/x/pkg v0.0.0-20200516092703-0a53bc9270aa
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 	yunion.io/x/sqlchemy v0.0.0-20200312002602-1177cd8fbc57
 	yunion.io/x/structarg v0.0.0-20200423163001-168d0687be7e

--- a/go.sum
+++ b/go.sum
@@ -1115,10 +1115,6 @@ yunion.io/x/log v0.0.0-20190629062853-9f6483a7103d h1:59zrDL7Ft+hDukguJRmLr/Gdu/
 yunion.io/x/log v0.0.0-20190629062853-9f6483a7103d/go.mod h1:LC6f/4FozL0iaAbnFt2eDX9jlsyo3WiOUPm03d7+U4U=
 yunion.io/x/log v0.0.0-20200313080802-57a4ce5966b3 h1:5Wc5hkB8PtMudmHuzCyok960RuOa9I55imIGrigSdjs=
 yunion.io/x/log v0.0.0-20200313080802-57a4ce5966b3/go.mod h1:LC6f/4FozL0iaAbnFt2eDX9jlsyo3WiOUPm03d7+U4U=
-yunion.io/x/ovsdb v0.0.0-20200508121407-498ee891147e h1:M6sOv52s2wqXECm9w9eMHfEnxvSAfPsVwVmyD4yKbiI=
-yunion.io/x/ovsdb v0.0.0-20200508121407-498ee891147e/go.mod h1:0vLkNEhlmA64HViPBAnSTUMrx5QP1CLsxXmxDKQ80tc=
-yunion.io/x/ovsdb v0.0.0-20200508142751-3e60f3fc7d18 h1:MTR7IYAR5oxAjmBIcnk8A6PIjHz7gLN69jUgnkgYgQ8=
-yunion.io/x/ovsdb v0.0.0-20200508142751-3e60f3fc7d18/go.mod h1:0vLkNEhlmA64HViPBAnSTUMrx5QP1CLsxXmxDKQ80tc=
 yunion.io/x/ovsdb v0.0.0-20200512112253-a3601d1ee987 h1:BlHpXbNhqG1rZ57io0+XI4L9ckWunn7LHR2JQikGqQg=
 yunion.io/x/ovsdb v0.0.0-20200512112253-a3601d1ee987/go.mod h1:0vLkNEhlmA64HViPBAnSTUMrx5QP1CLsxXmxDKQ80tc=
 yunion.io/x/pkg v0.0.0-20190620104149-945c25821dbf/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
@@ -1126,6 +1122,8 @@ yunion.io/x/pkg v0.0.0-20190628082551-f4033ba2ea30/go.mod h1:t6rEGG2sQ4J7DhFxSZV
 yunion.io/x/pkg v0.0.0-20200302034534-fdf44d54b070/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/pkg v0.0.0-20200416145704-22c189971435 h1:Fwf1rjdl+Qmw9BNxQN7wi2lQpYVExV7eBLifd0emHaI=
 yunion.io/x/pkg v0.0.0-20200416145704-22c189971435/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
+yunion.io/x/pkg v0.0.0-20200516092703-0a53bc9270aa h1:VizPfW8+mLFEE7W/97zxQJbfdxchi2dn1M/Y7YBwTTc=
+yunion.io/x/pkg v0.0.0-20200516092703-0a53bc9270aa/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8J50Cise/HCylsOJngmo=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e/go.mod h1:0iFKpOs1y4lbCxeOmq3Xx/0AcQoewVPwj62eRluioEo=
 yunion.io/x/sqlchemy v0.0.0-20200312002602-1177cd8fbc57 h1:KtQAuLJ00RSUVqkiRmJ1DiDABiw0U3xxXnzD3lGavaY=

--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -929,7 +929,7 @@ func (h *AuthHandlers) getPermissionDetails(ctx context.Context, w http.Response
 	if query != nil {
 		name, _ = query.GetString("policy")
 	}
-	result, err := policy.PolicyManager.ExplainRpc(t, body, name)
+	result, err := policy.ExplainRpc(ctx, t, body, name)
 	if err != nil {
 		httperrors.GeneralServerError(w, err)
 		return

--- a/pkg/apis/image/guestimage.go
+++ b/pkg/apis/image/guestimage.go
@@ -26,7 +26,7 @@ type GuestImageDetails struct {
 	apis.SharableVirtualResourceDetails
 	SGuestImage
 
-	ImageIds jsonutils.JSONObject `json:"image_ids"`
+	ImageIds []string `json:"image_ids"`
 
 	//Status     string               `json:"status"`
 	Size       int64          `json:"size"`

--- a/pkg/apis/image/image.go
+++ b/pkg/apis/image/image.go
@@ -61,3 +61,27 @@ type ImageDetails struct {
 	DisableDelete bool `json:"disable_delete"`
 	//OssChecksum   string    `json:"oss_checksum"`
 }
+
+type ImageCreateInput struct {
+	apis.SharableVirtualResourceCreateInput
+
+	// 镜像大小, 单位Byte
+	Size *int64 `json:"size"`
+	// 镜像格式
+	DiskFormat string `json:"disk_format"`
+	// 最小系统盘要求
+	MinDiskMB *int32 `json:"min_disk"`
+	// 最小内存要求
+	MinRamMB *int32 `json:"min_ram"`
+	// 是否有删除保护
+	Protected *bool `json:"protected"`
+	// 是否是标准镜像
+	IsStandard *bool `json:"is_standard"`
+	// 是否是主机镜像
+	IsGuestImage *bool `json:"is_guest_image"`
+	// 是否是数据盘镜像
+	IsData *bool `json:"is_data"`
+
+	// 镜像属性
+	Properties map[string]string `json:"properties"`
+}

--- a/pkg/baremetal/manager.go
+++ b/pkg/baremetal/manager.go
@@ -377,6 +377,7 @@ func (m *SBaremetalManager) fetchIpmiIp(sshCli *ssh.Client) (string, error) {
 func (m *SBaremetalManager) checkNetworkFromIp(ip string) (string, error) {
 	params := jsonutils.NewDict()
 	params.Set("ip", jsonutils.NewString(ip))
+	params.Set("scope", jsonutils.NewString("system"))
 	params.Set("is_on_premise", jsonutils.JSONTrue)
 	res, err := modules.Networks.List(m.GetClientSession(), params)
 	if err != nil {
@@ -403,6 +404,7 @@ func (m *SBaremetalManager) verifyMacAddr(sshCli *ssh.Client) (error, bool) {
 	for _, nic := range nicinfo {
 		if len(nic.Mac) > 0 {
 			params.Set("any_mac", jsonutils.NewString(nic.Mac.String()))
+			params.Set("scope", jsonutils.NewString("system"))
 			res, err := modules.Hosts.List(m.GetClientSession(), params)
 			if err != nil {
 				return fmt.Errorf("Get hosts info failed: %s", err), false
@@ -1038,6 +1040,7 @@ func (b *SBaremetalInstance) getSyslinuxPath(filename string, isTftp bool) strin
 func (b *SBaremetalInstance) findAccessNetwork(accessIp string) (*types.SNetworkConfig, error) {
 	params := jsonutils.NewDict()
 	params.Add(jsonutils.NewString(accessIp), "ip")
+	params.Add(jsonutils.NewString("system"), "scope")
 	params.Add(jsonutils.JSONTrue, "is_on_premise")
 	session := b.manager.GetClientSession()
 	ret, err := modules.Networks.List(session, params)

--- a/pkg/baremetal/pxe/dhcp.go
+++ b/pkg/baremetal/pxe/dhcp.go
@@ -272,6 +272,7 @@ func (req *dhcpRequest) findNetworkConf(session *mcclient.ClientSession, filterU
 		params.Add(jsonutils.JSONTrue, "filter_any")
 	}
 	params.Add(jsonutils.JSONTrue, "is_on_premise")
+	params.Add(jsonutils.NewString("system"), "scope")
 	ret, err := modules.Networks.List(session, params)
 	if err != nil {
 		return nil, err
@@ -299,6 +300,7 @@ func (req *dhcpRequest) findNetworkConf(session *mcclient.ClientSession, filterU
 func (req *dhcpRequest) findBaremetalsByUuid(session *mcclient.ClientSession) (*modulebase.ListResult, error) {
 	params := jsonutils.NewDict()
 	params.Add(jsonutils.NewString(req.ClientGuid), "uuid")
+	params.Add(jsonutils.NewString("system"), "scope")
 	ret, err := modules.Hosts.List(session, params)
 	if err != nil {
 		return nil, err

--- a/pkg/baremetal/tasks/baseprepare.go
+++ b/pkg/baremetal/tasks/baseprepare.go
@@ -559,6 +559,7 @@ type ipmiIPConfig struct {
 func (task *sBaremetalPrepareTask) getIPMIIPConfig(ipAddr string) (*ipmiIPConfig, error) {
 	params := jsonutils.NewDict()
 	params.Add(jsonutils.NewString(ipAddr), "ip")
+	params.Add(jsonutils.NewString("system"), "scope")
 	params.Add(jsonutils.JSONTrue, "is_on_premise")
 	listRet, err := modules.Networks.List(task.getClientSession(), params)
 	if err != nil {

--- a/pkg/baremetal/tasks/bm_register.go
+++ b/pkg/baremetal/tasks/bm_register.go
@@ -185,6 +185,7 @@ func (s *sBaremetalRegisterTask) UpdateBaremetal() (string, error) {
 
 	params := jsonutils.NewDict()
 	params.Set("any_mac", jsonutils.NewString(accessMacAddr.String()))
+	params.Set("scope", jsonutils.NewString("system"))
 	res, err := modules.Hosts.List(s.BmManager.GetClientSession(), params)
 	if err != nil {
 		return "", fmt.Errorf("Fetch baremetal failed %s", err)

--- a/pkg/cloudcommon/agent/agent.go
+++ b/pkg/cloudcommon/agent/agent.go
@@ -202,6 +202,7 @@ func (agent *SBaseAgent) getZoneByIP(session *mcclient.ClientSession) (jsonutils
 	}
 	params.Add(jsonutils.NewString(listenIP.String()), "ip")
 	params.Add(jsonutils.JSONTrue, "is_on_premise")
+	params.Add(jsonutils.NewString("system"), "scope")
 	networks, err := modules.Networks.List(session, params)
 	if err != nil {
 		return nil, err

--- a/pkg/cloudcommon/db/sharablebase.go
+++ b/pkg/cloudcommon/db/sharablebase.go
@@ -153,9 +153,6 @@ func SharableManagerValidateCreateData(
 	query jsonutils.JSONObject,
 	input apis.SharableResourceBaseCreateInput,
 ) (apis.SharableResourceBaseCreateInput, error) {
-	if len(input.PublicScope) == 0 {
-		return input, nil
-	}
 	resScope := manager.ResourceScope()
 	reqScope := resScope
 	isPublic := true
@@ -167,10 +164,10 @@ func SharableManagerValidateCreateData(
 		} else if input.PublicScope == string(rbacutils.ScopeDomain) {
 			input.IsPublic = &isPublic
 			reqScope = rbacutils.ScopeDomain
-		} else if input.IsPublic != nil && *input.IsPublic {
-			// return input, errors.Wrap(httperrors.ErrNotSupported, "project level resource can be shared to domain or system ONLY")
-			input.IsPublic = nil
-			input.PublicScope = string(rbacutils.ScopeNone)
+		} else if input.IsPublic != nil && *input.IsPublic && len(input.PublicScope) == 0 {
+			// backward compatible, if only is_public is true, make it share to system
+			input.IsPublic = &isPublic
+			input.PublicScope = string(rbacutils.ScopeSystem)
 		} else {
 			input.IsPublic = nil
 			input.PublicScope = string(rbacutils.ScopeNone)
@@ -179,10 +176,10 @@ func SharableManagerValidateCreateData(
 		if input.PublicScope == string(rbacutils.ScopeSystem) {
 			input.IsPublic = &isPublic
 			reqScope = rbacutils.ScopeSystem
-		} else if input.IsPublic != nil && *input.IsPublic {
-			// return input, errors.Wrap(httperrors.ErrNotSupported, "domain level resource can be shared to system ONLY")
-			input.IsPublic = nil
-			input.PublicScope = string(rbacutils.ScopeNone)
+		} else if input.IsPublic != nil && *input.IsPublic && len(input.PublicScope) == 0 {
+			// backward compatible, if only is_public is true, make it share to system
+			input.IsPublic = &isPublic
+			input.PublicScope = string(rbacutils.ScopeSystem)
 		} else {
 			input.IsPublic = nil
 			input.PublicScope = string(rbacutils.ScopeNone)

--- a/pkg/cloudprovider/instance.go
+++ b/pkg/cloudprovider/instance.go
@@ -37,6 +37,8 @@ const (
 	CLOUD_SHELL                 = "cloud-shell"
 	CLOUD_SHELL_WITHOUT_ENCRYPT = "cloud-shell-without-encrypt"
 	CLOUD_CONFIG                = "cloud-config"
+	CLOUD_POWER_SHELL           = "powershell"
+	CLOUD_EC2                   = "ec2"
 )
 
 type SManagedVMCreateConfig struct {

--- a/pkg/cloudprovider/resources.go
+++ b/pkg/cloudprovider/resources.go
@@ -757,7 +757,9 @@ type ICloudDBInstance interface {
 
 	GetConnectionStr() string
 	GetInternalConnectionStr() string
-	GetIZoneId() string
+	GetZone1Id() string
+	GetZone2Id() string
+	GetZone3Id() string
 	GetIVpcId() string
 
 	GetDBNetwork() (*SDBInstanceNetwork, error)

--- a/pkg/compute/guestdrivers/aws.go
+++ b/pkg/compute/guestdrivers/aws.go
@@ -78,6 +78,14 @@ func (self *SAwsGuestDriver) IsNeedInjectPasswordByCloudInit(desc *cloudprovider
 	return true
 }
 
+func (self *SAwsGuestDriver) IsWindowsUserDataTypeNeedEncode() bool {
+	return true
+}
+
+func (self *SAwsGuestDriver) GetWindowsUserDataType() string {
+	return cloudprovider.CLOUD_EC2
+}
+
 func (self *SAwsGuestDriver) GetLinuxDefaultAccount(desc cloudprovider.SManagedVMCreateConfig) string {
 	// return fetchAwsUserName(desc)
 	if desc.OsType == "Windows" {

--- a/pkg/compute/guestdrivers/base.go
+++ b/pkg/compute/guestdrivers/base.go
@@ -298,6 +298,14 @@ func (self *SBaseGuestDriver) IsNeedInjectPasswordByCloudInit(desc *cloudprovide
 	return false
 }
 
+func (self *SBaseGuestDriver) GetWindowsUserDataType() string {
+	return cloudprovider.CLOUD_POWER_SHELL
+}
+
+func (self *SBaseGuestDriver) IsWindowsUserDataTypeNeedEncode() bool {
+	return false
+}
+
 func (self *SBaseGuestDriver) GetUserDataType() string {
 	return cloudprovider.CLOUD_CONFIG
 }

--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -16,6 +16,7 @@ package guestdrivers
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"math"
 	"strings"
@@ -347,7 +348,15 @@ func (self *SManagedVirtualizedGuestDriver) RequestDeployGuestOnHost(ctx context
 			desc.UserData = oUserData.UserDataBase64()
 		}
 		if strings.ToLower(desc.OsType) == strings.ToLower(osprofile.OS_TYPE_WINDOWS) {
-			desc.UserData = oUserData.UserDataPowerShell()
+			switch guest.GetDriver().GetWindowsUserDataType() {
+			case cloudprovider.CLOUD_EC2:
+				desc.UserData = oUserData.UserDataEc2()
+			default:
+				desc.UserData = oUserData.UserDataPowerShell()
+			}
+			if guest.GetDriver().IsWindowsUserDataTypeNeedEncode() {
+				desc.UserData = base64.StdEncoding.EncodeToString([]byte(desc.UserData))
+			}
 		}
 	}
 

--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -883,7 +883,7 @@ func (self *SCloudaccount) importSubAccount(ctx context.Context, userCred mcclie
 				ownerId = userCred
 			} else {
 				// find default project of domain
-				t, err := db.TenantCacheManager.FindFirstProjectOfDomain(ownerId.GetProjectDomainId())
+				t, err := db.TenantCacheManager.FindFirstProjectOfDomain(ctx, ownerId.GetProjectDomainId())
 				if err != nil {
 					log.Errorf("cannot find a valid porject for domain %s", ownerId.GetProjectDomainId())
 					return nil, err

--- a/pkg/compute/models/dbinstanceresource.go
+++ b/pkg/compute/models/dbinstanceresource.go
@@ -95,7 +95,7 @@ func (manager *SDBInstanceResourceBaseManager) FetchCustomizeColumns(
 	rows := make([]api.DBInstanceResourceInfo, len(objs))
 	dbinstanceIds := make([]string, len(objs))
 	for i := range objs {
-		var base *SDBInstanceDatabase
+		var base *SDBInstanceResourceBase
 		reflectutils.FindAnonymouStructPointer(objs[i], &base)
 		if base != nil {
 			dbinstanceIds[i] = base.DBInstanceId

--- a/pkg/compute/models/guestdrivers.go
+++ b/pkg/compute/models/guestdrivers.go
@@ -178,6 +178,8 @@ type IGuestDriver interface {
 
 	IsNeedInjectPasswordByCloudInit(desc *cloudprovider.SManagedVMCreateConfig) bool
 	GetUserDataType() string
+	GetWindowsUserDataType() string
+	IsWindowsUserDataTypeNeedEncode() bool
 	CancelExpireTime(ctx context.Context, userCred mcclient.TokenCredential, guest *SGuest) error
 
 	IsSupportCdrom(guest *SGuest) (bool, error)

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1187,6 +1187,9 @@ func (manager *SGuestManager) validateCreateData(
 				rootDiskConfig.SizeMb = sysMinDiskMB
 			}
 		}
+		if len(rootDiskConfig.Driver) == 0 {
+			rootDiskConfig.Driver = osProf.DiskDriver
+		}
 		log.Debugf("ROOT DISK: %#v", rootDiskConfig)
 		input.Disks[0] = rootDiskConfig
 		//data.Set("disk.0", jsonutils.Marshal(rootDiskConfig))

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -3954,10 +3954,16 @@ func (self *SHost) EnableNetif(ctx context.Context, userCred mcclient.TokenCrede
 			}
 			net, err = wire.GetCandidatePrivateNetwork(userCred, NetworkManager.AllowScope(userCred), false, netTypes)
 			if err != nil {
-				return fmt.Errorf("fail to find network %s", err)
+				return fmt.Errorf("fail to find private network %s", err)
 			}
 			if net == nil {
-				return fmt.Errorf("No network found")
+				net, err = wire.GetCandidatePublicNetwork(userCred, NetworkManager.AllowScope(userCred), false, netTypes)
+				if err != nil {
+					return fmt.Errorf("fail to find public network %s", err)
+				}
+				if net == nil {
+					return fmt.Errorf("No network found")
+				}
 			}
 		}
 	} else if net.WireId != wire.Id {

--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -1665,37 +1665,7 @@ func (self *SManagedVirtualizationRegionDriver) RequestCreateDBInstance(ctx cont
 			log.Errorf("timeout for waiting dbinstance running error: %v", err)
 		}
 
-		dbinstance.ZoneId = idbinstance.GetIZoneId()
-		err = dbinstance.SetZoneInfo(ctx, userCred)
-		if err != nil {
-			log.Errorf("failed to set dbinstance %s(%s) zoneInfo from cloud dbinstance: %v", dbinstance.Name, dbinstance.Id, err)
-		}
-
-		_, err = db.Update(dbinstance, func() error {
-			dbinstance.Engine = idbinstance.GetEngine()
-			dbinstance.EngineVersion = idbinstance.GetEngineVersion()
-			dbinstance.StorageType = idbinstance.GetStorageType()
-			dbinstance.DiskSizeGB = idbinstance.GetDiskSizeGB()
-			dbinstance.Category = idbinstance.GetCategory()
-			dbinstance.VcpuCount = idbinstance.GetVcpuCount()
-			dbinstance.VmemSizeMb = idbinstance.GetVmemSizeMB()
-			dbinstance.InstanceType = idbinstance.GetInstanceType()
-			dbinstance.ConnectionStr = idbinstance.GetConnectionStr()
-			dbinstance.InternalConnectionStr = idbinstance.GetInternalConnectionStr()
-			dbinstance.MaintainTime = idbinstance.GetMaintainTime()
-			dbinstance.Port = idbinstance.GetPort()
-
-			if createdAt := idbinstance.GetCreatedAt(); !createdAt.IsZero() {
-				dbinstance.CreatedAt = idbinstance.GetCreatedAt()
-			}
-			if expiredAt := idbinstance.GetExpiredAt(); !expiredAt.IsZero() {
-				dbinstance.ExpiredAt = expiredAt
-			}
-			return nil
-		})
-		if err != nil {
-			log.Errorf("failed to update dbinstance conf: %v", err)
-		}
+		dbinstance.SyncWithCloudDBInstance(ctx, userCred, dbinstance.GetCloudprovider(), idbinstance)
 
 		network, err := idbinstance.GetDBNetwork()
 		if err != nil {

--- a/pkg/hostman/guestfs/core.go
+++ b/pkg/hostman/guestfs/core.go
@@ -146,7 +146,7 @@ func DoDeployGuestFs(rootfs fsdriver.IRootFsDriver, guestDesc *deployapi.GuestDe
 		}
 	}
 
-	if err = rootfs.DeployYunionroot(partition, deployInfo.PublicKey, deployInfo.IsInit, deployInfo.EnableCloudInit); err != nil {
+	if err = rootfs.DeployYunionroot(partition, deployInfo.PublicKey, deployInfo.EnableCloudInit); err != nil {
 		return nil, fmt.Errorf("DeployYunionroot: %v", err)
 	}
 	if partition.SupportSerialPorts() {

--- a/pkg/hostman/guestfs/fsdriver/base.go
+++ b/pkg/hostman/guestfs/fsdriver/base.go
@@ -80,7 +80,7 @@ func (d *sGuestRootFsDriver) IsFsCaseInsensitive() bool {
 	return false
 }
 
-func (d *sGuestRootFsDriver) DeployYunionroot(rootfs IDiskPartition, pubkeys *deployapi.SSHKeys, isInit, enableCloudInit bool) error {
+func (d *sGuestRootFsDriver) DeployYunionroot(rootfs IDiskPartition, pubkeys *deployapi.SSHKeys, enableCloudInit bool) error {
 	return nil
 }
 

--- a/pkg/hostman/guestfs/fsdriver/interface.go
+++ b/pkg/hostman/guestfs/fsdriver/interface.go
@@ -73,7 +73,7 @@ type IRootFsDriver interface {
 	GetLoginAccount(IDiskPartition, string, bool, bool) (string, error)
 	DeployPublicKey(IDiskPartition, string, *deployapi.SSHKeys) error
 	ChangeUserPasswd(part IDiskPartition, account, gid, publicKey, password string) (string, error)
-	DeployYunionroot(rootFs IDiskPartition, pubkeys *deployapi.SSHKeys, isInit bool, enableCloudInit bool) error
+	DeployYunionroot(rootFs IDiskPartition, pubkeys *deployapi.SSHKeys, enableCloudInit bool) error
 	EnableSerialConsole(IDiskPartition, *jsonutils.JSONDict) error
 	DisableSerialConsole(IDiskPartition) error
 	CommitChanges(IDiskPartition) error

--- a/pkg/hostman/guestfs/fsdriver/linux.go
+++ b/pkg/hostman/guestfs/fsdriver/linux.go
@@ -148,9 +148,9 @@ func (l *sLinuxRootFs) DeployPublicKey(rootFs IDiskPartition, selUsr string, pub
 	return DeployAuthorizedKeys(rootFs, usrDir, pubkeys, false)
 }
 
-func (l *sLinuxRootFs) DeployYunionroot(rootFs IDiskPartition, pubkeys *deployapi.SSHKeys, isInit, enableCloudInit bool) error {
+func (l *sLinuxRootFs) DeployYunionroot(rootFs IDiskPartition, pubkeys *deployapi.SSHKeys, enableCloudInit bool) error {
 	l.DisableSelinux(rootFs)
-	if !enableCloudInit && isInit {
+	if !enableCloudInit {
 		l.DisableCloudinit(rootFs)
 	}
 	var yunionroot = YUNIONROOT_USER

--- a/pkg/hostman/guestman/guestman.go
+++ b/pkg/hostman/guestman/guestman.go
@@ -128,7 +128,7 @@ func (m *SGuestManager) Bootstrap() {
 func (m *SGuestManager) VerifyExistingGuests(pendingDelete bool) {
 	params := jsonutils.NewDict()
 	params.Set("limit", jsonutils.NewInt(0))
-	params.Set("admin", jsonutils.JSONTrue)
+	params.Set("scope", jsonutils.NewString("system"))
 	params.Set("system", jsonutils.JSONTrue)
 	params.Set("host", jsonutils.NewString(m.host.GetHostId()))
 	params.Set("pending_delete", jsonutils.NewBool(pendingDelete))

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -782,6 +782,7 @@ func (h *SHostInfo) fetchAccessNetworkInfo() {
 	params := jsonutils.NewDict()
 	params.Set("ip", jsonutils.NewString(masterIp))
 	params.Set("is_on_premise", jsonutils.JSONTrue)
+	params.Set("scope", jsonutils.NewString("system"))
 	params.Set("limit", jsonutils.NewInt(0))
 	// use default vpc
 	params.Set("vpc", jsonutils.NewString(api.DEFAULT_VPC_ID))
@@ -1106,6 +1107,7 @@ func (h *SHostInfo) uploadNetworkInfo() {
 				kwargs := jsonutils.NewDict()
 				kwargs.Set("ip", jsonutils.NewString(nic.Ip))
 				kwargs.Set("is_on_premise", jsonutils.JSONTrue)
+				kwargs.Set("scope", jsonutils.NewString("system"))
 				kwargs.Set("limit", jsonutils.NewInt(0))
 
 				wireInfo, err := hostutils.GetWireOfIp(context.Background(), kwargs)
@@ -1319,6 +1321,7 @@ func (h *SHostInfo) getIsolatedDevices() {
 	params.Set("details", jsonutils.JSONTrue)
 	params.Set("limit", jsonutils.NewInt(0))
 	params.Set("host", jsonutils.NewString(h.GetHostId()))
+	params.Set("scope", jsonutils.NewString("system"))
 	res, err := modules.IsolatedDevices.List(h.GetSession(), params)
 	if err != nil {
 		h.onFail(fmt.Sprintf("getIsolatedDevices: %v", err))
@@ -1372,7 +1375,7 @@ func (h *SHostInfo) deployAdminAuthorizedKeys() {
 	}
 
 	query := jsonutils.NewDict()
-	query.Add(jsonutils.JSONTrue, "admin")
+	query.Add(jsonutils.NewString("system"), "scope")
 	ret, err := modules.Sshkeypairs.List(h.GetSession(), query)
 	if err != nil {
 		onErr("Get admin sshkey: %v", err)

--- a/pkg/hostman/storageman/storage_agent.go
+++ b/pkg/hostman/storageman/storage_agent.go
@@ -286,10 +286,11 @@ func (as *SAgentStorage) AgentDeployGuest(ctx context.Context, data interface{})
 		DiskPath:  rootPath,
 		GuestDesc: &guestDesc,
 		DeployInfo: &deployapi.DeployInfo{
-			PublicKey: &key,
-			Deploys:   deployArray,
-			Password:  passwd,
-			IsInit:    init,
+			PublicKey:               &key,
+			Deploys:                 deployArray,
+			Password:                passwd,
+			IsInit:                  init,
+			WindowsDefaultAdminUser: true,
 		},
 		VddkInfo: &vddkInfo,
 	})

--- a/pkg/hostman/storageman/storage_agent.go
+++ b/pkg/hostman/storageman/storage_agent.go
@@ -151,9 +151,14 @@ func (as *SAgentStorage) agentCreateGuest(ctx context.Context, data *jsonutils.J
 	if err != nil {
 		return errors.Wrapf(err, "%s: fail to unmarshal to esxi.SCreateVMParam", hostutils.ParamsError)
 	}
-	_, err = host.CreateVM2(ctx, ds, createParam)
+	vm, err := host.CreateVM2(ctx, ds, createParam)
 	if err != nil {
 		return errors.Wrap(err, "SHost.CreateVM2")
+	}
+	name, _ := descDict.GetString("name")
+	err = as.tryRenameVm(ctx, vm, name)
+	if err != nil {
+		return errors.Wrapf(err, "RenameVm name '%s'", name)
 	}
 	return nil
 }

--- a/pkg/hostman/storageman/storage_agent.go
+++ b/pkg/hostman/storageman/storage_agent.go
@@ -197,6 +197,7 @@ func (as *SAgentStorage) AgentDeployGuest(ctx context.Context, data interface{})
 		if err != nil {
 			return nil, errors.Wrap(err, "agentRebuildRoot")
 		}
+		init = true
 	}
 
 	var (

--- a/pkg/hostman/storageman/storage_agent.go
+++ b/pkg/hostman/storageman/storage_agent.go
@@ -191,6 +191,7 @@ func (as *SAgentStorage) AgentDeployGuest(ctx context.Context, data interface{})
 	init := false
 	dataDict := data.(*jsonutils.JSONDict)
 	action, _ := dataDict.GetString("action")
+	log.Debugf("data: %s", dataDict.String())
 	if action == "create" {
 		err := as.agentCreateGuest(ctx, dataDict)
 		if err != nil {

--- a/pkg/image/models/image_guest_joint.go
+++ b/pkg/image/models/image_guest_joint.go
@@ -52,7 +52,7 @@ func init() {
 }
 
 func (gm *SGuestImageJointManager) GetByGuestImageId(guestImageId string) ([]SGuestImageJoint, error) {
-	q := gm.Query().Equals("guest_image_id", guestImageId)
+	q := gm.Query().Equals("guest_image_id", guestImageId).Asc("row_id") // order by row_id ascending
 	ret := make([]SGuestImageJoint, 0, 1)
 	err := db.FetchModelObjects(gm, q, &ret)
 	if err != nil {

--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -694,6 +694,9 @@ func (self *SImage) ValidateDeleteCondition(ctx context.Context) error {
 	if self.IsGuestImage.IsTrue() {
 		return httperrors.NewForbiddenError("image is the part of guest image")
 	}
+	if self.IsStandard.IsTrue() {
+		return httperrors.NewForbiddenError("image is standard")
+	}
 	// if self.IsShared() {
 	// 	return httperrors.NewForbiddenError("image is shared")
 	// }

--- a/pkg/keystone/tokens/verify.go
+++ b/pkg/keystone/tokens/verify.go
@@ -15,13 +15,15 @@
 package tokens
 
 import (
+	"context"
+
 	"yunion.io/x/log"
 
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 
-func FernetTokenVerifier(tokenStr string) (mcclient.TokenCredential, error) {
+func FernetTokenVerifier(ctx context.Context, tokenStr string) (mcclient.TokenCredential, error) {
 	token := SAuthToken{}
 	err := token.ParseFernetToken(tokenStr)
 	if err != nil {

--- a/pkg/mcclient/auth/auth.go
+++ b/pkg/mcclient/auth/auth.go
@@ -112,7 +112,7 @@ func (c *TokenCacheVerify) DeleteToken(token string) bool {
 	return c.Delete(token)
 }
 
-func (c *TokenCacheVerify) Verify(cli *mcclient.Client, adminToken, token string) (mcclient.TokenCredential, error) {
+func (c *TokenCacheVerify) Verify(ctx context.Context, cli *mcclient.Client, adminToken, token string) (mcclient.TokenCredential, error) {
 	cred, found := c.GetToken(token)
 	if found {
 		if cred.IsValid() {
@@ -132,7 +132,7 @@ func (c *TokenCacheVerify) Verify(cli *mcclient.Client, adminToken, token string
 	if err != nil {
 		return nil, fmt.Errorf("Add %s credential to cache: %#v", cred.GetTokenString(), err)
 	}
-	callbackAuthhooks(cred)
+	callbackAuthhooks(ctx, cred)
 	// log.Debugf("Add token: %s", cred)
 	return cred, nil
 }
@@ -165,11 +165,11 @@ func (a *authManager) verifyRequest(req http.Request, virtualHost bool) (mcclien
 	return cred, nil
 }
 
-func (a *authManager) verify(token string) (mcclient.TokenCredential, error) {
+func (a *authManager) verify(ctx context.Context, token string) (mcclient.TokenCredential, error) {
 	if a.adminCredential == nil {
 		return nil, fmt.Errorf("No valid admin token credential")
 	}
-	cred, err := a.tokenCacheVerify.Verify(a.client, a.adminCredential.GetTokenString(), token)
+	cred, err := a.tokenCacheVerify.Verify(ctx, a.client, a.adminCredential.GetTokenString(), token)
 	if err != nil {
 		return nil, err
 	}
@@ -258,8 +258,8 @@ func GetCatalogData(serviceTypes []string, region string) jsonutils.JSONObject {
 	return manager.adminCredential.GetCatalogData(serviceTypes, region)
 }
 
-func Verify(tokenId string) (mcclient.TokenCredential, error) {
-	return manager.verify(tokenId)
+func Verify(ctx context.Context, tokenId string) (mcclient.TokenCredential, error) {
+	return manager.verify(ctx, tokenId)
 }
 
 func VerifyRequest(req http.Request, virtualHost bool) (mcclient.TokenCredential, error) {

--- a/pkg/mcclient/auth/authhook.go
+++ b/pkg/mcclient/auth/authhook.go
@@ -14,9 +14,13 @@
 
 package auth
 
-import "yunion.io/x/onecloud/pkg/mcclient"
+import (
+	"context"
 
-type TAuthHook func(userCred mcclient.TokenCredential)
+	"yunion.io/x/onecloud/pkg/mcclient"
+)
+
+type TAuthHook func(ctx context.Context, userCred mcclient.TokenCredential)
 
 var (
 	authHooks = make([]TAuthHook, 0)
@@ -26,8 +30,8 @@ func RegisterAuthHook(hook TAuthHook) {
 	authHooks = append(authHooks, hook)
 }
 
-func callbackAuthhooks(userCred mcclient.TokenCredential) {
+func callbackAuthhooks(ctx context.Context, userCred mcclient.TokenCredential) {
 	for i := range authHooks {
-		authHooks[i](userCred)
+		authHooks[i](ctx, userCred)
 	}
 }

--- a/pkg/mcclient/auth/middleware.go
+++ b/pkg/mcclient/auth/middleware.go
@@ -58,7 +58,7 @@ func AuthenticateWithDelayDecision(f appsrv.FilterHandler, delayDecision bool) a
 			token = &GuestToken
 		} else {
 			var err error
-			token, err = DefaultTokenVerifier(tokenStr)
+			token, err = DefaultTokenVerifier(ctx, tokenStr)
 			if err != nil {
 				log.Errorf("Verify token failed: %s", err)
 				if !delayDecision {

--- a/pkg/monitor/alerting/conditions/query.go
+++ b/pkg/monitor/alerting/conditions/query.go
@@ -122,12 +122,14 @@ func (c *QueryCondition) Eval(context *alerting.EvalContext) (*alerting.Conditio
 		if len(metas) > idx {
 			meta = &metas[idx]
 		}
-		matches = append(matches, &monitor.EvalMatch{
-			Condition: c.GenerateFormatCond(meta).String(),
-			Metric:    series.Name,
-			Value:     reducedValue,
-			Tags:      tags,
-		})
+		if evalMatch {
+			matches = append(matches, &monitor.EvalMatch{
+				Condition: c.GenerateFormatCond(meta).String(),
+				Metric:    series.Name,
+				Value:     reducedValue,
+				Tags:      tags,
+			})
+		}
 	}
 
 	// handle no series special case
@@ -215,7 +217,6 @@ func (c *QueryCondition) executeQuery(context *alerting.EvalContext, timeRange *
 
 		return nil, errors.Wrap(err, "tsdb.HandleRequest() error")
 	}
-
 	for _, v := range resp.Results {
 		if v.Error != nil {
 			return nil, errors.Wrap(err, "tsdb.HandleResult() response")

--- a/pkg/monitor/models/suggestsysrule.go
+++ b/pkg/monitor/models/suggestsysrule.go
@@ -62,7 +62,7 @@ type SSuggestSysRule struct {
 	Period   string               `width:"256" charset:"ascii" list:"user" update:"user"`
 	TimeFrom string               `width:"256" charset:"ascii" list:"user" update:"user"`
 	Setting  jsonutils.JSONObject ` list:"user" update:"user"`
-	ExecTime time.Time            `json:"exec_time"`
+	ExecTime time.Time            `list:"user" update:"user"`
 }
 
 func (man *SSuggestSysRuleManager) FetchSuggestSysAlartSettings(ruleTypes ...string) (map[string]*monitor.SuggestSysRuleDetails, error) {
@@ -194,6 +194,7 @@ func (man *SSuggestSysRuleManager) FetchCustomizeColumns(
 		rows[i] = monitor.SuggestSysRuleDetails{
 			VirtualResourceDetails: virtRows[i],
 		}
+		rows[i] = objs[i].(*SSuggestSysRule).getMoreDetails(rows[i])
 	}
 	return rows
 }
@@ -334,4 +335,11 @@ func (self *SSuggestSysRuleManager) GetRules(tp ...string) ([]SSuggestSysRule, e
 		return rules, err
 	}
 	return rules, nil
+}
+
+func (self *SSuggestSysRule) UpdateExecTime() {
+	db.Update(self, func() error {
+		self.ExecTime = time.Now()
+		return nil
+	})
 }

--- a/pkg/monitor/suggestsysdrivers/common.go
+++ b/pkg/monitor/suggestsysdrivers/common.go
@@ -15,7 +15,10 @@ import (
 	"yunion.io/x/onecloud/pkg/monitor/models"
 )
 
-func DealAlertData(oldAlerts []models.SSuggestSysAlert, newAlerts []jsonutils.JSONObject) {
+func DealAlertData(typ string, oldAlerts []models.SSuggestSysAlert, newAlerts []jsonutils.JSONObject) {
+	rules, _ := models.SuggestSysRuleManager.GetRules(typ)
+	rules[0].UpdateExecTime()
+
 	oldMap := make(map[string]models.SSuggestSysAlert, 0)
 	for _, alert := range oldAlerts {
 		oldMap[alert.ResId] = alert

--- a/pkg/monitor/suggestsysdrivers/diskunused.go
+++ b/pkg/monitor/suggestsysdrivers/diskunused.go
@@ -48,7 +48,7 @@ func (rule *DiskUnused) Run(instance *monitor.SSuggestSysAlertSetting) {
 		log.Errorln(errors.Wrap(err, "DiskUnused getLatestAlerts error"))
 		return
 	}
-	DealAlertData(oldAlert, newAlerts.Value())
+	DealAlertData(rule.GetType(), oldAlert, newAlerts.Value())
 }
 
 func (rule *DiskUnused) getLatestAlerts(instance *monitor.SSuggestSysAlertSetting) (*jsonutils.JSONArray, error) {

--- a/pkg/monitor/suggestsysdrivers/eipunused.go
+++ b/pkg/monitor/suggestsysdrivers/eipunused.go
@@ -65,7 +65,7 @@ func (rule *EIPUnused) Run(instance *monitor.SSuggestSysAlertSetting) {
 		return
 	}
 
-	DealAlertData(oldAlert, newAlert.Value())
+	DealAlertData(rule.GetType(), oldAlert, newAlert.Value())
 }
 
 func (rule *EIPUnused) getEIPUnused(instance *monitor.SSuggestSysAlertSetting) (*jsonutils.JSONArray, error) {

--- a/pkg/monitor/suggestsysdrivers/lbunused.go
+++ b/pkg/monitor/suggestsysdrivers/lbunused.go
@@ -54,7 +54,7 @@ func (rule *LBUnused) Run(instance *monitor.SSuggestSysAlertSetting) {
 		log.Errorln(errors.Wrap(err, "getEIPUnused error"))
 		return
 	}
-	DealAlertData(oldAlert, newAlert.Value())
+	DealAlertData(rule.GetType(), oldAlert, newAlert.Value())
 }
 
 func (rule *LBUnused) getLatestAlerts(instance *monitor.SSuggestSysAlertSetting) (*jsonutils.JSONArray, error) {

--- a/pkg/monitor/suggestsysdrivers/scaledown.go
+++ b/pkg/monitor/suggestsysdrivers/scaledown.go
@@ -92,7 +92,7 @@ func (rule *ScaleDown) Run(instance *monitor.SSuggestSysAlertSetting) {
 		log.Errorln(err)
 		return
 	}
-	DealAlertData(oldAlert, newAlert.Value())
+	DealAlertData(rule.GetType(), oldAlert, newAlert.Value())
 }
 
 func (rule *ScaleDown) getLatestAlerts(instance *monitor.SSuggestSysAlertSetting) (*jsonutils.JSONArray, error) {

--- a/pkg/multicloud/aws/dbinstance.go
+++ b/pkg/multicloud/aws/dbinstance.go
@@ -232,7 +232,7 @@ func (region *SRegion) GetDBInstance(instanceId string) (*SDBInstance, error) {
 	return nil, cloudprovider.ErrDuplicateId
 }
 
-func (rds *SDBInstance) GetIZoneId() string {
+func (rds *SDBInstance) GetZone1Id() string {
 	if len(rds.AvailabilityZone) > 0 {
 		zone, err := rds.region.getZoneById(rds.AvailabilityZone)
 		if err != nil {
@@ -241,6 +241,14 @@ func (rds *SDBInstance) GetIZoneId() string {
 		}
 		return zone.GetGlobalId()
 	}
+	return ""
+}
+
+func (rds *SDBInstance) GetZone2Id() string {
+	return ""
+}
+
+func (rds *SDBInstance) GetZone3Id() string {
 	return ""
 }
 

--- a/pkg/multicloud/aws/host.go
+++ b/pkg/multicloud/aws/host.go
@@ -15,13 +15,10 @@
 package aws
 
 import (
-	"encoding/base64"
 	"fmt"
-	"strings"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
-	"yunion.io/x/pkg/util/osprofile"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
@@ -176,12 +173,6 @@ func (self *SHost) GetInstanceById(instanceId string) (*SInstance, error) {
 }
 
 func (self *SHost) CreateVM(desc *cloudprovider.SManagedVMCreateConfig) (cloudprovider.ICloudVM, error) {
-	if strings.ToLower(desc.OsType) == strings.ToLower(osprofile.OS_TYPE_WINDOWS) {
-		// powershell scripts
-		data := fmt.Sprintf("<powershell>%s</powershell>", desc.UserData)
-		desc.UserData = base64.StdEncoding.EncodeToString([]byte(data))
-	}
-
 	vmId, err := self._createVM(desc.Name, desc.ExternalImageId, desc.SysDisk, desc.InstanceType, desc.ExternalNetworkId, desc.IpAddr, desc.Description, desc.Password, desc.DataDisks, desc.PublicKey, desc.ExternalSecgroupId, desc.UserData)
 	if err != nil {
 		return nil, err

--- a/pkg/multicloud/esxi/devtools.go
+++ b/pkg/multicloud/esxi/devtools.go
@@ -125,6 +125,17 @@ func NewCDROMDev(path string, key, ctlKey int32) types.BaseVirtualDevice {
 	return &device
 }
 
+func NewUSBController(key *int32) types.BaseVirtualDevice {
+	device := types.VirtualUSBController{}
+	device.DeviceInfo = &types.Description{
+		Label: "USB controller",
+	}
+	if key != nil {
+		device.Key = *key
+	}
+	return &device
+}
+
 func NewVNICDev(host *SHost, mac, driver string, vlanId int32, key, ctlKey, index int32) (types.BaseVirtualDevice, error) {
 	desc := types.Description{Label: fmt.Sprintf("Network adapter %d", index+1), Summary: "VM Network"}
 

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -692,9 +692,10 @@ func (self *SHost) CreateVM2(ctx context.Context, ds *SDatastore, params SCreate
 func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreateVMParam) (*SVirtualMachine, error) {
 	deviceChange := make([]types.BaseVirtualDeviceConfigSpec, 0, 5)
 
-	// name first
-	if len(params.Name) == 0 {
-		params.Name = params.Uuid
+	// uuid first
+	name := params.Name
+	if len(params.Uuid) != 0 {
+		name = params.Uuid
 	}
 	datastorePath := fmt.Sprintf("[%s] ", ds.GetRelName())
 
@@ -718,7 +719,7 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 	}
 
 	spec := types.VirtualMachineConfigSpec{
-		Name:     params.Name,
+		Name:     name,
 		Version:  version,
 		Uuid:     params.Uuid,
 		GuestId:  guestId,
@@ -862,8 +863,7 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 	return NewVirtualMachine(self.manager, &moVM, self.datacenter), nil
 }
 
-func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SDatastore,
-	params SCreateVMParam) (*SVirtualMachine, error) {
+func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SDatastore, params SCreateVMParam) (*SVirtualMachine, error) {
 	ovm := from.getVmObj()
 
 	deviceChange := make([]types.BaseVirtualDeviceConfigSpec, 0, 5)
@@ -1008,11 +1008,13 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SData
 		Location: relocateSpec,
 	}
 
-	if len(params.Name) == 0 {
-		params.Name = params.Uuid
+	// uuid first
+	name := params.Name
+	if len(params.Uuid) != 0 {
+		name = params.Uuid
 	}
 	spec := types.VirtualMachineConfigSpec{
-		Name:     params.Name,
+		Name:     name,
 		Uuid:     params.Uuid,
 		NumCPUs:  int32(params.Cpu),
 		MemoryMB: int64(params.Mem),

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -802,6 +802,10 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 		deviceChange = append(deviceChange, spec)
 	}
 
+	// add usb to support mouse
+	usbController := addDevSpec(NewUSBController(nil))
+	deviceChange = append(deviceChange, usbController)
+
 	nics := params.Nics
 	for _, nic := range nics {
 		index, _ := nic.Int("index")

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -795,7 +795,8 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 			index = ideIdx % 2
 			ideIdx += 1
 		}
-		log.Debugf("size: %d, image path: %s, uuid: %s, index: %d, ctrlKey: %d", size, imagePath, uuid, index, ctrlKey)
+		log.Debugf("size: %d, image path: %s, uuid: %s, index: %d, ctrlKey: %d, driver: %s.", size, imagePath, uuid,
+			index, ctrlKey, disk.Driver)
 		spec := addDevSpec(NewDiskDev(size, imagePath, uuid, int32(index), 2000, int32(ctrlKey)))
 		spec.FileOperation = "create"
 		deviceChange = append(deviceChange, spec)

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -1326,13 +1326,14 @@ func (host *SHost) findVlanDVPG(vlanId int32) (*SDistributedVirtualPortgroup, er
 			if dvpg.ContainHost(host) {
 				return dvpg, nil
 			}
+			msg := "Find dvpg with correct vlan but it didn't contain this host"
+			log.Debugf(msg)
 			// add host to dvg
-			log.Debugf("Find dvpg with correct vlan but it didn't contain this host")
-			err := dvpg.AddHostToDVS(host)
-			if err != nil {
-				return nil, errors.Wrapf(err, "dvpg %s add host to dvs error", dvpg.GetName())
-			}
-			return dvpg, nil
+			// err := dvpg.AddHostToDVS(host)
+			// if err != nil {
+			//     return nil, errors.Wrapf(err, "dvpg %s add host to dvs error", dvpg.GetName())
+			// }
+			continue
 		}
 	}
 	return nil, nil

--- a/pkg/multicloud/esxi/monitor.go
+++ b/pkg/multicloud/esxi/monitor.go
@@ -122,17 +122,19 @@ func (cli *SESXiClient) getManagerEntityofVm(server jsonutils.JSONObject) (*mo.M
 }
 
 func (cli *SESXiClient) getManagerEntityofHost(host jsonutils.JSONObject) (*mo.ManagedEntity, error) {
-	name, _ := host.GetString("name")
+	extId, _ := host.GetString("external_id")
 	hostSystems, err := cli.GetHostSystem()
 	if err != nil {
 		return nil, err
 	}
 	for _, hostSystem := range hostSystems {
-		if strings.Contains(hostSystem.Name, name) || strings.Contains(name, hostSystem.Name) {
+		host := NewHost(cli, &hostSystem, nil)
+		ip := host.GetGlobalId()
+		if ip == extId {
 			return hostSystem.Entity(), nil
 		}
 	}
-	return nil, fmt.Errorf("No ManagerEntiry for %s host", name)
+	return nil, fmt.Errorf("No VMware ManagerEntiry for %s host", extId)
 }
 
 //根据perfCounterInfos装载metricIdTable、metricNameTable、metricIdNameTable

--- a/pkg/multicloud/esxi/storage.go
+++ b/pkg/multicloud/esxi/storage.go
@@ -694,7 +694,6 @@ func (self *SDatastore) GetVmdkInfo(ctx context.Context, remotePath string) (*vm
 
 func (self *SDatastore) CheckVmdk(ctx context.Context, remotePath string) error {
 	dm := object.NewVirtualDiskManager(self.manager.client.Client)
-	defer dm.Destroy(ctx)
 
 	dc, err := self.GetDatacenter()
 	if err != nil {

--- a/pkg/multicloud/esxi/storage.go
+++ b/pkg/multicloud/esxi/storage.go
@@ -610,6 +610,28 @@ func (self *SDatastore) FilePutContent(ctx context.Context, remotePath string, c
 	return self.Upload(ctx, remotePath, strings.NewReader(content))
 }
 
+// Delete2 can delete file from this Datastore.
+// isNamespace: remotePath is uuid of namespace on vsan datastore
+// force: ignore nonexistent files and arguments
+func (self *SDatastore) Delete2(ctx context.Context, remotePath string, isNamespace, force bool) error {
+	var err error
+	ds := self.getDatastoreObj()
+	dc := self.datacenter.getObjectDatacenter()
+	if isNamespace {
+		nm := object.NewDatastoreNamespaceManager(self.manager.client.Client)
+		err = nm.DeleteDirectory(ctx, dc, remotePath)
+	} else {
+		fm := ds.NewFileManager(dc, force)
+		err = fm.Delete(ctx, remotePath)
+	}
+
+	if err != nil && types.IsFileNotFound(err) && force {
+		// Ignore error
+		return nil
+	}
+	return err
+}
+
 func (self *SDatastore) Delete(ctx context.Context, remotePath string) error {
 	url := self.GetPathUrl(remotePath)
 

--- a/pkg/multicloud/esxi/vdisk.go
+++ b/pkg/multicloud/esxi/vdisk.go
@@ -270,7 +270,10 @@ func (disk *SVirtualDisk) GetDriver() string {
 	controller := disk.vm.getVdev(disk.getControllerKey())
 	name := controller.GetDriver()
 	name = strings.Replace(name, "controller", "", -1)
-	return driverMap[name]
+	if driver, ok := driverMap[name]; ok {
+		return driver
+	}
+	return name
 }
 
 func (disk *SVirtualDisk) GetCacheMode() string {

--- a/pkg/multicloud/esxi/vdisk.go
+++ b/pkg/multicloud/esxi/vdisk.go
@@ -296,7 +296,7 @@ func (disk *SVirtualDisk) Delete(ctx context.Context) error {
 		return err
 	}
 	ds := istorage.(*SDatastore)
-	return ds.DeleteVmdk(ctx, disk.getBackingInfo().GetFileName())
+	return ds.Delete2(ctx, disk.getBackingInfo().GetFileName(), false, false)
 }
 
 func (disk *SVirtualDisk) CreateISnapshot(ctx context.Context, name string, desc string) (cloudprovider.ICloudSnapshot, error) {

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -511,6 +511,14 @@ func (self *SVirtualMachine) shutdownVM(ctx context.Context) error {
 func (self *SVirtualMachine) doDelete(ctx context.Context) error {
 	vm := self.getVmObj()
 
+	// detach all disks first
+	for i := range self.vdisks {
+		err := self.doDetachAndDeleteDisk(ctx, &self.vdisks[i])
+		if err != nil {
+			return errors.Wrap(err, "doDetachAndDeteteDisk")
+		}
+	}
+
 	task, err := vm.Destroy(ctx)
 	if err != nil {
 		log.Errorf("vm.Destroy(ctx) fail %s", err)

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -547,10 +547,6 @@ func (self *SVirtualMachine) doDetachDisk(ctx context.Context, vdisk *SVirtualDi
 	removeSpec.Operation = types.VirtualDeviceConfigSpecOperationRemove
 	removeSpec.Device = vdisk.dev
 
-	if remove {
-		removeSpec.FileOperation = types.VirtualDeviceConfigSpecFileOperationDestroy
-	}
-
 	spec := types.VirtualMachineConfigSpec{}
 	spec.DeviceChange = []types.BaseVirtualDeviceConfigSpec{&removeSpec}
 
@@ -568,7 +564,10 @@ func (self *SVirtualMachine) doDetachDisk(ctx context.Context, vdisk *SVirtualDi
 		return err
 	}
 
-	return nil
+	if !remove {
+		return nil
+	}
+	return vdisk.Delete(ctx)
 }
 
 func (self *SVirtualMachine) GetVNCInfo() (jsonutils.JSONObject, error) {

--- a/pkg/multicloud/google/dbinstance.go
+++ b/pkg/multicloud/google/dbinstance.go
@@ -352,8 +352,21 @@ func (rds *SDBInstance) GetInternalConnectionStr() string {
 	return strings.Join(ret, ",")
 }
 
-func (rds *SDBInstance) GetIZoneId() string {
-	return rds.GceZone
+func (rds *SDBInstance) GetZone1Id() string {
+	zone, err := rds.region.GetZone(rds.GceZone)
+	if err != nil {
+		log.Errorf("failed to found rds %s zone %s", rds.Name, rds.GceZone)
+		return ""
+	}
+	return zone.GetGlobalId()
+}
+
+func (rds *SDBInstance) GetZone2Id() string {
+	return ""
+}
+
+func (rds *SDBInstance) GetZone3Id() string {
+	return ""
 }
 
 func (rds *SDBInstance) GetIVpcId() string {

--- a/pkg/notify/cache/usercache.go
+++ b/pkg/notify/cache/usercache.go
@@ -52,7 +52,7 @@ func RegistUserCredCacheUpdater() {
 	auth.RegisterAuthHook(onAuthCompleteUpdateCache)
 }
 
-func onAuthCompleteUpdateCache(userCred mcclient.TokenCredential) {
+func onAuthCompleteUpdateCache(ctx context.Context, userCred mcclient.TokenCredential) {
 	UserCacheManager.updateUserCache(userCred)
 }
 

--- a/pkg/scheduler/algorithm/predicates/guest/status_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/guest/status_predicate.go
@@ -75,6 +75,9 @@ func (p *StatusPredicate) Execute(u *core.Unit, c core.Candidater) (bool, []core
 		if !utils.IsInStringArray(cloudprovider.HealthStatus, api.CLOUD_PROVIDER_VALID_HEALTH_STATUS) {
 			h.Exclude2("cloud_provider_health_status", cloudprovider.HealthStatus, api.CLOUD_PROVIDER_VALID_HEALTH_STATUS)
 		}
+		if !cloudprovider.Enabled.Bool() {
+			h.Exclude2("cloud_provider_enable", cloudprovider.Enabled.Bool(), true)
+		}
 	}
 
 	return h.GetResult()

--- a/pkg/scheduler/algorithm/predicates/schedtag_helper.go
+++ b/pkg/scheduler/algorithm/predicates/schedtag_helper.go
@@ -123,6 +123,16 @@ func GetRequestSchedtags(reqTags []*computeapi.SchedtagConfig, allTags []models.
 
 	appendedTagIds := make(map[string]int)
 
+	for _, reqTag := range reqTags {
+		for _, dbTag := range allTags {
+			if reqTag.Id == dbTag.Id || reqTag.Id == dbTag.Name {
+				if reqTag.Strategy == "" {
+					reqTag.Strategy = dbTag.DefaultStrategy
+				}
+			}
+		}
+	}
+
 	appendTagByStrategy := func(tag *computeapi.SchedtagConfig, defaultWeight int) {
 		if tag.Weight <= 0 {
 			tag.Weight = defaultWeight

--- a/pkg/util/billing/billingcycle.go
+++ b/pkg/util/billing/billingcycle.go
@@ -110,6 +110,124 @@ func (cycle SBillingCycle) EndAt(tm time.Time) time.Time {
 	}
 }
 
+func minuteStart(tm time.Time) time.Time {
+	return time.Date(
+		tm.Year(),
+		tm.Month(),
+		tm.Day(),
+		tm.Hour(),
+		tm.Minute(),
+		0,
+		0,
+		tm.Location(),
+	)
+}
+
+func hourStart(tm time.Time) time.Time {
+	return time.Date(
+		tm.Year(),
+		tm.Month(),
+		tm.Day(),
+		tm.Hour(),
+		0,
+		0,
+		0,
+		tm.Location(),
+	)
+}
+
+func dayStart(tm time.Time) time.Time {
+	return time.Date(
+		tm.Year(),
+		tm.Month(),
+		tm.Day(),
+		0,
+		0,
+		0,
+		0,
+		tm.Location(),
+	)
+}
+
+func weekStart(tm time.Time) time.Time {
+	tm = dayStart(tm)
+	dayOff := int(tm.Weekday()) - 1
+	if dayOff < 0 {
+		dayOff += 7
+	}
+	return tm.Add(-time.Duration(dayOff) * time.Hour * 24)
+}
+
+func monthStart(tm time.Time) time.Time {
+	return time.Date(
+		tm.Year(),
+		tm.Month(),
+		1,
+		0,
+		0,
+		0,
+		0,
+		tm.Location(),
+	)
+}
+
+func yearStart(tm time.Time) time.Time {
+	return time.Date(
+		tm.Year(),
+		time.January,
+		1,
+		0,
+		0,
+		0,
+		0,
+		tm.Location(),
+	)
+}
+
+func (cycle SBillingCycle) LatestLastStart(tm time.Time) time.Time {
+	if tm.IsZero() {
+		tm = time.Now().UTC()
+	}
+	switch cycle.Unit {
+	case BillingCycleMinute:
+		return minuteStart(tm)
+	case BillingCycleHour:
+		return hourStart(tm)
+	case BillingCycleDay:
+		return dayStart(tm)
+	case BillingCycleWeek:
+		return weekStart(tm)
+	case BillingCycleMonth:
+		return monthStart(tm)
+	case BillingCycleYear:
+		return yearStart(tm)
+	default: // hour
+		return hourStart(tm)
+	}
+}
+
+func (cycle SBillingCycle) TimeString(tm time.Time) string {
+	if tm.IsZero() {
+		tm = time.Now().UTC()
+	}
+	switch cycle.Unit {
+	case BillingCycleMinute:
+		return tm.Format("200601021504")
+	case BillingCycleHour:
+		return tm.Format("2006010215")
+	case BillingCycleDay:
+		return tm.Format("20060102")
+	case BillingCycleWeek:
+		return tm.Format("20060102w")
+	case BillingCycleMonth:
+		return tm.Format("200601")
+	case BillingCycleYear:
+		return tm.Format("2006")
+	default: // hour
+		return tm.Format("2006010215")
+	}
+}
+
 func (cycle SBillingCycle) Duration() time.Duration {
 	now := time.Now().UTC()
 	endAt := cycle.EndAt(now)

--- a/pkg/util/billing/billingcycle_test.go
+++ b/pkg/util/billing/billingcycle_test.go
@@ -30,3 +30,73 @@ func TestParseBillingCycle(t *testing.T) {
 		}
 	}
 }
+
+func TestLatestLastStart(t *testing.T) {
+	cases := []struct {
+		tm   string
+		bc   string
+		want string
+	}{
+		{
+			tm:   "2020-05-16T00:00:00Z",
+			bc:   "1m",
+			want: "2020-05-01T00:00:00Z",
+		},
+		{
+			tm:   "2020-05-16T23:34:02Z",
+			bc:   "1h",
+			want: "2020-05-16T23:00:00Z",
+		},
+		{
+			tm:   "2020-05-16T23:34:02Z",
+			bc:   "1i",
+			want: "2020-05-16T23:34:00Z",
+		},
+		{
+			tm:   "2020-05-16T23:34:02Z",
+			bc:   "1d",
+			want: "2020-05-16T00:00:00Z",
+		},
+		{
+			tm:   "2020-05-16T23:34:02Z",
+			bc:   "1w",
+			want: "2020-05-11T00:00:00Z",
+		},
+		{
+			tm:   "2020-05-16T23:34:02Z",
+			bc:   "1y",
+			want: "2020-01-01T00:00:00Z",
+		},
+	}
+	for _, c := range cases {
+		tm, _ := time.Parse(time.RFC3339, c.tm)
+		bc, _ := ParseBillingCycle(c.bc)
+		got := bc.LatestLastStart(tm)
+		want, _ := time.Parse(time.RFC3339, c.want)
+		if got != want {
+			t.Errorf("bc: %s want: %s got: %s", c.bc, want, got)
+		}
+	}
+}
+
+func TestTimeString(t *testing.T) {
+	cases := []struct {
+		tm   string
+		bc   string
+		want string
+	}{
+		{
+			tm:   "2020-05-16T23:23:54Z",
+			bc:   "1m",
+			want: "202005",
+		},
+	}
+	for _, c := range cases {
+		tm, _ := time.Parse(time.RFC3339, c.tm)
+		bc, _ := ParseBillingCycle(c.bc)
+		got := bc.TimeString(tm)
+		if c.want != got {
+			t.Errorf("bc: %s TimeString want: %s got: %s", c.bc, c.want, got)
+		}
+	}
+}

--- a/pkg/util/cloudinit/cloudconfig.go
+++ b/pkg/util/cloudinit/cloudconfig.go
@@ -37,8 +37,9 @@ type TSudoPolicy string
 type TSshPwauth string
 
 const (
-	CLOUD_CONFIG_HEADER = "#cloud-config\n"
-	CLOUD_SHELL_HEADER  = "#!/usr/bin/env bash\n"
+	CLOUD_CONFIG_HEADER      = "#cloud-config\n"
+	CLOUD_SHELL_HEADER       = "#!/usr/bin/env bash\n"
+	CLOUD_POWER_SHELL_HEADER = "#ps1\n"
 
 	USER_SUDO_NOPASSWD = TSudoPolicy("sudo_nopasswd")
 	USER_SUDO          = TSudoPolicy("sudo")
@@ -255,7 +256,16 @@ func (conf *SCloudConfig) UserDataPowerShell() string {
 	}
 	shells = append(shells, conf.Runcmd...)
 
-	return strings.Join(shells, "\n")
+	return CLOUD_POWER_SHELL_HEADER + strings.Join(shells, "\n")
+}
+
+func (conf *SCloudConfig) UserDataEc2() string {
+	shells := []string{}
+	for _, u := range conf.Users {
+		shells = append(shells, u.PowerShellScripts()...)
+	}
+	shells = append(shells, conf.Runcmd...)
+	return "<powershell>\n" + strings.Join(shells, "\n") + "\n</powershell>"
 }
 
 func (conf *SCloudConfig) UserDataBase64() string {

--- a/pkg/util/gin/middleware/keystone_auth.go
+++ b/pkg/util/gin/middleware/keystone_auth.go
@@ -45,7 +45,7 @@ func KeystoneTokenVerifyMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		_, err := auth.Verify(token)
+		_, err := auth.Verify(c, token)
 		if err != nil {
 			c.AbortWithError(http.StatusUnauthorized, err)
 			return

--- a/pkg/util/rbacutils/policyset.go
+++ b/pkg/util/rbacutils/policyset.go
@@ -14,14 +14,20 @@
 
 package rbacutils
 
+type SPolicyInfo struct {
+	Id     string
+	Name   string
+	Policy *SRbacPolicy
+}
+
 type TPolicySet []*SRbacPolicy
 
-func GetMatchedPolicies(policies map[string]*SRbacPolicy, userCred IRbacIdentity) (TPolicySet, []string) {
+func GetMatchedPolicies(policies []SPolicyInfo, userCred IRbacIdentity) (TPolicySet, []string) {
 	matchedPolicies := make([]*SRbacPolicy, 0)
 	matchedNames := make([]string, 0)
 	maxMatchWeight := 0
-	for k := range policies {
-		isMatched, matchWeight := policies[k].Match(userCred)
+	for i := range policies {
+		isMatched, matchWeight := policies[i].Policy.Match(userCred)
 		if !isMatched || matchWeight < maxMatchWeight {
 			continue
 		}
@@ -31,8 +37,8 @@ func GetMatchedPolicies(policies map[string]*SRbacPolicy, userCred IRbacIdentity
 				matchedPolicies = matchedPolicies[:0]
 				matchedNames = matchedNames[:0]
 			}
-			matchedPolicies = append(matchedPolicies, policies[k])
-			matchedNames = append(matchedNames, k)
+			matchedPolicies = append(matchedPolicies, policies[i].Policy)
+			matchedNames = append(matchedNames, policies[i].Name)
 		}
 	}
 	return matchedPolicies, matchedNames

--- a/pkg/vpcagent/ovn/cmp.go
+++ b/pkg/vpcagent/ovn/cmp.go
@@ -32,7 +32,7 @@ func cmp(db *ovn_nb.OVNNorthbound, ocver string, irows ...types.IRow) (bool, []s
 	if len(irowsFound) == len(irows) {
 		return true, nil
 	}
-	args := ovnutil.OvnNbctlArgsDestroy(irowsFound)
-	args = append(args, ovnutil.OvnNbctlArgsDestroy(irowsDiff)...)
+	irowsCleanup := append(irowsFound, irowsDiff...)
+	args := ovnutil.OvnNbctlArgsDestroy(irowsCleanup)
 	return false, args
 }

--- a/pkg/vpcagent/ovnutil/ovn_nbctl.go
+++ b/pkg/vpcagent/ovnutil/ovn_nbctl.go
@@ -153,18 +153,26 @@ func OvnNbctlArgsDestroy(irows []types.IRow) []string {
 	})
 	var args []string
 	for _, irow := range irows {
+		var newArgs []string
 		switch irow.(type) {
 		case *ovn_nb.LogicalSwitchPort:
-			args = append(args, "--", "--if-exists", "lsp-del", irow.OvsdbUuid())
+			newArgs = []string{"--", "--if-exists", "lsp-del", irow.OvsdbUuid()}
 		case *ovn_nb.LogicalRouterPort:
-			args = append(args, "--", "--if-exists", "lrp-del", irow.OvsdbUuid())
+			newArgs = []string{"--", "--if-exists", "lrp-del", irow.OvsdbUuid()}
 		case *ovn_nb.LogicalRouterStaticRoute:
 		case *ovn_nb.ACL:
 		default:
 			if !irow.OvsdbIsRoot() {
 				panic(irow.OvsdbTableName())
 			}
-			args = append(args, "--", "--if-exists", "destroy", irow.OvsdbTableName(), irow.OvsdbUuid())
+			newArgs = []string{"--", "--if-exists", "destroy", irow.OvsdbTableName(), irow.OvsdbUuid()}
+		}
+		if len(newArgs) > 0 {
+			if irow.OvsdbIsRoot() {
+				args = append(args, newArgs...)
+			} else {
+				args = append(newArgs, args...)
+			}
 		}
 	}
 	return args

--- a/pkg/yunionconf/policy/defaults.go
+++ b/pkg/yunionconf/policy/defaults.go
@@ -25,6 +25,7 @@ const (
 	PolicyActionList   = common_policy.PolicyActionList
 	PolicyActionCreate = common_policy.PolicyActionCreate
 	PolicyActionUpdate = common_policy.PolicyActionUpdate
+	PolicyActionDelete = common_policy.PolicyActionDelete
 )
 
 var (
@@ -55,6 +56,12 @@ var (
 					Service:  api.SERVICE_TYPE,
 					Resource: "parameters",
 					Action:   PolicyActionUpdate,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "parameters",
+					Action:   PolicyActionDelete,
 					Result:   rbacutils.Allow,
 				},
 			},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1000,7 +1000,7 @@ yunion.io/x/log/hooks
 yunion.io/x/ovsdb/cli_util
 yunion.io/x/ovsdb/schema/ovn_nb
 yunion.io/x/ovsdb/types
-# yunion.io/x/pkg v0.0.0-20200416145704-22c189971435
+# yunion.io/x/pkg v0.0.0-20200516092703-0a53bc9270aa
 yunion.io/x/pkg/errors
 yunion.io/x/pkg/gotypes
 yunion.io/x/pkg/prettytable

--- a/vendor/yunion.io/x/pkg/util/osprofile/osprofile.go
+++ b/vendor/yunion.io/x/pkg/util/osprofile/osprofile.go
@@ -64,7 +64,7 @@ func GetOSProfile(osname string, hypervisor string) SOSProfile {
 	case OS_TYPE_WINDOWS:
 		if hypervisor == "esxi" {
 			return SOSProfile{
-				DiskDriver: "scsi",
+				DiskDriver: "ide",
 				NetDriver:  "e1000",
 				FsFormat:   "ntfs",
 			}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. Remove 'Destory' operation that is unnecessary for VirtualDiskManager
2. Separate detach disk and delete disk when rebuilding.

    In previous versions, set
    `removeSpec.FileOperation = types.VirtualDeviceConfigSpecFileOperationDestroy'
    to delete disk indirectly.

    But, when its parent has only one child, the parent will be deleted along with it.
    And the consequence is failure to reinstall the system.

    Now, detach disk without deleteing backing file and then remove backing
    file via datastore's operation.
3. Modify the disk size correctly when creating vm
4. Detach all disk first when deleting vm to prevent to delete delta disk's parent disk.


针对问题2：

之前为了修复振华的问题做的修改：#4994
现在来看没有测试以下情况：image_cache中的某个image (简称IM） 只有一个vm在用，重装vm就会触发问题，因为 IM 会被删除掉。

另外，此次修改需要在振华的环境中测试一下[完毕]，看看 #4994 中的问题是不是也会被修复，因为 换了 datastore delete disk 的方式。
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.0
- release/3.1
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->
/area esxiagent
/cc @swordqiu @zexi 