### PR TITLE
Hotfix/qj fix local storage ownership sync

### DIFF
--- a/pkg/cloudcommon/db/sharablebase.go
+++ b/pkg/cloudcommon/db/sharablebase.go
@@ -537,7 +537,9 @@ func SharableModelIsShared(model ISharableBaseModel) bool {
 	}
 	switch model.GetPublicScope() {
 	case rbacutils.ScopeSystem:
-		return true
+		if model.GetIsPublic() {
+			return true
+		}
 	case rbacutils.ScopeDomain:
 		if model.GetModelManager().ResourceScope() == rbacutils.ScopeProject {
 			return true

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -828,6 +828,8 @@ func (self *SHost) PerformUpdateStorage(
 		storage.Enabled = tristate.True
 		storage.ZoneId = zoneId
 		storage.StoragecacheId = storageCacheId
+		storage.DomainId = self.DomainId
+		storage.DomainSrc = string(apis.OWNER_SOURCE_LOCAL)
 		err := StorageManager.TableSpec().Insert(&storage)
 		if err != nil {
 			return nil, fmt.Errorf("Create baremetal storage error: %v", err)
@@ -846,6 +848,7 @@ func (self *SHost) PerformUpdateStorage(
 		}
 		bmStorage.SetModelManager(HoststorageManager, &bmStorage)
 		db.OpsLog.LogAttachEvent(ctx, self, &storage, userCred, bmStorage.GetShortDesc(ctx))
+		bmStorage.syncLocalStorageShare(ctx, userCred)
 		return nil, nil
 	}
 	storage := bs.GetStorage()
@@ -854,12 +857,15 @@ func (self *SHost) PerformUpdateStorage(
 		storage.Capacity = capacity
 		storage.StoragecacheId = storageCacheId
 		storage.Enabled = tristate.True
+		storage.DomainId = self.DomainId
+		storage.DomainSrc = string(apis.OWNER_SOURCE_LOCAL)
 		return nil
 	})
 	if err != nil {
 		return nil, fmt.Errorf("Update baremetal storage error: %v", err)
 	}
 	db.OpsLog.LogEvent(storage, db.ACT_UPDATE, diff, userCred)
+	bs.syncLocalStorageShare(ctx, userCred)
 	//}
 	return nil, nil
 }

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -1073,6 +1073,7 @@ func (h *SHostInfo) getNetworkInfo() {
 	params := jsonutils.NewDict()
 	params.Set("details", jsonutils.JSONTrue)
 	params.Set("limit", jsonutils.NewInt(0))
+	params.Set("scope", jsonutils.NewString("system"))
 	res, err := modules.Hostwires.ListDescendent(
 		h.GetSession(),
 		h.HostId, params)
@@ -1228,6 +1229,7 @@ func (h *SHostInfo) getStorageInfo() {
 	params := jsonutils.NewDict()
 	params.Set("details", jsonutils.JSONTrue)
 	params.Set("limit", jsonutils.NewInt(0))
+	params.Set("scope", jsonutils.NewString("system"))
 	res, err := modules.Hoststorages.ListDescendent(
 		h.GetSession(),
 		h.HostId, params)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：host同步本地存储时自动设置存储的domain_id和共享范围

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/area region
/cc @zexi 

/hold