### PR TITLE
fix: remove default allow policy for storages

### DIFF
--- a/pkg/compute/policy/defaults.go
+++ b/pkg/compute/policy/defaults.go
@@ -229,18 +229,6 @@ var (
 				},
 				{
 					Service:  api.SERVICE_TYPE,
-					Resource: "storages",
-					Action:   PolicyActionList,
-					Result:   rbacutils.Allow,
-				},
-				{
-					Service:  api.SERVICE_TYPE,
-					Resource: "storages",
-					Action:   PolicyActionGet,
-					Result:   rbacutils.Allow,
-				},
-				{
-					Service:  api.SERVICE_TYPE,
 					Resource: "vpcs",
 					Action:   PolicyActionList,
 					Result:   rbacutils.Allow,


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修改：去掉默认的storages的list、get权限，普通项目用户不需要这些权限

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area region