### PR TITLE
webconsole: fix version and others handler not handle

### DIFF
--- a/pkg/webconsole/service/service.go
+++ b/pkg/webconsole/service/service.go
@@ -15,8 +15,10 @@
 package service
 
 import (
+	"context"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"net/url"
 	"os"
 	"strconv"
@@ -26,6 +28,7 @@ import (
 	"yunion.io/x/log"
 
 	api "yunion.io/x/onecloud/pkg/apis/webconsole"
+	"yunion.io/x/onecloud/pkg/appsrv"
 	app_common "yunion.io/x/onecloud/pkg/cloudcommon/app"
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
 	"yunion.io/x/onecloud/pkg/webconsole"
@@ -88,6 +91,9 @@ func start() {
 	// websocketproxy handler
 	root.Handle(webconsole.WebsocketProxyPathPrefix, srv)
 
+	// misc handler
+	addMiscHandlers(root)
+
 	addr := net.JoinHostPort(o.Options.Address, strconv.Itoa(o.Options.Port))
 	log.Infof("Start listen on %s", addr)
 	if o.Options.EnableSsl {
@@ -104,4 +110,25 @@ func start() {
 			log.Fatalf("%v", err)
 		}
 	}
+}
+
+func addMiscHandlers(root *mux.Router) {
+	adapterF := func(appHandleFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request)) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			appHandleFunc(context.TODO(), w, r)
+		}
+	}
+
+	// ref: pkg/appsrv/appsrv:addDefaultHandlers
+	root.HandleFunc("/version", adapterF(appsrv.VersionHandler))
+	root.HandleFunc("/stats", adapterF(appsrv.StatisticHandler))
+	root.HandleFunc("/ping", adapterF(appsrv.PingHandler))
+	root.HandleFunc("/worker_stats", adapterF(appsrv.WorkerStatsHandler))
+
+	// pprof handler
+	root.HandleFunc("/debug/pprof/", pprof.Index)
+	root.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	root.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	root.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	root.HandleFunc("/debug/pprof/trace", pprof.Trace)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

webconsole 服务因为使用了 mux，没有注册 version, ping 等 handler

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->
- 2.13
/cc @wanyaoqi @rainzm @swordqiu