### PR TITLE
fix informer worker heap large usage

### DIFF
--- a/pkg/cloudcommon/informer/worker.go
+++ b/pkg/cloudcommon/informer/worker.go
@@ -26,7 +26,7 @@ var (
 )
 
 func init() {
-	informerWorkerMan = appsrv.NewWorkerManager("InformerWorkerManager", 1024, 10240, false)
+	informerWorkerMan = appsrv.NewWorkerManager("InformerWorkerManager", 10, 10240, false)
 }
 
 func run(f func(be IInformerBackend) error) error {

--- a/pkg/mcclient/mcclient.go
+++ b/pkg/mcclient/mcclient.go
@@ -90,6 +90,10 @@ func (this *Client) SetDebug(debug bool) {
 	this.debug = debug
 }
 
+func (this *Client) GetDebug() bool {
+	return this.debug
+}
+
 func (this *Client) AuthVersion() string {
 	pos := strings.LastIndexByte(this.authUrl, '/')
 	if pos > 0 {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

informer worker 的 Ring size 设置太大了, 1024 * 10240 * 16(Ring 里面每个 interface 占用 16 bytes) = 160MB，导致 heap 分配了 160MB
```go
informerWorkerMan = appsrv.NewWorkerManager("InformerWorkerManager", 1024, 10240, false)
```

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->
NONE

/cc @swordqiu @wanyaoqi @yousong 