### PR TITLE
zstack宿主机监控中增加参数信息进行Unmarshal

### DIFF
--- a/pkg/multicloud/zstack/monitor.go
+++ b/pkg/multicloud/zstack/monitor.go
@@ -31,7 +31,8 @@ type DataPoint struct {
 }
 
 type Label struct {
-	VMUuid string `json:"VMUuid"`
+	VMUuid   string `json:"VMUuid"`
+	HostUuid string `json:"HostUuid"`
 }
 
 func (region *SRegion) GetMonitorData(name string, namespace string, since time.Time,


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
zstack宿主机监控中增加参数信息进行Unmarshal

**是否需要 backport 到之前的 release 分支**:
- release/2.13
- release/3.0
- release/3.1
- release/3.2

/cc @zexi 
/area region
