### PR TITLE
fix: base64 decode 12-bytes plain text password return nil

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -42,6 +42,7 @@ import (
 	"yunion.io/x/onecloud/pkg/util/httputils"
 	"yunion.io/x/onecloud/pkg/util/netutils2"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
+	"yunion.io/x/onecloud/pkg/util/stringutils2"
 )
 
 func AppContextToken(ctx context.Context) mcclient.TokenCredential {
@@ -271,7 +272,7 @@ func (h *AuthHandlers) doCredentialLogin(ctx context.Context, req *http.Request,
 			return nil, httperrors.NewInputParameterError("get password in body")
 		}
 		// try base64 decryption
-		if decPasswd, err := base64.StdEncoding.DecodeString(passwd); err == nil {
+		if decPasswd, err := base64.StdEncoding.DecodeString(passwd); err == nil && stringutils2.IsPrintableAsciiString(string(decPasswd)) {
 			passwd = string(decPasswd)
 		}
 		if len(uname) == 0 || len(passwd) == 0 {

--- a/pkg/util/stringutils2/i18n.go
+++ b/pkg/util/stringutils2/i18n.go
@@ -22,3 +22,19 @@ func IsUtf8(str string) bool {
 	}
 	return false
 }
+
+func IsPrintableAscii(b byte) bool {
+	if b >= 32 && b <= 126 {
+		return true
+	}
+	return false
+}
+
+func IsPrintableAsciiString(str string) bool {
+	for _, b := range []byte(str) {
+		if !IsPrintableAscii(b) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/util/stringutils2/i18n_test.go
+++ b/pkg/util/stringutils2/i18n_test.go
@@ -33,3 +33,29 @@ func TestIsUtf8(t *testing.T) {
 		}
 	}
 }
+
+func TestIsPrintableAscii(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{
+			in:   "passw0rd",
+			want: true,
+		},
+		{
+			in:   string([]byte{128, 45, 48}),
+			want: false,
+		},
+		{
+			in:   "中文",
+			want: false,
+		},
+	}
+	for _, c := range cases {
+		got := IsPrintableAsciiString(c.in)
+		if got != c.want {
+			t.Errorf("%s IsPringtableAsciiString got %v want %v", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：base64 deoce 12字符长度的未编码密码时不报错

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi @ioito 
/area apigateway
