### PR TITLE
Feature/yousong default params

### DIFF
--- a/cmd/climc/shell/compute/loadbalanceragents.go
+++ b/cmd/climc/shell/compute/loadbalanceragents.go
@@ -70,8 +70,12 @@ func init() {
 		printLbagent(lbagent)
 		return nil
 	})
-	R(&options.EmptyOption{}, "lbagent-show-default-params", "Show lbagent default params", func(s *mcclient.ClientSession, opts *options.EmptyOption) error {
-		lbagent, err := modules.LoadbalancerAgents.Get(s, "default-params", nil)
+	R(&options.LoadbalancerAgentDefaultParamsOptions{}, "lbagent-show-default-params", "Show lbagent default params", func(s *mcclient.ClientSession, opts *options.LoadbalancerAgentDefaultParamsOptions) error {
+		params, err := options.StructToParams(opts)
+		if err != nil {
+			return err
+		}
+		lbagent, err := modules.LoadbalancerAgents.Get(s, "default-params", params)
 		if err != nil {
 			return err
 		}

--- a/pkg/apis/compute/loadbalancer.go
+++ b/pkg/apis/compute/loadbalancer.go
@@ -48,6 +48,8 @@ type LoadbalancerListenerListInput struct {
 
 	Scheduler []string `json:"scheduler"`
 
+	Certificate []string `json:"certificate"`
+
 	SendProxy []string `json:"send_proxy"`
 
 	AclStatus []string `json:"acl_status"`

--- a/pkg/compute/models/loadbalanceragents.go
+++ b/pkg/compute/models/loadbalanceragents.go
@@ -142,6 +142,9 @@ func (p *SLoadbalancerAgentParamsVrrp) Validate(data *jsonutils.JSONDict) error 
 	if p.VirtualRouterId < 1 || p.VirtualRouterId > 255 {
 		return httperrors.NewInputParameterError("invalid vrrp virtual_router_id %d: want [1,255]", p.VirtualRouterId)
 	}
+	if p.AdvertInt < 1 || p.AdvertInt > 255 {
+		return httperrors.NewInputParameterError("invalid vrrp advert_int %d: want [1,255]", p.AdvertInt)
+	}
 	return nil
 }
 

--- a/pkg/compute/models/loadbalancerlisteners.go
+++ b/pkg/compute/models/loadbalancerlisteners.go
@@ -248,6 +248,9 @@ func (man *SLoadbalancerListenerManager) ListItemFilter(
 	if len(query.Scheduler) > 0 {
 		q = q.In("scheduler", query.Scheduler)
 	}
+	if len(query.Certificate) > 0 {
+		q = q.In("certificate_id", query.Certificate)
+	}
 	if len(query.SendProxy) > 0 {
 		q = q.In("send_proxy", query.SendProxy)
 	}

--- a/pkg/compute/regiondrivers/kvm.go
+++ b/pkg/compute/regiondrivers/kvm.go
@@ -153,15 +153,6 @@ func (self *SKVMRegionDriver) ValidateUpdateLoadbalancerCertificateData(ctx cont
 }
 
 func (self *SKVMRegionDriver) ValidateCreateLoadbalancerBackendGroupData(ctx context.Context, userCred mcclient.TokenCredential, data *jsonutils.JSONDict, lb *models.SLoadbalancer, backends []cloudprovider.SLoadbalancerBackend) (*jsonutils.JSONDict, error) {
-	for _, backend := range backends {
-		switch backend.BackendType {
-		case api.LB_BACKEND_GUEST:
-			if backend.ZoneId != lb.ZoneId {
-				return nil, fmt.Errorf("zone of host %q (%s) != zone of loadbalancer %q (%s)",
-					backend.HostName, backend.ZoneId, lb.Name, lb.ZoneId)
-			}
-		}
-	}
 	return data, nil
 }
 
@@ -238,12 +229,15 @@ func (self *SKVMRegionDriver) ValidateCreateLoadbalancerBackendData(ctx context.
 			if host == nil {
 				return nil, httperrors.NewInputParameterError("error getting host of guest %s", guest.GetId())
 			}
-
 			if lb == nil {
 				return nil, httperrors.NewInputParameterError("error loadbalancer of backend group %s", backendGroup.GetId())
 			}
-			if host.ZoneId != lb.ZoneId {
-				return nil, httperrors.NewInputParameterError("zone of host %q (%s) != zone of loadbalancer %q (%s)",
+			var (
+				lbRegion   = lb.GetRegion()
+				hostRegion = host.GetRegion()
+			)
+			if lbRegion.Id != hostRegion.Id {
+				return nil, httperrors.NewInputParameterError("region of host %q (%s) != region of loadbalancer %q (%s)",
 					host.Name, host.ZoneId, lb.Name, lb.ZoneId)
 			}
 		}

--- a/pkg/mcclient/options/loadbalanceragents.go
+++ b/pkg/mcclient/options/loadbalanceragents.go
@@ -169,3 +169,7 @@ func (opts *LoadbalancerAgentActionDeployOptions) Params() (*jsonutils.JSONDict,
 type LoadbalancerAgentActionUndeployOptions struct {
 	ID string `json:"-"`
 }
+
+type LoadbalancerAgentDefaultParamsOptions struct {
+	Cluster string
+}

--- a/pkg/mcclient/options/loadbalancers.go
+++ b/pkg/mcclient/options/loadbalancers.go
@@ -23,7 +23,7 @@ type LoadbalancerCreateOptions struct {
 	ChargeType       string `choices:"traffic|bandwidth"`
 	Bandwidth        int
 	Zone             string
-	Cluster          string
+	Cluster          string `json:"cluster_id"`
 	Manager          string
 }
 
@@ -35,7 +35,7 @@ type LoadbalancerUpdateOptions struct {
 	ID   string `json:"-"`
 	Name string
 
-	Cluster      string
+	Cluster      string `json:"cluster_id"`
 	BackendGroup string
 }
 
@@ -56,7 +56,7 @@ type LoadbalancerListOptions struct {
 	BackendGroup string
 	Cloudregion  string
 	Zone         string
-	Cluster      string
+	Cluster      string `json:"cluster_id"`
 }
 
 type LoadbalancerActionStatusOptions struct {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
lbagent: default-params: default vrrp params from peer lbagents
climc: lbagent-show-default-params: add --cluster option support
lbbackends: allow backends of the same region (vs. zone)
lbagents: params: add needsUpdatePeer() and updateBy() methods
lbagents: add check on vrrp.advert_int
mcclient: options: lb: arg rename cluster{,_id} 
lblisteners: list: filter with certificate ids
```

- [x] 冒烟测试
  - [x] climc lbagent-show-default-params --cluster cluster0，比较没有--cluster参数的情形
  - [x] climc lbagent-params-patch --haproxy-log-tcp off，比较default-params的输出
  - [x] climc lblistener-list --certificate cr0输出

**是否需要 backport 到之前的 release 分支**:

NONE

/area region
/cc @ioito @tb365 @swordqiu @zexi 