### PR TITLE
suggestions  increase time screening range

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1120,8 +1120,6 @@ yunion.io/x/ovsdb v0.0.0-20200512112253-a3601d1ee987/go.mod h1:0vLkNEhlmA64HViPB
 yunion.io/x/pkg v0.0.0-20190620104149-945c25821dbf/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/pkg v0.0.0-20190628082551-f4033ba2ea30/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/pkg v0.0.0-20200302034534-fdf44d54b070/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
-yunion.io/x/pkg v0.0.0-20200416145704-22c189971435 h1:Fwf1rjdl+Qmw9BNxQN7wi2lQpYVExV7eBLifd0emHaI=
-yunion.io/x/pkg v0.0.0-20200416145704-22c189971435/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/pkg v0.0.0-20200516092703-0a53bc9270aa h1:VizPfW8+mLFEE7W/97zxQJbfdxchi2dn1M/Y7YBwTTc=
 yunion.io/x/pkg v0.0.0-20200516092703-0a53bc9270aa/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8J50Cise/HCylsOJngmo=

--- a/pkg/apis/monitor/suggestsys_const.go
+++ b/pkg/apis/monitor/suggestsys_const.go
@@ -45,3 +45,9 @@ const (
 	LB_MONITOR_SUGGEST         = MonitorSuggest("释放未使用的LB")
 	SCALE_DOWN_MONITOR_SUGGEST = MonitorSuggest("缩减机器配置")
 )
+
+const (
+	LB_UNUSED_NLISTENER = "没有监听"
+	LB_UNUSED_NBCGROUP  = "没有后端服务器组"
+	LB_UNUSED_NBC       = "没有后端服务器"
+)

--- a/pkg/apis/monitor/suggestsys_const.go
+++ b/pkg/apis/monitor/suggestsys_const.go
@@ -15,6 +15,13 @@
 package monitor
 
 const (
+	SUGGEST_ALERT_READY        = "ready"
+	SUGGEST_ALERT_START_DELETE = "start_delete"
+	SUGGEST_ALERT_DELETE_FAIL  = "delete_fail"
+	SUGGEST_ALERT_DELETING     = "deleting"
+)
+
+const (
 	EIP_UN_USED  = "EIP_UNUSED"
 	DISK_UN_USED = "DISK_UNUSED"
 	LB_UN_USED   = "LB_UNUSED"
@@ -22,10 +29,7 @@ const (
 	SCALE_UP     = "SCALE_UP"
 
 	DRIVER_ACTION            = "DELETE"
-	SCALE_DOWN_DRIVER_ACTION = "SCALE DOWN"
-
-	EIP_UNUSED_START_DELETE = "start_delete"
-	EIP_UNUSED_DELETE_FAIL  = "delete_fail"
+	SCALE_DOWN_DRIVER_ACTION = "SCALE_DOWN"
 )
 
 type MonitorSuggest string

--- a/pkg/monitor/alerting/conditions/query.go
+++ b/pkg/monitor/alerting/conditions/query.go
@@ -39,7 +39,7 @@ func init() {
 type QueryCondition struct {
 	Index         int
 	Query         AlertQuery
-	Reducer       *queryReducer
+	Reducer       Reduce
 	Evaluator     AlertEvaluator
 	Operator      string
 	HandleRequest tsdb.HandleRequestFunc
@@ -63,7 +63,7 @@ type FormatCond struct {
 func (c *QueryCondition) GenerateFormatCond(meta *tsdb.QueryResultMeta) *FormatCond {
 	return &FormatCond{
 		QueryMeta: meta,
-		Reducer:   c.Reducer.Type,
+		Reducer:   c.Reducer.GetType(),
 		Evaluator: c.Evaluator,
 	}
 }

--- a/pkg/monitor/alerting/conditions/query.go
+++ b/pkg/monitor/alerting/conditions/query.go
@@ -39,7 +39,7 @@ func init() {
 type QueryCondition struct {
 	Index         int
 	Query         AlertQuery
-	Reducer       Reduce
+	Reducer       Reducer
 	Evaluator     AlertEvaluator
 	Operator      string
 	HandleRequest tsdb.HandleRequestFunc

--- a/pkg/monitor/alerting/conditions/reducer.go
+++ b/pkg/monitor/alerting/conditions/reducer.go
@@ -21,11 +21,20 @@ import (
 	"yunion.io/x/onecloud/pkg/monitor/tsdb"
 )
 
+type Reduce interface {
+	Reduce(series *tsdb.TimeSeries) *float64
+	GetType() string
+}
+
 // queryReducer reduces an timeseries to a float
 type queryReducer struct {
 	// Type is how the timeseries should be reduced.
 	// Ex: avg, sum, max, min, count
 	Type string
+}
+
+func (s *queryReducer) GetType() string {
+	return s.Type
 }
 
 func (s *queryReducer) Reduce(series *tsdb.TimeSeries) *float64 {

--- a/pkg/monitor/alerting/conditions/reducer.go
+++ b/pkg/monitor/alerting/conditions/reducer.go
@@ -21,7 +21,7 @@ import (
 	"yunion.io/x/onecloud/pkg/monitor/tsdb"
 )
 
-type Reduce interface {
+type Reducer interface {
 	Reduce(series *tsdb.TimeSeries) *float64
 	GetType() string
 }

--- a/pkg/monitor/alerting/conditions/suggestrulereducer.go
+++ b/pkg/monitor/alerting/conditions/suggestrulereducer.go
@@ -1,0 +1,26 @@
+package conditions
+
+import (
+	"time"
+
+	"yunion.io/x/onecloud/pkg/monitor/tsdb"
+)
+
+type suggestRuleReducer struct {
+	*queryReducer
+	duration time.Duration
+}
+
+func NewSuggestRuleReducer(t string, duration time.Duration) Reduce {
+	return &suggestRuleReducer{
+		queryReducer: &queryReducer{Type: t},
+		duration:     duration,
+	}
+}
+
+func (s *suggestRuleReducer) Reduce(series *tsdb.TimeSeries) *float64 {
+	if int(s.duration.Seconds()) > len(series.Points) {
+		return nil
+	}
+	return s.queryReducer.Reduce(series)
+}

--- a/pkg/monitor/alerting/conditions/suggestrulereducer.go
+++ b/pkg/monitor/alerting/conditions/suggestrulereducer.go
@@ -11,7 +11,7 @@ type suggestRuleReducer struct {
 	duration time.Duration
 }
 
-func NewSuggestRuleReducer(t string, duration time.Duration) Reduce {
+func NewSuggestRuleReducer(t string, duration time.Duration) Reducer {
 	return &suggestRuleReducer{
 		queryReducer: &queryReducer{Type: t},
 		duration:     duration,

--- a/pkg/monitor/models/suggestsysalart.go
+++ b/pkg/monitor/models/suggestsysalart.go
@@ -271,7 +271,7 @@ func (self *SSuggestSysAlert) RealDelete(ctx context.Context, userCred mcclient.
 func (self *SSuggestSysAlert) StartDeleteTask(
 	ctx context.Context, userCred mcclient.TokenCredential) error {
 	params := jsonutils.NewDict()
-	self.SetStatus(userCred, api.EIP_UNUSED_START_DELETE, "")
+	self.SetStatus(userCred, api.SUGGEST_ALERT_START_DELETE, "")
 	return GetSuggestSysRuleDrivers()[self.Type].StartResolveTask(ctx, userCred, self, params)
 }
 

--- a/pkg/monitor/suggestsysdrivers/diskunused.go
+++ b/pkg/monitor/suggestsysdrivers/diskunused.go
@@ -78,8 +78,9 @@ func (rule *DiskUnused) getLatestAlerts(instance *monitor.SSuggestSysAlertSettin
 			ObjType: "disk",
 			Limit:   "0",
 			Scope:   "system",
+			Action:  db.ACT_DETACH,
 		}
-		latestTime, err := getResourceObjLatestUsedTime(disk, logInput, db.ACT_DETACH)
+		latestTime, err := getResourceObjLatestUsedTime(disk, logInput)
 		if err != nil {
 			continue
 		}
@@ -117,6 +118,7 @@ func (rule *DiskUnused) ValidateSetting(input *monitor.SSuggestSysAlertSetting) 
 
 func (rule *DiskUnused) StartResolveTask(ctx context.Context, userCred mcclient.TokenCredential,
 	suggestSysAlert *models.SSuggestSysAlert, params *jsonutils.JSONDict) error {
+	suggestSysAlert.SetStatus(userCred, monitor.SUGGEST_ALERT_DELETING, "")
 	task, err := taskman.TaskManager.NewTask(ctx, "ResolveUnusedTask", suggestSysAlert, userCred, params, "", "", nil)
 	if err != nil {
 		return err
@@ -129,7 +131,7 @@ func (rule *DiskUnused) Resolve(data *models.SSuggestSysAlert) error {
 	session := auth.GetAdminSession(context.Background(), "", "")
 	_, err := modules.Disks.Delete(session, data.ResId, jsonutils.NewDict())
 	if err != nil {
-		log.Errorln("delete unused eip error", err)
+		log.Errorln("delete unused error", err)
 		return err
 	}
 	return nil

--- a/pkg/monitor/suggestsysdrivers/eipunused.go
+++ b/pkg/monitor/suggestsysdrivers/eipunused.go
@@ -16,12 +16,15 @@ package suggestsysdrivers
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/apis/monitor"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
@@ -69,6 +72,12 @@ func (rule *EIPUnused) Run(instance *monitor.SSuggestSysAlertSetting) {
 }
 
 func (rule *EIPUnused) getEIPUnused(instance *monitor.SSuggestSysAlertSetting) (*jsonutils.JSONArray, error) {
+	rules, _ := models.SuggestSysRuleManager.GetRules(rule.GetType())
+	if len(rules) == 0 {
+		log.Println("Rule may have been deleted")
+		return jsonutils.NewArray(), nil
+	}
+	duration, _ := time.ParseDuration(rules[0].TimeFrom)
 	//处理逻辑
 	session := auth.GetAdminSession(context.Background(), "", "")
 	query := jsonutils.NewDict()
@@ -80,7 +89,24 @@ func (rule *EIPUnused) getEIPUnused(instance *monitor.SSuggestSysAlertSetting) (
 	}
 	EIPUnsedArr := jsonutils.NewArray()
 	for _, row := range rtn.Data {
+		//Determine whether EIP is used
 		if row.ContainsIgnoreCases("associate_type") || row.ContainsIgnoreCases("associate_id") {
+			continue
+		}
+		id, _ := row.GetString("id")
+		logInput := logInput{
+			ObjId:   id,
+			ObjType: "eip",
+			Limit:   "0",
+			Scope:   "system",
+		}
+
+		latestTime, err := getResourceObjLatestUsedTime(row, logInput, db.ACT_DETACH)
+		if err != nil {
+			continue
+		}
+		//Judge that the unused time is beyond the duration time
+		if time.Now().Add(-duration).Sub(latestTime) < 0 {
 			continue
 		}
 		suggestSysAlert, err := getSuggestSysAlertFromJson(row, rule)
@@ -97,7 +123,8 @@ func (rule *EIPUnused) getEIPUnused(instance *monitor.SSuggestSysAlertSetting) (
 		}
 
 		problem := jsonutils.NewDict()
-		problem.Add(jsonutils.NewString(rule.GetType()), "eip")
+		rtnTime := fmt.Sprintf("%.1fm", time.Now().Sub(latestTime).Minutes())
+		problem.Add(jsonutils.NewString(rtnTime), "eipUnused time")
 		suggestSysAlert.Problem = problem
 
 		EIPUnsedArr.Add(jsonutils.Marshal(suggestSysAlert))

--- a/pkg/monitor/suggestsysdrivers/eipunused.go
+++ b/pkg/monitor/suggestsysdrivers/eipunused.go
@@ -99,9 +99,10 @@ func (rule *EIPUnused) getEIPUnused(instance *monitor.SSuggestSysAlertSetting) (
 			ObjType: "eip",
 			Limit:   "0",
 			Scope:   "system",
+			Action:  db.ACT_DETACH,
 		}
 
-		latestTime, err := getResourceObjLatestUsedTime(row, logInput, db.ACT_DETACH)
+		latestTime, err := getResourceObjLatestUsedTime(row, logInput)
 		if err != nil {
 			continue
 		}

--- a/pkg/monitor/suggestsysdrivers/scaledown.go
+++ b/pkg/monitor/suggestsysdrivers/scaledown.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
@@ -16,6 +17,7 @@ import (
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/monitor/alerting"
+	"yunion.io/x/onecloud/pkg/monitor/alerting/conditions"
 	"yunion.io/x/onecloud/pkg/monitor/models"
 	"yunion.io/x/onecloud/pkg/monitor/validators"
 )
@@ -129,6 +131,9 @@ func (rule *ScaleDown) getScaleEvalResult(scales []monitor.Scale) (bool, map[str
 			return firing, scaleEvalMatchs, errors.Wrapf(err, "construct query condition %s",
 				jsonutils.Marshal(condition))
 		}
+		duration, _ := time.ParseDuration(condition.Query.From)
+		queryCon := queryCondition.(*conditions.QueryCondition)
+		queryCon.Reducer = conditions.NewSuggestRuleReducer(queryCon.Reducer.GetType(), duration)
 		//evalContext := alerting.NewEvalContext(context.Background(), auth.AdminCredential(), nil)
 		evalContext := alerting.EvalContext{
 			Ctx:       context.Background(),


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

优化建议增加时间筛选范围
1.在时间范围内查询未使用的资源，对于存在解绑的操作，通过查询对应的日志来确定最近的使用时间
2.基于监控的优化建议，增加新的reducer，当有足够多的points时，再进行其他逻辑

**是否需要 backport 到之前的 release 分支**:
- release/3.2

/cc @zexi 
/cc @yousong 
/area monitor
