### PR TITLE
fix: cloudaccount share_mode not initialized

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -479,6 +479,13 @@ func (self *SCloudaccount) CustomizeCreate(ctx context.Context, userCred mcclien
 		// mark the public_scope has been set
 		data.(*jsonutils.JSONDict).Set("public_scope", jsonutils.NewString(self.PublicScope))
 	}
+	if len(self.ShareMode) == 0 {
+		if self.IsPublic {
+			self.ShareMode = api.CLOUD_ACCOUNT_SHARE_MODE_SYSTEM
+		} else {
+			self.ShareMode = api.CLOUD_ACCOUNT_SHARE_MODE_ACCOUNT_DOMAIN
+		}
+	}
 	return self.SEnabledStatusInfrasResourceBase.CustomizeCreate(ctx, userCred, ownerId, query, data)
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：云账号创建未初始化share_mode字段

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/area region
/cc @zexi 