### PR TITLE
Automated cherry pick of #6636: fix: ignore match weights when searching matched policysets

### DIFF
--- a/pkg/util/rbacutils/policyset.go
+++ b/pkg/util/rbacutils/policyset.go
@@ -19,21 +19,13 @@ type TPolicySet []*SRbacPolicy
 func GetMatchedPolicies(policies map[string]*SRbacPolicy, userCred IRbacIdentity) (TPolicySet, []string) {
 	matchedPolicies := make([]*SRbacPolicy, 0)
 	matchedNames := make([]string, 0)
-	maxMatchWeight := 0
 	for k := range policies {
-		isMatched, matchWeight := policies[k].Match(userCred)
-		if !isMatched || matchWeight < maxMatchWeight {
+		isMatched, _ := policies[k].Match(userCred)
+		if !isMatched {
 			continue
 		}
-		if maxMatchWeight <= matchWeight {
-			if maxMatchWeight < matchWeight {
-				maxMatchWeight = matchWeight
-				matchedPolicies = matchedPolicies[:0]
-				matchedNames = matchedNames[:0]
-			}
-			matchedPolicies = append(matchedPolicies, policies[k])
-			matchedNames = append(matchedNames, k)
-		}
+		matchedPolicies = append(matchedPolicies, policies[k])
+		matchedNames = append(matchedNames, k)
 	}
 	return matchedPolicies, matchedNames
 }

--- a/pkg/util/rbacutils/rbac.go
+++ b/pkg/util/rbacutils/rbac.go
@@ -635,11 +635,12 @@ func (policy *SRbacPolicy) Match(userCred IRbacIdentity) (bool, int) {
 	weight := 0
 	if policy.MatchDomain(userCred.GetProjectDomainId()) {
 		if len(policy.DomainId) > 0 {
-			weight += 10
+			if policy.DomainId == userCred.GetProjectDomainId() {
+				weight += 30 // exact domain match
+			} else {
+				weight += 10 // else, system scope match
+			}
 		}
-		if !policy.IsPublic {
-			weight += 30 // exact domain match
-		} // else, system scope match
 		if policy.MatchRoles(userCred.GetRoles()) {
 			if len(policy.Roles) != 0 {
 				weight += 100


### PR DESCRIPTION
Cherry pick of #6636 on release/2.13.

#6636: fix: ignore match weights when searching matched policysets