### PR TITLE
fix: empty matched policies list for roles

### DIFF
--- a/pkg/cloudcommon/policy/policy.go
+++ b/pkg/cloudcommon/policy/policy.go
@@ -553,10 +553,10 @@ func (manager *SPolicyManager) AllPolicies() map[string][]string {
 }
 
 func (manager *SPolicyManager) RoleMatchPolicies(roleName string) []string {
+	ident := rbacutils.NewRbacIdentity("", "", []string{roleName})
 	ret := make([]string, 0)
 	for _, policies := range manager.policies {
 		for i := range policies {
-			ident := rbacutils.NewRbacIdentity("", "", []string{roleName})
 			if matched, _ := policies[i].Policy.Match(ident); matched {
 				ret = append(ret, policies[i].Name)
 			}

--- a/pkg/util/rbacutils/rbac.go
+++ b/pkg/util/rbacutils/rbac.go
@@ -591,7 +591,7 @@ func (policy *SRbacPolicy) IsSystemWidePolicy() bool {
 }
 
 func (policy *SRbacPolicy) MatchDomain(domainId string) bool {
-	if len(policy.DomainId) == 0 {
+	if len(domainId) == 0 {
 		return true
 	}
 	if policy.DomainId == domainId {

--- a/pkg/util/rbacutils/rbac_test.go
+++ b/pkg/util/rbacutils/rbac_test.go
@@ -489,6 +489,15 @@ func TestSRbacPolicyMatch(t *testing.T) {
 			},
 			true,
 		},
+		{
+			SRbacPolicy{
+				Projects: []string{},
+				Roles:    []string{"admin"},
+				Auth:     true,
+			},
+			NewRbacIdentity("", "", []string{"admin"}),
+			true,
+		},
 	}
 	for i, c := range cases {
 		got, _ := c.policy.Match(c.userCred)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：角色的matched_policies为空

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area keystone

/hold