### PR TITLE
fix: handler param.convert's error in caller.go

### DIFF
--- a/pkg/cloudcommon/db/caller.go
+++ b/pkg/cloudcommon/db/caller.go
@@ -120,16 +120,23 @@ func callFunc(funcVal reflect.Value, fName string, inputs ...interface{}) ([]ref
 	for i := range inputs {
 		params[i] = newParam(funcType.In(i), inputs[i])
 	}
-	args := convertParams(params)
+	args, err := convertParams(params)
+	if err != nil {
+		return nil, err
+	}
 	return funcVal.Call(args), nil
 }
 
-func convertParams(params []*param) []reflect.Value {
+func convertParams(params []*param) ([]reflect.Value, error) {
 	ret := make([]reflect.Value, 0)
 	for _, p := range params {
-		ret = append(ret, p.convert())
+		val, err := p.convert()
+		if err != nil {
+			return ret, err
+		}
+		ret = append(ret, val)
 	}
-	return ret
+	return ret, nil
 }
 
 type param struct {
@@ -153,18 +160,21 @@ func isJSONObject(input interface{}) (jsonutils.JSONObject, bool) {
 	return obj, true
 }
 
-func (p *param) convert() reflect.Value {
+func (p *param) convert() (reflect.Value, error) {
 	if p.input == nil {
-		return reflect.New(p.pType).Elem()
+		return reflect.New(p.pType).Elem(), nil
 	}
 	obj, ok := isJSONObject(p.input)
 	if !ok {
-		return reflect.ValueOf(p.input)
+		return reflect.ValueOf(p.input), nil
 	}
 	// generate object by type
 	val := reflect.New(p.pType)
-	obj.Unmarshal(val.Interface())
-	return val.Elem()
+	err := obj.Unmarshal(val.Interface())
+	if err != nil {
+		return reflect.Value{}, errors.Wrapf(err, "unable to convert '%v' to Type %q", p.input, p.pType.Name())
+	}
+	return val.Elem(), nil
 }
 
 func ValueToJSONObject(out reflect.Value) jsonutils.JSONObject {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

如果前端传递的参数有问题（比如，某个字段是数组，却按照map传递），就会导致param.convert失败，这里的错误应该抛出。否则错误出现的地方就会滞后，不能正确锁定错误。
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->
/cc @zexi 
