### PR TITLE
implement generic service informer

### DIFF
--- a/cmd/climc/main.go
+++ b/cmd/climc/main.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/climc/promputils/complete_zsh.go
+++ b/cmd/climc/promputils/complete_zsh.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package promputils
 
 import (

--- a/cmd/climc/shell/k8s/event.go
+++ b/cmd/climc/shell/k8s/event.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package k8s
 
 import (

--- a/cmd/climc/shell/watch.go
+++ b/cmd/climc/shell/watch.go
@@ -1,0 +1,94 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shell
+
+import (
+	"context"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/sets"
+
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/informer"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
+)
+
+type eventHandler struct {
+	man informer.IResourceManager
+}
+
+func (e eventHandler) keyword() string {
+	return e.man.GetKeyword()
+}
+
+func (e eventHandler) OnAdd(obj *jsonutils.JSONDict) {
+	log.Infof("%s [CREATED]: \n%s", e.keyword(), obj.String())
+}
+
+func (e eventHandler) OnUpdate(oldObj, newObj *jsonutils.JSONDict) {
+	log.Infof("%s [UPDATED]: \n[NEW]: %s\n[OLD]: %s", e.keyword(), newObj.String(), oldObj.String())
+}
+
+func (e eventHandler) OnDelete(obj *jsonutils.JSONDict) {
+	log.Infof("%s [DELETED]: \n%s", e.keyword(), obj.String())
+}
+
+func init() {
+	type WatchOptions struct {
+		Resource []string `help:"Resource manager plural keyword, e.g.'servers, disks, guestdisks'" short-token:"s"`
+		All      bool     `help:"Watch all resources"`
+	}
+
+	R(&WatchOptions{}, "watch", "Watch resources", func(s *mcclient.ClientSession, opts *WatchOptions) error {
+		watchMan, err := informer.NewWatchManagerBySession(s, nil)
+		if err != nil {
+			return err
+		}
+		resources := opts.Resource
+		if opts.All {
+			resSets := sets.NewString()
+			mods, _ := modulebase.GetRegisterdModules()
+			for _, ress := range mods {
+				resSets.Insert(ress...)
+			}
+			resources = resSets.List()
+		}
+		if len(resources) == 0 {
+			return errors.Errorf("no watch resources specified")
+		}
+		for _, res := range resources {
+			var resMan informer.IResourceManager
+			if modMan, _ := modulebase.GetModule(s, res); modMan != nil {
+				resMan = modMan
+			}
+			if resMan == nil {
+				if jointModMan, _ := modulebase.GetJointModule(s, res); jointModMan != nil {
+					resMan = jointModMan
+				}
+			}
+			if resMan == nil {
+				//return errors.Errorf("Not found %q resource manager", res)
+				log.Warningf("Not found %q resource manager", res)
+				continue
+			}
+			if err := watchMan.For(resMan).AddEventHandler(context.Background(), eventHandler{resMan}); err != nil {
+				return errors.Wrapf(err, "watch resource %s", res)
+			}
+		}
+		select {}
+	})
+}

--- a/pkg/apis/compute/vpcs_ovn.go
+++ b/pkg/apis/compute/vpcs_ovn.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package compute
 
 import (

--- a/pkg/apis/identity/endpoint.go
+++ b/pkg/apis/identity/endpoint.go
@@ -38,5 +38,5 @@ type CertificateDetails struct {
 }
 
 const (
-	ENDPOINT_ETCD_INTERNAL = "etcd-internal"
+	SERVICE_TYPE_ETCD = "etcd"
 )

--- a/pkg/cloudcommon/database.go
+++ b/pkg/cloudcommon/database.go
@@ -27,6 +27,8 @@ import (
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
+	"yunion.io/x/onecloud/pkg/cloudcommon/etcd"
+	"yunion.io/x/onecloud/pkg/cloudcommon/informer"
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
 )
 
@@ -77,6 +79,26 @@ func InitDB(options *common_options.DBOptions) {
 		lockman.Init(lm)
 	}
 	// lm := lockman.NewNoopLockManager()
+
+	if len(options.EtcdEndpoints) != 0 {
+		log.Infof("using etcd as resource informer backend")
+		tlsCfg, err := options.GetEtcdTLSConfig()
+		if err != nil {
+			log.Fatalf("get etcd informer backend tls config err: %v", err)
+		}
+		informerBackend, err := informer.NewEtcdBackend(&etcd.SEtcdOptions{
+			EtcdEndpoint:              options.EtcdEndpoints,
+			EtcdTimeoutSeconds:        5,
+			EtcdRequestTimeoutSeconds: 2,
+			EtcdLeaseExpireSeconds:    5,
+			EtcdEnabldSsl:             options.EtcdUseTLS,
+			TLSConfig:                 tlsCfg,
+		}, nil)
+		if err != nil {
+			log.Fatalf("new etcd informer backend error: %v", err)
+		}
+		informer.Init(informerBackend)
+	}
 }
 
 func CloseDB() {

--- a/pkg/cloudcommon/db/certificateresource.go
+++ b/pkg/cloudcommon/db/certificateresource.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package db
 
 import (

--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -1167,7 +1167,7 @@ func _doCreateItem(
 	if err != nil {
 		return nil, httperrors.NewGeneralError(err)
 	}
-	err = manager.TableSpec().InsertOrUpdate(model)
+	err = manager.TableSpec().InsertOrUpdate(ctx, model)
 	if err != nil {
 		return nil, httperrors.NewGeneralError(err)
 	}

--- a/pkg/cloudcommon/db/interface.go
+++ b/pkg/cloudcommon/db/interface.go
@@ -40,7 +40,7 @@ type IModelManager interface {
 	GetIModelManager() IModelManager
 
 	// Table() *sqlchemy.STable
-	TableSpec() *sqlchemy.STableSpec
+	TableSpec() ITableSpec
 
 	// Keyword() string
 	KeywordPlural() string

--- a/pkg/cloudcommon/db/metadata.go
+++ b/pkg/cloudcommon/db/metadata.go
@@ -514,7 +514,7 @@ func (manager *SMetadataManager) SetValues(ctx context.Context, obj IModel, stor
 		}
 
 		if len(record.Id) == 0 {
-			err = manager.TableSpec().InsertOrUpdate(&newRecord)
+			err = manager.TableSpec().InsertOrUpdate(ctx, &newRecord)
 		} else {
 			rV, rD := record.Value, record.Deleted
 			_, err = Update(&record, func() error {

--- a/pkg/cloudcommon/db/modelbase.go
+++ b/pkg/cloudcommon/db/modelbase.go
@@ -44,7 +44,7 @@ type SModelBase struct {
 type SModelBaseManager struct {
 	object.SObject
 
-	tableSpec     *sqlchemy.STableSpec
+	tableSpec     ITableSpec
 	keyword       string
 	keywordPlural string
 	alias         string
@@ -52,7 +52,7 @@ type SModelBaseManager struct {
 }
 
 func NewModelBaseManager(model interface{}, tableName string, keyword string, keywordPlural string) SModelBaseManager {
-	ts := sqlchemy.NewTableSpecFromStruct(model, tableName)
+	ts := newTableSpec(model, tableName)
 	modelMan := SModelBaseManager{tableSpec: ts, keyword: keyword, keywordPlural: keywordPlural}
 	return modelMan
 }
@@ -78,7 +78,7 @@ func (manager *SModelBaseManager) SetAlias(alias string, aliasPlural string) {
 	manager.aliasPlural = aliasPlural
 }
 
-func (manager *SModelBaseManager) TableSpec() *sqlchemy.STableSpec {
+func (manager *SModelBaseManager) TableSpec() ITableSpec {
 	return manager.tableSpec
 }
 

--- a/pkg/cloudcommon/db/opslog.go
+++ b/pkg/cloudcommon/db/opslog.go
@@ -399,7 +399,7 @@ func (manager *SOpsLogManager) LogEvent(model IModel, action string, notes inter
 		}
 	}
 
-	err := manager.TableSpec().Insert(&opslog)
+	err := manager.TableSpec().Insert(context.Background(), &opslog)
 	if err != nil {
 		log.Errorf("fail to insert opslog: %s", err)
 	}

--- a/pkg/cloudcommon/db/proxy/proxysetting.go
+++ b/pkg/cloudcommon/db/proxy/proxysetting.go
@@ -228,7 +228,7 @@ func (man *SProxySettingManager) InitializeData() error {
 	ps.Description = "Connect directly"
 	ps.IsPublic = true
 	ps.PublicScope = string(rbacutils.ScopeSystem)
-	if err := man.TableSpec().Insert(ps); err != nil {
+	if err := man.TableSpec().Insert(context.Background(), ps); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cloudcommon/db/quotas/models.go
+++ b/pkg/cloudcommon/db/quotas/models.go
@@ -155,7 +155,7 @@ func (manager *SQuotaBaseManager) getQuotasInternal(ctx context.Context, keys IQ
 }
 
 func (manager *SQuotaBaseManager) setQuotaInternal(ctx context.Context, userCred mcclient.TokenCredential, quota IQuota) error {
-	err := manager.TableSpec().InsertOrUpdate(quota)
+	err := manager.TableSpec().InsertOrUpdate(ctx, quota)
 	if err != nil {
 		return errors.Wrap(err, "InsertOrUpdate")
 	}
@@ -292,7 +292,7 @@ func (manager *SQuotaBaseManager) InitializeData() error {
 		if quota.IsEmpty() {
 			quota.FetchSystemQuota()
 		}
-		err = manager.TableSpec().Insert(quota)
+		err = manager.TableSpec().Insert(context.Background(), quota)
 		if err != nil {
 			log.Errorf("%s insert error %s", manager.KeywordPlural(), err)
 			continue

--- a/pkg/cloudcommon/db/sharablebase_test.go
+++ b/pkg/cloudcommon/db/sharablebase_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package db
 
 import (

--- a/pkg/cloudcommon/db/sharedresource.go
+++ b/pkg/cloudcommon/db/sharedresource.go
@@ -205,7 +205,7 @@ func (manager *SSharedResourceManager) shareToTarget(
 		sharedResource.ResourceId = model.GetId()
 		sharedResource.TargetProjectId = targetId
 		sharedResource.TargetType = targetType
-		if insetErr := SharedResourceManager.TableSpec().Insert(sharedResource); insetErr != nil {
+		if insetErr := SharedResourceManager.TableSpec().Insert(ctx, sharedResource); insetErr != nil {
 			return nil, httperrors.NewInternalServerError("Insert shared resource failed %s", insetErr)
 		}
 	}

--- a/pkg/cloudcommon/db/tablespec.go
+++ b/pkg/cloudcommon/db/tablespec.go
@@ -1,0 +1,154 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"context"
+	"reflect"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/sqlchemy"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/informer"
+	"yunion.io/x/onecloud/pkg/util/nopanic"
+)
+
+type ITableSpec interface {
+	Name() string
+	DataType() reflect.Type
+	Insert(dt interface{}) error
+	InsertOrUpdate(dt interface{}) error
+	Update(dt interface{}, doUpdate func() error) (sqlchemy.UpdateDiffs, error)
+	Instance() *sqlchemy.STable
+	ColumnSpec(name string) sqlchemy.IColumnSpec
+	PrimaryColumns() []sqlchemy.IColumnSpec
+	Columns() []sqlchemy.IColumnSpec
+	Fetch(dt interface{}) error
+	FetchAll(dest interface{}) error
+	SyncSQL() []string
+	DropForeignKeySQL() []string
+	AddIndex(unique bool, cols ...string) bool
+}
+
+type sTableSpec struct {
+	*sqlchemy.STableSpec
+}
+
+func newTableSpec(model interface{}, tableName string) ITableSpec {
+	return &sTableSpec{
+		STableSpec: sqlchemy.NewTableSpecFromStruct(model, tableName),
+	}
+}
+
+func (ts *sTableSpec) newInformerModel(dt interface{}) (*informer.ModelObject, error) {
+	obj, ok := dt.(IModel)
+	if !ok {
+		return nil, errors.Errorf("informer model is not IModel")
+	}
+	if obj.GetVirtualObject() == nil {
+		return nil, errors.Errorf("object %v virtual object is nil", obj)
+	}
+	if obj.GetModelManager() == nil {
+		return nil, errors.Errorf("object %v model manager is nil", obj)
+	}
+	jointObj, isJoint := obj.(IJointModel)
+	if isJoint {
+		mObj := jointObj.Master()
+		sObj := jointObj.Slave()
+		return informer.NewJointModel(jointObj, jointObj.KeywordPlural(), mObj.GetId(), sObj.GetId()), nil
+	}
+	return informer.NewModel(obj, obj.KeywordPlural(), obj.GetId()), nil
+}
+
+func (ts *sTableSpec) isMarkDeleted(dt interface{}) (bool, error) {
+	if vObj, ok := dt.(IVirtualModel); ok {
+		if vObj.GetPendingDeleted() {
+			return true, nil
+		}
+	}
+	obj, ok := dt.(IModel)
+	if !ok {
+		return false, errors.Errorf("informer model is not IModel")
+	}
+	return obj.GetDeleted(), nil
+}
+
+func (ts *sTableSpec) Insert(dt interface{}) error {
+	if err := ts.STableSpec.Insert(dt); err != nil {
+		return err
+	}
+	ts.inform(dt, informer.Create)
+	return nil
+}
+
+func (ts *sTableSpec) InsertOrUpdate(dt interface{}) error {
+	if err := ts.STableSpec.InsertOrUpdate(dt); err != nil {
+		return err
+	}
+	ts.inform(dt, informer.Create)
+	return nil
+}
+
+func (ts *sTableSpec) Update(dt interface{}, doUpdate func() error) (sqlchemy.UpdateDiffs, error) {
+	oldObj := jsonutils.Marshal(dt)
+	diffs, err := ts.STableSpec.Update(dt, doUpdate)
+	if err != nil {
+		return nil, err
+	}
+	if diffs == nil {
+		// no data to update
+		return nil, nil
+	}
+	isDeleted, err := ts.isMarkDeleted(dt)
+	if err != nil {
+		return nil, errors.Wrap(err, "check is mark deleted")
+	}
+	if isDeleted {
+		ts.inform(dt, informer.Delete)
+	} else {
+		ts.informUpdate(dt, oldObj.(*jsonutils.JSONDict))
+	}
+	return diffs, nil
+}
+
+func (ts *sTableSpec) inform(dt interface{}, f func(ctx context.Context, obj *informer.ModelObject) error) {
+	nf := func() {
+		obj, err := ts.newInformerModel(dt)
+		if err != nil {
+			log.Warningf("newInformerModel error: %v", err)
+			return
+		}
+		if err := f(context.Background(), obj); err != nil {
+			log.Errorf("call informer func error: %v", err)
+		}
+	}
+	nopanic.Run(nf)
+}
+
+func (ts *sTableSpec) informUpdate(dt interface{}, oldObj *jsonutils.JSONDict) {
+	nf := func() {
+		obj, err := ts.newInformerModel(dt)
+		if err != nil {
+			log.Warningf("newInformerModel error: %v", err)
+			return
+		}
+		if err := informer.Update(context.Background(), obj, oldObj); err != nil {
+			log.Errorf("call informer update func error: %v", err)
+		}
+	}
+	nopanic.Run(nf)
+}

--- a/pkg/cloudcommon/db/taskman/tasks.go
+++ b/pkg/cloudcommon/db/taskman/tasks.go
@@ -263,7 +263,7 @@ func (manager *STaskManager) NewTask(
 		Params:   data,
 		Stage:    TASK_INIT_STAGE,
 	}
-	err := manager.TableSpec().Insert(&task)
+	err := manager.TableSpec().Insert(ctx, &task)
 	if err != nil {
 		log.Errorf("Task insert error %s", err)
 		return nil, err
@@ -271,7 +271,7 @@ func (manager *STaskManager) NewTask(
 	parentTask := task.GetParentTask()
 	if parentTask != nil {
 		st := SSubTask{TaskId: parentTask.Id, Stage: parentTask.Stage, SubtaskId: task.Id}
-		err := SubTaskManager.TableSpec().Insert(&st)
+		err := SubTaskManager.TableSpec().Insert(ctx, &st)
 		if err != nil {
 			log.Errorf("Subtask insert error %s", err)
 			return nil, err
@@ -311,14 +311,14 @@ func (manager *STaskManager) NewParallelTask(
 		Params:   data,
 		Stage:    TASK_INIT_STAGE,
 	}
-	err := manager.TableSpec().Insert(&task)
+	err := manager.TableSpec().Insert(ctx, &task)
 	if err != nil {
 		log.Errorf("Task insert error %s", err)
 		return nil, err
 	}
 	for _, obj := range objs {
 		to := STaskObject{TaskId: task.Id, ObjId: obj.GetId()}
-		err := TaskObjectManager.TableSpec().Insert(&to)
+		err := TaskObjectManager.TableSpec().Insert(ctx, &to)
 		if err != nil {
 			log.Errorf("Taskobject insert error %s", err)
 			return nil, err
@@ -327,7 +327,7 @@ func (manager *STaskManager) NewParallelTask(
 	parentTask := task.GetParentTask()
 	if parentTask != nil {
 		st := SSubTask{TaskId: parentTask.Id, Stage: parentTask.Stage, SubtaskId: task.Id}
-		err := SubTaskManager.TableSpec().Insert(&st)
+		err := SubTaskManager.TableSpec().Insert(ctx, &st)
 		if err != nil {
 			log.Errorf("Subtask insert error %s", err)
 			return nil, err

--- a/pkg/cloudcommon/db/tenantcache.go
+++ b/pkg/cloudcommon/db/tenantcache.go
@@ -336,7 +336,7 @@ func (manager *STenantCacheManager) Save(ctx context.Context, idStr string, name
 		obj.Domain = domain
 		obj.DomainId = domainId
 		obj.LastCheck = now
-		err = manager.TableSpec().InsertOrUpdate(obj)
+		err = manager.TableSpec().InsertOrUpdate(ctx, obj)
 		if err != nil {
 			return nil, errors.Wrap(err, "InsertOrUpdate")
 		} else {

--- a/pkg/cloudcommon/db/update.go
+++ b/pkg/cloudcommon/db/update.go
@@ -23,7 +23,7 @@ import (
 )
 
 func Update(model IModel, updateFunc func() error) (sqlchemy.UpdateDiffs, error) {
-	return model.GetModelManager().TableSpec().Update(model, updateFunc)
+	return model.GetModelManager().TableSpec().Update(context.Background(), model, updateFunc)
 }
 
 func UpdateWithLock(ctx context.Context, model IModel, updateFunc func() error) (sqlchemy.UpdateDiffs, error) {

--- a/pkg/cloudcommon/db/usercache.go
+++ b/pkg/cloudcommon/db/usercache.go
@@ -172,7 +172,7 @@ func (manager *SUserCacheManager) Save(ctx context.Context, idStr string, name s
 		obj.Domain = domain
 		obj.DomainId = domainId
 		obj.LastCheck = time.Now().UTC()
-		err = manager.TableSpec().InsertOrUpdate(obj)
+		err = manager.TableSpec().InsertOrUpdate(ctx, obj)
 		if err != nil {
 			return nil, err
 		} else {

--- a/pkg/cloudcommon/etcd/etcd.go
+++ b/pkg/cloudcommon/etcd/etcd.go
@@ -17,7 +17,6 @@ package etcd
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"time"
 
@@ -25,12 +24,13 @@ import (
 	"google.golang.org/grpc"
 
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/util/seclib2"
 )
 
 var (
-	ErrNoSuchKey = errors.New("No such key")
+	ErrNoSuchKey = errors.Error("No such key")
 )
 
 type SEtcdClient struct {
@@ -178,7 +178,7 @@ func (cli *SEtcdClient) startSession() error {
 
 func (cli *SEtcdClient) RestartSession() error {
 	if cli.leaseLiving {
-		return errors.New("session is living, can't restart")
+		return errors.Error("session is living, can't restart")
 	}
 	return cli.startSession()
 }
@@ -197,6 +197,34 @@ func (cli *SEtcdClient) Put(ctx context.Context, key string, val string) error {
 
 func (cli *SEtcdClient) PutSession(ctx context.Context, key string, val string) error {
 	return cli.put(ctx, key, val, true)
+}
+
+func (cli *SEtcdClient) grantLease(ctx context.Context, ttlSeconds int64) (*clientv3.LeaseGrantResponse, error) {
+	nctx, cancel := context.WithTimeout(ctx, cli.requestTimeout)
+	defer cancel()
+	resp, err := cli.client.Grant(nctx, ttlSeconds)
+	if err != nil {
+		return nil, errors.Wrap(err, "grant lease")
+	}
+	return resp, err
+}
+
+func (cli *SEtcdClient) PutWithLease(ctx context.Context, key string, val string, ttlSeconds int64) error {
+	resp, err := cli.grantLease(ctx, ttlSeconds)
+	if err != nil {
+		return errors.Wrap(err, "put with grant lease")
+	}
+
+	nctx, cancel := context.WithTimeout(ctx, cli.requestTimeout)
+	defer cancel()
+
+	key = cli.getKey(key)
+	leaseId := resp.ID
+	opts := []clientv3.OpOption{
+		clientv3.WithLease(leaseId),
+	}
+	_, err = cli.client.Put(nctx, key, val, opts...)
+	return err
 }
 
 func (cli *SEtcdClient) put(ctx context.Context, key string, val string, session bool) error {
@@ -269,10 +297,10 @@ func (w *SEtcdWatcher) Cancel() {
 	w.cancel()
 }
 
-func (cli *SEtcdClient) Watch(ctx context.Context, prefix string, onCreate TEtcdCreateEventFunc, onModify TEtcdModifyEventFunc) {
+func (cli *SEtcdClient) Watch(ctx context.Context, prefix string, onCreate TEtcdCreateEventFunc, onModify TEtcdModifyEventFunc) error {
 	_, ok := cli.watchers[prefix]
 	if ok {
-		return
+		return errors.Errorf("watch prefix %s already registered", prefix)
 	}
 
 	watcher := clientv3.NewWatcher(cli.client)
@@ -298,6 +326,7 @@ func (cli *SEtcdClient) Watch(ctx context.Context, prefix string, onCreate TEtcd
 		}
 		log.Infof("stop watching %s", prefix)
 	}()
+	return nil
 }
 
 func (cli *SEtcdClient) Unwatch(prefix string) {

--- a/pkg/cloudcommon/informer/doc.go
+++ b/pkg/cloudcommon/informer/doc.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package hosthandler // import "yunion.io/x/onecloud/pkg/hostman/hosthandler"
+package informer // import "yunion.io/x/onecloud/pkg/cloudcommon/informer"

--- a/pkg/cloudcommon/informer/etcd.go
+++ b/pkg/cloudcommon/informer/etcd.go
@@ -1,0 +1,184 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package informer
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/etcd"
+)
+
+const (
+	EtcdInformerPrefix = "/onecloud/informer"
+
+	EventTypeCreate = "CREATE"
+	EventTypeUpdate = "UPDATE"
+	EventTypeDelete = "DELETE"
+)
+
+type TEventType string
+
+type modelObject struct {
+	EventType TEventType          `json:"event_type"`
+	Object    *jsonutils.JSONDict `json:"object"`
+	OldObject *jsonutils.JSONDict `json:"old_object"`
+}
+
+func (obj modelObject) ToKey() string {
+	return jsonutils.Marshal(obj).String()
+}
+
+func newModelObjectFromValue(val []byte) (*modelObject, error) {
+	jObj, err := jsonutils.Parse(val)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parse key %s", val)
+	}
+	ret := new(modelObject)
+	if err := jObj.Unmarshal(ret); err != nil {
+		return nil, errors.Wrap(err, "unmarshal to model object")
+	}
+	return ret, nil
+}
+
+type EtcdBackend struct {
+	client   *etcd.SEtcdClient
+	leaseTTL int64
+}
+
+func NewEtcdBackend(opt *etcd.SEtcdOptions, onKeepaliveFailure func()) (*EtcdBackend, error) {
+	opt.EtcdNamspace = EtcdInformerPrefix
+	be := new(EtcdBackend)
+	be.leaseTTL = int64(opt.EtcdLeaseExpireSeconds)
+	if onKeepaliveFailure == nil {
+		onKeepaliveFailure = be.onKeepaliveFailure
+	}
+	cli, err := etcd.NewEtcdClient(opt, onKeepaliveFailure)
+	if err != nil {
+		return nil, errors.Wrap(err, "new etcd client")
+	}
+	be.client = cli
+	return be, nil
+}
+
+func (b *EtcdBackend) getObjectKey(obj *ModelObject) string {
+	if obj.IsJoint {
+		return fmt.Sprintf("/%s/%s/%s", obj.KeywordPlural, obj.MasterId, obj.SlaveId)
+	}
+	return fmt.Sprintf("/%s/%s", obj.KeywordPlural, obj.Id)
+}
+
+func (b *EtcdBackend) getValue(eventType TEventType, obj *ModelObject) string {
+	modelObject := modelObject{
+		EventType: eventType,
+		Object:    obj.Object,
+	}
+	return modelObject.ToKey()
+}
+
+func (b *EtcdBackend) getUpdateValue(obj *ModelObject, oldObj *jsonutils.JSONDict) string {
+	modelObject := modelObject{
+		EventType: EventTypeUpdate,
+		Object:    obj.Object,
+		OldObject: oldObj,
+	}
+	return modelObject.ToKey()
+}
+
+func (b *EtcdBackend) GetType() string {
+	return "etcd"
+}
+
+func (b *EtcdBackend) Create(ctx context.Context, obj *ModelObject) error {
+	key := b.getObjectKey(obj)
+	val := b.getValue(EventTypeCreate, obj)
+	return b.put(ctx, key, val)
+}
+
+func (b *EtcdBackend) Update(ctx context.Context, obj *ModelObject, oldObj *jsonutils.JSONDict) error {
+	key := b.getObjectKey(obj)
+	val := b.getUpdateValue(obj, oldObj)
+	return b.put(ctx, key, val)
+}
+
+func (b *EtcdBackend) Delete(ctx context.Context, obj *ModelObject) error {
+	key := b.getObjectKey(obj)
+	val := b.getValue(EventTypeDelete, obj)
+	err := b.put(ctx, key, val)
+	return err
+}
+
+func (b *EtcdBackend) put(ctx context.Context, key, val string) error {
+	return b.client.PutWithLease(ctx, key, val, b.leaseTTL)
+}
+
+func (b *EtcdBackend) onKeepaliveFailure() {
+	if err := b.client.RestartSession(); err != nil {
+		log.Errorf("restart etcd session error: %v", err)
+	}
+}
+
+func (b *EtcdBackend) getWatchKey(key string) string {
+	return filepath.Join("/", key)
+}
+
+func (b *EtcdBackend) Watch(ctx context.Context, key string, handler ResourceEventHandler) error {
+	return b.client.Watch(ctx, b.getWatchKey(key), b.onCreate(handler), b.onModify(handler))
+}
+
+func (b *EtcdBackend) Unwatch(key string) {
+	b.client.Unwatch(b.getWatchKey(key))
+}
+
+func (b *EtcdBackend) onCreate(handler ResourceEventHandler) etcd.TEtcdCreateEventFunc {
+	return func(key, value []byte) {
+		b.processEvent(handler, string(key), value)
+	}
+}
+
+func (b *EtcdBackend) onModify(handler ResourceEventHandler) etcd.TEtcdModifyEventFunc {
+	return func(key, _, value []byte) {
+		// not care about oldvalue, so ignore it
+		b.processEvent(handler, string(key), value)
+	}
+}
+
+func (b *EtcdBackend) processEvent(handler ResourceEventHandler, key string, value []byte) {
+	if len(value) == 0 {
+		// object already deleted by lease out of ttl
+		return
+	}
+	mObj, err := newModelObjectFromValue(value)
+	if err != nil {
+		log.Errorf("new %s model objecd from value error: %v", key, err)
+		return
+	}
+	eType := mObj.EventType
+	switch eType {
+	case EventTypeCreate:
+		handler.OnAdd(mObj.Object)
+	case EventTypeUpdate:
+		handler.OnUpdate(mObj.OldObject, mObj.Object)
+	case EventTypeDelete:
+		handler.OnDelete(mObj.Object)
+	default:
+		log.Errorf("Invalid event type: %s, mObj: %#v", eType, mObj)
+	}
+}

--- a/pkg/cloudcommon/informer/informer.go
+++ b/pkg/cloudcommon/informer/informer.go
@@ -1,0 +1,114 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package informer
+
+import (
+	"context"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+)
+
+const (
+	ErrBackendNotInit = errors.Error("InformerBackend not init")
+)
+
+var (
+	defaultBackend IInformerBackend
+)
+
+type IInformerBackend interface {
+	GetType() string
+	Create(ctx context.Context, obj *ModelObject) error
+	Update(ctx context.Context, obj *ModelObject, oldObj *jsonutils.JSONDict) error
+	Delete(ctx context.Context, obj *ModelObject) error
+}
+
+type IWatcher interface {
+	Watch(ctx context.Context, key string, handler ResourceEventHandler) error
+	Unwatch(key string)
+}
+
+func Init(be IInformerBackend) {
+	if defaultBackend != nil {
+		log.Fatalf("informer backend %q already init", be.GetType())
+	}
+	defaultBackend = be
+}
+
+func Set(be IInformerBackend) {
+	defaultBackend = be
+}
+
+func GetDefaultBackend() IInformerBackend {
+	if defaultBackend == nil {
+		log.Warningf("default informer backend is not init")
+	}
+	return defaultBackend
+}
+
+func IsInit() bool {
+	return defaultBackend != nil
+}
+
+type ModelObject struct {
+	Object        *jsonutils.JSONDict
+	KeywordPlural string
+	Id            string
+	IsJoint       bool
+	MasterId      string
+	SlaveId       string
+}
+
+func NewModel(obj interface{}, keywordPlural, id string) *ModelObject {
+	return &ModelObject{
+		Object:        jsonutils.Marshal(obj).(*jsonutils.JSONDict),
+		KeywordPlural: keywordPlural,
+		Id:            id,
+	}
+}
+
+func NewJointModel(obj interface{}, keywordPlural, masterId, slaveId string) *ModelObject {
+	model := NewModel(obj, keywordPlural, "")
+	model.IsJoint = true
+	model.MasterId = masterId
+	model.SlaveId = slaveId
+	return model
+}
+
+func Create(ctx context.Context, obj *ModelObject) error {
+	return run(func(be IInformerBackend) error {
+		return be.Create(ctx, obj)
+	})
+}
+
+func Update(ctx context.Context, obj *ModelObject, oldObj *jsonutils.JSONDict) error {
+	return run(func(be IInformerBackend) error {
+		return be.Update(ctx, obj, oldObj)
+	})
+}
+
+func Delete(ctx context.Context, obj *ModelObject) error {
+	return run(func(be IInformerBackend) error {
+		return be.Delete(ctx, obj)
+	})
+}
+
+type ResourceEventHandler interface {
+	OnAdd(obj *jsonutils.JSONDict)
+	OnUpdate(oldObj, newObj *jsonutils.JSONDict)
+	OnDelete(obj *jsonutils.JSONDict)
+}

--- a/pkg/cloudcommon/informer/informer.go
+++ b/pkg/cloudcommon/informer/informer.go
@@ -55,7 +55,7 @@ func Set(be IInformerBackend) {
 
 func GetDefaultBackend() IInformerBackend {
 	if defaultBackend == nil {
-		log.Warningf("default informer backend is not init")
+		log.V(10).Warningf("default informer backend is not init")
 	}
 	return defaultBackend
 }

--- a/pkg/cloudevent/models/cloudevents.go
+++ b/pkg/cloudevent/models/cloudevents.go
@@ -148,7 +148,7 @@ func (manager *SCloudeventManager) SyncCloudevent(ctx context.Context, userCred 
 
 		event.CreatedAt = iEvent.GetCreatedAt()
 		event.SetModelManager(manager, event)
-		err := manager.TableSpec().Insert(event)
+		err := manager.TableSpec().Insert(ctx, event)
 		if err != nil {
 			log.Errorf("failed to insert event: %s for cloudprovider: %s(%s) error: %v", jsonutils.Marshal(event).PrettyString(), cloudprovider.Name, cloudprovider.Id, err)
 			continue

--- a/pkg/cloudevent/models/cloudproviders.go
+++ b/pkg/cloudevent/models/cloudproviders.go
@@ -206,7 +206,7 @@ func (self *SCloudprovider) SetLastSyncTimeAt(userCred mcclient.TokenCredential,
 
 func (manager *SCloudproviderManager) newFromRegionProvider(ctx context.Context, userCred mcclient.TokenCredential, cloudprovider SCloudprovider) error {
 	cloudprovider.SyncStatus = api.CLOUD_PROVIDER_SYNC_STATUS_IDLE
-	return manager.TableSpec().Insert(&cloudprovider)
+	return manager.TableSpec().Insert(ctx, &cloudprovider)
 }
 
 func (manager *SCloudproviderManager) syncCloudeventTask(ctx context.Context, userCred mcclient.TokenCredential) error {

--- a/pkg/cloudnet/models/ifaces.go
+++ b/pkg/cloudnet/models/ifaces.go
@@ -170,7 +170,7 @@ func (iface *SIface) addOrUpdatePeer(ctx context.Context, userCred mcclient.Toke
 			PersistentKeepalive: persistentKeepalive,
 		}
 		ifacePeer.Name = fmt.Sprintf("%s-%s", iface.Name, peerIface.Name)
-		err := IfacePeerManager.TableSpec().Insert(ifacePeer)
+		err := IfacePeerManager.TableSpec().Insert(ctx, ifacePeer)
 		return err
 	}
 	_, err = db.Update(ifacePeer, func() error {
@@ -396,7 +396,7 @@ func (man *SIfaceManager) addWireguardIface(ctx context.Context, userCred mcclie
 	}
 
 	iface.SetModelManager(man, iface)
-	err := man.TableSpec().Insert(iface)
+	err := man.TableSpec().Insert(ctx, iface)
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +419,7 @@ func (man *SIfaceManager) addIface(ctx context.Context, userCred mcclient.TokenC
 		Ifname:   ifname,
 	}
 	iface.SetModelManager(man, iface)
-	err := man.TableSpec().Insert(iface)
+	err := man.TableSpec().Insert(ctx, iface)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudnet/models/meshnetwork_members.go
+++ b/pkg/cloudnet/models/meshnetwork_members.go
@@ -147,6 +147,6 @@ func (man *SMeshNetworkMemberManager) addMember(ctx context.Context, userCred mc
 	}
 	member.SetModelManager(man, member)
 	member.Name = fmt.Sprintf("%s-%s", mn.Name, router.Name)
-	man.TableSpec().Insert(member)
+	man.TableSpec().Insert(ctx, member)
 	return member, nil
 }

--- a/pkg/cloudnet/models/rules.go
+++ b/pkg/cloudnet/models/rules.go
@@ -380,7 +380,7 @@ func (man *SRuleManager) addRules(ctx context.Context, userCred mcclient.TokenCr
 }
 
 func (man *SRuleManager) addRule(ctx context.Context, userCred mcclient.TokenCredential, rule *SRule) error {
-	return man.TableSpec().Insert(rule)
+	return man.TableSpec().Insert(ctx, rule)
 }
 
 func (rule *SRule) firewalldRule() (*firewalld.Rule, error) {

--- a/pkg/compute/models/buckets.go
+++ b/pkg/compute/models/buckets.go
@@ -213,7 +213,7 @@ func (manager *SBucketManager) newFromCloudBucket(
 
 	bucket.IsEmulated = false
 
-	err = manager.TableSpec().Insert(&bucket)
+	err = manager.TableSpec().Insert(ctx, &bucket)
 	if err != nil {
 		return nil, errors.Wrap(err, "Insert")
 	}

--- a/pkg/compute/models/cachedimages.go
+++ b/pkg/compute/models/cachedimages.go
@@ -220,7 +220,7 @@ func (manager *SCachedimageManager) cacheGlanceImageInfo(ctx context.Context, us
 			imageCache.Info = info
 			imageCache.LastSync = timeutils.UtcNow()
 
-			err = manager.TableSpec().Insert(&imageCache)
+			err = manager.TableSpec().Insert(ctx, &imageCache)
 			if err != nil {
 				return nil, err
 			}
@@ -490,7 +490,7 @@ func (manager *SCachedimageManager) newFromCloudImage(ctx context.Context, userC
 	cachedImage.ImageType = image.GetImageType()
 	cachedImage.ExternalId = image.GetGlobalId()
 
-	err = manager.TableSpec().Insert(&cachedImage)
+	err = manager.TableSpec().Insert(ctx, &cachedImage)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -906,7 +906,7 @@ func (self *SCloudaccount) importSubAccount(ctx context.Context, userCred mcclie
 
 		newCloudprovider.SetModelManager(CloudproviderManager, &newCloudprovider)
 
-		err = CloudproviderManager.TableSpec().Insert(&newCloudprovider)
+		err = CloudproviderManager.TableSpec().Insert(ctx, &newCloudprovider)
 		if err != nil {
 			return nil, err
 		} else {
@@ -1173,7 +1173,7 @@ func migrateCloudprovider(cloudprovider *SCloudprovider) error {
 		account.Name = providerName
 		account.Status = cloudprovider.Status
 
-		err := CloudaccountManager.TableSpec().Insert(&account)
+		err := CloudaccountManager.TableSpec().Insert(context.Background(), &account)
 		if err != nil {
 			log.Errorf("Insert Account error: %v", err)
 			return err

--- a/pkg/compute/models/cloudprovider_quotas.go
+++ b/pkg/compute/models/cloudprovider_quotas.go
@@ -283,7 +283,7 @@ func (manager *SCloudproviderQuotaManager) newFromCloudQuota(ctx context.Context
 		quota.CloudregionId = region.Id
 	}
 
-	return manager.TableSpec().Insert(&quota)
+	return manager.TableSpec().Insert(ctx, &quota)
 }
 
 func (manager *SCloudproviderQuotaManager) ListItemExportKeys(ctx context.Context,

--- a/pkg/compute/models/cloudprovidercapacities.go
+++ b/pkg/compute/models/cloudprovidercapacities.go
@@ -73,7 +73,7 @@ func (manager *SCloudproviderCapabilityManager) setRegionCapabilities(ctx contex
 
 	for _, capability := range added {
 		cpc.Capability = capability
-		err := manager.TableSpec().InsertOrUpdate(&cpc)
+		err := manager.TableSpec().InsertOrUpdate(ctx, &cpc)
 		if err != nil {
 			return errors.Wrap(err, "manager.TableSpec().InsertOrUpdate")
 		}

--- a/pkg/compute/models/cloudproviderregions.go
+++ b/pkg/compute/models/cloudproviderregions.go
@@ -253,7 +253,7 @@ func (manager *SCloudproviderregionManager) FetchByIdsOrCreate(providerId string
 	cpr.Enabled = true
 	cpr.SyncStatus = api.CLOUD_PROVIDER_SYNC_STATUS_IDLE
 
-	err := manager.TableSpec().Insert(cpr)
+	err := manager.TableSpec().Insert(context.Background(), cpr)
 	if err != nil {
 		log.Errorf("insert fail %s", err)
 		return nil

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -1053,7 +1053,7 @@ func (manager *SCloudproviderManager) migrateVCenterInfo(vc *SVCenter) error {
 	cp.LastSync = vc.LastSync
 	cp.Provider = api.CLOUD_PROVIDER_VMWARE
 
-	return manager.TableSpec().Insert(&cp)
+	return manager.TableSpec().Insert(context.TODO(), &cp)
 }
 
 // 云订阅列表

--- a/pkg/compute/models/cloudregions.go
+++ b/pkg/compute/models/cloudregions.go
@@ -483,7 +483,7 @@ func (manager *SCloudregionManager) newFromCloudRegion(ctx context.Context, user
 		region.ManagerId = provider.Id
 	}
 
-	err = manager.TableSpec().Insert(&region)
+	err = manager.TableSpec().Insert(ctx, &region)
 	if err != nil {
 		log.Errorf("newFromCloudRegion fail %s", err)
 		return nil, err
@@ -549,7 +549,7 @@ func (manager *SCloudregionManager) InitializeData() error {
 			defRegion.Description = "Default Region"
 			defRegion.Status = api.CLOUD_REGION_STATUS_INSERVER
 			defRegion.Provider = api.CLOUD_PROVIDER_ONECLOUD
-			err := manager.TableSpec().Insert(&defRegion)
+			err := manager.TableSpec().Insert(context.TODO(), &defRegion)
 			if err != nil {
 				return errors.Wrap(err, "insert default region")
 			}

--- a/pkg/compute/models/dbinstance_accounts.go
+++ b/pkg/compute/models/dbinstance_accounts.go
@@ -680,7 +680,7 @@ func (manager *SDBInstanceAccountManager) newFromCloudDBInstanceAccount(ctx cont
 	account.Status = extAccount.GetStatus()
 	account.ExternalId = extAccount.GetGlobalId()
 
-	err := manager.TableSpec().Insert(&account)
+	err := manager.TableSpec().Insert(ctx, &account)
 	if err != nil {
 		return nil, errors.Wrapf(err, "newFromCloudDBInstanceAccount.Insert")
 	}

--- a/pkg/compute/models/dbinstance_backups.go
+++ b/pkg/compute/models/dbinstance_backups.go
@@ -504,7 +504,7 @@ func (manager *SDBInstanceBackupManager) newFromCloudDBInstanceBackup(
 		}
 	}
 
-	err = manager.TableSpec().Insert(&backup)
+	err = manager.TableSpec().Insert(ctx, &backup)
 	if err != nil {
 		return errors.Wrapf(err, "newFromCloudDBInstanceBackup.Insert")
 	}

--- a/pkg/compute/models/dbinstance_databases.go
+++ b/pkg/compute/models/dbinstance_databases.go
@@ -436,7 +436,7 @@ func (manager *SDBInstanceDatabaseManager) newFromCloudDBInstanceDatabase(ctx co
 	database.CharacterSet = extDatabase.GetCharacterSet()
 	database.ExternalId = extDatabase.GetGlobalId()
 
-	err := manager.TableSpec().Insert(&database)
+	err := manager.TableSpec().Insert(ctx, &database)
 	if err != nil {
 		return errors.Wrapf(err, "newFromCloudDBInstanceDatabase.Insert")
 	}

--- a/pkg/compute/models/dbinstance_parameters.go
+++ b/pkg/compute/models/dbinstance_parameters.go
@@ -211,7 +211,7 @@ func (manager *SDBInstanceParameterManager) newFromCloudDBInstanceParameter(ctx 
 	parameter.Value = extParameter.GetValue()
 	parameter.ExternalId = extParameter.GetGlobalId()
 
-	err := manager.TableSpec().Insert(&parameter)
+	err := manager.TableSpec().Insert(ctx, &parameter)
 	if err != nil {
 		return errors.Wrapf(err, "newFromCloudDBInstanceParameter.Insert")
 	}

--- a/pkg/compute/models/dbinstance_privileges.go
+++ b/pkg/compute/models/dbinstance_privileges.go
@@ -195,7 +195,7 @@ func (manager *SDBInstancePrivilegeManager) newFromCloudPrivileges(ctx context.C
 
 	privilege.DBInstancedatabaseId = database.Id
 
-	err = manager.TableSpec().Insert(&privilege)
+	err = manager.TableSpec().Insert(ctx, &privilege)
 	if err != nil {
 		return errors.Wrapf(err, "newFromCloudDBInstanceDatabase.Insert")
 	}

--- a/pkg/compute/models/dbinstance_skus.go
+++ b/pkg/compute/models/dbinstance_skus.go
@@ -586,7 +586,7 @@ func (manager *SDBInstanceSkuManager) newFromCloudSku(ctx context.Context, userC
 		sku.Zone3 = zone.Id
 	}
 
-	return manager.TableSpec().Insert(sku)
+	return manager.TableSpec().Insert(ctx, sku)
 }
 
 func SyncRegionDBInstanceSkus(ctx context.Context, userCred mcclient.TokenCredential, regionId string, isStart bool) {

--- a/pkg/compute/models/dbinstancenetworks.go
+++ b/pkg/compute/models/dbinstancenetworks.go
@@ -122,7 +122,7 @@ func (m *SDBInstanceNetworkManager) NewDBInstanceNetwork(ctx context.Context, us
 		return nil, err
 	}
 	in.IpAddr = ipAddr
-	err = m.TableSpec().Insert(in)
+	err = m.TableSpec().Insert(ctx, in)
 	if err != nil {
 		// NOTE no need to free ipAddr as GetFreeIP has no side effect
 		return nil, err
@@ -210,7 +210,7 @@ func (manager *SDBInstanceNetworkManager) newFromCloudDBNetwork(ctx context.Cont
 	dbNetwork.NetworkId = localnetwork.Id
 	dbNetwork.IpAddr = network.IP
 
-	err = manager.TableSpec().Insert(&dbNetwork)
+	err = manager.TableSpec().Insert(ctx, &dbNetwork)
 	if err != nil {
 		return errors.Wrapf(err, "newFromCloudDBNetwork.Insert")
 	}

--- a/pkg/compute/models/dbinstances.go
+++ b/pkg/compute/models/dbinstances.go
@@ -1608,7 +1608,7 @@ func (manager *SDBInstanceManager) newFromCloudDBInstance(ctx context.Context, u
 		instance.AutoRenew = extInstance.IsAutoRenew()
 	}
 
-	err = manager.TableSpec().Insert(&instance)
+	err = manager.TableSpec().Insert(ctx, &instance)
 	if err != nil {
 		return nil, errors.Wrapf(err, "newFromCloudDBInstance.Insert")
 	}

--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -1517,7 +1517,7 @@ func (manager *SDiskManager) newFromCloudDisk(ctx context.Context, userCred mccl
 		disk.CreatedAt = createAt
 	}
 
-	err = manager.TableSpec().Insert(&disk)
+	err = manager.TableSpec().Insert(ctx, &disk)
 	if err != nil {
 		log.Errorf("newFromCloudZone fail %s", err)
 		return nil, err

--- a/pkg/compute/models/elasticcache_accounts.go
+++ b/pkg/compute/models/elasticcache_accounts.go
@@ -179,7 +179,7 @@ func (manager *SElasticcacheAccountManager) newFromCloudElasticcacheAccount(ctx 
 	account.AccountType = extAccount.GetAccountType()
 	account.AccountPrivilege = extAccount.GetAccountPrivilege()
 
-	err := manager.TableSpec().Insert(&account)
+	err := manager.TableSpec().Insert(ctx, &account)
 	if err != nil {
 		return nil, errors.Wrapf(err, "newFromCloudElasticcacheAccount.Insert")
 	}

--- a/pkg/compute/models/elasticcache_acls.go
+++ b/pkg/compute/models/elasticcache_acls.go
@@ -159,7 +159,7 @@ func (manager *SElasticcacheAclManager) newFromCloudElasticcacheAcl(ctx context.
 	acl.ExternalId = extAcl.GetGlobalId()
 	acl.IpList = extAcl.GetIpList()
 
-	err := manager.TableSpec().Insert(&acl)
+	err := manager.TableSpec().Insert(ctx, &acl)
 	if err != nil {
 		return nil, errors.Wrapf(err, "newFromCloudElasticcacheAcl.Insert")
 	}

--- a/pkg/compute/models/elasticcache_backups.go
+++ b/pkg/compute/models/elasticcache_backups.go
@@ -187,7 +187,7 @@ func (manager *SElasticcacheBackupManager) newFromCloudElasticcacheBackup(ctx co
 	backup.StartTime = extBackup.GetStartTime()
 	backup.EndTime = extBackup.GetEndTime()
 
-	err := manager.TableSpec().Insert(&backup)
+	err := manager.TableSpec().Insert(ctx, &backup)
 	if err != nil {
 		return nil, errors.Wrapf(err, "newFromCloudElasticcacheBackup.Insert")
 	}

--- a/pkg/compute/models/elasticcache_instances.go
+++ b/pkg/compute/models/elasticcache_instances.go
@@ -613,7 +613,7 @@ func (manager *SElasticcacheManager) newFromCloudElasticcache(ctx context.Contex
 		instance.AutoRenew = extInstance.IsAutoRenew()
 	}
 
-	err = manager.TableSpec().Insert(&instance)
+	err = manager.TableSpec().Insert(ctx, &instance)
 	if err != nil {
 		return nil, errors.Wrapf(err, "newFromCloudElasticcache.Insert")
 	}

--- a/pkg/compute/models/elasticcache_parameters.go
+++ b/pkg/compute/models/elasticcache_parameters.go
@@ -175,7 +175,7 @@ func (manager *SElasticcacheParameterManager) newFromCloudElasticcacheParameter(
 	parameter.ForceRestart = extParameter.GetForceRestart()
 	parameter.Description = extParameter.GetDescription()
 
-	err := manager.TableSpec().Insert(&parameter)
+	err := manager.TableSpec().Insert(ctx, &parameter)
 	if err != nil {
 		return nil, errors.Wrapf(err, "newFromCloudElasticcacheParameter.Insert")
 	}

--- a/pkg/compute/models/elasticcache_skus.go
+++ b/pkg/compute/models/elasticcache_skus.go
@@ -454,7 +454,7 @@ func (self *SElasticcacheSku) syncWithCloudSku(ctx context.Context, userCred mcc
 }
 
 func (manager *SElasticcacheSkuManager) newFromCloudSku(ctx context.Context, userCred mcclient.TokenCredential, extSku SElasticcacheSku) error {
-	return manager.TableSpec().Insert(&extSku)
+	return manager.TableSpec().Insert(ctx, &extSku)
 }
 
 func (manager *SElasticcacheSkuManager) AllowGetPropertyInstanceSpecs(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {

--- a/pkg/compute/models/elasticips.go
+++ b/pkg/compute/models/elasticips.go
@@ -510,7 +510,7 @@ func (manager *SElasticipManager) newFromCloudEip(ctx context.Context, userCred 
 		eip.NetworkId = network.GetId()
 	}
 
-	err = manager.TableSpec().Insert(&eip)
+	err = manager.TableSpec().Insert(ctx, &eip)
 	if err != nil {
 		log.Errorf("newFromCloudEip fail %s", err)
 		return nil, err
@@ -1236,7 +1236,7 @@ func (manager *SElasticipManager) NewEipForVMOnHost(ctx context.Context, userCre
 		return nil, errors.Wrap(err, "db.GenerateName")
 	}
 
-	err = manager.TableSpec().Insert(&eip)
+	err = manager.TableSpec().Insert(ctx, &eip)
 	if err != nil {
 		log.Errorf("create EIP record fail %s", err)
 		return nil, err

--- a/pkg/compute/models/external_projects.go
+++ b/pkg/compute/models/external_projects.go
@@ -232,7 +232,7 @@ func (manager *SExternalProjectManager) newFromCloudProject(ctx context.Context,
 		}
 	}
 
-	err := manager.TableSpec().Insert(&project)
+	err := manager.TableSpec().Insert(ctx, &project)
 	if err != nil {
 		log.Errorf("newFromCloudProject fail %s", err)
 		return nil, err

--- a/pkg/compute/models/groupguests.go
+++ b/pkg/compute/models/groupguests.go
@@ -148,7 +148,7 @@ func (self *SGroupguestManager) Attach(ctx context.Context, groupId, guestId str
 	joint.GuestId = guestId
 	joint.GroupId = groupId
 
-	err := self.TableSpec().Insert(joint)
+	err := self.TableSpec().Insert(ctx, joint)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -3731,7 +3731,7 @@ func (man *SGuestManager) createImportGuest(ctx context.Context, userCred mcclie
 	gst.VcpuCount = desc.Cpu
 	gst.BootOrder = desc.BootOrder
 	gst.Description = desc.Description
-	err = man.TableSpec().Insert(gst)
+	err = man.TableSpec().Insert(ctx, gst)
 	return gst, err
 }
 

--- a/pkg/compute/models/guestdisks.go
+++ b/pkg/compute/models/guestdisks.go
@@ -167,7 +167,7 @@ func (manager *SGuestdiskManager) FetchCustomizeColumns(
 	return rows
 }
 
-func (self *SGuestdisk) DoSave(driver string, cache string, mountpoint string) error {
+func (self *SGuestdisk) DoSave(ctx context.Context, driver string, cache string, mountpoint string) error {
 	self.ImagePath = ""
 	if len(driver) == 0 {
 		driver = "scsi"
@@ -181,7 +181,7 @@ func (self *SGuestdisk) DoSave(driver string, cache string, mountpoint string) e
 	self.Driver = driver
 	self.CacheMode = cache
 	self.AioMode = "native"
-	return GuestdiskManager.TableSpec().Insert(self)
+	return GuestdiskManager.TableSpec().Insert(ctx, self)
 }
 
 func (self *SGuestdisk) GetDisk() *SDisk {

--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -277,7 +277,7 @@ func (manager *SGuestnetworkManager) newGuestNetwork(
 	}
 	gn.Ifname = ifname
 	gn.TeamWith = teamWithMac
-	err = manager.TableSpec().Insert(&gn)
+	err = manager.TableSpec().Insert(ctx, &gn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -1661,7 +1661,7 @@ func (guest *SGuest) PostCreate(ctx context.Context, userCred mcclient.TokenCred
 		gs := SGuestsecgroup{}
 		gs.SecgroupId = secgroup
 		gs.GuestId = guest.Id
-		GuestsecgroupManager.TableSpec().Insert(&gs)
+		GuestsecgroupManager.TableSpec().Insert(ctx, &gs)
 	}
 }
 
@@ -1982,7 +1982,7 @@ func (self *SGuest) getCdrom(create bool) *SGuestcdrom {
 		if err == sql.ErrNoRows {
 			if create {
 				cdrom.Id = self.Id
-				err = GuestcdromManager.TableSpec().Insert(&cdrom)
+				err = GuestcdromManager.TableSpec().Insert(context.TODO(), &cdrom)
 				if err != nil {
 					log.Errorf("insert cdrom fail %s", err)
 					return nil
@@ -2510,7 +2510,7 @@ func (manager *SGuestManager) newCloudVM(ctx context.Context, userCred mcclient.
 		guest.VmemSize = extVM.GetVmemSizeMB()
 	}
 
-	err := manager.TableSpec().Insert(&guest)
+	err := manager.TableSpec().Insert(ctx, &guest)
 	if err != nil {
 		log.Errorf("Insert fail %s", err)
 		return nil, err
@@ -2700,20 +2700,20 @@ type sAddGuestnic struct {
 	reserve bool
 }
 
-func getCloudNicNetwork(vnic cloudprovider.ICloudNic, host *SHost, ipList []string, index int) (*SNetwork, error) {
+func getCloudNicNetwork(ctx context.Context, vnic cloudprovider.ICloudNic, host *SHost, ipList []string, index int) (*SNetwork, error) {
 	vnet := vnic.GetINetwork()
 	if vnet == nil {
 		if vnic.InClassicNetwork() {
-			vpc, err := VpcManager.GetOrCreateVpcForClassicNetwork(host)
+			vpc, err := VpcManager.GetOrCreateVpcForClassicNetwork(ctx, host)
 			if err != nil {
 				return nil, errors.Wrap(err, "NewVpcForClassicNetwork")
 			}
 			zone := host.GetZone()
-			wire, err := WireManager.GetOrCreateWireForClassicNetwork(vpc, zone)
+			wire, err := WireManager.GetOrCreateWireForClassicNetwork(ctx, vpc, zone)
 			if err != nil {
 				return nil, errors.Wrap(err, "NewWireForClassicNetwork")
 			}
-			return NetworkManager.GetOrCreateClassicNetwork(wire)
+			return NetworkManager.GetOrCreateClassicNetwork(ctx, wire)
 		}
 		ip := vnic.GetIP()
 		if len(ip) == 0 {
@@ -2749,7 +2749,7 @@ func (self *SGuest) SyncVMNics(ctx context.Context, userCred mcclient.TokenCrede
 
 	for i := 0; i < len(guestnics) || i < len(vnics); i += 1 {
 		if i < len(guestnics) && i < len(vnics) {
-			localNet, err := getCloudNicNetwork(vnics[i], host, ipList, i)
+			localNet, err := getCloudNicNetwork(ctx, vnics[i], host, ipList, i)
 			if err != nil {
 				log.Errorf("%s", err)
 				result.Error(err)
@@ -2783,7 +2783,7 @@ func (self *SGuest) SyncVMNics(ctx context.Context, userCred mcclient.TokenCrede
 		} else if i < len(guestnics) {
 			removed = append(removed, sRemoveGuestnic{nic: &guestnics[i]})
 		} else if i < len(vnics) {
-			localNet, err := getCloudNicNetwork(vnics[i], host, ipList, i)
+			localNet, err := getCloudNicNetwork(ctx, vnics[i], host, ipList, i)
 			if err != nil {
 				log.Errorf("%s", err) // ignore this case
 			} else {
@@ -2907,7 +2907,7 @@ func (self *SGuest) attach2Disk(ctx context.Context, disk *SDisk, userCred mccli
 	lockman.LockObject(ctx, self)
 
 	guestdisk.Index = self.getDiskIndex()
-	err = guestdisk.DoSave(driver, cache, mountpoint)
+	err = guestdisk.DoSave(ctx, driver, cache, mountpoint)
 	if err == nil {
 		db.OpsLog.LogAttachEvent(ctx, self, disk, userCred, nil)
 	}
@@ -3326,7 +3326,7 @@ func (self *SGuest) createDiskOnStorage(ctx context.Context, userCred mcclient.T
 	if storage.IsLocal() || billingType == billing_api.BILLING_TYPE_PREPAID || isWithServerCreate {
 		autoDelete = true
 	}
-	disk, err := storage.createDisk(diskName, diskConfig, userCred, self.GetOwnerId(), autoDelete, self.IsSystem,
+	disk, err := storage.createDisk(ctx, diskName, diskConfig, userCred, self.GetOwnerId(), autoDelete, self.IsSystem,
 		billingType, billingCycle)
 
 	if err != nil {

--- a/pkg/compute/models/guestsecgroups.go
+++ b/pkg/compute/models/guestsecgroups.go
@@ -93,7 +93,7 @@ func (manager *SGuestsecgroupManager) newGuestSecgroup(ctx context.Context, user
 	lockman.LockObject(ctx, secgroup)
 	defer lockman.ReleaseObject(ctx, secgroup)
 
-	return &gs, manager.TableSpec().Insert(&gs)
+	return &gs, manager.TableSpec().Insert(ctx, &gs)
 }
 
 func (manager *SGuestsecgroupManager) GetGuestSecgroups(guest *SGuest, secgroup *SSecurityGroup) ([]SGuestsecgroup, error) {

--- a/pkg/compute/models/host_health.go
+++ b/pkg/compute/models/host_health.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package models
 
 import (

--- a/pkg/compute/models/host_recycle.go
+++ b/pkg/compute/models/host_recycle.go
@@ -174,7 +174,7 @@ func (self *SGuest) doPrepaidRecycleNoLock(ctx context.Context, userCred mcclien
 	fakeHost.IsEmulated = true
 	fakeHost.Description = "fake host for prepaid vm recycling"
 
-	err = HostManager.TableSpec().Insert(&fakeHost)
+	err = HostManager.TableSpec().Insert(ctx, &fakeHost)
 	if err != nil {
 		log.Errorf("fail to insert fake host %s", err)
 		return err
@@ -245,7 +245,7 @@ func (self *SGuest) doPrepaidRecycleNoLock(ctx context.Context, userCred mcclien
 	fakeStorage.ManagerId = sysStorage.ManagerId
 	fakeStorage.ExternalId = externalId
 
-	err = StorageManager.TableSpec().Insert(&fakeStorage)
+	err = StorageManager.TableSpec().Insert(ctx, &fakeStorage)
 	if err != nil {
 		log.Errorf("fail to insert fake storage %s", err)
 		fakeHost.RealDelete(ctx, userCred)

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -830,7 +830,7 @@ func (self *SHost) PerformUpdateStorage(
 		storage.StoragecacheId = storageCacheId
 		storage.DomainId = self.DomainId
 		storage.DomainSrc = string(apis.OWNER_SOURCE_LOCAL)
-		err := StorageManager.TableSpec().Insert(&storage)
+		err := StorageManager.TableSpec().Insert(ctx, &storage)
 		if err != nil {
 			return nil, fmt.Errorf("Create baremetal storage error: %v", err)
 		}
@@ -842,7 +842,7 @@ func (self *SHost) PerformUpdateStorage(
 		bmStorage.StorageId = storage.Id
 		bmStorage.RealCapacity = capacity
 		bmStorage.MountPoint = ""
-		err = HoststorageManager.TableSpec().Insert(&bmStorage)
+		err = HoststorageManager.TableSpec().Insert(ctx, &bmStorage)
 		if err != nil {
 			return nil, fmt.Errorf("Create baremetal hostStorage error: %v", err)
 		}
@@ -1747,7 +1747,7 @@ func (manager *SHostManager) newFromCloudHost(ctx context.Context, userCred mccl
 	host.IsPublic = false
 	host.PublicScope = string(rbacutils.ScopeNone)
 
-	err = manager.TableSpec().Insert(&host)
+	err = manager.TableSpec().Insert(ctx, &host)
 	if err != nil {
 		log.Errorf("newFromCloudHost fail %s", err)
 		return nil, err
@@ -1882,7 +1882,7 @@ func (self *SHost) Attach2Storage(ctx context.Context, userCred mcclient.TokenCr
 	hs.StorageId = storage.Id
 	hs.HostId = self.Id
 	hs.MountPoint = mountPoint
-	err := HoststorageManager.TableSpec().Insert(&hs)
+	err := HoststorageManager.TableSpec().Insert(ctx, &hs)
 	if err != nil {
 		return err
 	}
@@ -1999,7 +1999,7 @@ func (self *SHost) Attach2Wire(ctx context.Context, userCred mcclient.TokenCrede
 
 	hs.WireId = wire.Id
 	hs.HostId = self.Id
-	err := HostwireManager.TableSpec().Insert(&hs)
+	err := HostwireManager.TableSpec().Insert(ctx, &hs)
 	if err != nil {
 		return err
 	}
@@ -3694,7 +3694,7 @@ func (self *SHost) PerformInitialize(
 	guest.Status = api.VM_RUNNING
 	guest.OsType = "Linux"
 	guest.SetModelManager(GuestManager, guest)
-	err = GuestManager.TableSpec().Insert(guest)
+	err = GuestManager.TableSpec().Insert(ctx, guest)
 	if err != nil {
 		return nil, httperrors.NewInternalServerError("Guest Insert error: %s", err)
 	}
@@ -3815,7 +3815,7 @@ func (self *SHost) addNetif(ctx context.Context, userCred mcclient.TokenCredenti
 			netif.LinkUp = linkUp.Bool()
 		}
 		netif.Mtu = mtu
-		err = NetInterfaceManager.TableSpec().Insert(netif)
+		err = NetInterfaceManager.TableSpec().Insert(ctx, netif)
 		if err != nil {
 			return err
 		}
@@ -3876,7 +3876,7 @@ func (self *SHost) addNetif(ctx context.Context, userCred mcclient.TokenCredenti
 				hw.WireId = sw.Id
 				hw.IsMaster = isMaster
 				hw.MacAddr = mac
-				err := HostwireManager.TableSpec().Insert(hw)
+				err := HostwireManager.TableSpec().Insert(ctx, hw)
 				if err != nil {
 					return err
 				}
@@ -4074,7 +4074,7 @@ func (self *SHost) Attach2Network(ctx context.Context, userCred mcclient.TokenCr
 	bn.NetworkId = net.Id
 	bn.IpAddr = freeIp
 	bn.MacAddr = netif.Mac
-	err = HostnetworkManager.TableSpec().Insert(bn)
+	err = HostnetworkManager.TableSpec().Insert(ctx, bn)
 	if err != nil {
 		return nil, errors.Wrap(err, "HostnetworkManager.TableSpec().Insert")
 	}

--- a/pkg/compute/models/instance_snapshot_joint.go
+++ b/pkg/compute/models/instance_snapshot_joint.go
@@ -14,7 +14,11 @@
 
 package models
 
-import "yunion.io/x/onecloud/pkg/cloudcommon/db"
+import (
+	"context"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+)
 
 func init() {
 	db.InitManager(func() {
@@ -56,14 +60,14 @@ func (manager *SInstanceSnapshotJointManager) GetSlaveFieldName() string {
 
 var InstanceSnapshotJointManager *SInstanceSnapshotJointManager
 
-func (manager *SInstanceSnapshotJointManager) CreateJoint(instanceSnapshotId, snapshotId string, diskIndex int8) error {
+func (manager *SInstanceSnapshotJointManager) CreateJoint(ctx context.Context, instanceSnapshotId, snapshotId string, diskIndex int8) error {
 	instanceSnapshotJoint := &SInstanceSnapshotJoint{}
 	instanceSnapshotJoint.SetModelManager(manager, instanceSnapshotJoint)
 
 	instanceSnapshotJoint.InstanceSnapshotId = instanceSnapshotId
 	instanceSnapshotJoint.SnapshotId = snapshotId
 	instanceSnapshotJoint.DiskIndex = diskIndex
-	return manager.TableSpec().Insert(instanceSnapshotJoint)
+	return manager.TableSpec().Insert(ctx, instanceSnapshotJoint)
 }
 
 func (manager *SInstanceSnapshotJointManager) IsSubSnapshot(snapshotId string) (bool, error) {

--- a/pkg/compute/models/instance_snapshots.go
+++ b/pkg/compute/models/instance_snapshots.go
@@ -284,7 +284,7 @@ func (manager *SInstanceSnapshotManager) CreateInstanceSnapshot(
 	instanceSnapshot.OsType = guest.OsType
 	instanceSnapshot.ServerMetadata = serverMetadata
 	instanceSnapshot.InstanceType = guest.InstanceType
-	err := manager.TableSpec().Insert(instanceSnapshot)
+	err := manager.TableSpec().Insert(ctx, instanceSnapshot)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/loadbalanceracls.go
+++ b/pkg/compute/models/loadbalanceracls.go
@@ -446,7 +446,7 @@ func (manager *SLoadbalancerAclManager) InitializeData() error {
 		}
 		cachedAcl.Id = ""
 		cachedAcl.AclId = acl.Id
-		err = CachedLoadbalancerAclManager.TableSpec().Insert(cachedAcl)
+		err = CachedLoadbalancerAclManager.TableSpec().Insert(context.TODO(), cachedAcl)
 		if err != nil {
 			return err
 		}

--- a/pkg/compute/models/loadbalanceragents.go
+++ b/pkg/compute/models/loadbalanceragents.go
@@ -684,7 +684,7 @@ func (lbagent *SLoadbalancerAgent) PerformHb(ctx context.Context, userCred mccli
 			}
 		}
 	}
-	diff, err := lbagent.GetModelManager().TableSpec().Update(lbagent, func() error {
+	diff, err := lbagent.GetModelManager().TableSpec().Update(ctx, lbagent, func() error {
 		lbagent.HbLastSeen = time.Now()
 		if jVer, err := data.Get("version"); err == nil {
 			if jVerStr, ok := jVer.(*jsonutils.JSONString); ok {

--- a/pkg/compute/models/loadbalancerawscachedlbb.go
+++ b/pkg/compute/models/loadbalancerawscachedlbb.go
@@ -89,7 +89,7 @@ func (man *SAwsCachedLbManager) CreateAwsCachedLb(ctx context.Context, userCred 
 		return nil, err
 	}
 
-	err = man.TableSpec().Insert(cachedlbb)
+	err = man.TableSpec().Insert(ctx, cachedlbb)
 
 	if err != nil {
 		return nil, err
@@ -269,7 +269,7 @@ func (man *SAwsCachedLbManager) newFromCloudLoadbalancerBackend(ctx context.Cont
 		return nil, err
 	}
 
-	err = man.TableSpec().Insert(lbb)
+	err = man.TableSpec().Insert(ctx, lbb)
 
 	if err != nil {
 		return nil, err

--- a/pkg/compute/models/loadbalancerawscachedlbbg.go
+++ b/pkg/compute/models/loadbalancerawscachedlbbg.go
@@ -422,7 +422,7 @@ func (man *SAwsCachedLbbgManager) newFromCloudLoadbalancerBackendgroup(ctx conte
 	lbbg.Name = newName
 	lbbg.Status = extLoadbalancerBackendgroup.GetStatus()
 
-	err = man.TableSpec().Insert(lbbg)
+	err = man.TableSpec().Insert(ctx, lbbg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/loadbalancerbackendgroups.go
+++ b/pkg/compute/models/loadbalancerbackendgroups.go
@@ -977,7 +977,7 @@ func (man *SLoadbalancerBackendGroupManager) newFromCloudLoadbalancerBackendgrou
 
 	lbbg.Type = extLoadbalancerBackendgroup.GetType()
 	lbbg.Status = extLoadbalancerBackendgroup.GetStatus()
-	err = man.TableSpec().Insert(lbbg)
+	err = man.TableSpec().Insert(ctx, lbbg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/loadbalancerbackends.go
+++ b/pkg/compute/models/loadbalancerbackends.go
@@ -609,7 +609,7 @@ func (man *SLoadbalancerBackendManager) newFromCloudLoadbalancerBackend(ctx cont
 		return nil, err
 	}
 
-	err = man.TableSpec().Insert(lbb)
+	err = man.TableSpec().Insert(ctx, lbb)
 
 	if err != nil {
 		return nil, err

--- a/pkg/compute/models/loadbalancercachedacls.go
+++ b/pkg/compute/models/loadbalancercachedacls.go
@@ -363,7 +363,7 @@ func (man *SCachedLoadbalancerAclManager) GetOrCreateCachedAcl(ctx context.Conte
 	lbacl, err := man.getLoadbalancerAclByRegion(provider, region.Id, acl.Id, listenerId)
 	if err == nil {
 		if lbacl.Id != acl.Id {
-			_, err := man.TableSpec().Update(&lbacl, func() error {
+			_, err := man.TableSpec().Update(ctx, &lbacl, func() error {
 				lbacl.Name = acl.Name
 				lbacl.AclId = acl.Id
 				return nil
@@ -389,7 +389,7 @@ func (man *SCachedLoadbalancerAclManager) GetOrCreateCachedAcl(ctx context.Conte
 	lbacl.AclId = acl.Id
 	lbacl.ListenerId = listenerId
 
-	err = man.TableSpec().Insert(&lbacl)
+	err = man.TableSpec().Insert(ctx, &lbacl)
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +514,7 @@ func (man *SCachedLoadbalancerAclManager) newFromCloudLoadbalancerAcl(ctx contex
 		localAcl.DomainId = userCred.GetProjectDomainId()
 		localAcl.ProjectId = userCred.GetProjectId()
 		localAcl.ProjectSrc = string(apis.OWNER_SOURCE_CLOUD)
-		err := LoadbalancerAclManager.TableSpec().Insert(&localAcl)
+		err := LoadbalancerAclManager.TableSpec().Insert(ctx, &localAcl)
 		if err != nil {
 			return nil, errors.Wrap(err, "cachedLoadbalancerAclManager.new.InsertAcl")
 		}
@@ -529,7 +529,7 @@ func (man *SCachedLoadbalancerAclManager) newFromCloudLoadbalancerAcl(ctx contex
 		acl.AclId = localAcl.GetId()
 	}
 
-	err = man.TableSpec().Insert(&acl)
+	err = man.TableSpec().Insert(ctx, &acl)
 	if err != nil {
 		log.Errorf("newFromCloudLoadbalancerAcl fail %s", err)
 		return nil, errors.Wrap(err, "cachedLoadbalancerAclManager.new.InsertCachedAcl")

--- a/pkg/compute/models/loadbalancercachedcertificates.go
+++ b/pkg/compute/models/loadbalancercachedcertificates.go
@@ -281,7 +281,7 @@ func (man *SCachedLoadbalancerCertificateManager) GetOrCreateCachedCertificate(c
 	lbcert.IsSystem = cert.IsSystem
 	lbcert.CertificateId = cert.Id
 
-	err = man.TableSpec().Insert(&lbcert)
+	err = man.TableSpec().Insert(ctx, &lbcert)
 	if err != nil {
 		return nil, errors.Wrap(err, "cachedLoadbalancerCertificateManager.create")
 	}
@@ -317,7 +317,7 @@ func (man *SCachedLoadbalancerCertificateManager) newFromCloudLoadbalancerCertif
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
-			localcert, err := LoadbalancerCertificateManager.CreateCertificate(userCred, lbcert.Name, extCertificate.GetPublickKey(), extCertificate.GetPrivateKey(), extCertificate.GetFingerprint())
+			localcert, err := LoadbalancerCertificateManager.CreateCertificate(ctx, userCred, lbcert.Name, extCertificate.GetPublickKey(), extCertificate.GetPrivateKey(), extCertificate.GetFingerprint())
 			if err != nil {
 				return nil, fmt.Errorf("newFromCloudLoadbalancerCertificate CreateCertificate %s", err)
 			}
@@ -330,7 +330,7 @@ func (man *SCachedLoadbalancerCertificateManager) newFromCloudLoadbalancerCertif
 		lbcert.CertificateId = c.Id
 	}
 
-	err = man.TableSpec().Insert(&lbcert)
+	err = man.TableSpec().Insert(ctx, &lbcert)
 	if err != nil {
 		log.Errorf("newFromCloudLoadbalancerCertificate fail %s", err)
 		return nil, err

--- a/pkg/compute/models/loadbalancercertificates.go
+++ b/pkg/compute/models/loadbalancercertificates.go
@@ -357,7 +357,7 @@ func (man *SLoadbalancerCertificateManager) InitializeData() error {
 	return nil
 }
 
-func (man *SLoadbalancerCertificateManager) CreateCertificate(userCred mcclient.TokenCredential, name string, publicKey string, privateKey, fingerprint string) (*SLoadbalancerCertificate, error) {
+func (man *SLoadbalancerCertificateManager) CreateCertificate(ctx context.Context, userCred mcclient.TokenCredential, name string, publicKey string, privateKey, fingerprint string) (*SLoadbalancerCertificate, error) {
 	if len(fingerprint) == 0 {
 		return nil, fmt.Errorf("CreateCertificate fingerprint can not be empty")
 	}
@@ -385,7 +385,7 @@ func (man *SLoadbalancerCertificateManager) CreateCertificate(userCred mcclient.
 		cert.ProjectId = userCred.GetProjectId()
 		cert.ProjectSrc = string(apis.OWNER_SOURCE_CLOUD)
 
-		err = man.TableSpec().Insert(cert)
+		err = man.TableSpec().Insert(ctx, cert)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/compute/models/loadbalancerclusters.go
+++ b/pkg/compute/models/loadbalancerclusters.go
@@ -360,7 +360,7 @@ func (man *SLoadbalancerClusterManager) InitializeData() error {
 				lbc = m.(*SLoadbalancerCluster)
 				lbc.Name = "auto-lbc-" + zoneId
 				lbc.ZoneId = zoneId
-				if err := man.TableSpec().Insert(lbc); err != nil {
+				if err := man.TableSpec().Insert(context.TODO(), lbc); err != nil {
 					return errors.Wrap(err, "insert lbcluster model")
 				}
 			} else {

--- a/pkg/compute/models/loadbalancerhuaweicachedlbb.go
+++ b/pkg/compute/models/loadbalancerhuaweicachedlbb.go
@@ -92,7 +92,7 @@ func (man *SHuaweiCachedLbManager) CreateHuaweiCachedLb(ctx context.Context, use
 		return nil, err
 	}
 
-	err = man.TableSpec().Insert(cachedlbb)
+	err = man.TableSpec().Insert(ctx, cachedlbb)
 
 	if err != nil {
 		return nil, err
@@ -272,7 +272,7 @@ func (man *SHuaweiCachedLbManager) newFromCloudLoadbalancerBackend(ctx context.C
 		return nil, err
 	}
 
-	err = man.TableSpec().Insert(lbb)
+	err = man.TableSpec().Insert(ctx, lbb)
 
 	if err != nil {
 		return nil, err
@@ -354,7 +354,7 @@ func newLocalBackendFromCloudLoadbalancerBackend(ctx context.Context, userCred m
 			return nil, err
 		}
 
-		err = man.TableSpec().Insert(lbb)
+		err = man.TableSpec().Insert(ctx, lbb)
 
 		if err != nil {
 			return nil, err

--- a/pkg/compute/models/loadbalancerhuaweicachedlbbg.go
+++ b/pkg/compute/models/loadbalancerhuaweicachedlbbg.go
@@ -359,7 +359,7 @@ func (man *SHuaweiCachedLbbgManager) newFromCloudLoadbalancerBackendgroup(ctx co
 	lbbg.Name = newName
 	lbbg.Status = extLoadbalancerBackendgroup.GetStatus()
 
-	err = man.TableSpec().Insert(lbbg)
+	err = man.TableSpec().Insert(ctx, lbbg)
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +389,7 @@ func newLocalBackendgroupFromCloudLoadbalancerBackendgroup(ctx context.Context, 
 	lbbg.Type = extLoadbalancerBackendgroup.GetType()
 	lbbg.Status = extLoadbalancerBackendgroup.GetStatus()
 
-	err = localman.TableSpec().Insert(lbbg)
+	err = localman.TableSpec().Insert(ctx, lbbg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/loadbalancerlistenerrules.go
+++ b/pkg/compute/models/loadbalancerlistenerrules.go
@@ -850,7 +850,7 @@ func (man *SLoadbalancerListenerRuleManager) newFromCloudLoadbalancerListenerRul
 	}
 	lbr.Name = newName
 	lbr.constructFieldsFromCloudListenerRule(userCred, extRule)
-	err = man.TableSpec().Insert(lbr)
+	err = man.TableSpec().Insert(ctx, lbr)
 
 	if err != nil {
 		log.Errorf("newFromCloudLoadbalancerListenerRule fail %s", err)

--- a/pkg/compute/models/loadbalancerlisteners.go
+++ b/pkg/compute/models/loadbalancerlisteners.go
@@ -1191,7 +1191,7 @@ func (man *SLoadbalancerListenerManager) newFromCloudLoadbalancerListener(ctx co
 
 	lblis.constructFieldsFromCloudListener(userCred, lb, extListener)
 
-	err = man.TableSpec().Insert(lblis)
+	err = man.TableSpec().Insert(ctx, lblis)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/loadbalancernetworks.go
+++ b/pkg/compute/models/loadbalancernetworks.go
@@ -121,7 +121,7 @@ func (m *SLoadbalancernetworkManager) NewLoadbalancerNetwork(ctx context.Context
 		return nil, err
 	}
 	ln.IpAddr = ipAddr
-	err = m.TableSpec().Insert(ln)
+	err = m.TableSpec().Insert(ctx, ln)
 	if err != nil {
 		// NOTE no need to free ipAddr as GetFreeIP has no side effect
 		return nil, err
@@ -179,7 +179,7 @@ func (m *SLoadbalancernetworkManager) syncLoadbalancerNetwork(ctx context.Contex
 	}
 	if len(lns) == 0 {
 		ln := &SLoadbalancerNetwork{LoadbalancerId: req.Loadbalancer.Id, NetworkId: req.NetworkId, IpAddr: req.Address}
-		return m.TableSpec().Insert(ln)
+		return m.TableSpec().Insert(ctx, ln)
 	}
 	for i := 0; i < len(lns); i++ {
 		if i == 0 {

--- a/pkg/compute/models/loadbalancerqcloudcachedlbb.go
+++ b/pkg/compute/models/loadbalancerqcloudcachedlbb.go
@@ -170,7 +170,7 @@ func (man *SQcloudCachedLbManager) newFromCloudLoadbalancerBackend(ctx context.C
 		return nil, err
 	}
 
-	err = man.TableSpec().Insert(lbb)
+	err = man.TableSpec().Insert(ctx, lbb)
 
 	if err != nil {
 		return nil, err
@@ -275,7 +275,7 @@ func (man *SQcloudCachedLbManager) CreateQcloudCachedLb(ctx context.Context, use
 		return nil, err
 	}
 
-	err = man.TableSpec().Insert(cachedlbb)
+	err = man.TableSpec().Insert(ctx, cachedlbb)
 
 	if err != nil {
 		return nil, err

--- a/pkg/compute/models/loadbalancerqcloudcachedlbbg.go
+++ b/pkg/compute/models/loadbalancerqcloudcachedlbbg.go
@@ -341,7 +341,7 @@ func (man *SQcloudCachedLbbgManager) newFromCloudLoadbalancerBackendgroup(ctx co
 	lbbg.Name = newName
 	lbbg.Status = extLoadbalancerBackendgroup.GetStatus()
 
-	err = man.TableSpec().Insert(lbbg)
+	err = man.TableSpec().Insert(ctx, lbbg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/loadbalancers.go
+++ b/pkg/compute/models/loadbalancers.go
@@ -792,7 +792,7 @@ func (man *SLoadbalancerManager) newFromCloudLoadbalancer(ctx context.Context, u
 		lb.LBInfo = extLb.GetMetadata()
 	}
 
-	if err := man.TableSpec().Insert(&lb); err != nil {
+	if err := man.TableSpec().Insert(ctx, &lb); err != nil {
 		log.Errorf("newFromCloudRegion fail %s", err)
 		return nil, err
 	}

--- a/pkg/compute/models/natdtable.go
+++ b/pkg/compute/models/natdtable.go
@@ -283,7 +283,7 @@ func (manager *SNatDEntryManager) newFromCloudNatDTable(ctx context.Context, use
 	table.InternalPort = extEntry.GetInternalPort()
 	table.IpProtocol = extEntry.GetIpProtocol()
 
-	err := manager.TableSpec().Insert(&table)
+	err := manager.TableSpec().Insert(ctx, &table)
 	if err != nil {
 		log.Errorf("newFromCloudNatDTable fail %s", err)
 		return nil, err

--- a/pkg/compute/models/natgateways.go
+++ b/pkg/compute/models/natgateways.go
@@ -411,7 +411,7 @@ func (manager *SNatGatewayManager) newFromCloudNatGateway(ctx context.Context, u
 		nat.AutoRenew = extNat.IsAutoRenew()
 	}
 
-	err = manager.TableSpec().Insert(&nat)
+	err = manager.TableSpec().Insert(ctx, &nat)
 	if err != nil {
 		log.Errorf("newFromCloudNatGateway fail %s", err)
 		return nil, errors.Wrap(err, "Insert")

--- a/pkg/compute/models/natstable.go
+++ b/pkg/compute/models/natstable.go
@@ -329,7 +329,7 @@ func (manager *SNatSEntryManager) newFromCloudNatSTable(ctx context.Context, use
 		table.NetworkId = network.GetId()
 	}
 
-	err := manager.TableSpec().Insert(&table)
+	err := manager.TableSpec().Insert(ctx, &table)
 	if err != nil {
 		log.Errorf("newFromCloudNatSTable fail %s", err)
 		return nil, err

--- a/pkg/compute/models/networkinterfacenetwork.go
+++ b/pkg/compute/models/networkinterfacenetwork.go
@@ -199,7 +199,7 @@ func (manager *SNetworkinterfacenetworkManager) newFromCloudInterfaceAddress(ctx
 
 	address.NetworkId = network.Id
 
-	err = manager.TableSpec().Insert(&address)
+	err = manager.TableSpec().Insert(ctx, &address)
 	if err != nil {
 		return errors.Wrap(err, "TableSpec().Insert(&address)")
 	}

--- a/pkg/compute/models/networkinterfaces.go
+++ b/pkg/compute/models/networkinterfaces.go
@@ -347,7 +347,7 @@ func (manager *SNetworkInterfaceManager) newFromCloudNetworkInterface(ctx contex
 		}
 	}
 
-	err = manager.TableSpec().Insert(&networkinterface)
+	err = manager.TableSpec().Insert(ctx, &networkinterface)
 	if err != nil {
 		return nil, errors.Wrap(err, "TableSpec().Insert(&networkinterface)")
 	}

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -308,7 +308,7 @@ func (self *SNetwork) GetNetworkInterfacesCount() (int, error) {
 	return NetworkInterfaceManager.Query().In("id", sq).CountWithError()
 }
 
-func (manager *SNetworkManager) GetOrCreateClassicNetwork(wire *SWire) (*SNetwork, error) {
+func (manager *SNetworkManager) GetOrCreateClassicNetwork(ctx context.Context, wire *SWire) (*SNetwork, error) {
 	_network, err := db.FetchByExternalId(manager, wire.Id)
 	if err == nil {
 		return _network.(*SNetwork), nil
@@ -334,7 +334,7 @@ func (manager *SNetworkManager) GetOrCreateClassicNetwork(wire *SWire) (*SNetwor
 	network.DomainId = admin.GetProjectDomainId()
 	network.ProjectId = admin.GetProjectId()
 	network.Status = api.NETWORK_STATUS_UNAVAILABLE
-	err = manager.TableSpec().Insert(&network)
+	err = manager.TableSpec().Insert(ctx, &network)
 	if err != nil {
 		return nil, errors.Wrap(err, "Insert classic network")
 	}
@@ -726,7 +726,7 @@ func (manager *SNetworkManager) newFromCloudNetwork(ctx context.Context, userCre
 
 	net.AllocTimoutSeconds = extNet.GetAllocTimeoutSeconds()
 
-	err = manager.TableSpec().Insert(&net)
+	err = manager.TableSpec().Insert(ctx, &net)
 	if err != nil {
 		log.Errorf("newFromCloudZone fail %s", err)
 		return nil, err
@@ -2156,7 +2156,7 @@ func (self *SNetwork) PerformSplit(ctx context.Context, userCred mcclient.TokenC
 	network.IsSystem = self.IsSystem
 	network.Description = self.Description
 
-	err = NetworkManager.TableSpec().Insert(network)
+	err = NetworkManager.TableSpec().Insert(ctx, network)
 	if err != nil {
 		return nil, err
 	}
@@ -2286,7 +2286,7 @@ func (manager *SNetworkManager) PerformTryCreateNetwork(ctx context.Context, use
 		}
 		newNetwork.Name = newName
 
-		err = NetworkManager.TableSpec().Insert(newNetwork)
+		err = NetworkManager.TableSpec().Insert(ctx, newNetwork)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/compute/models/policy_assignment.go
+++ b/pkg/compute/models/policy_assignment.go
@@ -106,19 +106,19 @@ func (manager *SPolicyAssignmentManager) QueryDistinctExtraField(q *sqlchemy.SQu
 	return q, httperrors.ErrNotFound
 }
 
-func (manager *SPolicyAssignmentManager) checkAndSetAssignment(definition *SPolicyDefinition, domainId string) error {
+func (manager *SPolicyAssignmentManager) checkAndSetAssignment(ctx context.Context, definition *SPolicyDefinition, domainId string) error {
 	q := manager.Query().Equals("policydefinition_id", definition.Id).Equals("domain_id", domainId)
 	count, err := q.CountWithError()
 	if err != nil {
 		return errors.Wrap(err, "CountWithError")
 	}
 	if count == 0 {
-		return manager.newAssignment(definition, domainId)
+		return manager.newAssignment(ctx, definition, domainId)
 	}
 	return nil
 }
 
-func (manager *SPolicyAssignmentManager) newAssignment(definition *SPolicyDefinition, domainId string) error {
+func (manager *SPolicyAssignmentManager) newAssignment(ctx context.Context, definition *SPolicyDefinition, domainId string) error {
 	assignment := SPolicyAssignment{}
 	assignment.SetModelManager(manager, &assignment)
 
@@ -126,5 +126,5 @@ func (manager *SPolicyAssignmentManager) newAssignment(definition *SPolicyDefini
 	assignment.DomainId = domainId
 	assignment.PolicydefinitionId = definition.Id
 
-	return manager.TableSpec().Insert(&assignment)
+	return manager.TableSpec().Insert(ctx, &assignment)
 }

--- a/pkg/compute/models/regiondrivers.go
+++ b/pkg/compute/models/regiondrivers.go
@@ -153,7 +153,7 @@ type IDBInstanceDriver interface {
 	IsSupportDBInstancePublicConnection() bool
 	IsSupportKeepDBInstanceManualBackup() bool
 
-	InitDBInstanceUser(dbinstance *SDBInstance, task taskman.ITask, desc *cloudprovider.SManagedDBInstanceCreateConfig) error
+	InitDBInstanceUser(ctx context.Context, dbinstance *SDBInstance, task taskman.ITask, desc *cloudprovider.SManagedDBInstanceCreateConfig) error
 	IsDBInstanceNeedSecgroup() bool
 }
 

--- a/pkg/compute/models/reservedips.go
+++ b/pkg/compute/models/reservedips.go
@@ -113,7 +113,7 @@ func (manager *SReservedipManager) ReserveIPWithDurationAndStatus(userCred mccli
 	if rip == nil {
 		rip := SReservedip{IpAddr: ip, Notes: notes, ExpiredAt: expiredAt, Status: status}
 		rip.NetworkId = network.Id
-		err := manager.TableSpec().Insert(&rip)
+		err := manager.TableSpec().Insert(context.TODO(), &rip)
 		if err != nil {
 			log.Errorf("ReserveIP fail: %s", err)
 			return errors.Wrap(err, "Insert")

--- a/pkg/compute/models/routetables.go
+++ b/pkg/compute/models/routetables.go
@@ -425,7 +425,7 @@ func (man *SRouteTableManager) insertFromCloud(ctx context.Context, userCred mcc
 	if err != nil {
 		return nil, err
 	}
-	if err := man.TableSpec().Insert(routeTable); err != nil {
+	if err := man.TableSpec().Insert(ctx, routeTable); err != nil {
 		return nil, err
 	}
 	SyncCloudDomain(userCred, routeTable, provider.GetOwnerId())

--- a/pkg/compute/models/scaling_activity.go
+++ b/pkg/compute/models/scaling_activity.go
@@ -108,7 +108,7 @@ func (sam *SScalingActivity) SetReject(action string, reason string) error {
 	return sam.SetResult(action, compute.SA_STATUS_REJECT, reason, -1)
 }
 
-func (sam *SScalingActivityManager) CreateScalingActivity(sgId, triggerDesc, status string) (*SScalingActivity, error) {
+func (sam *SScalingActivityManager) CreateScalingActivity(ctx context.Context, sgId, triggerDesc, status string) (*SScalingActivity, error) {
 	scalingActivity := &SScalingActivity{
 		TriggerDesc: triggerDesc,
 		StartTime:   time.Now(),
@@ -116,7 +116,7 @@ func (sam *SScalingActivityManager) CreateScalingActivity(sgId, triggerDesc, sta
 	scalingActivity.ScalingGroupId = sgId
 	scalingActivity.Status = status
 	scalingActivity.SetModelManager(sam, scalingActivity)
-	return scalingActivity, sam.TableSpec().Insert(scalingActivity)
+	return scalingActivity, sam.TableSpec().Insert(ctx, scalingActivity)
 }
 
 func (sa *SScalingActivity) StartToScale(triggerDesc string) (*SScalingActivity, error) {

--- a/pkg/compute/models/scaling_group.go
+++ b/pkg/compute/models/scaling_group.go
@@ -510,7 +510,7 @@ func (sg *SScalingGroup) Scale(ctx context.Context, triggerDesc IScalingTriggerD
 	if sg.Enabled.IsFalse() {
 		return nil
 	}
-	scalingActivity, err := ScalingActivityManager.CreateScalingActivity(sg.Id, triggerDesc.TriggerDescription(), api.SA_STATUS_EXEC)
+	scalingActivity, err := ScalingActivityManager.CreateScalingActivity(ctx, sg.Id, triggerDesc.TriggerDescription(), api.SA_STATUS_EXEC)
 	if err != nil {
 		return errors.Wrapf(err, "create ScalingActivity whose ScalingGroup is %s error", sg.Id)
 	}

--- a/pkg/compute/models/scaling_trigger.go
+++ b/pkg/compute/models/scaling_trigger.go
@@ -337,7 +337,7 @@ func (st *SScalingTimer) ValidateCreateData(input api.ScalingPolicyCreateInput) 
 func (st *SScalingTimer) Register(ctx context.Context, userCred mcclient.TokenCredential) error {
 	// insert
 	st.Update(time.Time{})
-	err := ScalingTimerManager.TableSpec().Insert(st)
+	err := ScalingTimerManager.TableSpec().Insert(ctx, st)
 	if err != nil {
 		return errors.Wrap(err, "STableSpec.Insert")
 	}
@@ -469,7 +469,7 @@ func (sa *SScalingAlarm) Register(ctx context.Context, userCred mcclient.TokenCr
 	sa.AlarmId = alarmId
 
 	// insert
-	err = ScalingAlarmManager.TableSpec().Insert(sa)
+	err = ScalingAlarmManager.TableSpec().Insert(ctx, sa)
 	if err != nil {
 		return errors.Wrap(err, "STableSpec.Insert")
 	}

--- a/pkg/compute/models/scalinggroup_guest.go
+++ b/pkg/compute/models/scalinggroup_guest.go
@@ -68,7 +68,7 @@ func (sggm *SScalingGroupGuestManager) Attach(ctx context.Context, scaligGroupId
 	} else {
 		sgg.Manual = tristate.False
 	}
-	return sggm.TableSpec().Insert(sgg)
+	return sggm.TableSpec().Insert(ctx, sgg)
 }
 
 func (sgg *SScalingGroupGuest) Detach(ctx context.Context, userCred mcclient.TokenCredential) error {

--- a/pkg/compute/models/scalinggroup_network.go
+++ b/pkg/compute/models/scalinggroup_network.go
@@ -54,7 +54,7 @@ func (sgnm *SScalingGroupNetworkManager) Attach(ctx context.Context, scalingGrou
 		ScalingGroupId: scalingGroupId,
 		NetworkId:      networkId,
 	}
-	return sgnm.TableSpec().Insert(sgn)
+	return sgnm.TableSpec().Insert(ctx, sgn)
 }
 
 func (sgn *SScalingGroupNetwork) Detach(ctx context.Context, userCred mcclient.TokenCredential) error {

--- a/pkg/compute/models/schedtags.go
+++ b/pkg/compute/models/schedtags.go
@@ -550,7 +550,7 @@ func PerformSetResourceSchedtag(obj IModelWithSchedtag, ctx context.Context, use
 				if err := createData.Unmarshal(newTagObj); err != nil {
 					return nil, httperrors.NewGeneralError(fmt.Errorf("Create %s joint schedtag error: %v", jointMan.Keyword(), err))
 				}
-				if err := newTagObj.GetModelManager().TableSpec().Insert(newTagObj); err != nil {
+				if err := newTagObj.GetModelManager().TableSpec().Insert(ctx, newTagObj); err != nil {
 					return nil, httperrors.NewGeneralError(err)
 				}
 			}

--- a/pkg/compute/models/secgroupcache.go
+++ b/pkg/compute/models/secgroupcache.go
@@ -307,7 +307,7 @@ func (manager *SSecurityGroupCacheManager) NewCache(ctx context.Context, userCre
 	secgroupCache.CloudregionId = regionId
 	secgroupCache.Name = secgroup.GetName()
 	secgroupCache.SetModelManager(manager, secgroupCache)
-	if err := manager.TableSpec().Insert(secgroupCache); err != nil {
+	if err := manager.TableSpec().Insert(ctx, secgroupCache); err != nil {
 		log.Errorf("insert secgroupcache error: %v", err)
 		return nil, err
 	}

--- a/pkg/compute/models/secgrouprules.go
+++ b/pkg/compute/models/secgrouprules.go
@@ -498,7 +498,7 @@ func (manager *SSecurityGroupRuleManager) newFromCloudSecurityGroup(ctx context.
 	}
 	secrule.SecgroupId = secgroup.Id
 
-	err := manager.TableSpec().Insert(secrule)
+	err := manager.TableSpec().Insert(ctx, secrule)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/secgroups.go
+++ b/pkg/compute/models/secgroups.go
@@ -348,7 +348,7 @@ func (self *SSecurityGroup) PostCreate(ctx context.Context, userCred mcclient.To
 		}
 		rule.SecgroupId = self.Id
 
-		SecurityGroupRuleManager.TableSpec().Insert(rule)
+		SecurityGroupRuleManager.TableSpec().Insert(ctx, rule)
 	}
 }
 
@@ -499,7 +499,7 @@ func (self *SSecurityGroup) PerformAddRule(ctx context.Context, userCred mcclien
 	if err := rule.ValidateRule(); err != nil {
 		return nil, httperrors.NewInputParameterError(err.Error())
 	}
-	if err := SecurityGroupRuleManager.TableSpec().Insert(secgrouprule); err != nil {
+	if err := SecurityGroupRuleManager.TableSpec().Insert(ctx, secgrouprule); err != nil {
 		return nil, httperrors.NewInputParameterError(err.Error())
 	}
 	self.DoSync(ctx, userCred)
@@ -532,7 +532,7 @@ func (self *SSecurityGroup) PerformClone(ctx context.Context, userCred mcclient.
 	secgroup.ProjectId = userCred.GetProjectId()
 	secgroup.DomainId = userCred.GetProjectDomainId()
 
-	err = SecurityGroupManager.TableSpec().Insert(secgroup)
+	err = SecurityGroupManager.TableSpec().Insert(ctx, secgroup)
 	if err != nil {
 		return nil, err
 		//db.OpsLog.LogCloneEvent(self, secgroup, userCred, nil)
@@ -551,7 +551,7 @@ func (self *SSecurityGroup) PerformClone(ctx context.Context, userCred mcclient.
 		secgrouprule.Action = rule.Action
 		secgrouprule.Description = rule.Description
 		secgrouprule.SecgroupId = secgroup.Id
-		if err := SecurityGroupRuleManager.TableSpec().Insert(secgrouprule); err != nil {
+		if err := SecurityGroupRuleManager.TableSpec().Insert(ctx, secgrouprule); err != nil {
 			return nil, err
 		}
 	}
@@ -742,7 +742,7 @@ func (manager *SSecurityGroupManager) newFromCloudSecgroup(ctx context.Context, 
 	secgroup.ProjectId = provider.ProjectId
 	secgroup.DomainId = provider.DomainId
 
-	if err := manager.TableSpec().Insert(&secgroup); err != nil {
+	if err := manager.TableSpec().Insert(ctx, &secgroup); err != nil {
 		return nil, err
 	}
 
@@ -811,7 +811,7 @@ func (manager *SSecurityGroupManager) InitializeData() error {
 		// secGrp.IsEmulated = false
 		secGrp.IsPublic = true
 		secGrp.PublicScope = string(rbacutils.ScopeSystem)
-		err = manager.TableSpec().Insert(secGrp)
+		err = manager.TableSpec().Insert(context.TODO(), secGrp)
 		if err != nil {
 			log.Errorf("Insert default secgroup failed!!! %s", err)
 			return err
@@ -825,7 +825,7 @@ func (manager *SSecurityGroupManager) InitializeData() error {
 		defRule.CIDR = "0.0.0.0/0"
 		defRule.Action = string(secrules.SecurityRuleAllow)
 		defRule.SecgroupId = "default"
-		err = SecurityGroupRuleManager.TableSpec().Insert(&defRule)
+		err = SecurityGroupRuleManager.TableSpec().Insert(context.TODO(), &defRule)
 		if err != nil {
 			log.Errorf("Insert default secgroup rule fail %s", err)
 			return err

--- a/pkg/compute/models/skus.go
+++ b/pkg/compute/models/skus.go
@@ -1145,7 +1145,7 @@ func (manager *SServerSkuManager) newFromCloudSku(ctx context.Context, userCred 
 	sku.Name = extSku.GetName()
 	sku.CloudregionId = api.DEFAULT_REGION_ID
 	sku.SetModelManager(manager, sku)
-	err := manager.TableSpec().Insert(sku)
+	err := manager.TableSpec().Insert(ctx, sku)
 	if err != nil {
 		return errors.Wrapf(err, "newFromCloudSku.Insert")
 	}
@@ -1157,7 +1157,7 @@ func (manager *SServerSkuManager) newFromCloudSku(ctx context.Context, userCred 
 func (manager *SServerSkuManager) newPublicCloudSku(ctx context.Context, userCred mcclient.TokenCredential, extSku SServerSku) error {
 	extSku.Enabled = true
 	extSku.Status = api.SkuStatusReady
-	return manager.TableSpec().Insert(&extSku)
+	return manager.TableSpec().Insert(ctx, &extSku)
 }
 
 func (self *SServerSku) AllowPerformEnable(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) bool {
@@ -1288,7 +1288,7 @@ func (manager *SServerSkuManager) SyncServerSkus(ctx context.Context, userCred m
 }
 
 // sku标记为soldout状态。
-func (manager *SServerSkuManager) MarkAsSoldout(id string) error {
+func (manager *SServerSkuManager) MarkAsSoldout(ctx context.Context, id string) error {
 	if len(id) == 0 {
 		log.Debugf("MarkAsSoldout sku id should not be emtpy")
 		return nil
@@ -1304,7 +1304,7 @@ func (manager *SServerSkuManager) MarkAsSoldout(id string) error {
 		return fmt.Errorf("%s is not a sku object", id)
 	}
 
-	_, err = manager.TableSpec().Update(sku, func() error {
+	_, err = manager.TableSpec().Update(ctx, sku, func() error {
 		sku.PrepaidStatus = api.SkuStatusSoldout
 		sku.PostpaidStatus = api.SkuStatusSoldout
 		return nil
@@ -1318,10 +1318,10 @@ func (manager *SServerSkuManager) MarkAsSoldout(id string) error {
 }
 
 // sku标记为soldout状态。
-func (manager *SServerSkuManager) MarkAllAsSoldout(ids []string) error {
+func (manager *SServerSkuManager) MarkAllAsSoldout(ctx context.Context, ids []string) error {
 	var err error
 	for _, id := range ids {
-		err = manager.MarkAsSoldout(id)
+		err = manager.MarkAsSoldout(ctx, id)
 		if err != nil {
 			return err
 		}
@@ -1487,7 +1487,7 @@ func (manager *SServerSkuManager) InitializeData() error {
 				sku.Name = name
 				sku.PrepaidStatus = api.SkuStatusAvailable
 				sku.PostpaidStatus = api.SkuStatusAvailable
-				err := manager.TableSpec().Insert(sku)
+				err := manager.TableSpec().Insert(context.TODO(), sku)
 				if err != nil {
 					log.Errorf("ServerSkuManager Initialize local sku %s", err)
 				}
@@ -1504,7 +1504,7 @@ func (manager *SServerSkuManager) InitializeData() error {
 	}
 
 	for _, sku := range privateSkus {
-		_, err = manager.TableSpec().Update(&sku, func() error {
+		_, err = manager.TableSpec().Update(context.TODO(), &sku, func() error {
 			sku.LocalCategory = sku.InstanceTypeCategory
 			return nil
 		})

--- a/pkg/compute/models/snapshotpolicy.go
+++ b/pkg/compute/models/snapshotpolicy.go
@@ -577,7 +577,7 @@ func (manager *SSnapshotPolicyManager) newFromCloudSnapshotPolicy(
 		snapshotPolicyTmp.Name = newName
 		snapshotPolicyTmp.Status = ext.GetStatus()
 
-		err = manager.TableSpec().Insert(&snapshotPolicyTmp)
+		err = manager.TableSpec().Insert(ctx, &snapshotPolicyTmp)
 		if err != nil {
 			log.Errorf("newFromCloudEip fail %s", err)
 			return nil, err

--- a/pkg/compute/models/snapshotpolicycache.go
+++ b/pkg/compute/models/snapshotpolicycache.go
@@ -270,7 +270,7 @@ func (spcm *SSnapshotPolicyCacheManager) NewCache(ctx context.Context, userCred 
 	snapshotPolicyCache.Status = api.SNAPSHOT_POLICY_CACHE_STATUS_READY
 
 	// should have lock
-	if err := spcm.TableSpec().Insert(snapshotPolicyCache); err != nil {
+	if err := spcm.TableSpec().Insert(ctx, snapshotPolicyCache); err != nil {
 		return nil, errors.Wrapf(err, "insert snapshotpolicycache failed")
 	}
 	return snapshotPolicyCache, nil
@@ -285,7 +285,7 @@ func (spcm *SSnapshotPolicyCacheManager) NewCacheWithExternalId(ctx context.Cont
 	snapshotPolicyCache.Status = api.SNAPSHOT_POLICY_CACHE_STATUS_READY
 	snapshotPolicyCache.Name = name
 	// should have lock
-	if err := spcm.TableSpec().Insert(snapshotPolicyCache); err != nil {
+	if err := spcm.TableSpec().Insert(ctx, snapshotPolicyCache); err != nil {
 		return nil, errors.Wrapf(err, "insert snapshotpolicycache failed")
 	}
 	return snapshotPolicyCache, nil

--- a/pkg/compute/models/snapshotpolicydisks.go
+++ b/pkg/compute/models/snapshotpolicydisks.go
@@ -322,7 +322,7 @@ func (m *SSnapshotPolicyDiskManager) SyncAttachDisk(ctx context.Context, userCre
 		sd.DiskId = disk.GetId()
 		sd.SnapshotpolicyId = spId
 		sd.Status = api.SNAPSHOT_POLICY_DISK_READY
-		err = m.TableSpec().Insert(&sd)
+		err = m.TableSpec().Insert(ctx, &sd)
 		if err != nil {
 			failRecord = append(failRecord, fmt.Sprintf("attachsnapshotpolicy %s to disk %s failed",
 				spId, disk.GetId()))
@@ -424,7 +424,7 @@ func (self *SSnapshotPolicyDiskManager) newSnapshotpolicyDisk(ctx context.Contex
 
 	lockman.LockJointObject(ctx, disk, sp)
 	defer lockman.ReleaseJointObject(ctx, disk, sp)
-	return &spd, self.TableSpec().Insert(&spd)
+	return &spd, self.TableSpec().Insert(ctx, &spd)
 
 }
 func (self *SSnapshotPolicyDiskManager) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {

--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -575,7 +575,7 @@ func (self *SSnapshotManager) CreateSnapshot(ctx context.Context, owner mcclient
 	if retentionDay > 0 {
 		snapshot.ExpiredAt = time.Now().AddDate(0, 0, retentionDay)
 	}
-	err = SnapshotManager.TableSpec().Insert(snapshot)
+	err = SnapshotManager.TableSpec().Insert(ctx, snapshot)
 	if err != nil {
 		return nil, err
 	}
@@ -892,7 +892,7 @@ func (manager *SSnapshotManager) newFromCloudSnapshot(ctx context.Context, userC
 	snapshot.ManagerId = provider.Id
 	snapshot.CloudregionId = region.Id
 
-	err = manager.TableSpec().Insert(&snapshot)
+	err = manager.TableSpec().Insert(ctx, &snapshot)
 	if err != nil {
 		log.Errorf("newFromCloudEip fail %s", err)
 		return nil, err

--- a/pkg/compute/models/storagecachedimages.go
+++ b/pkg/compute/models/storagecachedimages.go
@@ -360,7 +360,7 @@ func (manager *SStoragecachedimageManager) Register(ctx context.Context, userCre
 	}
 	cachedimage.Status = status
 
-	err := manager.TableSpec().Insert(cachedimage)
+	err := manager.TableSpec().Insert(ctx, cachedimage)
 
 	if err != nil {
 		log.Errorf("insert error %s", err)

--- a/pkg/compute/models/storagecaches.go
+++ b/pkg/compute/models/storagecaches.go
@@ -209,7 +209,7 @@ func (manager *SStoragecacheManager) newFromCloudStoragecache(ctx context.Contex
 
 	local.Path = cloudCache.GetPath()
 
-	err = manager.TableSpec().Insert(&local)
+	err = manager.TableSpec().Insert(ctx, &local)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -812,7 +812,7 @@ func (manager *SStorageManager) newFromCloudStorage(ctx context.Context, userCre
 
 	storage.IsSysDiskStore = tristate.NewFromBool(extStorage.IsSysDiskStore())
 
-	err = manager.TableSpec().Insert(&storage)
+	err = manager.TableSpec().Insert(ctx, &storage)
 	if err != nil {
 		log.Errorf("newFromCloudStorage fail %s", err)
 		return nil, err
@@ -1064,7 +1064,7 @@ func (manager *SStorageManager) TotalCapacity(
 	return res1
 }
 
-func (self *SStorage) createDisk(name string, diskConfig *api.DiskConfig, userCred mcclient.TokenCredential,
+func (self *SStorage) createDisk(ctx context.Context, name string, diskConfig *api.DiskConfig, userCred mcclient.TokenCredential,
 	ownerId mcclient.IIdentityProvider, autoDelete bool, isSystem bool,
 	billingType string, billingCycle string,
 ) (*SDisk, error) {
@@ -1084,7 +1084,7 @@ func (self *SStorage) createDisk(name string, diskConfig *api.DiskConfig, userCr
 	disk.BillingType = billingType
 	disk.BillingCycle = billingCycle
 
-	err := disk.GetModelManager().TableSpec().Insert(&disk)
+	err := disk.GetModelManager().TableSpec().Insert(ctx, &disk)
 	if err != nil {
 		return nil, err
 	}
@@ -1227,7 +1227,7 @@ func (manager *SStorageManager) InitializeData() error {
 				log.Fatalf("Get storage %s pool info error", s.Name)
 			} else {
 				storagecache.Path = "rbd:" + pool
-				if err := StoragecacheManager.TableSpec().Insert(storagecache); err != nil {
+				if err := StoragecacheManager.TableSpec().Insert(context.TODO(), storagecache); err != nil {
 					log.Fatalf("Cannot Add storagecache for %s", s.Name)
 				} else {
 					db.Update(&s, func() error {

--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -179,7 +179,7 @@ func (manager *SVpcManager) getVpcExternalIdForClassicNetwork(regionId, cloudpro
 	return fmt.Sprintf("%s-%s", regionId, cloudproviderId)
 }
 
-func (manager *SVpcManager) GetOrCreateVpcForClassicNetwork(host *SHost) (*SVpc, error) {
+func (manager *SVpcManager) GetOrCreateVpcForClassicNetwork(ctx context.Context, host *SHost) (*SVpc, error) {
 	region := host.GetRegion()
 	cloudprovider := host.GetCloudprovider()
 	externalId := manager.getVpcExternalIdForClassicNetwork(region.Id, cloudprovider.Id)
@@ -200,7 +200,7 @@ func (manager *SVpcManager) GetOrCreateVpcForClassicNetwork(host *SHost) (*SVpc,
 	vpc.Status = api.VPC_STATUS_UNAVAILABLE
 	vpc.ExternalId = externalId
 	vpc.ManagerId = host.ManagerId
-	err = manager.TableSpec().Insert(vpc)
+	err = manager.TableSpec().Insert(ctx, vpc)
 	if err != nil {
 		return nil, errors.Wrap(err, "Insert vpc for classic network")
 	}
@@ -471,7 +471,7 @@ func (self *SVpc) SyncGlobalVpc(ctx context.Context, userCred mcclient.TokenCred
 			gv.SetEnabled(true)
 			gv.Status = api.GLOBAL_VPC_STATUS_AVAILABLE
 			gv.SetModelManager(GlobalVpcManager, gv)
-			err = GlobalVpcManager.TableSpec().Insert(gv)
+			err = GlobalVpcManager.TableSpec().Insert(ctx, gv)
 			if err != nil {
 				return errors.Wrap(err, "GlobalVpcManager.Insert")
 			}
@@ -532,7 +532,7 @@ func (manager *SVpcManager) newFromCloudVpc(ctx context.Context, userCred mcclie
 
 	vpc.IsEmulated = extVPC.IsEmulated()
 
-	err = manager.TableSpec().Insert(&vpc)
+	err = manager.TableSpec().Insert(ctx, &vpc)
 	if err != nil {
 		log.Errorf("newFromCloudVpc fail %s", err)
 		return nil, err
@@ -575,7 +575,7 @@ func (manager *SVpcManager) InitializeData() error {
 			defVpc.IsDefault = true
 			defVpc.IsPublic = true
 			defVpc.PublicScope = string(rbacutils.ScopeSystem)
-			err = manager.TableSpec().Insert(&defVpc)
+			err = manager.TableSpec().Insert(context.TODO(), &defVpc)
 			if err != nil {
 				log.Errorf("Insert default vpc fail: %s", err)
 			}
@@ -1022,7 +1022,7 @@ func (self *SVpc) initWire(ctx context.Context, zone *SZone) (*SWire, error) {
 	wire.IsEmulated = true
 	wire.Name = fmt.Sprintf("vpc-%s", self.Name)
 	wire.SetModelManager(WireManager, wire)
-	err := WireManager.TableSpec().Insert(wire)
+	err := WireManager.TableSpec().Insert(ctx, wire)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/vpcs_mapped_address.go
+++ b/pkg/compute/models/vpcs_mapped_address.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package models
 
 import (

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -183,7 +183,7 @@ func (manager *SWireManager) getWireExternalIdForClassicNetwork(provider string,
 	return vpcId
 }
 
-func (manager *SWireManager) GetOrCreateWireForClassicNetwork(vpc *SVpc, zone *SZone) (*SWire, error) {
+func (manager *SWireManager) GetOrCreateWireForClassicNetwork(ctx context.Context, vpc *SVpc, zone *SZone) (*SWire, error) {
 	cloudprovider := vpc.GetCloudprovider()
 	if cloudprovider == nil {
 		return nil, fmt.Errorf("failed to found cloudprovider for vpc %s(%s)", vpc.Id, vpc.Id)
@@ -210,7 +210,7 @@ func (manager *SWireManager) GetOrCreateWireForClassicNetwork(vpc *SVpc, zone *S
 	wire.ExternalId = externalId
 	wire.IsEmulated = true
 	wire.Name = name
-	err = manager.TableSpec().Insert(wire)
+	err = manager.TableSpec().Insert(ctx, wire)
 	if err != nil {
 		return nil, errors.Wrap(err, "Insert wire for classic network")
 	}
@@ -406,7 +406,7 @@ func (manager *SWireManager) newFromCloudWire(ctx context.Context, userCred mccl
 
 	wire.IsEmulated = extWire.IsEmulated()
 
-	err = manager.TableSpec().Insert(&wire)
+	err = manager.TableSpec().Insert(ctx, &wire)
 	if err != nil {
 		log.Errorf("newFromCloudWire fail %s", err)
 		return nil, err

--- a/pkg/compute/models/zones.go
+++ b/pkg/compute/models/zones.go
@@ -296,7 +296,7 @@ func (manager *SZoneManager) newFromCloudZone(ctx context.Context, userCred mccl
 
 	zone.CloudregionId = region.Id
 
-	err = manager.TableSpec().Insert(&zone)
+	err = manager.TableSpec().Insert(ctx, &zone)
 	if err != nil {
 		log.Errorf("newFromCloudZone fail %s", err)
 		return nil, err

--- a/pkg/compute/regiondrivers/aws.go
+++ b/pkg/compute/regiondrivers/aws.go
@@ -802,7 +802,7 @@ func (self *SAwsRegionDriver) createLoadbalancerBackendGroup(ctx context.Context
 	cachedLbbg.HealthCheckProtocol = lblis.HealthCheckType
 	cachedLbbg.HealthCheckInterval = lblis.HealthCheckInterval
 
-	err = models.AwsCachedLbbgManager.TableSpec().Insert(cachedLbbg)
+	err = models.AwsCachedLbbgManager.TableSpec().Insert(ctx, cachedLbbg)
 	if err != nil {
 		return nil, errors.Wrap(err, "AwsRegionDriver.createlbBackendgroup.Insert")
 	}

--- a/pkg/compute/regiondrivers/base.go
+++ b/pkg/compute/regiondrivers/base.go
@@ -263,7 +263,7 @@ func (self *SBaseRegionDriver) GetSecgroupVpcid(vpcId string) string {
 	return vpcId
 }
 
-func (self *SBaseRegionDriver) InitDBInstanceUser(dbinstance *models.SDBInstance, task taskman.ITask, desc *cloudprovider.SManagedDBInstanceCreateConfig) error {
+func (self *SBaseRegionDriver) InitDBInstanceUser(ctx context.Context, dbinstance *models.SDBInstance, task taskman.ITask, desc *cloudprovider.SManagedDBInstanceCreateConfig) error {
 	return nil
 }
 

--- a/pkg/compute/regiondrivers/google.go
+++ b/pkg/compute/regiondrivers/google.go
@@ -175,7 +175,7 @@ func (self *SGoogleRegionDriver) ValidateCreateDBInstanceData(ctx context.Contex
 	return input, nil
 }
 
-func (self *SGoogleRegionDriver) InitDBInstanceUser(instance *models.SDBInstance, task taskman.ITask, desc *cloudprovider.SManagedDBInstanceCreateConfig) error {
+func (self *SGoogleRegionDriver) InitDBInstanceUser(ctx context.Context, instance *models.SDBInstance, task taskman.ITask, desc *cloudprovider.SManagedDBInstanceCreateConfig) error {
 	user := "root"
 	switch desc.Engine {
 	case api.DBINSTANCE_TYPE_POSTGRESQL:
@@ -192,7 +192,7 @@ func (self *SGoogleRegionDriver) InitDBInstanceUser(instance *models.SDBInstance
 	account.Status = api.DBINSTANCE_USER_AVAILABLE
 	account.ExternalId = user
 	account.SetModelManager(models.DBInstanceAccountManager, &account)
-	err := models.DBInstanceAccountManager.TableSpec().Insert(&account)
+	err := models.DBInstanceAccountManager.TableSpec().Insert(ctx, &account)
 	if err != nil {
 		return err
 	}

--- a/pkg/compute/regiondrivers/huawei.go
+++ b/pkg/compute/regiondrivers/huawei.go
@@ -557,7 +557,7 @@ func (self *SHuaWeiRegionDriver) ValidateUpdateLoadbalancerListenerData(ctx cont
 	return self.SManagedVirtualizationRegionDriver.ValidateUpdateLoadbalancerListenerData(ctx, userCred, data, lblis, backendGroup)
 }
 
-func (self *SHuaWeiRegionDriver) createCachedLbbg(lb *models.SLoadbalancer, lblis *models.SLoadbalancerListener, lbr *models.SLoadbalancerListenerRule, lbbg *models.SLoadbalancerBackendGroup) (*models.SHuaweiCachedLbbg, error) {
+func (self *SHuaWeiRegionDriver) createCachedLbbg(ctx context.Context, lb *models.SLoadbalancer, lblis *models.SLoadbalancerListener, lbr *models.SLoadbalancerListenerRule, lbbg *models.SLoadbalancerBackendGroup) (*models.SHuaweiCachedLbbg, error) {
 	// create loadbalancer backendgroup cache
 	cachedLbbg := &models.SHuaweiCachedLbbg{}
 	cachedLbbg.ManagerId = lb.GetCloudproviderId()
@@ -574,7 +574,7 @@ func (self *SHuaWeiRegionDriver) createCachedLbbg(lb *models.SLoadbalancer, lbli
 		cachedLbbg.ProtocolType = lblis.ListenerType
 	}
 
-	err := models.HuaweiCachedLbbgManager.TableSpec().Insert(cachedLbbg)
+	err := models.HuaweiCachedLbbgManager.TableSpec().Insert(ctx, cachedLbbg)
 	if err != nil {
 		return nil, err
 	}
@@ -646,7 +646,7 @@ func (self *SHuaWeiRegionDriver) createLoadbalancerBackendGroup(ctx context.Cont
 		return nil, err
 	}
 
-	cachedLbbg, err := self.createCachedLbbg(lb, lblis, lbr, lbbg)
+	cachedLbbg, err := self.createCachedLbbg(ctx, lb, lblis, lbr, lbbg)
 	if err != nil {
 		return nil, errors.Wrap(err, "HuaWeiRegionDriver.createLoadbalancerBackendGroupCache")
 	}
@@ -948,7 +948,7 @@ func (self *SHuaWeiRegionDriver) RequestSyncLoadbalancerBackendGroup(ctx context
 
 			// case 2：新绑定,创建本地缓存
 			if olbbg == nil && nlbbg == nil && rlbbg != nil {
-				cachedLbbg, err := self.createCachedLbbg(lb, lblis, nil, lbbg)
+				cachedLbbg, err := self.createCachedLbbg(ctx, lb, lblis, nil, lbbg)
 				if err != nil {
 					return nil, errors.Wrap(err, "HuaWeiRegionDriver.Sync.Case2.createCachedLbbg")
 				}
@@ -2145,7 +2145,7 @@ func (self *SHuaWeiRegionDriver) ValidateCreateDBInstanceData(ctx context.Contex
 	return input, nil
 }
 
-func (self *SHuaWeiRegionDriver) InitDBInstanceUser(instance *models.SDBInstance, task taskman.ITask, desc *cloudprovider.SManagedDBInstanceCreateConfig) error {
+func (self *SHuaWeiRegionDriver) InitDBInstanceUser(ctx context.Context, instance *models.SDBInstance, task taskman.ITask, desc *cloudprovider.SManagedDBInstanceCreateConfig) error {
 	user := "root"
 	if desc.Engine == api.DBINSTANCE_TYPE_SQLSERVER {
 		user = "rdsuser"
@@ -2157,7 +2157,7 @@ func (self *SHuaWeiRegionDriver) InitDBInstanceUser(instance *models.SDBInstance
 	account.Status = api.DBINSTANCE_USER_AVAILABLE
 	account.ExternalId = user
 	account.SetModelManager(models.DBInstanceAccountManager, &account)
-	err := models.DBInstanceAccountManager.TableSpec().Insert(&account)
+	err := models.DBInstanceAccountManager.TableSpec().Insert(ctx, &account)
 	if err != nil {
 		return err
 	}

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -701,7 +701,7 @@ func (self *SKVMRegionDriver) RequestCreateLoadbalancerBackendGroup(ctx context.
 			loadbalancerBackend.ProjectId = userCred.GetProjectId()
 			loadbalancerBackend.DomainId = userCred.GetProjectDomainId()
 			loadbalancerBackend.Name = fmt.Sprintf("%s-%s-%s", lbbg.Name, backend.BackendType, backend.Name)
-			if err := models.LoadbalancerBackendManager.TableSpec().Insert(&loadbalancerBackend); err != nil {
+			if err := models.LoadbalancerBackendManager.TableSpec().Insert(ctx, &loadbalancerBackend); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -1628,7 +1628,7 @@ func (self *SManagedVirtualizationRegionDriver) RequestCreateDBInstance(ctx cont
 
 		region := dbinstance.GetRegion()
 
-		err = region.GetDriver().InitDBInstanceUser(dbinstance, task, &desc)
+		err = region.GetDriver().InitDBInstanceUser(ctx, dbinstance, task, &desc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/compute/regiondrivers/qcloud.go
+++ b/pkg/compute/regiondrivers/qcloud.go
@@ -366,7 +366,7 @@ func (self *SQcloudRegionDriver) RequestDeleteLoadbalancerBackend(ctx context.Co
 	return nil
 }
 
-func (self *SQcloudRegionDriver) createCachedLbbg(lb *models.SLoadbalancer, lblis *models.SLoadbalancerListener, lbr *models.SLoadbalancerListenerRule, lbbg *models.SLoadbalancerBackendGroup) (*models.SQcloudCachedLbbg, error) {
+func (self *SQcloudRegionDriver) createCachedLbbg(ctx context.Context, lb *models.SLoadbalancer, lblis *models.SLoadbalancerListener, lbr *models.SLoadbalancerListenerRule, lbbg *models.SLoadbalancerBackendGroup) (*models.SQcloudCachedLbbg, error) {
 	// create loadbalancer backendgroup cache
 	cachedLbbg := &models.SQcloudCachedLbbg{}
 	cachedLbbg.ManagerId = lb.GetCloudproviderId()
@@ -381,7 +381,7 @@ func (self *SQcloudRegionDriver) createCachedLbbg(lb *models.SLoadbalancer, lbli
 		cachedLbbg.AssociatedId = lblis.GetId()
 	}
 
-	err := models.QcloudCachedLbbgManager.TableSpec().Insert(cachedLbbg)
+	err := models.QcloudCachedLbbgManager.TableSpec().Insert(ctx, cachedLbbg)
 	if err != nil {
 		return nil, errors.Wrap(err, "SQcloudRegionDriver.createCachedLbbg.Insert")
 	}
@@ -486,7 +486,7 @@ func (self *SQcloudRegionDriver) createLoadbalancerBackendGroup(ctx context.Cont
 		return nil, fmt.Errorf("could not create loadbalancer backendgroup, loadbalancer listener & rule are nil")
 	}
 
-	cachedLbbg, err := self.createCachedLbbg(lb, lblis, lbr, lbbg)
+	cachedLbbg, err := self.createCachedLbbg(ctx, lb, lblis, lbr, lbbg)
 	if err != nil {
 		return nil, errors.Wrap(err, "QcloudRegionDriver.createLoadbalancerBackendGroupCache")
 	}

--- a/pkg/compute/storagedrivers/gpfs.go
+++ b/pkg/compute/storagedrivers/gpfs.go
@@ -52,7 +52,7 @@ func (self *SGpfsStorageDriver) PostCreate(ctx context.Context, userCred mcclien
 	sc.ExternalId = storage.Id
 	timeutils.IsoTime(time.Now())
 	sc.Name = "gpfs-" + storage.Name + timeutils.IsoTime(time.Now())
-	if err := models.StoragecacheManager.TableSpec().Insert(sc); err != nil {
+	if err := models.StoragecacheManager.TableSpec().Insert(ctx, sc); err != nil {
 		log.Errorf("insert storagecache for storage %s error: %v", storage.Name, err)
 		return
 	}

--- a/pkg/compute/storagedrivers/nfs.go
+++ b/pkg/compute/storagedrivers/nfs.go
@@ -62,7 +62,7 @@ func (self *SNfsStorageDriver) PostCreate(ctx context.Context, userCred mcclient
 	sc.Path = options.Options.DefaultImageCacheDir
 	sc.ExternalId = storage.Id
 	sc.Name = "nfs-" + storage.Name + time.Now().Format("2006-01-02 15:04:05")
-	if err := models.StoragecacheManager.TableSpec().Insert(sc); err != nil {
+	if err := models.StoragecacheManager.TableSpec().Insert(ctx, sc); err != nil {
 		log.Errorf("insert storagecache for storage %s error: %v", storage.Name, err)
 		return
 	}

--- a/pkg/compute/storagedrivers/rbd.go
+++ b/pkg/compute/storagedrivers/rbd.go
@@ -118,7 +118,7 @@ func (self *SRbdStorageDriver) ValidateUpdateData(ctx context.Context, userCred 
 	}
 
 	if update, _ := data.Bool("update_storage_conf"); update {
-		_, err := storage.GetModelManager().TableSpec().Update(storage, func() error {
+		_, err := storage.GetModelManager().TableSpec().Update(ctx, storage, func() error {
 			storage.StorageConf = conf
 			return nil
 		})
@@ -159,7 +159,7 @@ func (self *SRbdStorageDriver) PostCreate(ctx context.Context, userCred mcclient
 		sc.Name = fmt.Sprintf("imagecache-%s", storage.Id)
 		pool, _ := data.GetString("rbd_pool")
 		sc.Path = fmt.Sprintf("rbd:%s", pool)
-		if err := models.StoragecacheManager.TableSpec().Insert(sc); err != nil {
+		if err := models.StoragecacheManager.TableSpec().Insert(ctx, sc); err != nil {
 			log.Errorf("insert storagecache for storage %s error: %v", storage.Name, err)
 			return
 		}

--- a/pkg/compute/tasks/dbinstance_account_create_task.go
+++ b/pkg/compute/tasks/dbinstance_account_create_task.go
@@ -123,7 +123,7 @@ func (self *DBInstanceAccountCreateTask) CreateDBInstanceAccount(ctx context.Con
 			DBInstanceaccountId:  account.Id,
 			DBInstancedatabaseId: privilege.DBInstancedatabaseId,
 		}
-		models.DBInstancePrivilegeManager.TableSpec().Insert(&_privilege)
+		models.DBInstancePrivilegeManager.TableSpec().Insert(ctx, &_privilege)
 		logclient.AddActionLogWithStartable(self, account, logclient.ACT_GRANT_PRIVILEGE, privilege, self.UserCred, true)
 	}
 

--- a/pkg/compute/tasks/dbinstance_account_grant_privilege_task.go
+++ b/pkg/compute/tasks/dbinstance_account_grant_privilege_task.go
@@ -94,7 +94,7 @@ func (self *DBInstanceAccountGrantPrivilegeTask) OnInit(ctx context.Context, obj
 		DBInstancedatabaseId: database.Id,
 	}
 
-	models.DBInstancePrivilegeManager.TableSpec().Insert(&privilege)
+	models.DBInstancePrivilegeManager.TableSpec().Insert(ctx, &privilege)
 
 	account.SetStatus(self.UserCred, api.DBINSTANCE_USER_AVAILABLE, "")
 	logclient.AddActionLogWithStartable(self, account, logclient.ACT_GRANT_PRIVILEGE, nil, self.UserCred, true)

--- a/pkg/compute/tasks/dbinstance_account_set_privileges_task.go
+++ b/pkg/compute/tasks/dbinstance_account_set_privileges_task.go
@@ -120,7 +120,7 @@ func (self *DBInstanceAccountSetPrivilegesTask) OnInit(ctx context.Context, obj 
 			DBInstanceaccountId:  account.Id,
 			DBInstancedatabaseId: database.Id,
 		}
-		models.DBInstancePrivilegeManager.TableSpec().Insert(&pri)
+		models.DBInstancePrivilegeManager.TableSpec().Insert(ctx, &pri)
 		logclient.AddActionLogWithStartable(self, account, logclient.ACT_GRANT_PRIVILEGE, nil, self.UserCred, true)
 	}
 

--- a/pkg/compute/tasks/dbinstance_database_create_task.go
+++ b/pkg/compute/tasks/dbinstance_database_create_task.go
@@ -146,7 +146,7 @@ func (self *DBInstanceDatabaseCreateTask) CreateDBInstanceDatabase(ctx context.C
 			DBInstanceaccountId:  account.DBInstanceaccountId,
 			DBInstancedatabaseId: database.Id,
 		}
-		models.DBInstancePrivilegeManager.TableSpec().Insert(&privilege)
+		models.DBInstancePrivilegeManager.TableSpec().Insert(ctx, &privilege)
 		logclient.AddActionLogWithStartable(self, database, logclient.ACT_GRANT_PRIVILEGE, account, self.UserCred, true)
 	}
 	database.SetStatus(self.UserCred, api.DBINSTANCE_DATABASE_RUNNING, "")

--- a/pkg/compute/tasks/instance_snapshot_create_task.go
+++ b/pkg/compute/tasks/instance_snapshot_create_task.go
@@ -119,7 +119,7 @@ func (self *InstanceSnapshotCreateTask) GuestDiskCreateSnapshot(
 		return
 	}
 
-	err = models.InstanceSnapshotJointManager.CreateJoint(isp.Id, snapshot.Id, int8(diskIndex))
+	err = models.InstanceSnapshotJointManager.CreateJoint(ctx, isp.Id, snapshot.Id, int8(diskIndex))
 	if err != nil {
 		self.taskFail(ctx, isp, guest, err.Error())
 		return

--- a/pkg/controller/autoscaling/controller.go
+++ b/pkg/controller/autoscaling/controller.go
@@ -221,6 +221,7 @@ func (asc *SASController) Scale(ctx context.Context, userCred mcclient.TokenCred
 	log.Debugf("insert sa")
 
 	scalingActivity, err := models.ScalingActivityManager.CreateScalingActivity(
+		ctx,
 		sg.Id,
 		fmt.Sprintf(`The Desire Instance Number was changed, so change the Total Instance Number from "%d" to "%d"`,
 			total, sg.DesireInstanceNumber,

--- a/pkg/controller/autoscaling/timer.go
+++ b/pkg/controller/autoscaling/timer.go
@@ -74,7 +74,7 @@ func (asc *SASController) Timer(ctx context.Context, userCred mcclient.TokenCred
 				scalingTimer.Update(timeScope.Start)
 				// scalingTimer should not exec for now.
 				if scalingTimer.NextTime.After(timeScope.End) || scalingTimer.IsExpired {
-					err = models.ScalingTimerManager.TableSpec().InsertOrUpdate(&scalingTimer)
+					err = models.ScalingTimerManager.TableSpec().InsertOrUpdate(ctx, &scalingTimer)
 					if err != nil {
 						log.Errorf("update ScalingTimer whose ScalingPolicyId is %s error: %s",
 							scalingTimer.ScalingPolicyId, err.Error())
@@ -88,7 +88,7 @@ func (asc *SASController) Timer(ctx context.Context, userCred mcclient.TokenCred
 				log.Errorf("unable to request to trigger ScalingPolicy '%s'", scalingTimer.ScalingPolicyId)
 			}
 			scalingTimer.Update(timeScope.End)
-			err = models.ScalingTimerManager.TableSpec().InsertOrUpdate(&scalingTimer)
+			err = models.ScalingTimerManager.TableSpec().InsertOrUpdate(ctx, &scalingTimer)
 			if err != nil {
 				log.Errorf("update ScalingTimer whose ScalingPolicyId is %s error: %s",
 					scalingTimer.ScalingPolicyId, err.Error())

--- a/pkg/devtool/models/actions.go
+++ b/pkg/devtool/models/actions.go
@@ -22,6 +22,7 @@ import (
 	"yunion.io/x/log"
 
 	apis "yunion.io/x/onecloud/pkg/apis/ansible"
+	apiidentity "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
@@ -59,7 +60,7 @@ func getServerAttrs(ID string, s *mcclient.ClientSession) (map[string]string, er
 func getInfluxdbURL() (string, error) {
 
 	s := auth.GetAdminSessionWithPublic(nil, "", "")
-	url, err := s.GetServiceURL("influxdb", auth.PublicEndpointType)
+	url, err := s.GetServiceURL("influxdb", apiidentity.EndpointInterfacePublic)
 
 	if err != nil {
 		log.Errorf("get influxdb Endpoint error %s", err)

--- a/pkg/hostman/host_health/doc.go
+++ b/pkg/hostman/host_health/doc.go
@@ -1,1 +1,15 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package host_health // import "yunion.io/x/onecloud/pkg/hostman/host_health"

--- a/pkg/hostman/host_health/etcd.go
+++ b/pkg/hostman/host_health/etcd.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package host_health
 
 import (

--- a/pkg/hostman/host_health/health_manager.go
+++ b/pkg/hostman/host_health/health_manager.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package host_health
 
 import (

--- a/pkg/hostman/hosthandler/handler.go
+++ b/pkg/hostman/hosthandler/handler.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package hosthandler
 
 import (

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -35,6 +35,7 @@ import (
 	"yunion.io/x/pkg/utils"
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
+	identityapi "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/hostman/guestfs/fsdriver"
 	"yunion.io/x/onecloud/pkg/hostman/host_health"
 	deployapi "yunion.io/x/onecloud/pkg/hostman/hostdeployer/apis"
@@ -45,7 +46,6 @@ import (
 	"yunion.io/x/onecloud/pkg/hostman/storageman"
 	"yunion.io/x/onecloud/pkg/hostman/system_service"
 	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/util/cgrouputils"
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
@@ -1500,7 +1500,7 @@ func (h *SHostInfo) OnCatalogChanged(catalog mcclient.KeystoneServiceCatalogV3) 
 	// TODO: dynamic probe endpoint type
 	defaultEndpointType := options.HostOptions.SessionEndpointType
 	if len(defaultEndpointType) == 0 {
-		defaultEndpointType = auth.PublicEndpointType
+		defaultEndpointType = identityapi.EndpointInterfacePublic
 	}
 	if options.HostOptions.ManageNtpConfiguration {
 		ntpd := system_service.GetService("ntpd")

--- a/pkg/image/models/image_guest_joint.go
+++ b/pkg/image/models/image_guest_joint.go
@@ -126,7 +126,7 @@ func (gt *SGuestImageJointManager) CreateGuestImageJoint(ctx context.Context, gu
 	gi.ImageId = imageId
 
 	//
-	if err := gt.TableSpec().Insert(&gi); err != nil {
+	if err := gt.TableSpec().Insert(ctx, &gi); err != nil {
 		return nil, errors.Wrapf(err, "insert guestimage joint error")
 	}
 	gi.SetVirtualObject(gt)

--- a/pkg/image/models/image_properties.go
+++ b/pkg/image/models/image_properties.go
@@ -123,7 +123,7 @@ func (manager *SImagePropertyManager) NewProperty(ctx context.Context, userCred 
 	prop.Name = key
 	prop.Value = value
 
-	err := manager.TableSpec().Insert(&prop)
+	err := manager.TableSpec().Insert(ctx, &prop)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/keystone/cronjobs/project_resources.go
+++ b/pkg/keystone/cronjobs/project_resources.go
@@ -111,11 +111,11 @@ func FetchProjectResourceCount(ctx context.Context, userCred mcclient.TokenCrede
 		if err != nil {
 			continue
 		}
-		syncProjectResourceCount(ep.regionId, ep.serviceId, projectResCounts)
+		syncProjectResourceCount(ctx, ep.regionId, ep.serviceId, projectResCounts)
 	}
 }
 
-func syncProjectResourceCount(regionId string, serviceId string, projResCnt map[string][]db.SScopeResourceCount) {
+func syncProjectResourceCount(ctx context.Context, regionId string, serviceId string, projResCnt map[string][]db.SScopeResourceCount) {
 	projList := make([]string, 0)
 	for res, resCnts := range projResCnt {
 		for i := range resCnts {
@@ -136,7 +136,7 @@ func syncProjectResourceCount(regionId string, serviceId string, projResCnt map[
 
 			projList = append(projList, projRes.ProjectId)
 
-			err := models.ProjectResourceManager.TableSpec().InsertOrUpdate(&projRes)
+			err := models.ProjectResourceManager.TableSpec().InsertOrUpdate(ctx, &projRes)
 			if err != nil {
 				log.Errorf("table insert error %s", err)
 			}

--- a/pkg/keystone/models/assignments.go
+++ b/pkg/keystone/models/assignments.go
@@ -79,10 +79,10 @@ type SAssignment struct {
 }
 
 func (manager *SAssignmentManager) InitializeData() error {
-	return manager.initSysAssignment()
+	return manager.initSysAssignment(context.TODO())
 }
 
-func (manager *SAssignmentManager) initSysAssignment() error {
+func (manager *SAssignmentManager) initSysAssignment(ctx context.Context) error {
 	adminUser, err := UserManager.FetchUserExtended("", api.SystemAdminUser, api.DEFAULT_DOMAIN_ID, "")
 	if err != nil {
 		return errors.Wrap(err, "FetchUserExtended")
@@ -119,7 +119,7 @@ func (manager *SAssignmentManager) initSysAssignment() error {
 	assign.RoleId = adminRole.Id
 	assign.Inherited = tristate.False
 
-	err = manager.TableSpec().Insert(&assign)
+	err = manager.TableSpec().Insert(ctx, &assign)
 	if err != nil {
 		return errors.Wrap(err, "insert")
 	}
@@ -259,7 +259,7 @@ func (manager *SAssignmentManager) ProjectAddUser(ctx context.Context, userCred 
 			return httperrors.NewForbiddenError("not enough privilege")
 		}
 	}
-	err = manager.add(api.AssignmentUserProject, user.Id, project.Id, role.Id)
+	err = manager.add(ctx, api.AssignmentUserProject, user.Id, project.Id, role.Id)
 	if err != nil {
 		return errors.Wrap(err, "manager.add")
 	}
@@ -359,7 +359,7 @@ func (manager *SAssignmentManager) projectAddGroup(ctx context.Context, userCred
 			return httperrors.NewForbiddenError("not enough privilege")
 		}
 	}
-	err = manager.add(api.AssignmentGroupProject, group.Id, project.Id, role.Id)
+	err = manager.add(ctx, api.AssignmentGroupProject, group.Id, project.Id, role.Id)
 	if err != nil {
 		return errors.Wrap(err, "manager.add")
 	}
@@ -408,7 +408,7 @@ func (manager *SAssignmentManager) remove(typeStr, actorId, projectId, roleId st
 	return nil
 }
 
-func (manager *SAssignmentManager) add(typeStr, actorId, projectId, roleId string) error {
+func (manager *SAssignmentManager) add(ctx context.Context, typeStr, actorId, projectId, roleId string) error {
 	assign := SAssignment{
 		Type:      typeStr,
 		ActorId:   actorId,
@@ -417,7 +417,7 @@ func (manager *SAssignmentManager) add(typeStr, actorId, projectId, roleId strin
 		Inherited: tristate.False,
 	}
 	assign.SetModelManager(manager, &assign)
-	err := manager.TableSpec().InsertOrUpdate(&assign)
+	err := manager.TableSpec().InsertOrUpdate(ctx, &assign)
 	if err != nil {
 		return errors.Wrap(err, "InsertOrUpdate")
 	}

--- a/pkg/keystone/models/configs.go
+++ b/pkg/keystone/models/configs.go
@@ -15,6 +15,7 @@
 package models
 
 import (
+	"context"
 	"database/sql"
 	"sort"
 
@@ -130,7 +131,7 @@ func (manager *SConfigOptionManager) deleteConfigs(model db.IModel) error {
 
 func (manager *SConfigOptionManager) updateConfigs(newOpts TConfigOptions) error {
 	for i := range newOpts {
-		err := manager.TableSpec().InsertOrUpdate(&newOpts[i])
+		err := manager.TableSpec().InsertOrUpdate(context.Background(), &newOpts[i])
 		if err != nil {
 			return errors.Wrap(err, "Insert")
 		}
@@ -179,7 +180,7 @@ func (manager *SConfigOptionManager) syncConfigs(model db.IModel, newOpts TConfi
 		}
 	}
 	for i := range added {
-		err = manager.TableSpec().InsertOrUpdate(&added[i])
+		err = manager.TableSpec().InsertOrUpdate(context.TODO(), &added[i])
 		if err != nil {
 			return errors.Wrap(err, "Insert")
 		}

--- a/pkg/keystone/models/domains.go
+++ b/pkg/keystone/models/domains.go
@@ -79,7 +79,7 @@ func (manager *SDomainManager) InitializeData() error {
 		root.DomainId = api.KeystoneDomainRoot
 		root.Enabled = tristate.False
 		root.Description = "The hidden root domain"
-		err := manager.TableSpec().Insert(root)
+		err := manager.TableSpec().Insert(context.TODO(), root)
 		if err != nil {
 			log.Errorf("fail to insert root domain ... %s", err)
 			return err
@@ -97,7 +97,7 @@ func (manager *SDomainManager) InitializeData() error {
 		defDomain.DomainId = api.KeystoneDomainRoot
 		defDomain.Enabled = tristate.True
 		defDomain.Description = "The default domain"
-		err := manager.TableSpec().Insert(defDomain)
+		err := manager.TableSpec().Insert(context.TODO(), defDomain)
 		if err != nil {
 			log.Errorf("fail to insert default domain ... %s", err)
 			return err

--- a/pkg/keystone/models/fernetkeys.go
+++ b/pkg/keystone/models/fernetkeys.go
@@ -15,6 +15,7 @@
 package models
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"path/filepath"
@@ -140,7 +141,7 @@ func (manager *SFernetKeyManager) setupKeys(keyType string, repoDir string) ([]*
 			Index: i,
 			Key:   fkey.Encode(),
 		}
-		err := manager.TableSpec().Insert(&key)
+		err := manager.TableSpec().Insert(context.TODO(), &key)
 		if err != nil {
 			return nil, errors.Wrap(err, "insertFernetKeys")
 		}

--- a/pkg/keystone/models/groups.go
+++ b/pkg/keystone/models/groups.go
@@ -240,7 +240,7 @@ func (manager *SGroupManager) RegisterExternalGroup(ctx context.Context, idpId s
 		group.Name = groupName
 		group.Displayname = groupName
 
-		err = manager.TableSpec().Insert(&group)
+		err = manager.TableSpec().Insert(ctx, &group)
 		if err != nil {
 			return nil, errors.Wrap(err, "Insert")
 		}

--- a/pkg/keystone/models/id_mappings.go
+++ b/pkg/keystone/models/id_mappings.go
@@ -95,7 +95,7 @@ func (manager *SIdmappingManager) RegisterIdMapWithId(ctx context.Context, idpId
 		mapping.IdpEntityId = entityId
 		mapping.EntityType = entityType
 
-		err = manager.TableSpec().InsertOrUpdate(&mapping)
+		err = manager.TableSpec().InsertOrUpdate(ctx, &mapping)
 		if err != nil {
 			return "", errors.Wrap(err, "Insert")
 		}

--- a/pkg/keystone/models/identity_provider.go
+++ b/pkg/keystone/models/identity_provider.go
@@ -109,7 +109,7 @@ func (manager *SIdentityProviderManager) InitializeData() error {
 	sqldrv.Status = api.IdentityDriverStatusConnected
 	sqldrv.Driver = api.IdentityDriverSQL
 	sqldrv.Description = "Default sql identity provider"
-	err = manager.TableSpec().Insert(&sqldrv)
+	err = manager.TableSpec().Insert(context.TODO(), &sqldrv)
 	if err != nil {
 		return errors.Wrap(err, "insert default sql driver")
 	}
@@ -141,7 +141,7 @@ func (manager *SIdentityProviderManager) InitializeData() error {
 		drv.Status = api.IdentityDriverStatusDisconnected
 		drv.Driver = driver
 		drv.Description = domains[i].Description
-		err = manager.TableSpec().Insert(&drv)
+		err = manager.TableSpec().Insert(context.TODO(), &drv)
 		if err != nil {
 			return errors.Wrap(err, "insert driver")
 		}
@@ -840,7 +840,7 @@ func (self *SIdentityProvider) SyncOrCreateDomain(ctx context.Context, extId str
 	domain.IsDomain = tristate.True
 	domain.DomainId = api.KeystoneDomainRoot
 	domain.Description = fmt.Sprintf("domain for %s", extDesc)
-	err = DomainManager.TableSpec().Insert(domain)
+	err = DomainManager.TableSpec().Insert(ctx, domain)
 	if err != nil {
 		return nil, errors.Wrap(err, "insert")
 	}
@@ -899,7 +899,7 @@ func (self *SIdentityProvider) SyncOrCreateUser(ctx context.Context, extId strin
 		user.Id = userId
 		user.Name = extName
 		user.DomainId = domainId
-		err = UserManager.TableSpec().Insert(user)
+		err = UserManager.TableSpec().Insert(ctx, user)
 		if err != nil {
 			return nil, errors.Wrap(err, "Insert")
 		}

--- a/pkg/keystone/models/localusers.go
+++ b/pkg/keystone/models/localusers.go
@@ -15,6 +15,7 @@
 package models
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"time"
@@ -114,7 +115,7 @@ func (manager *SLocalUserManager) register(userId string, domainId string, name 
 	localUser.DomainId = domainId
 	localUser.Name = name
 
-	err = manager.TableSpec().Insert(localUser)
+	err = manager.TableSpec().Insert(context.TODO(), localUser)
 	if err != nil {
 		return nil, errors.Wrap(err, "Insert")
 	}

--- a/pkg/keystone/models/passwords.go
+++ b/pkg/keystone/models/passwords.go
@@ -15,6 +15,7 @@
 package models
 
 import (
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
@@ -148,7 +149,7 @@ func (manager *SPasswordManager) savePassword(localUserId int, password string, 
 		rec.ExpiresAt = now.Add(time.Second * time.Duration(o.Options.PasswordExpirationSeconds))
 		rec.ExpiresAtInt = rec.ExpiresAt.UnixNano() / 1000
 	}
-	err = manager.TableSpec().Insert(&rec)
+	err = manager.TableSpec().Insert(context.TODO(), &rec)
 	if err != nil {
 		return errors.Wrap(err, "Insert")
 	}

--- a/pkg/keystone/models/projects.go
+++ b/pkg/keystone/models/projects.go
@@ -90,10 +90,10 @@ func (manager *SProjectManager) GetContextManagers() [][]db.IModelManager {
 }
 
 func (manager *SProjectManager) InitializeData() error {
-	return manager.initSysProject()
+	return manager.initSysProject(context.TODO())
 }
 
-func (manager *SProjectManager) initSysProject() error {
+func (manager *SProjectManager) initSysProject(ctx context.Context) error {
 	q := manager.Query().Equals("name", api.SystemAdminProject)
 	q = q.Equals("domain_id", api.DEFAULT_DOMAIN_ID)
 	cnt, err := q.CountWithError()
@@ -117,7 +117,7 @@ func (manager *SProjectManager) initSysProject() error {
 	project.ParentId = api.DEFAULT_DOMAIN_ID
 	project.SetModelManager(manager, &project)
 
-	err = manager.TableSpec().Insert(&project)
+	err = manager.TableSpec().Insert(ctx, &project)
 	if err != nil {
 		return errors.Wrap(err, "insert")
 	}
@@ -659,7 +659,7 @@ func (manager *SProjectManager) NewProject(ctx context.Context, projectName stri
 	project.Description = desc
 	project.IsDomain = tristate.False
 	project.ParentId = domainId
-	err = ProjectManager.TableSpec().Insert(project)
+	err = ProjectManager.TableSpec().Insert(ctx, project)
 	if err != nil {
 		return nil, errors.Wrap(err, "Insert")
 	}

--- a/pkg/keystone/models/roles.go
+++ b/pkg/keystone/models/roles.go
@@ -104,7 +104,7 @@ func (manager *SRoleManager) InitializeData() error {
 	if err != nil {
 		return errors.Wrap(err, "InitializeDomainId")
 	}
-	err = manager.initSysRole()
+	err = manager.initSysRole(context.TODO())
 	if err != nil {
 		return errors.Wrap(err, "initSysRole")
 	}
@@ -127,7 +127,7 @@ func (manager *SRoleManager) initializeDomainId() error {
 	return nil
 }
 
-func (manager *SRoleManager) initSysRole() error {
+func (manager *SRoleManager) initSysRole(ctx context.Context) error {
 	q := manager.Query().Equals("name", api.SystemAdminRole)
 	q = q.Equals("domain_id", api.DEFAULT_DOMAIN_ID)
 	cnt, err := q.CountWithError()
@@ -148,7 +148,7 @@ func (manager *SRoleManager) initSysRole() error {
 	role.Description = "Boostrap system default admin role"
 	role.SetModelManager(manager, &role)
 
-	err = manager.TableSpec().Insert(&role)
+	err = manager.TableSpec().Insert(ctx, &role)
 	if err != nil {
 		return errors.Wrap(err, "insert")
 	}

--- a/pkg/keystone/models/servicecertificates.go
+++ b/pkg/keystone/models/servicecertificates.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package models
 
 import (

--- a/pkg/keystone/models/user_group_memberships.go
+++ b/pkg/keystone/models/user_group_memberships.go
@@ -187,7 +187,7 @@ func (manager *SUsergroupManager) add(ctx context.Context, userCred mcclient.Tok
 		// create one
 		membership.UserId = user.Id
 		membership.GroupId = group.Id
-		err = manager.TableSpec().Insert(&membership)
+		err = manager.TableSpec().Insert(ctx, &membership)
 		if err != nil {
 			return errors.Wrap(err, "insert")
 		}

--- a/pkg/keystone/models/users.go
+++ b/pkg/keystone/models/users.go
@@ -148,7 +148,7 @@ func (manager *SUserManager) InitializeData() error {
 	if err != nil {
 		return errors.Wrap(err, "initSystemAccount")
 	}
-	return manager.initSysUser()
+	return manager.initSysUser(context.TODO())
 }
 
 func (manager *SUserManager) initSystemAccount() error {
@@ -171,7 +171,7 @@ func (manager *SUserManager) initSystemAccount() error {
 	return nil
 }
 
-func (manager *SUserManager) initSysUser() error {
+func (manager *SUserManager) initSysUser(ctx context.Context) error {
 	q := manager.Query().Equals("name", api.SystemAdminUser)
 	q = q.Equals("domain_id", api.DEFAULT_DOMAIN_ID)
 	cnt, err := q.CountWithError()
@@ -209,7 +209,7 @@ func (manager *SUserManager) initSysUser() error {
 	usr.Description = "Boostrap system default admin user"
 	usr.SetModelManager(manager, &usr)
 
-	err = manager.TableSpec().Insert(&usr)
+	err = manager.TableSpec().Insert(ctx, &usr)
 	if err != nil {
 		return errors.Wrap(err, "insert")
 	}

--- a/pkg/keystone/options/options.go
+++ b/pkg/keystone/options/options.go
@@ -49,6 +49,8 @@ type SKeystoneOptions struct {
 	DefaultProjectQuota int `default:"100" help:"default quota for project per domain, default is 500"`
 	DefaultRoleQuota    int `default:"100" help:"default quota for role per domain, default is 500"`
 	DefaultPolicyQuota  int `default:"100" help:"default quota for policy per domain, default is 500"`
+
+	SessionEndpointType string `help:"Client session end point type"`
 }
 
 var (

--- a/pkg/mcclient/auth/auth.go
+++ b/pkg/mcclient/auth/auth.go
@@ -24,6 +24,7 @@ import (
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/util/cache"
 
+	"yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 
@@ -33,11 +34,6 @@ var (
 	defaultCacheCount  int64     = 100000
 	initCh             chan bool = make(chan bool)
 	globalEndpointType string
-)
-
-const (
-	PublicEndpointType   string = "public"
-	InternalEndpointType string = "internal"
 )
 
 type AuthInfo struct {
@@ -271,7 +267,7 @@ func GetServiceURL(service, region, zone, endpointType string) (string, error) {
 }
 
 func GetPublicServiceURL(service, region, zone string) (string, error) {
-	return manager.GetServiceURL(service, region, zone, PublicEndpointType)
+	return manager.GetServiceURL(service, region, zone, identity.EndpointInterfacePublic)
 }
 
 func GetServiceURLs(service, region, zone, endpointType string) ([]string, error) {
@@ -369,11 +365,11 @@ func GetSession(ctx context.Context, token mcclient.TokenCredential, region stri
 }
 
 func GetSessionWithInternal(ctx context.Context, token mcclient.TokenCredential, region string, apiVersion string) *mcclient.ClientSession {
-	return getSessionByType(ctx, token, region, apiVersion, InternalEndpointType)
+	return getSessionByType(ctx, token, region, apiVersion, identity.EndpointInterfaceInternal)
 }
 
 func GetSessionWithPublic(ctx context.Context, token mcclient.TokenCredential, region string, apiVersion string) *mcclient.ClientSession {
-	return getSessionByType(ctx, token, region, apiVersion, PublicEndpointType)
+	return getSessionByType(ctx, token, region, apiVersion, identity.EndpointInterfacePublic)
 }
 
 func getSessionByType(ctx context.Context, token mcclient.TokenCredential, region string, apiVersion string, epType string) *mcclient.ClientSession {

--- a/pkg/mcclient/informer/doc.go
+++ b/pkg/mcclient/informer/doc.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package hosthandler // import "yunion.io/x/onecloud/pkg/hostman/hosthandler"
+package informer // import "yunion.io/x/onecloud/pkg/mcclient/informer"

--- a/pkg/mcclient/informer/watcher.go
+++ b/pkg/mcclient/informer/watcher.go
@@ -1,0 +1,183 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package informer
+
+import (
+	"context"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/etcd"
+	"yunion.io/x/onecloud/pkg/cloudcommon/informer"
+	"yunion.io/x/onecloud/pkg/mcclient"
+)
+
+type SWatchManager struct {
+	client       *mcclient.Client
+	watchBackend informer.IWatcher
+}
+
+func NewWatchManagerBySession(session *mcclient.ClientSession, onKeepaliveFailure func()) (*SWatchManager, error) {
+	return NewWatchManager(session.GetClient(), session.GetToken(), session.GetRegion(), session.GetEndpointType(), onKeepaliveFailure)
+}
+
+func NewWatchManager(client *mcclient.Client, token mcclient.TokenCredential, region, interfaceType string, onKeepaliveFailure func()) (*SWatchManager, error) {
+	endpoint, err := client.GetCommonEtcdEndpoint(token, region, interfaceType)
+	if err != nil {
+		return nil, errors.Wrap(err, "get common etcd endpoint")
+	}
+	tlsCfg, err := client.GetCommonEtcdTLSConfig(endpoint)
+	if err != nil {
+		return nil, errors.Wrap(err, "get common etcd tls config")
+	}
+	opt := &etcd.SEtcdOptions{
+		EtcdEndpoint:              []string{endpoint.Url},
+		EtcdTimeoutSeconds:        5,
+		EtcdRequestTimeoutSeconds: 10,
+		EtcdLeaseExpireSeconds:    5,
+	}
+	if tlsCfg != nil {
+		tlsCfg.InsecureSkipVerify = true
+		opt.EtcdEnabldSsl = true
+		opt.TLSConfig = tlsCfg
+	}
+	be, err := informer.NewEtcdBackend(opt, onKeepaliveFailure)
+	if err != nil {
+		return nil, errors.Wrap(err, "new etcd informer backend")
+	}
+	man := &SWatchManager{
+		client:       client,
+		watchBackend: be,
+	}
+	return man, nil
+}
+
+type IResourceManager interface {
+	KeyString() string
+	GetKeyword() string
+}
+
+type EventHandler interface {
+	OnAdd(obj *jsonutils.JSONDict)
+	OnUpdate(oldObj, newObj *jsonutils.JSONDict)
+	OnDelete(obj *jsonutils.JSONDict)
+}
+
+type IWatcher interface {
+	AddEventHandler(ctx context.Context, handler EventHandler) error
+}
+
+type sWatcher struct {
+	manager         *SWatchManager
+	resourceManager IResourceManager
+	ctx             context.Context
+	eventHandler    EventHandler
+}
+
+func (man *SWatchManager) For(resourceManager IResourceManager) IWatcher {
+	return &sWatcher{
+		manager:         man,
+		resourceManager: resourceManager,
+	}
+}
+
+func (w *sWatcher) AddEventHandler(ctx context.Context, handler EventHandler) error {
+	w.ctx = ctx
+	w.eventHandler = w.wrapEventHandler(handler)
+	return w.manager.watch(w.ctx, w.resourceManager, w.eventHandler)
+}
+
+func (man *SWatchManager) watch(ctx context.Context, resourceManager IResourceManager, handler informer.ResourceEventHandler) error {
+	return man.watchBackend.Watch(ctx, resourceManager.KeyString(), handler)
+}
+
+func (w *sWatcher) wrapEventHandler(handler EventHandler) informer.ResourceEventHandler {
+	return &wrapEventHandler{handler}
+}
+
+type wrapEventHandler struct {
+	handler EventHandler
+}
+
+func (h *wrapEventHandler) OnAdd(obj *jsonutils.JSONDict) {
+	h.handler.OnAdd(obj)
+}
+
+func (h *wrapEventHandler) OnUpdate(oldObj, newObj *jsonutils.JSONDict) {
+	h.handler.OnUpdate(oldObj, newObj)
+}
+
+func (h *wrapEventHandler) OnDelete(obj *jsonutils.JSONDict) {
+	h.handler.OnDelete(obj)
+}
+
+type EventHandlerFuncs struct {
+	AddFunc    func(obj *jsonutils.JSONDict)
+	UpdateFunc func(oldObj, newObj *jsonutils.JSONDict)
+	DeleteFunc func(obj *jsonutils.JSONDict)
+}
+
+func (r EventHandlerFuncs) OnAdd(obj *jsonutils.JSONDict) {
+	if r.AddFunc != nil {
+		r.AddFunc(obj)
+	}
+}
+
+func (r EventHandlerFuncs) OnUpdate(oldObj, newObj *jsonutils.JSONDict) {
+	if r.UpdateFunc != nil {
+		r.UpdateFunc(oldObj, newObj)
+	}
+}
+
+func (r EventHandlerFuncs) OnDelete(obj *jsonutils.JSONDict) {
+	if r.DeleteFunc != nil {
+		r.DeleteFunc(obj)
+	}
+}
+
+type FilteringEventHandler struct {
+	FilterFunc func(obj *jsonutils.JSONDict) bool
+	Handler    EventHandler
+}
+
+func (r FilteringEventHandler) OnAdd(obj *jsonutils.JSONDict) {
+	if !r.FilterFunc(obj) {
+		return
+	}
+	r.Handler.OnAdd(obj)
+}
+
+func (r FilteringEventHandler) OnUpdate(oldObj, newObj *jsonutils.JSONDict) {
+	newer := r.FilterFunc(newObj)
+	older := r.FilterFunc(oldObj)
+	switch {
+	case newer && older:
+		r.Handler.OnUpdate(oldObj, newObj)
+	case newer && !older:
+		r.Handler.OnAdd(newObj)
+	case !newer && older:
+		r.Handler.OnDelete(oldObj)
+	default:
+		// do nothing
+	}
+}
+
+func (r FilteringEventHandler) OnDelete(obj *jsonutils.JSONDict) {
+	if !r.FilterFunc(obj) {
+		return
+	}
+	r.Handler.OnDelete(obj)
+}

--- a/pkg/mcclient/modulebase/resource.go
+++ b/pkg/mcclient/modulebase/resource.go
@@ -47,27 +47,27 @@ type ResourceManager struct {
 	idFieldName   string
 }
 
-func (this *ResourceManager) GetKeyword() string {
+func (this ResourceManager) GetKeyword() string {
 	return this.Keyword
 }
 
-func (this *ResourceManager) KeyString() string {
+func (this ResourceManager) KeyString() string {
 	return this.KeywordPlural
 }
 
-func (this *ResourceManager) Version() string {
+func (this ResourceManager) Version() string {
 	return this.version
 }
 
-func (this *ResourceManager) ServiceType() string {
+func (this ResourceManager) ServiceType() string {
 	return this.serviceType
 }
 
-func (this *ResourceManager) EndpointType() string {
+func (this ResourceManager) EndpointType() string {
 	return this.endpointType
 }
 
-func (this *ResourceManager) URLPath() string {
+func (this ResourceManager) URLPath() string {
 	return strings.Replace(this.KeywordPlural, ":", "/", -1)
 }
 

--- a/pkg/mcclient/options/monitor/influxdbshema.go
+++ b/pkg/mcclient/options/monitor/influxdbshema.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package monitor
 
 import (

--- a/pkg/mcclient/options/servicecertificates.go
+++ b/pkg/mcclient/options/servicecertificates.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package options
 
 import (

--- a/pkg/mcclient/session.go
+++ b/pkg/mcclient/session.go
@@ -386,3 +386,14 @@ func (this *ClientSession) ToJson() jsonutils.JSONObject {
 func (cs *ClientSession) GetToken() TokenCredential {
 	return cs.token
 }
+
+func (cs *ClientSession) GetContext() context.Context {
+	if cs.ctx == nil {
+		return context.Background()
+	}
+	return cs.ctx
+}
+
+func (cs *ClientSession) GetCommonEtcdEndpoint() (*api.EndpointDetails, error) {
+	return cs.GetClient().GetCommonEtcdEndpoint(cs.GetToken(), cs.region, cs.endpointType)
+}

--- a/pkg/monitor/alerting/conditions/suggestrulereducer.go
+++ b/pkg/monitor/alerting/conditions/suggestrulereducer.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package conditions
 
 import (

--- a/pkg/monitor/models/alertnotification.go
+++ b/pkg/monitor/models/alertnotification.go
@@ -162,7 +162,7 @@ func (joint *SAlertnotification) GetExtraDetails(
 }
 
 func (joint *SAlertnotification) DoSave(ctx context.Context, userCred mcclient.TokenCredential) error {
-	if err := AlertNotificationManager.TableSpec().Insert(joint); err != nil {
+	if err := AlertNotificationManager.TableSpec().Insert(ctx, joint); err != nil {
 		return err
 	}
 	joint.SetModelManager(AlertNotificationManager, joint)

--- a/pkg/monitor/models/datasource.go
+++ b/pkg/monitor/models/datasource.go
@@ -109,7 +109,7 @@ func (man *SDataSourceManager) initDefaultDataSource(ctx context.Context) error 
 			Url:  url,
 		}
 		ds.Name = DefaultDataSource
-		if err := man.TableSpec().Insert(ds); err != nil {
+		if err := man.TableSpec().Insert(ctx, ds); err != nil {
 			log.Errorf("insert default influxdb: %v", err)
 		}
 	}

--- a/pkg/monitor/models/datasource.go
+++ b/pkg/monitor/models/datasource.go
@@ -29,6 +29,7 @@ import (
 	"yunion.io/x/pkg/tristate"
 	"yunion.io/x/pkg/util/wait"
 
+	identityapi "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/apis/monitor"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/httperrors"
@@ -98,7 +99,7 @@ func (man *SDataSourceManager) initDefaultDataSource(ctx context.Context) error 
 			log.Errorf("get empty public session for region %s", region)
 			return
 		}
-		url, err := s.GetServiceURL("influxdb", auth.PublicEndpointType)
+		url, err := s.GetServiceURL("influxdb", identityapi.EndpointInterfacePublic)
 		if err != nil {
 			log.Errorf("get influxdb public url: %v", err)
 			return

--- a/pkg/monitor/suggestsysdrivers/common.go
+++ b/pkg/monitor/suggestsysdrivers/common.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package suggestsysdrivers
 
 import (

--- a/pkg/monitor/suggestsysdrivers/diskunused.go
+++ b/pkg/monitor/suggestsysdrivers/diskunused.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package suggestsysdrivers
 
 import (

--- a/pkg/monitor/suggestsysdrivers/lbunused.go
+++ b/pkg/monitor/suggestsysdrivers/lbunused.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package suggestsysdrivers
 
 import (

--- a/pkg/monitor/suggestsysdrivers/scaledown.go
+++ b/pkg/monitor/suggestsysdrivers/scaledown.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package suggestsysdrivers
 
 import (

--- a/pkg/notify/cache/user_group_cache.go
+++ b/pkg/notify/cache/user_group_cache.go
@@ -131,7 +131,7 @@ func (manager *SUserGroupCacheManager) Sync(ctx context.Context, ugCache []SUser
 	now := time.Now().UTC()
 	for i := range added {
 		added[i].LastCheck = now
-		err := manager.TableSpec().Insert(&added[i])
+		err := manager.TableSpec().Insert(ctx, &added[i])
 		if err != nil {
 			syncResult.AddError(err)
 		} else {

--- a/pkg/notify/models/mod_config.go
+++ b/pkg/notify/models/mod_config.go
@@ -132,7 +132,7 @@ func (self *SConfigManager) InitializeData() error {
 		},
 	}
 	for _, config := range configs {
-		err := self.TableSpec().Insert(&config)
+		err := self.TableSpec().Insert(context.TODO(), &config)
 		if err != nil {
 			return err
 		}

--- a/pkg/notify/models/mod_template.go
+++ b/pkg/notify/models/mod_template.go
@@ -131,7 +131,7 @@ func (tm *STemplateManager) InitializeData() error {
 		if count > 0 {
 			continue
 		}
-		err := tm.TableSpec().InsertOrUpdate(&template)
+		err := tm.TableSpec().InsertOrUpdate(context.TODO(), &template)
 		if err != nil {
 			return errors.Wrap(err, "sqlchemy.TableSpec.InsertOrUpdate")
 		}

--- a/pkg/notify/models/worker.go
+++ b/pkg/notify/models/worker.go
@@ -168,7 +168,7 @@ func pullContact(ctx context.Context, uid string, contactType string) {
 	}
 	contact.Status = CONTACT_VERIFIED
 
-	err = ContactManager.TableSpec().Insert(&contact)
+	err = ContactManager.TableSpec().Insert(ctx, &contact)
 	if err != nil {
 		log.Errorf("create new %s contact failed", contactType)
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

实现对服务资源的 watch 机制，测试:

```bash
# 设置相关 keystone, region, climc 服务
$ kubectl -n onecloud set image deployments default-keystone keystone=registry.cn-beijing.aliyuncs.com/yunionio/keystone:lzx-dev
$ kubectl -n onecloud set image deployments default-region region=registry.cn-beijing.aliyuncs.com/yunionio/region:lzx-dev
$ kubectl -n onecloud set image deployments default-climc climc=registry.cn-beijing.aliyuncs.com/yunionio/climc:lzx-dev

# 进入 climc 容器
$ kubectl exec -it -n onecloud default-climc-xxxx -- bash

# 查看所有资源的变化
$ climc watch --all

# 查看某些资源的变化
$ climc watch -s servers -s disks -s guestdisks -s policies
```

watcher 的用法可看 *cmd/climc/shell/watch.go* 的实现代码

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->
NONE
/area util
/cc @wanyaoqi @swordqiu @yousong 