### PR TITLE
feature: 1. allow enable/disable idp-synced-users 2. turn off user's MFA by default

### DIFF
--- a/cmd/climc/shell/identity/identityproviders.go
+++ b/cmd/climc/shell/identity/identityproviders.go
@@ -299,7 +299,9 @@ func init() {
 		IDP string `help:"identity provider name or ID"`
 	}
 	R(&IdentityProviderConfigEditOptions{}, "idp-config-edit", "Edit config yaml of an identity provider", func(s *mcclient.ClientSession, args *IdentityProviderConfigEditOptions) error {
-		conf, err := modules.IdentityProviders.GetSpecific(s, args.IDP, "config", nil)
+		params := jsonutils.NewDict()
+		params.Add(jsonutils.JSONTrue, "sensitive")
+		conf, err := modules.IdentityProviders.GetSpecific(s, args.IDP, "config", params)
 		if err != nil {
 			return err
 		}

--- a/pkg/apigateway/options/options.go
+++ b/pkg/apigateway/options/options.go
@@ -26,7 +26,7 @@ type GatewayOptions struct {
 
 	DisableModuleApiVersion bool `help:"Disable each modules default api version" default:"false"`
 
-	EnableTotp bool `help:"Enable two-factor authentication"  default:"false"`
+	EnableTotp bool `help:"Enable two-factor authentication" default:"true"`
 
 	SqlitePath string `help:"sqlite db path" default:"/etc/yunion/data/yunionapi.db"`
 

--- a/pkg/apis/identity/config.go
+++ b/pkg/apis/identity/config.go
@@ -28,6 +28,8 @@ type SLDAPIdpConfigBaseOptions struct {
 	Suffix   string `json:"suffix,omitempty" required:"true"`
 	User     string `json:"user,omitempty" required:"true"`
 	Password string `json:"password,omitempty" required:"true"`
+
+	DisableUserOnImport bool `json:"disable_user_on_import"`
 }
 
 type SLDAPIdpConfigSingleDomainOptions struct {
@@ -50,6 +52,8 @@ type SLDAPIdpConfigOptions struct {
 
 	User     string `json:"user,omitempty"`
 	Password string `json:"password,omitempty"`
+
+	DisableUserOnImport bool `json:"disable_user_on_import"`
 
 	DomainTreeDN        string `json:"domain_tree_dn,omitempty" help:"Domain tree root node dn(distinguished name)"`
 	DomainFilter        string `json:"domain_filter,omitempty"`

--- a/pkg/keystone/driver/cas/cas.go
+++ b/pkg/keystone/driver/cas/cas.go
@@ -140,7 +140,7 @@ func (self *SCASDriver) Authenticate(ctx context.Context, ident mcclient.SAuthen
 	if err != nil {
 		return nil, errors.Wrap(err, "idp.GetSingleDomain")
 	}
-	usr, err := idp.SyncOrCreateUser(ctx, usrId, usrId, domain.Id, nil)
+	usr, err := idp.SyncOrCreateUser(ctx, usrId, usrId, domain.Id, true, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "idp.SyncOrCreateUser")
 	}

--- a/pkg/keystone/driver/ldap/info.go
+++ b/pkg/keystone/driver/ldap/info.go
@@ -34,3 +34,14 @@ type SGroupInfo struct {
 func (info SDomainInfo) isValid() bool {
 	return len(info.DN) > 0 && len(info.Id) > 0 && len(info.Name) > 0
 }
+
+func (info SUserInfo) isValid() bool {
+	if !info.SDomainInfo.isValid() {
+		return false
+	}
+	// regarding disabled LDAP user as invalid
+	if !info.Enabled {
+		return false
+	}
+	return true
+}

--- a/pkg/keystone/driver/ldap/sync.go
+++ b/pkg/keystone/driver/ldap/sync.go
@@ -22,7 +22,6 @@ import (
 
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
-	"yunion.io/x/pkg/tristate"
 
 	api "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/keystone/models"
@@ -230,12 +229,13 @@ func (self *SLDAPDriver) syncUserDB(ctx context.Context, ui SUserInfo, domainId 
 	if err != nil {
 		return "", errors.Wrap(err, "models.IdentityProviderManager.FetchIdentityProviderById")
 	}
-	usr, err := idp.SyncOrCreateUser(ctx, ui.Id, ui.Name, domainId, func(user *models.SUser) {
-		if ui.Enabled {
-			user.Enabled = tristate.True
-		} else {
-			user.Enabled = tristate.False
-		}
+	usr, err := idp.SyncOrCreateUser(ctx, ui.Id, ui.Name, domainId, !self.ldapConfig.DisableUserOnImport, func(user *models.SUser) {
+		// LDAP user is always enabled
+		// if ui.Enabled {
+		// 	user.Enabled = tristate.True
+		// } else {
+		//	user.Enabled = tristate.False
+		// }
 		if val, ok := ui.Extra["email"]; ok && len(val) > 0 {
 			user.Email = val
 		}

--- a/pkg/keystone/models/users.go
+++ b/pkg/keystone/models/users.go
@@ -91,7 +91,7 @@ type SUser struct {
 	DefaultProjectId string `width:"64" charset:"ascii" nullable:"true"`
 
 	AllowWebConsole tristate.TriState `nullable:"false" default:"true" list:"domain" update:"domain" create:"domain_optional"`
-	EnableMfa       tristate.TriState `nullable:"false" default:"true" list:"domain" update:"domain" create:"domain_optional"`
+	EnableMfa       tristate.TriState `nullable:"false" default:"false" list:"domain" update:"domain" create:"domain_optional"`
 }
 
 func (manager *SUserManager) GetContextManagers() [][]db.IModelManager {
@@ -481,7 +481,6 @@ func (user *SUser) ValidateUpdateData(ctx context.Context, userCred mcclient.Tok
 		data := jsonutils.Marshal(input)
 		for _, k := range []string{
 			"name",
-			"enabled",
 			"displayname",
 			"email",
 			"mobile",


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1, 默认关闭用户的MFA，默认开启yunionapi的MFA总开关。这样如果用户开启MFA则MFA生效。
2. idp导入用户可以被启用禁用，可以设置导入用户的默认启用禁用

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
None

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi 
/area keystone
