### PR TITLE
fix: xsky recode using endpoint as accesskey key

### DIFF
--- a/pkg/multicloud/objectstore/xsky/xsky.go
+++ b/pkg/multicloud/objectstore/xsky/xsky.go
@@ -48,7 +48,7 @@ func parseAccount(account string) (user string, accessKey string) {
 }
 
 func NewXskyClient(cfg *objectstore.ObjectStoreClientConfig) (*SXskyClient, error) {
-	usrname, accessKey := parseAccount(cfg.GetEndpoint())
+	usrname, accessKey := parseAccount(cfg.GetAccessKey())
 	adminApi := newXskyAdminApi(
 		usrname,
 		cfg.GetAccessSecret(),


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：xsky代码重构是用了endpoint信息作为access信息，导致账号认证失败

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.1
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi  @yousong 
/area region
