### PR TITLE
Fix the problem that notify cannot be triggered when prestate = alerting and newstate = alerting

### DIFF
--- a/pkg/monitor/alerting/notifiers/base.go
+++ b/pkg/monitor/alerting/notifiers/base.go
@@ -57,6 +57,10 @@ func (n *NotifierBase) ShouldNotify(_ context.Context, evalCtx *alerting.EvalCon
 		return false
 	}
 
+	if newState == monitor.AlertStateAlerting {
+		return true
+	}
+
 	// Only notify on state change
 	if prevState == newState && !n.SendReminder {
 		return false


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复当prestate=alerting，newstate=alerting的情况无法触发notify的问题
**是否需要 backport 到之前的 release 分支**:
- release/3.1
- release/3.2

/cc @zexi 
/area monitor