### PR TITLE
vpcagent: apihelper: 去除details=true查询

### DIFF
--- a/pkg/mcclient/options/base.go
+++ b/pkg/mcclient/options/base.go
@@ -267,7 +267,6 @@ func (opts *BaseListOptions) Params() (*jsonutils.JSONDict, error) {
 	}
 	if BoolV(opts.PendingDeleteAll) {
 		params.Set("pending_delete", jsonutils.NewString("all"))
-		params.Set("details", jsonutils.JSONTrue) // required to get pending_deleted field
 	}
 	/*if opts.Admin == nil {
 		requiresSystem := len(opts.Tenant) > 0 ||

--- a/pkg/mcclient/options/base_test.go
+++ b/pkg/mcclient/options/base_test.go
@@ -247,11 +247,8 @@ func TestBaseListOptions(t *testing.T) {
 		}
 		for _, f := range []string{"details"} {
 			got, err := params.Bool(f)
-			if err != nil {
-				t.Fatalf("getting %s field failed: %s", f, err)
-			}
-			if !got {
-				t.Errorf("expecting %s=true, got false", f)
+			if got {
+				t.Fatalf("pending_delete=all should not imply details=true: %v", err)
 			}
 		}
 	})

--- a/pkg/vpcagent/apihelper/interface.go
+++ b/pkg/vpcagent/apihelper/interface.go
@@ -37,6 +37,8 @@ type IModelSet interface {
 	NewModel() db.IModel
 	AddModel(db.IModel)
 	Copy() IModelSet
+
+	IncludeDetails() bool
 }
 
 func SyncModelSets(mssOld IModelSets, s *mcclient.ClientSession, batchSize int) (r ModelSetsUpdateResult, err error) {
@@ -50,7 +52,7 @@ func SyncModelSets(mssOld IModelSets, s *mcclient.ClientSession, batchSize int) 
 			MinUpdatedAt:   minUpdatedAt,
 			ModelSet:       msNew,
 			BatchListSize:  batchSize,
-			IncludeDetails: true,
+			IncludeDetails: msNew.IncludeDetails(),
 		})
 		if err != nil {
 			return

--- a/pkg/vpcagent/apihelper/interface.go
+++ b/pkg/vpcagent/apihelper/interface.go
@@ -39,6 +39,7 @@ type IModelSet interface {
 	Copy() IModelSet
 
 	IncludeDetails() bool
+	IncludeEmulated() bool
 }
 
 func SyncModelSets(mssOld IModelSets, s *mcclient.ClientSession, batchSize int) (r ModelSetsUpdateResult, err error) {
@@ -47,12 +48,14 @@ func SyncModelSets(mssOld IModelSets, s *mcclient.ClientSession, batchSize int) 
 	for i, msNew := range mssNews.ModelSetList() {
 		minUpdatedAt := ModelSetMaxUpdatedAt(mss[i])
 		err = GetModels(&GetModelsOptions{
-			ClientSession:  s,
-			ModelManager:   msNew.ModelManager(),
-			MinUpdatedAt:   minUpdatedAt,
-			ModelSet:       msNew,
-			BatchListSize:  batchSize,
-			IncludeDetails: msNew.IncludeDetails(),
+			ClientSession: s,
+			ModelManager:  msNew.ModelManager(),
+			MinUpdatedAt:  minUpdatedAt,
+			ModelSet:      msNew,
+			BatchListSize: batchSize,
+
+			IncludeDetails:  msNew.IncludeDetails(),
+			IncludeEmulated: msNew.IncludeEmulated(),
 		})
 		if err != nil {
 			return

--- a/pkg/vpcagent/apihelper/reflect.go
+++ b/pkg/vpcagent/apihelper/reflect.go
@@ -38,9 +38,10 @@ type GetModelsOptions struct {
 	ModelManager  mcclient_modulebase.IBaseManager
 	ModelSet      IModelSet
 
-	BatchListSize  int
-	MinUpdatedAt   time.Time
-	IncludeDetails bool
+	BatchListSize   int
+	MinUpdatedAt    time.Time
+	IncludeDetails  bool
+	IncludeEmulated bool
 }
 
 func GetModels(opts *GetModelsOptions) error {
@@ -100,8 +101,9 @@ func GetModels(opts *GetModelsOptions) error {
 	}
 
 	listOptions := options.BaseListOptions{
-		Admin:   options.Bool(true),
-		Details: options.Bool(opts.IncludeDetails),
+		Admin:        options.Bool(true),
+		Details:      options.Bool(opts.IncludeDetails),
+		ShowEmulated: options.Bool(opts.IncludeEmulated),
 		Filter: []string{
 			minUpdatedAtFilter(minUpdatedAt), // order matters, filter.0
 			"manager_id.isnullorempty()",     // len(manager_id) > 0 is for pubcloud objects

--- a/pkg/vpcagent/models/models.go
+++ b/pkg/vpcagent/models/models.go
@@ -21,6 +21,7 @@ import (
 type Vpc struct {
 	compute_models.SVpc
 
+	Wire     *Wire    `json:"-"`
 	Networks Networks `json:"-"`
 }
 
@@ -30,19 +31,29 @@ func (el *Vpc) Copy() *Vpc {
 	}
 }
 
+type Wire struct {
+	compute_models.SWire
+
+	Vpc *Vpc
+}
+
+func (el *Wire) Copy() *Wire {
+	return &Wire{
+		SWire: el.SWire,
+	}
+}
+
 type Network struct {
 	compute_models.SNetwork
-	// returned as extra column
-	VpcId string
 
 	Vpc           *Vpc          `json:"-"`
+	Wire          *Wire         `json:"-"`
 	Guestnetworks Guestnetworks `json:"-"`
 }
 
 func (el *Network) Copy() *Network {
 	return &Network{
 		SNetwork: el.SNetwork,
-		VpcId:    el.VpcId,
 	}
 }
 

--- a/pkg/vpcagent/models/modelset.go
+++ b/pkg/vpcagent/models/modelset.go
@@ -64,6 +64,10 @@ func (set Vpcs) IncludeDetails() bool {
 	return false
 }
 
+func (set Vpcs) IncludeEmulated() bool {
+	return false
+}
+
 func (ms Vpcs) joinNetworks(subEntries Networks) bool {
 	for _, m := range ms {
 		m.Networks = Networks{}
@@ -117,6 +121,10 @@ func (set Guests) Copy() apihelper.IModelSet {
 }
 
 func (set Guests) IncludeDetails() bool {
+	return false
+}
+
+func (set Guests) IncludeEmulated() bool {
 	return false
 }
 
@@ -203,6 +211,10 @@ func (set Hosts) IncludeDetails() bool {
 	return false
 }
 
+func (set Hosts) IncludeEmulated() bool {
+	return false
+}
+
 func (set Networks) ModelManager() mcclient_modulebase.IBaseManager {
 	return &mcclient_modules.Networks
 }
@@ -226,6 +238,10 @@ func (set Networks) Copy() apihelper.IModelSet {
 
 func (set Networks) IncludeDetails() bool {
 	return true
+}
+
+func (set Networks) IncludeEmulated() bool {
+	return false
 }
 
 func (ms Networks) joinGuestnetworks(subEntries Guestnetworks) bool {
@@ -278,6 +294,10 @@ func (set Guestnetworks) IncludeDetails() bool {
 	return false
 }
 
+func (set Guestnetworks) IncludeEmulated() bool {
+	return false
+}
+
 func (set Guestnetworks) joinGuests(subEntries Guests) bool {
 	for _, gn := range set {
 		gId := gn.GuestId
@@ -318,6 +338,10 @@ func (set SecurityGroups) Copy() apihelper.IModelSet {
 }
 
 func (set SecurityGroups) IncludeDetails() bool {
+	return false
+}
+
+func (set SecurityGroups) IncludeEmulated() bool {
 	return false
 }
 
@@ -370,6 +394,10 @@ func (set SecurityGroupRules) IncludeDetails() bool {
 	return false
 }
 
+func (set SecurityGroupRules) IncludeEmulated() bool {
+	return false
+}
+
 func (set Guestsecgroups) ModelManager() mcclient_modulebase.IBaseManager {
 	return &mcclient_modules.Serversecgroups
 }
@@ -392,6 +420,10 @@ func (set Guestsecgroups) Copy() apihelper.IModelSet {
 }
 
 func (set Guestsecgroups) IncludeDetails() bool {
+	return false
+}
+
+func (set Guestsecgroups) IncludeEmulated() bool {
 	return false
 }
 

--- a/pkg/vpcagent/models/modelset.go
+++ b/pkg/vpcagent/models/modelset.go
@@ -297,7 +297,7 @@ func (set Networks) Copy() apihelper.IModelSet {
 }
 
 func (set Networks) IncludeDetails() bool {
-	return true
+	return false
 }
 
 func (set Networks) IncludeEmulated() bool {

--- a/pkg/vpcagent/models/modelset.go
+++ b/pkg/vpcagent/models/modelset.go
@@ -60,6 +60,10 @@ func (set Vpcs) Copy() apihelper.IModelSet {
 	return setCopy
 }
 
+func (set Vpcs) IncludeDetails() bool {
+	return false
+}
+
 func (ms Vpcs) joinNetworks(subEntries Networks) bool {
 	for _, m := range ms {
 		m.Networks = Networks{}
@@ -110,6 +114,10 @@ func (set Guests) Copy() apihelper.IModelSet {
 		setCopy[id] = el.Copy()
 	}
 	return setCopy
+}
+
+func (set Guests) IncludeDetails() bool {
+	return false
 }
 
 func (set Guests) initJoin() {
@@ -191,6 +199,10 @@ func (set Hosts) Copy() apihelper.IModelSet {
 	return setCopy
 }
 
+func (set Hosts) IncludeDetails() bool {
+	return false
+}
+
 func (set Networks) ModelManager() mcclient_modulebase.IBaseManager {
 	return &mcclient_modules.Networks
 }
@@ -210,6 +222,10 @@ func (set Networks) Copy() apihelper.IModelSet {
 		setCopy[id] = el.Copy()
 	}
 	return setCopy
+}
+
+func (set Networks) IncludeDetails() bool {
+	return true
 }
 
 func (ms Networks) joinGuestnetworks(subEntries Guestnetworks) bool {
@@ -258,6 +274,10 @@ func (set Guestnetworks) Copy() apihelper.IModelSet {
 	return setCopy
 }
 
+func (set Guestnetworks) IncludeDetails() bool {
+	return false
+}
+
 func (set Guestnetworks) joinGuests(subEntries Guests) bool {
 	for _, gn := range set {
 		gId := gn.GuestId
@@ -295,6 +315,10 @@ func (set SecurityGroups) Copy() apihelper.IModelSet {
 		setCopy[id] = el.Copy()
 	}
 	return setCopy
+}
+
+func (set SecurityGroups) IncludeDetails() bool {
+	return false
 }
 
 func (ms SecurityGroups) joinSecurityGroupRules(subEntries SecurityGroupRules) bool {
@@ -342,6 +366,10 @@ func (set SecurityGroupRules) Copy() apihelper.IModelSet {
 	return setCopy
 }
 
+func (set SecurityGroupRules) IncludeDetails() bool {
+	return false
+}
+
 func (set Guestsecgroups) ModelManager() mcclient_modulebase.IBaseManager {
 	return &mcclient_modules.Serversecgroups
 }
@@ -361,6 +389,10 @@ func (set Guestsecgroups) Copy() apihelper.IModelSet {
 		setCopy[id] = el.Copy()
 	}
 	return setCopy
+}
+
+func (set Guestsecgroups) IncludeDetails() bool {
+	return false
 }
 
 func (set Guestsecgroups) joinSecurityGroups(subEntries SecurityGroups) bool {

--- a/pkg/vpcagent/models/modelsets.go
+++ b/pkg/vpcagent/models/modelsets.go
@@ -39,6 +39,7 @@ func init() {
 
 type ModelSetsMaxUpdatedAt struct {
 	Vpcs               time.Time
+	Wires              time.Time
 	Networks           time.Time
 	Guests             time.Time
 	Hosts              time.Time
@@ -51,6 +52,7 @@ type ModelSetsMaxUpdatedAt struct {
 func NewModelSetsMaxUpdatedAt() *ModelSetsMaxUpdatedAt {
 	return &ModelSetsMaxUpdatedAt{
 		Vpcs:               apihelper.PseudoZeroTime,
+		Wires:              apihelper.PseudoZeroTime,
 		Networks:           apihelper.PseudoZeroTime,
 		Guests:             apihelper.PseudoZeroTime,
 		Hosts:              apihelper.PseudoZeroTime,
@@ -63,6 +65,7 @@ func NewModelSetsMaxUpdatedAt() *ModelSetsMaxUpdatedAt {
 
 type ModelSets struct {
 	Vpcs               Vpcs
+	Wires              Wires
 	Networks           Networks
 	Guests             Guests
 	Hosts              Hosts
@@ -75,6 +78,7 @@ type ModelSets struct {
 func NewModelSets() *ModelSets {
 	return &ModelSets{
 		Vpcs:               Vpcs{},
+		Wires:              Wires{},
 		Networks:           Networks{},
 		Guests:             Guests{},
 		Hosts:              Hosts{},
@@ -89,6 +93,7 @@ func (mss *ModelSets) ModelSetList() []apihelper.IModelSet {
 	// it's ordered this way to favour creation, not deletion
 	return []apihelper.IModelSet{
 		mss.Vpcs,
+		mss.Wires,
 		mss.Networks,
 		mss.Guests,
 		mss.Hosts,
@@ -106,6 +111,7 @@ func (mss *ModelSets) NewEmpty() apihelper.IModelSets {
 func (mss *ModelSets) Copy() apihelper.IModelSets {
 	mssCopy := &ModelSets{
 		Vpcs:               mss.Vpcs.Copy().(Vpcs),
+		Wires:              mss.Wires.Copy().(Wires),
 		Networks:           mss.Networks.Copy().(Networks),
 		Guests:             mss.Guests.Copy().(Guests),
 		Hosts:              mss.Hosts.Copy().(Hosts),
@@ -141,6 +147,8 @@ func (mss *ModelSets) ApplyUpdates(mssNews apihelper.IModelSets) apihelper.Model
 func (mss *ModelSets) join() bool {
 	mss.Guests.initJoin()
 	var p []bool
+	p = append(p, mss.Vpcs.joinWires(mss.Wires))
+	p = append(p, mss.Wires.joinNetworks(mss.Networks))
 	p = append(p, mss.Vpcs.joinNetworks(mss.Networks))
 	p = append(p, mss.Networks.joinGuestnetworks(mss.Guestnetworks))
 	p = append(p, mss.Guests.joinHosts(mss.Hosts))

--- a/pkg/vpcagent/ovn/keeper.go
+++ b/pkg/vpcagent/ovn/keeper.go
@@ -190,7 +190,7 @@ func (keeper *OVNNorthboundKeeper) ClaimNetwork(ctx context.Context, network *ag
 	args = append(args, ovnCreateArgs(netMdp, netMdp.Name)...)
 	args = append(args, ovnCreateArgs(dhcpopts, "dhcpopts")...)
 	args = append(args, "--", "add", "Logical_Switch", netLs.Name, "ports", "@"+netNrp.Name, "@"+netMdp.Name)
-	args = append(args, "--", "add", "Logical_Router", vpcLrName(network.VpcId), "ports", "@"+netRnp.Name)
+	args = append(args, "--", "add", "Logical_Router", vpcLrName(network.Vpc.Id), "ports", "@"+netRnp.Name)
 	return keeper.cli.Must(ctx, "ClaimNetwork", args)
 }
 

--- a/pkg/vpcagent/ovn/worker.go
+++ b/pkg/vpcagent/ovn/worker.go
@@ -24,6 +24,7 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 
+	apis "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	mcclient_modules "yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/vpcagent/apihelper"
@@ -110,6 +111,9 @@ func (w *Worker) run(ctx context.Context, mss *agentmodels.ModelSets) (err error
 
 	ovndb.Mark(ctx)
 	for _, vpc := range mss.Vpcs {
+		if vpc.Id == apis.DEFAULT_VPC_ID {
+			continue
+		}
 		ovndb.ClaimVpc(ctx, vpc)
 		for _, network := range vpc.Networks {
 			ovndb.ClaimNetwork(ctx, network)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
mcclient: options: remove implied details=true for pending_delete=all
vpcagent: models: modelset: add IncludeDetails() method
vpcagent: apihelper: use IModelSet.IncludeDetails()
vpcagent: models: modelset: add IncludeEmulated() method
vpcagent: apihelper: use IModelSet.IncludeEmulated()
vpcagent: ovn: preparation: use network.Vpc.Id
vpcagent: ovn: preparation: skip default vpc
vpcagent: models: include wires
vpcagent: models: modelset: details=false for networks
```

- [x] 冒烟测试

**是否需要 backport 到之前的 release 分支**:

NONE

/area vpcagent
/area mcclient
/area climc

/cc @swordqiu @zexi @ioito @tb365 