### PR TITLE
Fix/esxi

### DIFF
--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -765,9 +766,8 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 	)
 	for _, disk := range disks {
 		imagePath := disk.ImagePath
-		var size int64 = 0
+		var size = disk.Size
 		if len(imagePath) == 0 {
-			size = disk.Size
 			if size == 0 {
 				size = 30 * 1024
 			}
@@ -928,6 +928,7 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SData
 		ctlKey = minDevKey(scsiDevs)
 	}
 	// change disk if set
+	newSizes := make([]int64, 0, len(from.vdisks))
 	if params.Disks != nil && len(params.Disks) > 0 {
 		var (
 			i    int
@@ -941,15 +942,9 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SData
 			}
 			size := disk.Size
 			if size == 0 {
-				continue
+				size = 30 * 1024
 			}
-			dev := from.vdisks[i].getVirtualDisk()
-			dev.CapacityInKB = size * 1024
-
-			deviceChange = append(deviceChange, &types.VirtualDeviceConfigSpec{
-				Operation: types.VirtualDeviceConfigSpecOperationEdit,
-				Device:    dev,
-			})
+			newSizes = append(newSizes, size)
 		}
 
 		// create new disk
@@ -1020,7 +1015,7 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SData
 		MemoryMB: int64(params.Mem),
 	}
 	cloneSpec.Config = &spec
-	task, err := ovm.Clone(ctx, folders.VmFolder, params.Name, *cloneSpec)
+	task, err := ovm.Clone(ctx, folders.VmFolder, name, *cloneSpec)
 	if err != nil {
 		return nil, errors.Wrap(err, "object.VirtualMachine.Clone")
 	}
@@ -1035,7 +1030,16 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SData
 		return nil, errors.Wrap(err, "fail to fetch virtual machine just created")
 	}
 
-	return NewVirtualMachine(host.manager, &moVM, host.datacenter), nil
+	// resize the disk
+	vm := NewVirtualMachine(host.manager, &moVM, host.datacenter)
+	sort.Sort(byDiskType(vm.vdisks))
+	for i, s := range newSizes {
+		err := vm.vdisks[i].Resize(ctx, s)
+		if err != nil {
+			log.Errorf("no.%d vdisk.Resize failed: %s", i, err.Error())
+		}
+	}
+	return vm, nil
 }
 
 func (host *SHost) changeNic(device types.BaseVirtualDevice, update types.BaseVirtualDevice) {

--- a/pkg/multicloud/esxi/storage.go
+++ b/pkg/multicloud/esxi/storage.go
@@ -694,7 +694,6 @@ func (self *SDatastore) GetVmdkInfo(ctx context.Context, remotePath string) (*vm
 
 func (self *SDatastore) CheckVmdk(ctx context.Context, remotePath string) error {
 	dm := object.NewVirtualDiskManager(self.manager.client.Client)
-	defer dm.Destroy(ctx)
 
 	dc, err := self.GetDatacenter()
 	if err != nil {

--- a/pkg/multicloud/esxi/storage.go
+++ b/pkg/multicloud/esxi/storage.go
@@ -610,6 +610,28 @@ func (self *SDatastore) FilePutContent(ctx context.Context, remotePath string, c
 	return self.Upload(ctx, remotePath, strings.NewReader(content))
 }
 
+// Delete2 can delete file from this Datastore.
+// isNamespace: remotePath is uuid of namespace on vsan datastore
+// force: ignore nonexistent files and arguments
+func (self *SDatastore) Delete2(ctx context.Context, remotePath string, isNamespace, force bool) error {
+	var err error
+	ds := self.getDatastoreObj()
+	dc := self.datacenter.getObjectDatacenter()
+	if isNamespace {
+		nm := object.NewDatastoreNamespaceManager(self.manager.client.Client)
+		err = nm.DeleteDirectory(ctx, dc, remotePath)
+	} else {
+		fm := ds.NewFileManager(dc, force)
+		err = fm.Delete(ctx, remotePath)
+	}
+
+	if err != nil && types.IsFileNotFound(err) && force {
+		// Ignore error
+		return nil
+	}
+	return err
+}
+
 func (self *SDatastore) Delete(ctx context.Context, remotePath string) error {
 	url := self.GetPathUrl(remotePath)
 

--- a/pkg/multicloud/esxi/vdisk.go
+++ b/pkg/multicloud/esxi/vdisk.go
@@ -296,7 +296,7 @@ func (disk *SVirtualDisk) Delete(ctx context.Context) error {
 		return err
 	}
 	ds := istorage.(*SDatastore)
-	return ds.DeleteVmdk(ctx, disk.getBackingInfo().GetFileName())
+	return ds.Delete2(ctx, disk.getBackingInfo().GetFileName(), false, false)
 }
 
 func (disk *SVirtualDisk) CreateISnapshot(ctx context.Context, name string, desc string) (cloudprovider.ICloudSnapshot, error) {

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -510,6 +510,13 @@ func (self *SVirtualMachine) shutdownVM(ctx context.Context) error {
 
 func (self *SVirtualMachine) doDelete(ctx context.Context) error {
 	vm := self.getVmObj()
+	// detach all disks first
+	for i := range self.vdisks {
+		err := self.doDetachAndDeleteDisk(ctx, &self.vdisks[i])
+		if err != nil {
+			return errors.Wrap(err, "doDetachAndDeteteDisk")
+		}
+	}
 
 	task, err := vm.Destroy(ctx)
 	if err != nil {

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -547,10 +547,6 @@ func (self *SVirtualMachine) doDetachDisk(ctx context.Context, vdisk *SVirtualDi
 	removeSpec.Operation = types.VirtualDeviceConfigSpecOperationRemove
 	removeSpec.Device = vdisk.dev
 
-	if remove {
-		removeSpec.FileOperation = types.VirtualDeviceConfigSpecFileOperationDestroy
-	}
-
 	spec := types.VirtualMachineConfigSpec{}
 	spec.DeviceChange = []types.BaseVirtualDeviceConfigSpec{&removeSpec}
 
@@ -568,7 +564,10 @@ func (self *SVirtualMachine) doDetachDisk(ctx context.Context, vdisk *SVirtualDi
 		return err
 	}
 
-	return nil
+	if !remove {
+		return nil
+	}
+	return vdisk.Delete(ctx)
 }
 
 func (self *SVirtualMachine) GetVNCInfo() (jsonutils.JSONObject, error) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. Remove 'Destory' operation that is unnecessary for VirtualDiskManager
2. Separate detach disk and delete disk when rebuilding.

    In previous versions, set
    `removeSpec.FileOperation = types.VirtualDeviceConfigSpecFileOperationDestroy'
    to delete disk indirectly.

    But, when its parent has only one child, the parent will be deleted along with it.
    And the consequence is failure to reinstall the system.

    Now, detach disk without deleteing backing file and then remove backing
    file via datastore's operation.
3. Modify the disk size correctly when creating vm
4. Detach all disk first when deleting vm to prevent to delete delta disk's parent disk.


针对问题2：

之前为了修复振华的问题做的修改：#4994
现在来看没有测试以下情况：image_cache中的某个image (简称IM） 只有一个vm在用，重装vm就会触发问题，因为 IM 会被删除掉。
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.0
- release/3.1
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->
/area esxiagent
/cc @swordqiu @zexi 