### PR TITLE
fix: disable updating zone_id for host, storage, wire

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -84,7 +84,7 @@ func init() {
 type SHost struct {
 	db.SEnabledStatusInfrasResourceBase
 	db.SExternalizedResourceBase
-	SZoneResourceBase
+	SZoneResourceBase `update:""`
 	SManagedResourceBase
 	SBillingResourceBase
 

--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -68,7 +68,7 @@ type SStorage struct {
 	db.SExternalizedResourceBase
 
 	SManagedResourceBase
-	SZoneResourceBase
+	SZoneResourceBase `update:""`
 
 	// 容量大小,单位Mb
 	Capacity int64 `nullable:"false" list:"domain" update:"domain" create:"domain_required"`

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -65,8 +65,8 @@ type SWire struct {
 	db.SInfrasResourceBase
 	db.SExternalizedResourceBase
 
-	SVpcResourceBase  `wdith:"36" charset:"ascii" nullable:"false" list:"domain" create:"domain_required"`
-	SZoneResourceBase `width:"36" charset:"ascii" nullable:"true" list:"domain" create:"domain_required"`
+	SVpcResourceBase  `wdith:"36" charset:"ascii" nullable:"false" list:"domain" create:"domain_required" update:""`
+	SZoneResourceBase `width:"36" charset:"ascii" nullable:"true" list:"domain" create:"domain_required" update:""`
 
 	// 带宽大小, 单位Mbps
 	// example: 1000


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：不允许修改host ,storage, wire的zone_id

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area region