### PR TITLE
fix: orderedstring add performance improvements

### DIFF
--- a/pkg/util/stringutils2/sortedstrings.go
+++ b/pkg/util/stringutils2/sortedstrings.go
@@ -29,6 +29,11 @@ func NewSortedStrings(strs []string) SSortedStrings {
 }
 
 func Append(ss SSortedStrings, ele ...string) SSortedStrings {
+	ss = ss.Append(ele...)
+	return ss
+}
+
+func (ss SSortedStrings) Append(ele ...string) SSortedStrings {
 	if ss == nil {
 		ss = NewSortedStrings([]string{})
 	}
@@ -38,10 +43,25 @@ func Append(ss SSortedStrings, ele ...string) SSortedStrings {
 			continue
 		}
 		ss = append(ss, e)
-		for i := len(ss) - 1; i > pos; i -= 1 {
-			ss[i] = ss[i-1]
-		}
+		copy(ss[pos+1:], ss[pos:])
 		ss[pos] = e
+	}
+	return ss
+}
+
+func (ss SSortedStrings) Remove(ele ...string) SSortedStrings {
+	if ss == nil {
+		return ss
+	}
+	for _, e := range ele {
+		pos, find := ss.Index(e)
+		if !find {
+			continue
+		}
+		if pos < len(ss)-1 {
+			copy(ss[pos:], ss[pos+1:])
+		}
+		ss = ss[:len(ss)-1]
 	}
 	return ss
 }

--- a/pkg/util/stringutils2/sortedstrings_test.go
+++ b/pkg/util/stringutils2/sortedstrings_test.go
@@ -15,6 +15,7 @@
 package stringutils2
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -73,4 +74,64 @@ func TestMergeStrings(t *testing.T) {
 	t.Logf("A: %s", ss1)
 	t.Logf("B: %s", ss2)
 	t.Logf("%s", m)
+}
+
+func TestSortedStringsAppend(t *testing.T) {
+	cases := []struct {
+		in   []string
+		ele  []string
+		want SSortedStrings
+	}{
+		{
+			in:   []string{"Alpha", "Bravo", "Go"},
+			ele:  []string{"Go2"},
+			want: []string{"Alpha", "Bravo", "Go", "Go2"},
+		},
+		{
+			in:   []string{"Alpha", "Bravo", "Go2"},
+			ele:  []string{"Go"},
+			want: []string{"Alpha", "Bravo", "Go", "Go2"},
+		},
+		{
+			in:   []string{"Alpha", "Bravo", "Go2"},
+			ele:  []string{"Aaaa", "Go"},
+			want: []string{"Aaaa", "Alpha", "Bravo", "Go", "Go2"},
+		},
+	}
+	for _, c := range cases {
+		got := NewSortedStrings(c.in).Append(c.ele...)
+		if !reflect.DeepEqual(c.want, got) {
+			t.Errorf("want: %s got: %s", c.want, got)
+		}
+	}
+}
+
+func TestSortedStringsRemove(t *testing.T) {
+	cases := []struct {
+		in   []string
+		ele  []string
+		want SSortedStrings
+	}{
+		{
+			in:   []string{"Alpha", "Bravo", "Go"},
+			ele:  []string{"Go", "Go2"},
+			want: []string{"Alpha", "Bravo"},
+		},
+		{
+			in:   []string{"Alpha", "Bravo", "Go2"},
+			ele:  []string{"Go"},
+			want: []string{"Alpha", "Bravo", "Go2"},
+		},
+		{
+			in:   []string{"Alpha", "Bravo", "Go", "Go2"},
+			ele:  []string{"Aaaa", "Alpha"},
+			want: []string{"Bravo", "Go", "Go2"},
+		},
+	}
+	for _, c := range cases {
+		got := NewSortedStrings(c.in).Remove(c.ele...)
+		if !reflect.DeepEqual(c.want, got) {
+			t.Errorf("want: %s got: %s", c.want, got)
+		}
+	}
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：使用copy提升sortedstring add的性能

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area util
/cc @zexi 