### PR TITLE
bugfix: isolated device manager:

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -1337,7 +1337,9 @@ func (h *SHostInfo) getIsolatedDevices() {
 func (h *SHostInfo) onGetIsolatedDeviceSucc(objs []jsonutils.JSONObject) {
 	for _, obj := range objs {
 		info := isolated_device.CloudDeviceInfo{}
-		obj.Unmarshal(&info)
+		if err := obj.Unmarshal(&info); err != nil {
+			h.onFail(fmt.Sprintf("unmarshal isolated device to cloud device info failed %s", err))
+		}
 		dev := h.IsolatedDeviceMan.GetDeviceByIdent(info.VendorDeviceId, info.Addr)
 		if dev != nil {
 			dev.SetDeviceInfo(info)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
- fix find boot_vag no such file or directory

ovn-controller会生成sys/devices/virtual/net/genev_sys_6081的临时文件，导致find过程中报错了
```
Execute command "find /sys/devices -name boot_vga" , error: exit status 1 , output: /sys/devices/pci0000:00/0000:00:1c.0/0000:01:00.0/0000:02:00.0/boot_vga
/sys/devices/pci0000:3a/0000:3a:00.0/0000:3b:00.0/0000:3c:00.0/0000:3d:00.0/boot_vga
/sys/devices/pci0000:3a/0000:3a:00.0/0000:3b:00.0/0000:3c:04.0/0000:3e:00.0/boot_vga
/sys/devices/pci0000:3a/0000:3a:00.0/0000:3b:00.0/0000:3c:10.0/0000:41:00.0/boot_vga
/sys/devices/pci0000:3a/0000:3a:00.0/0000:3b:00.0/0000:3c:14.0/0000:42:00.0/boot_vga
/sys/devices/pci0000:ae/0000:ae:00.0/0000:af:00.0/0000:b0:00.0/0000:b1:00.0/boot_vga
/sys/devices/pci0000:ae/0000:ae:00.0/0000:af:00.0/0000:b0:04.0/0000:b2:00.0/boot_vga
/sys/devices/pci0000:ae/0000:ae:00.0/0000:af:00.0/0000:b0:10.0/0000:b4:00.0/boot_vga
/sys/devices/pci0000:ae/0000:ae:00.0/0000:af:00.0/0000:b0:14.0/0000:b5:00.0/boot_vga
find: /sys/devices/virtual/net/genev_sys_6081: No such file or directory
```

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
release/3.0
/area host
/cc @swordqiu @zexi @yousong 
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->
