### PR TITLE
mcclient: options: lb: arg rename cluster{,_id}

### DIFF
--- a/pkg/mcclient/options/loadbalancers.go
+++ b/pkg/mcclient/options/loadbalancers.go
@@ -23,7 +23,7 @@ type LoadbalancerCreateOptions struct {
 	ChargeType       string `choices:"traffic|bandwidth"`
 	Bandwidth        int
 	Zone             string
-	Cluster          string
+	Cluster          string `json:"cluster_id"`
 	Manager          string
 }
 
@@ -55,7 +55,7 @@ type LoadbalancerListOptions struct {
 	BackendGroup string
 	Cloudregion  string
 	Zone         string
-	Cluster      string
+	Cluster      string `json:"cluster_id"`
 }
 
 type LoadbalancerActionStatusOptions struct {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

Ref b0537773cde3 ("fxi: 修复lb 有些有vpc_id为空的问题")

**是否需要 backport 到之前的 release 分支**:

NONE

Ref: #6765
/area climc
/cc @ioito @zexi 