### PR TITLE
fix: Override Master and Slave for scalinggroup_guest

### DIFF
--- a/pkg/compute/models/scalinggroup_guest.go
+++ b/pkg/compute/models/scalinggroup_guest.go
@@ -102,6 +102,15 @@ func (sgg *SScalingGroupGuest) SetGuestStatus(status string) error {
 	return err
 }
 
+func (sgg *SScalingGroupGuest) Master() db.IStandaloneModel {
+	return sgg.getGuest()
+}
+
+func (sgg *SScalingGroupGuest) Slave() db.IStandaloneModel {
+	sg, _ := ScalingGroupManager.FetchById(sgg.ScalingGroupId)
+	return sg.(*SScalingGroup)
+}
+
 func (sggm *SScalingGroupGuestManager) Query(fields ...string) *sqlchemy.SQuery {
 	return sggm.SVirtualJointResourceBaseManager.Query(fields...).NotEquals("guest_status",
 		compute.SG_GUEST_STATUS_PENDING_REMOVE)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

Override Master and Slave for scalinggroup_guest

不 Override 会在 https://github.com/yunionio/onecloud/blob/5e363dc748912958d2821580e8edf6b26b0973ed/pkg/cloudcommon/db/tablespec.go#L71-L76
触发 panic

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/cc @zexi 
/area region