### PR TITLE
Automated cherry pick of #6740: fix: xsky recode using endpoint as accesskey key

### DIFF
--- a/pkg/multicloud/objectstore/xsky/xsky.go
+++ b/pkg/multicloud/objectstore/xsky/xsky.go
@@ -48,7 +48,7 @@ func parseAccount(account string) (user string, accessKey string) {
 }
 
 func NewXskyClient(cfg *objectstore.ObjectStoreClientConfig) (*SXskyClient, error) {
-	usrname, accessKey := parseAccount(cfg.GetEndpoint())
+	usrname, accessKey := parseAccount(cfg.GetAccessKey())
 	adminApi := newXskyAdminApi(
 		usrname,
 		cfg.GetAccessSecret(),


### PR DESCRIPTION
Cherry pick of #6740 on release/3.1.

#6740: fix: xsky recode using endpoint as accesskey key