### PR TITLE
fix: keystone project resource count not accurate

### DIFF
--- a/pkg/keystone/cronjobs/project_resources.go
+++ b/pkg/keystone/cronjobs/project_resources.go
@@ -135,9 +135,15 @@ func syncScopeResourceCount(ctx context.Context, regionId string, serviceId stri
 			scopeRes.Resource = res
 			scopeRes.Count = resCnts[i].ResCount
 
-			projList = append(projList, scopeRes.ProjectId)
-			domainList = append(domainList, scopeRes.DomainId)
-			ownerList = append(ownerList, scopeRes.OwnerId)
+			if len(scopeRes.ProjectId) > 0 {
+				projList = append(projList, scopeRes.ProjectId)
+			}
+			if len(scopeRes.DomainId) > 0 {
+				domainList = append(domainList, scopeRes.DomainId)
+			}
+			if len(scopeRes.OwnerId) > 0 {
+				ownerList = append(ownerList, scopeRes.OwnerId)
+			}
 
 			err := models.ScopeResourceManager.TableSpec().InsertOrUpdate(ctx, &scopeRes)
 			if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：keystone的资源计数不准确，未正确清零

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @ioito @zexi 
/area keystone