### PR TITLE
fix: network created by sysadmin should be shared by default

### DIFF
--- a/pkg/cloudcommon/db/sharablebase.go
+++ b/pkg/cloudcommon/db/sharablebase.go
@@ -171,7 +171,7 @@ func SharableManagerValidateCreateData(
 			reqScope = rbacutils.ScopeSystem
 		} else {
 			input.IsPublic = nil
-			input.PublicScope = string(rbacutils.ScopeNone)
+			input.PublicScope = "" // string(rbacutils.ScopeNone)
 		}
 	case rbacutils.ScopeDomain:
 		if input.PublicScope == string(rbacutils.ScopeSystem) {
@@ -184,7 +184,7 @@ func SharableManagerValidateCreateData(
 			reqScope = rbacutils.ScopeSystem
 		} else {
 			input.IsPublic = nil
-			input.PublicScope = string(rbacutils.ScopeNone)
+			input.PublicScope = "" // string(rbacutils.ScopeNone)
 		}
 	default:
 		return input, errors.Wrap(httperrors.ErrInputParameter, "the resource is not sharable")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：sysadmin新建guest网络应该默认共享

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @zexi @yousong 
/area region