### PR TITLE
Automated cherry pick of #6607: vpcagent: apihelper: use its own options

### DIFF
--- a/pkg/hostman/options/options.go
+++ b/pkg/hostman/options/options.go
@@ -121,8 +121,8 @@ type SHostOptions struct {
 
 	OvnSouthDatabase     string `help:"address for accessing ovn south database" default:"$HOST_OVN_SOUTH_DATABASE|unix:/var/run/openvswitch/ovnsb_db.sock"`
 	OvnEncapIp           string `help:"encap ip for ovn datapath.  Default to output src address of default route" default:"$HOST_OVN_ENCAP_IP"`
-	OvnIntegrationBridge string `help:"name of integration bridge for logical ports" default:"brvpc" default:"$HOST_OVN_INTEGRATION_BRIDGE|brvpc"`
-	OvnMappedBridge      string `help:"name of bridge for mapped traffic management" default:"mapped" default:"$HOST_OVN_MAPPED_BRIDGE|brmapped"`
+	OvnIntegrationBridge string `help:"name of integration bridge for logical ports" default:"$HOST_OVN_INTEGRATION_BRIDGE|brvpc"`
+	OvnMappedBridge      string `help:"name of bridge for mapped traffic management" default:"$HOST_OVN_MAPPED_BRIDGE|brmapped"`
 
 	EnableHealthChecker bool   `help:"enable host health checker" default:"true"`
 	HealthDriver        string `help:"Component save host health state" default:"etcd"`

--- a/pkg/vpcagent/apihelper/apihelper.go
+++ b/pkg/vpcagent/apihelper/apihelper.go
@@ -24,7 +24,6 @@ import (
 
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
-	"yunion.io/x/onecloud/pkg/vpcagent/options"
 )
 
 const (
@@ -32,14 +31,14 @@ const (
 )
 
 type APIHelper struct {
-	opts        *options.Options
+	opts        *Options
 	modelSets   IModelSets
 	modelSetsCh chan IModelSets
 
 	mcclientSession *mcclient.ClientSession
 }
 
-func NewAPIHelper(opts *options.Options, modelSets IModelSets) (*APIHelper, error) {
+func NewAPIHelper(opts *Options, modelSets IModelSets) (*APIHelper, error) {
 	modelSetsCh := make(chan IModelSets)
 	helper := &APIHelper{
 		opts:        opts,
@@ -58,7 +57,7 @@ func (h *APIHelper) Start(ctx context.Context) {
 
 	h.run(ctx)
 
-	tickDuration := time.Duration(h.opts.APISyncInterval) * time.Second
+	tickDuration := time.Duration(h.opts.SyncInterval) * time.Second
 	tick := time.NewTimer(tickDuration)
 	defer tick.Stop()
 
@@ -101,7 +100,7 @@ func (h *APIHelper) doSync(ctx context.Context) (changed bool, err error) {
 	}
 
 	s := h.adminClientSession(ctx)
-	r, err := SyncModelSets(h.modelSets, s, h.opts.APIListBatchSize)
+	r, err := SyncModelSets(h.modelSets, s, h.opts.ListBatchSize)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/vpcagent/apihelper/apihelper.go
+++ b/pkg/vpcagent/apihelper/apihelper.go
@@ -82,7 +82,7 @@ func (h *APIHelper) run(ctx context.Context) {
 		log.Errorln(err)
 	}
 	if changed {
-		mssCopy := h.modelSets.Copy()
+		mssCopy := h.modelSets.CopyJoined()
 		select {
 		case h.modelSetsCh <- mssCopy:
 		case <-ctx.Done():
@@ -100,10 +100,12 @@ func (h *APIHelper) doSync(ctx context.Context) (changed bool, err error) {
 	}
 
 	s := h.adminClientSession(ctx)
-	r, err := SyncModelSets(h.modelSets, s, h.opts.ListBatchSize)
+	mss := h.modelSets.Copy()
+	r, err := SyncModelSets(mss, s, h.opts.ListBatchSize)
 	if err != nil {
 		return false, err
 	}
+	h.modelSets = mss
 	if !r.Correct {
 		return false, errors.Wrap(ErrSync, "incorrect")
 	}

--- a/pkg/vpcagent/apihelper/interface.go
+++ b/pkg/vpcagent/apihelper/interface.go
@@ -30,6 +30,7 @@ type IModelSets interface {
 	ModelSetList() []IModelSet
 	ApplyUpdates(IModelSets) ModelSetsUpdateResult
 	Copy() IModelSets
+	CopyJoined() IModelSets
 }
 
 type IModelSet interface {

--- a/pkg/vpcagent/apihelper/options.go
+++ b/pkg/vpcagent/apihelper/options.go
@@ -1,0 +1,26 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apihelper
+
+import (
+	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
+)
+
+type Options struct {
+	common_options.CommonOptions
+
+	SyncInterval  int
+	ListBatchSize int
+}

--- a/pkg/vpcagent/models/modelsets.go
+++ b/pkg/vpcagent/models/modelsets.go
@@ -15,27 +15,10 @@
 package models
 
 import (
-	"strings"
 	"time"
 
 	"yunion.io/x/onecloud/pkg/vpcagent/apihelper"
 )
-
-// pluralMap maps from KeyPlurals to underscore-separated field names
-var pluralMap = map[string]string{}
-
-func init() {
-	// XXX drop this
-	ss := []string{
-		"vpcs",
-		"networks",
-		"guestnetworks",
-	}
-	for _, s := range ss {
-		k := strings.Replace(s, "_", "", -1)
-		pluralMap[k] = s
-	}
-}
 
 type ModelSetsMaxUpdatedAt struct {
 	Vpcs          time.Time

--- a/pkg/vpcagent/models/modelsets.go
+++ b/pkg/vpcagent/models/modelsets.go
@@ -71,7 +71,7 @@ func (mss *ModelSets) NewEmpty() apihelper.IModelSets {
 	return NewModelSets()
 }
 
-func (mss *ModelSets) Copy() apihelper.IModelSets {
+func (mss *ModelSets) copy_() *ModelSets {
 	mssCopy := &ModelSets{
 		Vpcs:          mss.Vpcs.Copy().(Vpcs),
 		Networks:      mss.Networks.Copy().(Networks),
@@ -79,12 +79,17 @@ func (mss *ModelSets) Copy() apihelper.IModelSets {
 		Hosts:         mss.Hosts.Copy().(Hosts),
 		Guestnetworks: mss.Guestnetworks.Copy().(Guestnetworks),
 	}
-	mssCopy.join()
 	return mssCopy
 }
 
+func (mss *ModelSets) Copy() apihelper.IModelSets {
+	return mss.copy_()
+}
+
 func (mss *ModelSets) CopyJoined() apihelper.IModelSets {
-	return mss.Copy()
+	mssCopy := mss.copy_()
+	mssCopy.join()
+	return mssCopy
 }
 
 func (mss *ModelSets) ApplyUpdates(mssNews apihelper.IModelSets) apihelper.ModelSetsUpdateResult {

--- a/pkg/vpcagent/models/modelsets.go
+++ b/pkg/vpcagent/models/modelsets.go
@@ -83,6 +83,10 @@ func (mss *ModelSets) Copy() apihelper.IModelSets {
 	return mssCopy
 }
 
+func (mss *ModelSets) CopyJoined() apihelper.IModelSets {
+	return mss.Copy()
+}
+
 func (mss *ModelSets) ApplyUpdates(mssNews apihelper.IModelSets) apihelper.ModelSetsUpdateResult {
 	r := apihelper.ModelSetsUpdateResult{
 		Changed: false,

--- a/pkg/vpcagent/ovn/worker.go
+++ b/pkg/vpcagent/ovn/worker.go
@@ -41,7 +41,12 @@ type Worker struct {
 
 func NewWorker(opts *options.Options) worker.IWorker {
 	modelSets := agentmodels.NewModelSets()
-	apih, err := apihelper.NewAPIHelper(opts, modelSets)
+	apiOpts := &apihelper.Options{
+		CommonOptions: opts.CommonOptions,
+		SyncInterval:  opts.APISyncInterval,
+		ListBatchSize: opts.APIListBatchSize,
+	}
+	apih, err := apihelper.NewAPIHelper(apiOpts, modelSets)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
Cherry pick of #6607 on release/3.2.

#6607: vpcagent: apihelper: use its own options