### PR TITLE
修复优化建议资源列表cloudenv过滤失效的问题

### DIFF
--- a/pkg/monitor/models/suggestsysalart.go
+++ b/pkg/monitor/models/suggestsysalart.go
@@ -121,6 +121,9 @@ func (manager *SSuggestSysAlertManager) ListItemFilter(
 	if len(query.Cloudaccount) > 0 {
 		q.Equals("cloudaccount", query.Cloudaccount)
 	}
+	if len(query.CloudEnv) > 0 {
+		q = q.Equals("cloud_env", query.CloudEnv)
+	}
 	return q, nil
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修复优化建议资源列表cloudenv过滤失效的问题

**是否需要 backport 到之前的 release 分支**:
- release/3.2

/cc @zexi 
/area monitor