### PR TITLE
fix: apigateway expose esxiagent service avaiability

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -706,7 +706,24 @@ func isBaremetalAgentExists(s *mcclient.ClientSession) (bool, error) {
 	params.Add(jsonutils.JSONFalse, "details")
 	agents, err := modules.Baremetalagents.List(s, params)
 	if err != nil {
-		return false, errors.Wrap(err, "modules.LoadbalancerAgents.List")
+		return false, errors.Wrap(err, "modules.Baremetalagents.List")
+	}
+
+	if len(agents.Data) > 0 {
+		return true, nil
+	} else {
+		return false, nil
+	}
+}
+
+func isEsxiAgentExists(s *mcclient.ClientSession) (bool, error) {
+	params := jsonutils.NewDict()
+	params.Add(jsonutils.NewString("agent_type.equals(esxiagent)"), "filter.0")
+	params.Add(jsonutils.NewInt(1), "limit")
+	params.Add(jsonutils.JSONFalse, "details")
+	agents, err := modules.Baremetalagents.List(s, params)
+	if err != nil {
+		return false, errors.Wrap(err, "modules.Baremetalagents.List esxiagent")
 	}
 
 	if len(agents.Data) > 0 {
@@ -848,6 +865,10 @@ func getUserInfo(ctx context.Context, s *mcclient.ClientSession, token mcclient.
 		{
 			existFunc: isHostAgentExists,
 			srvName:   "hostagent",
+		},
+		{
+			existFunc: isEsxiAgentExists,
+			srvName:   "esxiagent",
 		},
 	} {
 		exist, err := cf.existFunc(s)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：apigateway userinfo显示esxiagent是否存在的字段

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area apigateway
