### PR TITLE
apis: WireDetails: fix wrong key for vpc name

### DIFF
--- a/pkg/apis/compute/wire.go
+++ b/pkg/apis/compute/wire.go
@@ -53,7 +53,7 @@ type WireDetails struct {
 	// example: 1
 	Networks int `json:"networks"`
 	// VPC名称
-	Vpc string `json:"vpc'`
+	Vpc string `json:"vpc"`
 	// VPC外部Id
 	VpcExtId string `json:"vpc_ext_id"`
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
apis: WireDetails: fix wrong key for vpc name
```

**是否需要 backport 到之前的 release 分支**:

NONE

/area region
/cc @ioito @zexi 