### PR TITLE
Automated cherry pick of #6580: hostman: deprecate k8s_cluster_cidr

### DIFF
--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -88,7 +88,7 @@ type SHostOptions struct {
 
 	EnableCpuBinding         bool   `default:"true" help:"Enable cpu binding and rebalance"`
 	EnableOpenflowController bool   `default:"false"`
-	K8sClusterCidr           string `default:"10.43.0.0/16" help:"Kubernetes cluster IP range"`
+	K8sClusterCidr           string `help:"Kubernetes cluster IP range"`
 
 	PingRegionInterval     int      `default:"60" help:"interval to ping region, deefault is 1 minute"`
 	ManageNtpConfiguration bool     `default:"true"`


### PR DESCRIPTION
Cherry pick of #6580 on release/3.1.

#6580: hostman: deprecate k8s_cluster_cidr