### PR TITLE
Bugfix/yousong region

### DIFF
--- a/pkg/cloudcommon/db/rbac.go
+++ b/pkg/cloudcommon/db/rbac.go
@@ -70,7 +70,7 @@ func isObjectRbacAllowed(model IModel, userCred mcclient.TokenCredential, action
 	if !requireScope.HigherThan(scope) {
 		return nil
 	}
-	return httperrors.NewForbiddenError(fmt.Sprintf("not enough privillege(require:%s,allow:%s)", requireScope, scope))
+	return httperrors.NewForbiddenError(fmt.Sprintf("not enough privilege(require:%s,allow:%s)", requireScope, scope))
 }
 
 func isJointObjectRbacAllowed(item IJointModel, userCred mcclient.TokenCredential, action string, extra ...string) error {

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -259,7 +259,7 @@ func GetProviderFactory(provider string) (ICloudProviderFactory, error) {
 	if ok {
 		return factory, nil
 	}
-	log.Errorf("Provider %s not registerd", provider)
+	log.Errorf("Provider %s not registered", provider)
 	return nil, fmt.Errorf("No such provider %s", provider)
 }
 

--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -1047,7 +1047,7 @@ func (self *SManagedVirtualizedGuestDriver) RequestAssociateEip(ctx context.Cont
 			return nil, fmt.Errorf("ManagedVirtualizedGuestDriver.RequestAssociateEip fail to local associate EIP %s", err)
 		}
 
-		eip.SetStatus(userCred, api.EIP_STATUS_READY, "associate")
+		eip.SetStatus(userCred, api.EIP_STATUS_READY, api.EIP_STATUS_ASSOCIATE)
 		return nil, nil
 	})
 

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1219,6 +1219,11 @@ func (manager *SNetworkManager) validateEnsureWire(ctx context.Context, userCred
 }
 
 func (manager *SNetworkManager) validateEnsureZoneVpc(ctx context.Context, userCred mcclient.TokenCredential, input api.NetworkCreateInput) (w *SWire, v *SVpc, cr *SCloudregion, err error) {
+	defer func() {
+		if cause := errors.Cause(err); cause == sql.ErrNoRows {
+			err = httperrors.NewResourceNotFoundError("%s", err)
+		}
+	}()
 	zObj, err := ZoneManager.FetchByIdOrName(userCred, input.Zone)
 	if err != nil {
 		err = errors.Wrapf(err, "zone %s", input.Zone)

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -53,10 +53,6 @@ import (
 	"yunion.io/x/onecloud/pkg/util/stringutils2"
 )
 
-var (
-	ALL_NETWORK_TYPES = api.ALL_NETWORK_TYPES
-)
-
 type SNetworkManager struct {
 	db.SSharableVirtualResourceBaseManager
 	db.SExternalizedResourceBaseManager
@@ -1271,7 +1267,7 @@ func (manager *SNetworkManager) validateEnsureZoneVpc(ctx context.Context, userC
 func (manager *SNetworkManager) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, input api.NetworkCreateInput) (api.NetworkCreateInput, error) {
 	if input.ServerType == "" {
 		input.ServerType = api.NETWORK_TYPE_GUEST
-	} else if !utils.IsInStringArray(input.ServerType, ALL_NETWORK_TYPES) {
+	} else if !utils.IsInStringArray(input.ServerType, api.ALL_NETWORK_TYPES) {
 		return input, httperrors.NewInputParameterError("Invalid server_type: %s", input.ServerType)
 	}
 

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -107,8 +107,8 @@ func (manager *SWireManager) ValidateCreateData(
 		return input, httperrors.NewOutOfRangeError("mtu must be range of 0~1000000")
 	}
 
-	if len(input.Vpc) == 0 {
-		return input, httperrors.NewMissingParameterError("vpc")
+	if input.Vpc == "" {
+		input.Vpc = api.DEFAULT_VPC_ID
 	}
 
 	var vpc *SVpc


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
networks: return HTTP 404 for sql.ErrNoRows
wires: default to "default" vpc on creation
networks: eliminate a variable
guestdrivers: managed: use const api.EIP_STATUS_ASSOCIATE
cloudprovider: fix typo
cloudcommon: rbac: fix typo
```

- [x] 冒烟测试

**是否需要 backport 到之前的 release 分支**:

- release/3.1
 - release/3.0, release/2.13, #6477

/area region
/cc @swordqiu @zexi @ioito 
