### PR TITLE
fix: Add '/version' handler for notify

### DIFF
--- a/pkg/notify/handlers.go
+++ b/pkg/notify/handlers.go
@@ -38,8 +38,12 @@ import (
 	"yunion.io/x/onecloud/pkg/notify/utils"
 )
 
+var API_VERSION = "api/v1"
+
 func InitHandlers(app *appsrv.Application) {
-	db.AddProjectResourceCountHandler("api/v1", app)
+	// add version handler with API_VERSION prefix
+	app.AddDefaultHandler("GET", API_VERSION+"/version", appsrv.VersionHandler, "version")
+	db.AddProjectResourceCountHandler(API_VERSION, app)
 	db.RegisterModelManager(models.ContactManager)
 	db.RegisterModelManager(models.VerifyManager)
 	db.RegisterModelManager(models.NotificationManager)
@@ -47,7 +51,7 @@ func InitHandlers(app *appsrv.Application) {
 	db.RegisterModelManager(cache.UserCacheManager)
 	db.RegisterModelManager(cache.UserGroupCacheManager)
 	db.RegisterModelManager(models.TemplateManager)
-	AddNotifyDispatcher("/api/v1/", app)
+	AddNotifyDispatcher(API_VERSION, app)
 }
 
 // Middleware


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修改notify的api prefix，这不会影响实际的调用。
为notify增加/version hanlder，以返回 version 信息。

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2
- release/3.1
- release/3.0

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->
