### PR TITLE
fix: reduce totp verification overhead

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -230,6 +230,9 @@ func doTenantLogin(ctx context.Context, w http.ResponseWriter, req *http.Request
 		} else {
 			otpVerified = true
 		}
+	} else {
+		// if totp disabled, then assume totp been verified
+		otpVerified = true
 	}
 
 	token, e = auth.Client().SetProject(tenantId, "", "", token)
@@ -536,6 +539,11 @@ func (h *AuthHandlers) postLoginHandler(ctx context.Context, w http.ResponseWrit
 			httperrors.GeneralServerError(w, err)
 			return
 		}
+	} else {
+		// if totp is disabled, assume totp been verified
+		totp := clientman.TokenMan.GetTotp(tid)
+		totp.MarkVerified()
+		clientman.TokenMan.SaveTotp(tid)
 	}
 
 	appsrv.Send(w, qrcode)

--- a/pkg/apigateway/handler/middleware.go
+++ b/pkg/apigateway/handler/middleware.go
@@ -112,15 +112,15 @@ func FetchAuthToken(f func(context.Context, http.ResponseWriter, *http.Request))
 			return
 		}
 		// 启用双因子认证
-		t := AppContextToken(ctx)
-		if isUserEnableTotp(ctx, r, t) {
-			tid := getAuthToken(r)
-			totp := clientman.TokenMan.GetTotp(tid)
-			if !totp.IsVerified() {
-				httperrors.UnauthorizedError(w, "TOTP authentication failed")
-				return
-			}
+		// t := AppContextToken(ctx)
+		// if isUserEnableTotp(ctx, r, t) {
+		tid := getAuthToken(r)
+		totp := clientman.TokenMan.GetTotp(tid)
+		if !totp.IsVerified() {
+			httperrors.UnauthorizedError(w, "TOTP authentication failed")
+			return
 		}
+		// }
 
 		f(ctx, w, r)
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：从3.3开始默认开启yunionapi的totp开关，默认关闭user的enable_mfa，这会导致在yunionapi每次请求都会向keystone查询用户是否启用enable_mfa，导致性能问题。这里改为查询yunionapi本地的totp是否verify的记录，降低请求keystone的开销。

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.1
-->

/cc @tb365 @zexi  
/area apigateway