### PR TITLE
Feature/yousong vpc dns

### DIFF
--- a/pkg/vpcagent/models/models.go
+++ b/pkg/vpcagent/models/models.go
@@ -149,3 +149,13 @@ func (el *Elasticip) Copy() *Elasticip {
 		SElasticip: el.SElasticip,
 	}
 }
+
+type DnsRecord struct {
+	compute_models.SDnsRecord
+}
+
+func (el *DnsRecord) Copy() *DnsRecord {
+	return &DnsRecord{
+		SDnsRecord: el.SDnsRecord,
+	}
+}

--- a/pkg/vpcagent/models/modelset.go
+++ b/pkg/vpcagent/models/modelset.go
@@ -35,6 +35,8 @@ type (
 
 	Guestnetworks  map[string]*Guestnetwork  // key: guestId/ifname
 	Guestsecgroups map[string]*Guestsecgroup // key: guestId/secgroupId
+
+	DnsRecords map[string]*DnsRecord
 )
 
 func (set Vpcs) ModelManager() mcclient_modulebase.IBaseManager {
@@ -527,6 +529,27 @@ func (set Elasticips) AddModel(i db.IModel) {
 
 func (set Elasticips) Copy() apihelper.IModelSet {
 	setCopy := Elasticips{}
+	for id, el := range set {
+		setCopy[id] = el.Copy()
+	}
+	return setCopy
+}
+
+func (set DnsRecords) ModelManager() mcclient_modulebase.IBaseManager {
+	return &mcclient_modules.DNSRecords
+}
+
+func (set DnsRecords) NewModel() db.IModel {
+	return &DnsRecord{}
+}
+
+func (set DnsRecords) AddModel(i db.IModel) {
+	m := i.(*DnsRecord)
+	set[m.Id] = m
+}
+
+func (set DnsRecords) Copy() apihelper.IModelSet {
+	setCopy := DnsRecords{}
 	for id, el := range set {
 		setCopy[id] = el.Copy()
 	}

--- a/pkg/vpcagent/models/modelsets.go
+++ b/pkg/vpcagent/models/modelsets.go
@@ -31,6 +31,8 @@ type ModelSetsMaxUpdatedAt struct {
 	Guestnetworks      time.Time
 	Guestsecgroups     time.Time
 	Elasticips         time.Time
+
+	DnsRecords time.Time
 }
 
 func NewModelSetsMaxUpdatedAt() *ModelSetsMaxUpdatedAt {
@@ -45,6 +47,8 @@ func NewModelSetsMaxUpdatedAt() *ModelSetsMaxUpdatedAt {
 		Guestnetworks:      apihelper.PseudoZeroTime,
 		Guestsecgroups:     apihelper.PseudoZeroTime,
 		Elasticips:         apihelper.PseudoZeroTime,
+
+		DnsRecords: apihelper.PseudoZeroTime,
 	}
 }
 
@@ -59,6 +63,8 @@ type ModelSets struct {
 	Guestnetworks      Guestnetworks
 	Guestsecgroups     Guestsecgroups
 	Elasticips         Elasticips
+
+	DnsRecords DnsRecords
 }
 
 func NewModelSets() *ModelSets {
@@ -73,6 +79,8 @@ func NewModelSets() *ModelSets {
 		Guestnetworks:      Guestnetworks{},
 		Guestsecgroups:     Guestsecgroups{},
 		Elasticips:         Elasticips{},
+
+		DnsRecords: DnsRecords{},
 	}
 }
 
@@ -89,6 +97,8 @@ func (mss *ModelSets) ModelSetList() []apihelper.IModelSet {
 		mss.Guestnetworks,
 		mss.Guestsecgroups,
 		mss.Elasticips,
+
+		mss.DnsRecords,
 	}
 }
 
@@ -108,6 +118,8 @@ func (mss *ModelSets) copy_() *ModelSets {
 		Guestnetworks:      mss.Guestnetworks.Copy().(Guestnetworks),
 		Guestsecgroups:     mss.Guestsecgroups.Copy().(Guestsecgroups),
 		Elasticips:         mss.Elasticips.Copy().(Elasticips),
+
+		DnsRecords: mss.DnsRecords.Copy().(DnsRecords),
 	}
 	return mssCopy
 }

--- a/pkg/vpcagent/ovn/keeper.go
+++ b/pkg/vpcagent/ovn/keeper.go
@@ -521,6 +521,7 @@ func (keeper *OVNNorthboundKeeper) Mark(ctx context.Context) {
 		&db.ACL,
 		&db.DHCPOptions,
 		&db.QoS,
+		&db.DNS,
 	}
 	for _, itbl := range itbls {
 		for _, irow := range itbl.Rows() {
@@ -538,6 +539,7 @@ func (keeper *OVNNorthboundKeeper) Sweep(ctx context.Context) error {
 		&db.LogicalSwitch,
 		&db.LogicalRouter,
 		&db.DHCPOptions,
+		&db.DNS,
 	}
 	var irows []types.IRow
 	for _, itbl := range itbls {

--- a/pkg/vpcagent/ovn/worker.go
+++ b/pkg/vpcagent/ovn/worker.go
@@ -165,6 +165,12 @@ func (w *Worker) run(ctx context.Context, mss *agentmodels.ModelSets) (err error
 			}
 		}
 	}
+	for _, vpc := range mss.Vpcs {
+		if vpc.Id == apis.DEFAULT_VPC_ID {
+			continue
+		}
+		ovndb.ClaimVpcGuestDnsRecords(ctx, vpc)
+	}
 	ovndb.Sweep(ctx)
 	return nil
 }

--- a/pkg/vpcagent/ovn/worker.go
+++ b/pkg/vpcagent/ovn/worker.go
@@ -171,6 +171,7 @@ func (w *Worker) run(ctx context.Context, mss *agentmodels.ModelSets) (err error
 		}
 		ovndb.ClaimVpcGuestDnsRecords(ctx, vpc)
 	}
+	ovndb.ClaimDnsRecords(ctx, mss.Vpcs, mss.DnsRecords)
 	ovndb.Sweep(ctx)
 	return nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
vpcagent: ovn: mark and sweep dns records
vpcagent: ovn: dns records for guest names
vpcagent: models: include dnsrecords
vpcagent: ovn: claim dnsrecords for all vpcs
```

- [x] 冒烟测试
  - [x] vpc内主机名解析
  - [x] 所有vpc内dnsrecords解析

dnsrecords在vpc中

 - 仅支持a, 4a，不支持cname, ptr等
 - 未处理public, private关系

**是否需要 backport 到之前的 release 分支**:

NONE

/area vpcagent
/cc @swordqiu @zexi 
