### PR TITLE
feat: Support suggest network config before creating vmware cloud account

### DIFF
--- a/cmd/climc/shell/compute/cloudaccounts.go
+++ b/cmd/climc/shell/compute/cloudaccounts.go
@@ -125,6 +125,22 @@ func init() {
 		printObject(result)
 		return nil
 	})
+	type SVMwareCloudAccountPrepareNetsOptions struct {
+		Project       string `help:"project for this account"`
+		ProjectDomain string `help:"domain for this account"`
+		NAME          string `help:"name for this account"`
+		options.SVMwareCredentialWithEnvironment
+	}
+	R(&SVMwareCloudAccountPrepareNetsOptions{}, "cloud-account-preparenets-vmware", "Prepare networks for a VMware cloud account before create this accout", func(s *mcclient.ClientSession, args *SVMwareCloudAccountPrepareNetsOptions) error {
+		params := jsonutils.Marshal(args)
+		params.(*jsonutils.JSONDict).Add(jsonutils.NewString("VMware"), "provider")
+		result, err := modules.Cloudaccounts.PerformClassAction(s, "prepare-nets", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
 
 	R(&options.SAliyunCloudAccountCreateOptions{}, "cloud-account-create-aliyun", "Create an Aliyun cloud account", func(s *mcclient.ClientSession, args *options.SAliyunCloudAccountCreateOptions) error {
 		params := jsonutils.Marshal(args)

--- a/pkg/apis/compute/cloudaccount.go
+++ b/pkg/apis/compute/cloudaccount.go
@@ -325,3 +325,62 @@ type CloudaccountPerformPublicInput struct {
 	// example: provider_domain
 	ShareMode string `json:"share_mode"`
 }
+
+type CloudaccountPerformPrepareNetsInput struct {
+	CloudaccountCreateInput
+}
+
+type CloudaccountPerformPrepareNetsOutput struct {
+	SuggestedWire CAWireConf  `json:"suggested_wire"`
+	SuitableWire  string      `json:"suitable_wire,allowempty"`
+	Hosts         []CAHostNet `json:"hosts"`
+	// description: 没有合适的已有网络，推荐的网络配置
+	HostSuggestedNetworks []CANetConf  `json:"host_suggested_networks"`
+	Guests                []CAGuestNet `json:"guests"`
+	// description: 没有合适的已有网络，推荐的网络配置
+	GuestSuggestedNetworks []CANetConf `json:"guest_suggested_networks"`
+}
+
+type CAWireConf struct {
+	// Zoneids to be selected
+	ZoneIds []string `json:"zone_ids"`
+	// description: wire name
+	Name string `json:"name"`
+	// description: wire description
+	Description string `json:"description"`
+}
+
+type CAHostNet struct {
+	// description: Host 的 Name
+	Name string `json:"name"`
+	// description: IP
+	IP string `json:"ip"`
+	// description: 合适的已有网络
+	SuitableNetwork string `json:"suitable_network,allowempty"`
+}
+
+type CAGuestNet struct {
+	// description: Host 的 Name
+	Name   string    `json:"name"`
+	IPNets []CAIPNet `json:"ip_nets"`
+}
+
+type CAIPNet struct {
+	// description: IP
+	IP string `json:"ip"`
+	// description: 合适的已有网络
+	SuitableNetwork string `json:"suitable_network,allowempty"`
+}
+
+type CASimpleNetConf struct {
+	GuestIpStart string `json:"guest_ip_start"`
+	GuestIpEnd   string `json:"guest_ip_end"`
+	GuestIpMask  int8   `json:"guest_ip_mask"`
+	GuestGateway string `json:"guest_gateway"`
+}
+
+type CANetConf struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	CASimpleNetConf
+}

--- a/pkg/compute/models/cloudaccounts_test.go
+++ b/pkg/compute/models/cloudaccounts_test.go
@@ -1,0 +1,186 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"yunion.io/x/pkg/util/netutils"
+
+	api "yunion.io/x/onecloud/pkg/apis/compute"
+)
+
+func TestSCloudaccount_suggestHostNetworks(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want []api.CASimpleNetConf
+	}{
+		{
+			[]string{
+				"10.168.13.234",
+				"10.168.13.235",
+				"10.168.13.233",
+				"10.168.13.222",
+			},
+			[]api.CASimpleNetConf{
+				{
+					GuestIpStart: "10.168.13.222",
+					GuestIpEnd:   "10.168.13.222",
+					GuestIpMask:  24,
+					GuestGateway: "10.168.13.1",
+				},
+				{
+					GuestIpStart: "10.168.13.233",
+					GuestIpEnd:   "10.168.13.235",
+					GuestIpMask:  24,
+					GuestGateway: "10.168.13.1",
+				},
+			},
+		},
+		{
+			[]string{
+				"10.168.12.254",
+				"10.168.43.1",
+			},
+			[]api.CASimpleNetConf{
+				{
+					GuestIpStart: "10.168.12.254",
+					GuestIpEnd:   "10.168.12.254",
+					GuestIpMask:  24,
+					GuestGateway: "10.168.12.1",
+				},
+				{
+					GuestIpStart: "10.168.43.1",
+					GuestIpEnd:   "10.168.43.1",
+					GuestIpMask:  24,
+					GuestGateway: "10.168.43.1",
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		ins := make([]netutils.IPV4Addr, len(c.in))
+		for i := range ins {
+			ins[i], _ = netutils.NewIPV4Addr(c.in[i])
+		}
+		out := CloudaccountManager.suggestHostNetworks(ins)
+		sort.Slice(out, func(i, j int) bool {
+			if out[i].GuestIpStart == out[j].GuestIpStart {
+				return out[i].GuestIpEnd < out[j].GuestIpEnd
+			}
+			return out[i].GuestIpStart < out[j].GuestIpStart
+		})
+		if !reflect.DeepEqual(out, c.want) {
+			t.Fatalf("want: %#v\nreal: %#v", c.want, out)
+		}
+	}
+}
+
+func TestSCloudaccount_suggestVMNetwors(t *testing.T) {
+	cases := []struct {
+		in1 []string
+		in2 []struct {
+			startIp string
+			endIp   string
+		}
+		want []api.CASimpleNetConf
+	}{
+		{
+			in1: []string{
+				"10.168.222.23",
+				"10.168.222.26",
+				"10.168.222.145",
+				"10.168.222.234",
+			},
+			in2: []struct {
+				startIp string
+				endIp   string
+			}{
+				{"10.168.222.45", "10.168.222.120"},
+				{"10.168.222.200", "10.168.222.230"},
+			},
+			want: []api.CASimpleNetConf{
+				{
+					GuestIpStart: "10.168.222.1",
+					GuestIpEnd:   "10.168.222.44",
+					GuestIpMask:  24,
+					GuestGateway: "10.168.222.1",
+				},
+				{
+					GuestIpStart: "10.168.222.121",
+					GuestIpEnd:   "10.168.222.199",
+					GuestIpMask:  24,
+					GuestGateway: "10.168.222.1",
+				},
+				{
+					GuestIpStart: "10.168.222.231",
+					GuestIpEnd:   "10.168.222.254",
+					GuestIpMask:  24,
+					GuestGateway: "10.168.222.1",
+				},
+			},
+		},
+		{
+			in1: []string{
+				"10.168.222.23",
+				"10.168.224.178",
+			},
+			in2: []struct {
+				startIp string
+				endIp   string
+			}{
+				{"10.168.222.100", "10.168.224.100"},
+			},
+			want: []api.CASimpleNetConf{
+				{
+					GuestIpStart: "10.168.222.1",
+					GuestIpEnd:   "10.168.222.99",
+					GuestIpMask:  24,
+					GuestGateway: "10.168.222.1",
+				},
+				{
+					GuestIpStart: "10.168.224.101",
+					GuestIpEnd:   "10.168.224.254",
+					GuestIpMask:  24,
+					GuestGateway: "10.168.224.1",
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		ins1 := make([]netutils.IPV4Addr, len(c.in1))
+		ins2 := make([]netutils.IPV4AddrRange, len(c.in2))
+		for i := range ins1 {
+			ins1[i], _ = netutils.NewIPV4Addr(c.in1[i])
+		}
+		for i := range ins2 {
+			ip1, _ := netutils.NewIPV4Addr(c.in2[i].startIp)
+			ip2, _ := netutils.NewIPV4Addr(c.in2[i].endIp)
+			ins2[i] = netutils.NewIPV4AddrRange(ip1, ip2)
+		}
+		out := CloudaccountManager.suggestVMNetwors(ins1, ins2)
+		sort.Slice(out, func(i, j int) bool {
+			if out[i].GuestIpStart == out[j].GuestIpStart {
+				return out[i].GuestIpEnd < out[j].GuestIpEnd
+			}
+			return out[i].GuestIpStart < out[j].GuestIpStart
+		})
+		if !reflect.DeepEqual(out, c.want) {
+			t.Fatalf("want: %#v\nreal: %#v", c.want, out)
+		}
+	}
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

Support suggest network config before create vmware cloud account.
大体的逻辑是：
1. 首先确定zoneids，根据esxiagent确定，如果没有esxiagent，默认使用zone0，根据指定的domain和zoneids过滤出wires
2. 在wires中，根据hosts的ip寻找合适的wire，寻找的标准就是能够尽量地包含所有hosts的ip。如果没有合适的wire，suitableWire就会为空。并给出suggestedWire用来新建，以下的子网配置建议对已有的wire和新建的wire都适用。
2. 对于没有合适子网的Hosts 的 ip，给出建议的子网配置，建议的规则是：掩码为24，网关为X.X.X.1，每一个ip一个子网，ip连续的合并为一个子网。
3. 在指定的project中，为所有vm的ip寻找合适的子网，如果没有，就给出建议的子网配置，建议的规则是：掩码为24，网关为X.X.X.1，在保证不和wire中其他子网冲突的情况下尽可能的大。

- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->
/area region
/cc @swordqiu @yousong @zexi 