### PR TITLE
host: configureable reload telegraf config

### DIFF
--- a/pkg/hostman/system_service/docker.go
+++ b/pkg/hostman/system_service/docker.go
@@ -44,3 +44,7 @@ func (s *SDocker) Reload(kwargs map[string]interface{}) error {
 func (s *SDocker) BgReload(kwargs map[string]interface{}) {
 	go s.Reload(kwargs)
 }
+
+func (s *SDocker) BgReloadConf(kwargs map[string]interface{}) {
+	go s.reloadConf(s.GetConfig(kwargs), s.GetConfigFile())
+}

--- a/pkg/hostman/system_service/fluentbit.go
+++ b/pkg/hostman/system_service/fluentbit.go
@@ -85,3 +85,7 @@ func (s *SFluentbit) Reload(kwargs map[string]interface{}) error {
 func (s *SFluentbit) BgReload(kwargs map[string]interface{}) {
 	go s.reload(s.GetConfig(kwargs), s.GetConfigFile())
 }
+
+func (s *SFluentbit) BgReloadConf(kwargs map[string]interface{}) {
+	go s.reloadConf(s.GetConfig(kwargs), s.GetConfigFile())
+}

--- a/pkg/hostman/system_service/host_deployer.go
+++ b/pkg/hostman/system_service/host_deployer.go
@@ -29,3 +29,7 @@ func (s *SHostDeployer) Reload(kwargs map[string]interface{}) error {
 func (s *SHostDeployer) BgReload(kwargs map[string]interface{}) {
 	go s.reload(s.GetConfig(kwargs), s.GetConfigFile())
 }
+
+func (s *SHostDeployer) BgReloadConf(kwargs map[string]interface{}) {
+	go s.reloadConf(s.GetConfig(kwargs), s.GetConfigFile())
+}

--- a/pkg/hostman/system_service/kube_agent.go
+++ b/pkg/hostman/system_service/kube_agent.go
@@ -43,3 +43,7 @@ func (s *SKubeAgent) Reload(kwargs map[string]interface{}) error {
 func (s *SKubeAgent) BgReload(kwargs map[string]interface{}) {
 	go s.reload(s.GetConfig(kwargs), s.GetConfigFile())
 }
+
+func (s *SKubeAgent) BgReloadConf(kwargs map[string]interface{}) {
+	go s.reloadConf(s.GetConfig(kwargs), s.GetConfigFile())
+}

--- a/pkg/hostman/system_service/ntpd.go
+++ b/pkg/hostman/system_service/ntpd.go
@@ -64,3 +64,7 @@ func (s *SNtpd) Reload(kwargs map[string]interface{}) error {
 func (s *SNtpd) BgReload(kwargs map[string]interface{}) {
 	go s.reload(s.GetConfig(kwargs), s.GetConfigFile())
 }
+
+func (s *SNtpd) BgReloadConf(kwargs map[string]interface{}) {
+	go s.reloadConf(s.GetConfig(kwargs), s.GetConfigFile())
+}

--- a/pkg/hostman/system_service/openvswitch.go
+++ b/pkg/hostman/system_service/openvswitch.go
@@ -29,3 +29,7 @@ func (s *SOpenvswitch) Reload(kwargs map[string]interface{}) error {
 func (s *SOpenvswitch) BgReload(kwargs map[string]interface{}) {
 	go s.reload(s.GetConfig(kwargs), s.GetConfigFile())
 }
+
+func (s *SOpenvswitch) BgReloadConf(kwargs map[string]interface{}) {
+	go s.reloadConf(s.GetConfig(kwargs), s.GetConfigFile())
+}

--- a/pkg/hostman/system_service/ovn_conroller.go
+++ b/pkg/hostman/system_service/ovn_conroller.go
@@ -31,3 +31,7 @@ func (s *SOvnController) Reload(kwargs map[string]interface{}) error {
 func (s *SOvnController) BgReload(kwargs map[string]interface{}) {
 	go s.reload(s.GetConfig(kwargs), s.GetConfigFile())
 }
+
+func (s *SOvnController) BgReloadConf(kwargs map[string]interface{}) {
+	go s.reloadConf(s.GetConfig(kwargs), s.GetConfigFile())
+}

--- a/pkg/hostman/system_service/sdnagent.go
+++ b/pkg/hostman/system_service/sdnagent.go
@@ -29,3 +29,7 @@ func (s *SHostSdnagent) Reload(kwargs map[string]interface{}) error {
 func (s *SHostSdnagent) BgReload(kwargs map[string]interface{}) {
 	go s.reload(s.GetConfig(kwargs), s.GetConfigFile())
 }
+
+func (s *SHostSdnagent) BgReloadConf(kwargs map[string]interface{}) {
+	go s.reloadConf(s.GetConfig(kwargs), s.GetConfigFile())
+}

--- a/pkg/hostman/system_service/system_service.go
+++ b/pkg/hostman/system_service/system_service.go
@@ -33,6 +33,7 @@ type ISystemService interface {
 	SetConf(interface{})
 	GetConf() interface{}
 	BgReload(kwargs map[string]interface{})
+	BgReloadConf(kwargs map[string]interface{})
 	Enable() error
 	Disable() error
 	Reload(kwargs map[string]interface{}) error
@@ -84,21 +85,31 @@ func NewBaseSystemService(name string, urls interface{}) *SBaseSystemService {
 }
 
 func (s *SBaseSystemService) reload(conf, conFile string) error {
+	if ok, err := s.reloadConf(conf, conFile); err != nil {
+		return err
+	} else if ok {
+		return s.Start(false)
+	} else {
+		return nil
+	}
+}
+
+func (s *SBaseSystemService) reloadConf(conf, conFile string) (bool, error) {
 	output, _ := procutils.NewRemoteCommandAsFarAsPossible("cat", conFile).Output()
 	oldConf := string(output)
 	if conf != oldConf {
 		log.Infof("Reload service %s ...", s.name)
 		err := procutils.NewRemoteCommandAsFarAsPossible("rm", "-f", conFile).Run()
 		if err != nil {
-			return nil
+			return false, err
 		}
 		err = procutils.NewRemoteCommandAsFarAsPossible("sh", "-c", fmt.Sprintf("echo '%s' > %s", conf, conFile)).Run()
 		if err != nil {
-			return err
+			return false, err
 		}
-		return s.Start(false)
+		return true, nil
 	}
-	return nil
+	return false, nil
 }
 
 func (s *SBaseSystemService) IsInstalled() bool {
@@ -156,4 +167,8 @@ func (s *SBaseSystemService) Enable() error {
 
 func (s *SBaseSystemService) Disable() error {
 	return s.manager.Disable(s.name)
+}
+
+func (s *SBaseSystemService) BgReloadConf(kwargs map[string]interface{}) {
+	go s.reloadConf(s.GetConfig(kwargs), s.GetConfigFile())
 }

--- a/pkg/hostman/system_service/telegraf.go
+++ b/pkg/hostman/system_service/telegraf.go
@@ -178,3 +178,7 @@ func (s *STelegraf) Reload(kwargs map[string]interface{}) error {
 func (s *STelegraf) BgReload(kwargs map[string]interface{}) {
 	go s.reload(s.GetConfig(kwargs), s.GetConfigFile())
 }
+
+func (s *STelegraf) BgReloadConf(kwargs map[string]interface{}) {
+	go s.reloadConf(s.GetConfig(kwargs), s.GetConfigFile())
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
telegraf as daemonset:
https://github.com/yunionio/onecloud-operator/pull/182
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->
/area host
/cc @swordqiu @zexi 
