### PR TITLE
Feature/yousong default params

### DIFF
--- a/cmd/climc/shell/compute/loadbalanceragents.go
+++ b/cmd/climc/shell/compute/loadbalanceragents.go
@@ -70,6 +70,14 @@ func init() {
 		printLbagent(lbagent)
 		return nil
 	})
+	R(&options.EmptyOption{}, "lbagent-show-default-params", "Show lbagent default params", func(s *mcclient.ClientSession, opts *options.EmptyOption) error {
+		lbagent, err := modules.LoadbalancerAgents.Get(s, "default-params", nil)
+		if err != nil {
+			return err
+		}
+		printLbagent(lbagent)
+		return nil
+	})
 	R(&options.LoadbalancerAgentListOptions{}, "lbagent-list", "List lbagents", func(s *mcclient.ClientSession, opts *options.LoadbalancerAgentListOptions) error {
 		params, err := options.ListStructToParams(opts)
 		if err != nil {

--- a/pkg/compute/models/loadbalanceragents.go
+++ b/pkg/compute/models/loadbalanceragents.go
@@ -93,29 +93,29 @@ type SLoadbalancerAgent struct {
 }
 
 type SLoadbalancerAgentParamsVrrp struct {
-	Priority          int
-	VirtualRouterId   int
-	GarpMasterRefresh int
+	Priority          int `json:",omitzero"`
+	VirtualRouterId   int `json:",omitzero"`
+	GarpMasterRefresh int `json:",omitzero"`
 	Preempt           bool
 	Interface         string
-	AdvertInt         int
+	AdvertInt         int `json:",omitzero"`
 	Pass              string
 }
 
 type SLoadbalancerAgentParamsHaproxy struct {
 	GlobalLog      string
-	GlobalNbthread int
+	GlobalNbthread int `json:",omitzero"`
 	LogHttp        bool
 	LogTcp         bool
 	LogNormal      bool
-	TuneHttpMaxhdr int
+	TuneHttpMaxhdr int `json:",omitzero"`
 }
 
 type SLoadbalancerAgentParamsTelegraf struct {
 	InfluxDbOutputUrl       string
 	InfluxDbOutputName      string
 	InfluxDbOutputUnsafeSsl bool
-	HaproxyInputInterval    int
+	HaproxyInputInterval    int `json:",omitzero"`
 }
 
 type SLoadbalancerAgentParams struct {
@@ -323,6 +323,20 @@ func (p *SLoadbalancerAgentParams) IsZero() bool {
 		return true
 	}
 	return false
+}
+
+func (man *SLoadbalancerAgentManager) AllowGetPropertyDefaultParams(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {
+	return db.IsAdminAllowGetSpec(userCred, man, "default-params")
+}
+
+func (man *SLoadbalancerAgentManager) GetPropertyDefaultParams(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+	params := SLoadbalancerAgentParams{}
+	params.initDefault(jsonutils.NewDict())
+	obj := jsonutils.Marshal(params)
+
+	r := jsonutils.NewDict()
+	r.Set("params", obj)
+	return r, nil
 }
 
 func (man *SLoadbalancerAgentManager) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data *jsonutils.JSONDict) (*jsonutils.JSONDict, error) {

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -84,9 +84,11 @@ func (self *SKVMRegionDriver) ValidateCreateLoadbalancerData(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-
 	if zone == nil {
 		return nil, httperrors.NewInputParameterError("zone info missing")
+	}
+	if vpc.Id != api.DEFAULT_VPC_ID {
+		return nil, httperrors.NewInputParameterError("vpc lb is not allowed for now")
 	}
 
 	if clusterV.Model == nil {

--- a/pkg/mcclient/options/empty.go
+++ b/pkg/mcclient/options/empty.go
@@ -1,0 +1,3 @@
+package options
+
+type EmptyOption struct{}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
lb: onecloud: disallow creating lb with vpc network
lbagent: new API: GET /loadbalanceragents/default-params
mcclient: options: add EmptyOption
climc: add command lbagent-show-default-params
```

- [x] 冒烟测试
  - [x] 禁止创建vpc subnet lb  
  - [x] 检查default-params内容，整数0的影响

**是否需要 backport 到之前的 release 分支**:

NONE

/area region
/cc @swordqiu @zexi 