### PR TITLE
Automated cherry pick of #6500: 修复当prestate=alerting，newstate=alerting的情况无法触发notify的问题

### DIFF
--- a/pkg/monitor/alerting/notifiers/base.go
+++ b/pkg/monitor/alerting/notifiers/base.go
@@ -57,6 +57,10 @@ func (n *NotifierBase) ShouldNotify(_ context.Context, evalCtx *alerting.EvalCon
 		return false
 	}
 
+	if newState == monitor.AlertStateAlerting {
+		return true
+	}
+
 	// Only notify on state change
 	if prevState == newState && !n.SendReminder {
 		return false


### PR DESCRIPTION
Cherry pick of #6500 on release/3.2.

#6500: 修复当prestate=alerting，newstate=alerting的情况无法触发notify的问题