### PR TITLE
fix: ignore match weights when searching matched policysets

### DIFF
--- a/pkg/util/rbacutils/policyset.go
+++ b/pkg/util/rbacutils/policyset.go
@@ -25,21 +25,13 @@ type TPolicySet []*SRbacPolicy
 func GetMatchedPolicies(policies []SPolicyInfo, userCred IRbacIdentity) (TPolicySet, []string) {
 	matchedPolicies := make([]*SRbacPolicy, 0)
 	matchedNames := make([]string, 0)
-	maxMatchWeight := 0
 	for i := range policies {
-		isMatched, matchWeight := policies[i].Policy.Match(userCred)
-		if !isMatched || matchWeight < maxMatchWeight {
+		isMatched, _ := policies[i].Policy.Match(userCred)
+		if !isMatched {
 			continue
 		}
-		if maxMatchWeight <= matchWeight {
-			if maxMatchWeight < matchWeight {
-				maxMatchWeight = matchWeight
-				matchedPolicies = matchedPolicies[:0]
-				matchedNames = matchedNames[:0]
-			}
-			matchedPolicies = append(matchedPolicies, policies[i].Policy)
-			matchedNames = append(matchedNames, policies[i].Name)
-		}
+		matchedPolicies = append(matchedPolicies, policies[i].Policy)
+		matchedNames = append(matchedNames, policies[i].Name)
 	}
 	return matchedPolicies, matchedNames
 }

--- a/pkg/util/rbacutils/rbac.go
+++ b/pkg/util/rbacutils/rbac.go
@@ -642,13 +642,14 @@ func (policy *SRbacPolicy) Match(userCred IRbacIdentity) (bool, int) {
 	weight := 0
 	if policy.MatchDomain(userCred.GetProjectDomainId()) {
 		if len(policy.DomainId) > 0 {
-			weight += 10
+			if policy.DomainId == userCred.GetProjectDomainId() {
+				weight += 30 // exact domain match
+			} else if len(policy.SharedDomainIds) > 0 {
+				weight += 20 // shared domain match
+			} else {
+				weight += 10 // else, system scope match
+			}
 		}
-		if !policy.IsPublic {
-			weight += 30 // exact domain match
-		} else if len(policy.SharedDomainIds) > 0 {
-			weight += 20 // shared domain match
-		} // else, system scope match
 		if policy.MatchRoles(userCred.GetRoles()) {
 			if len(policy.Roles) != 0 {
 				weight += 100


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：匹配权限policyset时，不再使用weight来匹配最大权重的权限。这导致很多复杂度和理解问题。

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/2.13

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/area keystone apigateway
/cc @zexi 

/hold