### PR TITLE
fix: cloudprovider list support filter by zone and cloudregion

### DIFF
--- a/pkg/apis/compute/cloudprovider.go
+++ b/pkg/apis/compute/cloudprovider.go
@@ -224,6 +224,8 @@ type CloudproviderListInput struct {
 
 	CloudregionResourceInput
 
+	ZoneResourceInput
+
 	CapabilityListInput
 
 	SyncableBaseResourceListInput


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：过滤usable云订阅时，需要考虑zone和cloudregion的过滤条件

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area region

/hold