### PR TITLE
Feature/yousong lb selective redirect

### DIFF
--- a/pkg/compute/models/loadbalancerlistenerrules.go
+++ b/pkg/compute/models/loadbalancerlistenerrules.go
@@ -558,7 +558,11 @@ func (lbr *SLoadbalancerListenerRule) AllowPerformStatus(ctx context.Context, us
 
 func (lbr *SLoadbalancerListenerRule) ValidateUpdateData(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {
 	backendGroupV := validators.NewModelIdOrNameValidator("backend_group", "loadbalancerbackendgroup", lbr.GetOwnerId())
-	backendGroupV.Optional(true)
+	if lbr.BackendGroupId != "" {
+		backendGroupV.Default(lbr.BackendGroupId)
+	} else {
+		backendGroupV.Optional(true)
+	}
 	if err := backendGroupV.Validate(data); err != nil {
 		return nil, err
 	}

--- a/pkg/compute/models/loadbalancerlisteners.go
+++ b/pkg/compute/models/loadbalancerlisteners.go
@@ -132,7 +132,7 @@ type SLoadbalancerListener struct {
 	BackendGroupId    string `width:"36" charset:"ascii" nullable:"true" list:"user" create:"optional" update:"user"`
 	BackendServerPort int    `nullable:"false" get:"user" list:"user" default:"0" create:"optional"`
 
-	Scheduler string `width:"16" charset:"ascii" nullable:"false" list:"user" create:"required" update:"user"`
+	Scheduler string `width:"16" charset:"ascii" nullable:"false" list:"user" create:"optional" update:"user"`
 
 	SendProxy string `width:"16" charset:"ascii" nullable:"false" list:"user" create:"optional" update:"user" default:"off"`
 

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -193,9 +193,6 @@ func (self *SKVMRegionDriver) ValidateCreateLoadbalancerBackendData(ctx context.
 		basename = guest.Name
 		backend = backendV.Model
 	case api.LB_BACKEND_HOST:
-		if !db.IsAdminAllowCreate(userCred, man) {
-			return nil, httperrors.NewInputParameterError("only sysadmin can specify host as backend")
-		}
 		backendV := validators.NewModelIdOrNameValidator("backend", "host", userCred)
 		err := backendV.Validate(data)
 		if err != nil {
@@ -211,9 +208,6 @@ func (self *SKVMRegionDriver) ValidateCreateLoadbalancerBackendData(ctx context.
 		basename = host.Name
 		backend = backendV.Model
 	case api.LB_BACKEND_IP:
-		if !db.IsAdminAllowCreate(userCred, man) {
-			return nil, fmt.Errorf("only sysadmin can specify ip address as backend")
-		}
 		backendV := validators.NewIPv4AddrValidator("backend")
 		err := backendV.Validate(data)
 		if err != nil {

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -403,7 +403,7 @@ func (self *SKVMRegionDriver) ValidateCreateLoadbalancerListenerData(ctx context
 		"acl_type":   aclTypeV.Optional(true),
 		"acl":        aclV.Optional(true),
 
-		"scheduler":   validators.NewStringChoicesValidator("scheduler", api.LB_SCHEDULER_TYPES),
+		"scheduler":   validators.NewStringChoicesValidator("scheduler", api.LB_SCHEDULER_TYPES).Default(api.LB_SCHEDULER_RR),
 		"egress_mbps": validators.NewRangeValidator("egress_mbps", api.LB_MbpsMin, api.LB_MbpsMax).Optional(true),
 
 		"client_request_timeout":  validators.NewRangeValidator("client_request_timeout", 0, 600).Default(10),

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -194,7 +194,7 @@ func (self *SKVMRegionDriver) ValidateCreateLoadbalancerBackendData(ctx context.
 		backend = backendV.Model
 	case api.LB_BACKEND_HOST:
 		if !db.IsAdminAllowCreate(userCred, man) {
-			return nil, fmt.Errorf("only sysadmin can specify host as backend")
+			return nil, httperrors.NewInputParameterError("only sysadmin can specify host as backend")
 		}
 		backendV := validators.NewModelIdOrNameValidator("backend", "host", userCred)
 		err := backendV.Validate(data)
@@ -204,7 +204,7 @@ func (self *SKVMRegionDriver) ValidateCreateLoadbalancerBackendData(ctx context.
 		host := backendV.Model.(*models.SHost)
 		{
 			if len(host.AccessIp) == 0 {
-				return nil, fmt.Errorf("host %s has no access ip", host.GetId())
+				return nil, httperrors.NewInputParameterError("host %s has no access ip", host.GetId())
 			}
 			data.Set("address", jsonutils.NewString(host.AccessIp))
 		}
@@ -223,7 +223,7 @@ func (self *SKVMRegionDriver) ValidateCreateLoadbalancerBackendData(ctx context.
 		data.Set("address", jsonutils.NewString(ip))
 		basename = ip
 	default:
-		return nil, fmt.Errorf("internal error: unexpected backend type %s", backendType)
+		return nil, httperrors.NewInputParameterError("internal error: unexpected backend type %s", backendType)
 	}
 
 	name, _ := data.GetString("name")
@@ -238,14 +238,14 @@ func (self *SKVMRegionDriver) ValidateCreateLoadbalancerBackendData(ctx context.
 			// guest zone must match that of loadbalancer's
 			host := guest.GetHost()
 			if host == nil {
-				return nil, fmt.Errorf("error getting host of guest %s", guest.GetId())
+				return nil, httperrors.NewInputParameterError("error getting host of guest %s", guest.GetId())
 			}
 
 			if lb == nil {
-				return nil, fmt.Errorf("error loadbalancer of backend group %s", backendGroup.GetId())
+				return nil, httperrors.NewInputParameterError("error loadbalancer of backend group %s", backendGroup.GetId())
 			}
 			if host.ZoneId != lb.ZoneId {
-				return nil, fmt.Errorf("zone of host %q (%s) != zone of loadbalancer %q (%s)",
+				return nil, httperrors.NewInputParameterError("zone of host %q (%s) != zone of loadbalancer %q (%s)",
 					host.Name, host.ZoneId, lb.Name, lb.ZoneId)
 			}
 		}

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -313,9 +313,6 @@ func (self *SKVMRegionDriver) ValidateCreateLoadbalancerListenerRuleData(ctx con
 	if listenerType != api.LB_LISTENER_TYPE_HTTP && listenerType != api.LB_LISTENER_TYPE_HTTPS {
 		return nil, httperrors.NewInputParameterError("listener type must be http/https, got %s", listenerType)
 	}
-	if listener.Redirect != api.LB_REDIRECT_OFF {
-		return nil, httperrors.NewInputParameterError("do not allow adding rules for redirect listener")
-	}
 
 	{
 		if redirectV.Value == api.LB_REDIRECT_OFF {

--- a/pkg/lbagent/models/haproxy.go
+++ b/pkg/lbagent/models/haproxy.go
@@ -581,7 +581,6 @@ frontend {{ .id }}
 	{{- println }}
 	{{- if .log }}	{{ println "option httplog clf" }} {{- end }}
 	{{- if .acl }}	{{ println .acl }} {{- end}}
-	{{- range .rate_rules }}	{{ println . }} {{- end }}
 	{{- if .client_request_timeout }}	timeout http-request {{ println .client_request_timeout }} {{- end}}
 	{{- if .client_idle_timeout }}	timeout http-keep-alive {{ println .client_idle_timeout }} {{- end}}
 	{{- if .xforwardedfor }}	{{ println "option forwardfor" }} {{- end}}

--- a/pkg/mcclient/options/loadbalancerlisteners.go
+++ b/pkg/mcclient/options/loadbalancerlisteners.go
@@ -23,7 +23,7 @@ type LoadbalancerListenerCreateOptions struct {
 	BackendServerPort *int
 	BackendGroup      *string `json:",allowempty"`
 
-	Scheduler string `required:"true" choices:"rr|wrr|wlc|sch|tch"`
+	Scheduler string `choices:"rr|wrr|wlc|sch|tch"`
 
 	SendProxy string `choices:"off|v1|v2|v2-ssl|v2-ssl-cn"`
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
lbagent: decouple rule redirect from listener redirect
lbagent: standalone rate control between listener and its rules
lbagent: fix condition for "nothing to serve"
lblistener: make scheduler an optional arg on creation
climc: lblistener-create: make --scheduler an optional arg
lblistenerrule: allow creation even for redirect listener
lblistener: redirect: try avoid endless redirect
lblistener: allow turning on/off redirect
lblistenerrule: redirect: try avoid endless redirect
lblistenerrule: allow turning on/off redirect
```

- [x] 冒烟测试
  - [x] lblis: 对于onecloud, scheduler默认值为rr
  - [x] lbr: 跳转型lblis下创建跳转型lbr
  - [x] lbr: 关闭/开启redirect
  - [x] lbr: scheme, host, path检查
  - [x] lblis: scheme, host, path检查
  - [x] lbagent: 调整限速配置

**是否需要 backport 到之前的 release 分支**:

NONE

/cc @ioito @swordqiu @zexi @tb365 
/area region
/area lbagent
/area climc