### PR TITLE
fix: adjust primary key length when sqlchemy utf8 default to utf8mb4

### DIFF
--- a/pkg/keystone/models/configs.go
+++ b/pkg/keystone/models/configs.go
@@ -82,8 +82,8 @@ type SConfigOption struct {
 
 	ResType string `width:"32" charset:"ascii" nullable:"false" default:"identity_provider" primary:"true"`
 	ResId   string `name:"domain_id" width:"64" charset:"ascii" primary:"true"`
-	Group   string `width:"255" charset:"utf8" primary:"true"`
-	Option  string `width:"255" charset:"utf8" primary:"true"`
+	Group   string `width:"191" charset:"utf8" primary:"true"`
+	Option  string `width:"191" charset:"utf8" primary:"true"`
 
 	Value jsonutils.JSONObject `nullable:"false"`
 }

--- a/pkg/keystone/models/nonlocal_users.go
+++ b/pkg/keystone/models/nonlocal_users.go
@@ -51,7 +51,7 @@ type SNonlocalUser struct {
 	db.SModelBase
 
 	DomainId string `width:"64" charset:"ascii" primary:"true"`
-	Name     string `width:"255" charset:"utf8" primary:"true"`
+	Name     string `width:"191" charset:"utf8" primary:"true"`
 	UserId   string `width:"64" charset:"ascii" nullable:"false" index:"true"`
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：mysql使用utf8mb4后，修改数据库utf8 varchar primary字段长度不超过191

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @yousong 
/area keystone region image

/hold
