### PR TITLE
fix: cleanup auth error message return by apigateway

### DIFF
--- a/pkg/apigateway/handler/middleware.go
+++ b/pkg/apigateway/handler/middleware.go
@@ -78,11 +78,11 @@ func fetchAuthInfo(ctx context.Context, r *http.Request) (mcclient.TokenCredenti
 	if len(authCookieStr) > 0 {
 		authCookie, err := jsonutils.ParseString(authCookieStr)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "Auth cookie decode")
+			return nil, nil, errors.Wrap(httperrors.ErrInputParameter, "Auth cookie decode")
 		}
 		auth, err = authCookie.GetString("session")
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "authCookie.GetString session")
+			return nil, nil, errors.Wrap(httperrors.ErrInputParameter, "authCookie missing session field")
 		}
 	}
 	// if len(auth) > 0 && auth != auth1 { // hack!!! browser cache problem???
@@ -93,11 +93,11 @@ func fetchAuthInfo(ctx context.Context, r *http.Request) (mcclient.TokenCredenti
 		var err error
 		authToken, err = clientman.Decode(auth)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "clientman.GetAuthToken")
+			return nil, nil, errors.Wrap(httperrors.ErrInputParameter, "clientman.Decode auth token fail")
 		}
 		token, err = authToken.GetToken(ctx)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "authToken.GetToken")
+			return nil, nil, errors.Wrap(httperrors.ErrInputParameter, "authToken.GetToken fail")
 		}
 	}
 	if token == nil {
@@ -127,7 +127,7 @@ func FetchAuthToken(f func(context.Context, http.ResponseWriter, *http.Request))
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		ctx, err := fetchAndSetAuthContext(ctx, w, r)
 		if err != nil {
-			httperrors.InvalidCredentialError(w, "invalid token: %v", err)
+			httperrors.InvalidCredentialError(w, "No token in header: %v", err)
 			return
 		}
 		f(ctx, w, r)

--- a/pkg/keystone/policy/resources.go
+++ b/pkg/keystone/policy/resources.go
@@ -21,12 +21,12 @@ import (
 
 var (
 	identitySystemResources = []string{
+		"identity_providers",
 		"domains",
 		"services",
 		"endpoints",
 	}
 	identityDomainResources = []string{
-		"identity_providers",
 		"users",
 		"groups",
 		"projects",


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：
1. apigateway解析authcookie失败后的错误消息不包含原始信息，避免包含乱码
2. 暂时把identity_provider改为system resource，等前端调整好了再改回来

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area apigateway