### PR TITLE
cloudcommon: taskman: fix table insert

### DIFF
--- a/pkg/cloudcommon/db/taskman/tasks.go
+++ b/pkg/cloudcommon/db/taskman/tasks.go
@@ -264,7 +264,7 @@ func (manager *STaskManager) NewTask(
 		Stage:    TASK_INIT_STAGE,
 	}
 	task.SetModelManager(manager, task)
-	err := manager.TableSpec().Insert(ctx, &task)
+	err := manager.TableSpec().Insert(ctx, task)
 	if err != nil {
 		log.Errorf("Task insert error %s", err)
 		return nil, err
@@ -313,7 +313,7 @@ func (manager *STaskManager) NewParallelTask(
 		Stage:    TASK_INIT_STAGE,
 	}
 	task.SetModelManager(manager, task)
-	err := manager.TableSpec().Insert(ctx, &task)
+	err := manager.TableSpec().Insert(ctx, task)
 	if err != nil {
 		log.Errorf("Task insert error %s", err)
 		return nil, err


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:

Fix the following error

	run error: reflect: NumField of non-struct type *taskman.STask

Fixes 08cd41b60d83 ("cloudcommon: taskman: SetModelManager")

Reported-by: Qu Xuan <quxuan@yunionyun.com>

**是否需要 backport 到之前的 release 分支**:

- release/3.3

/area region
/cc @zexi @ioito 
