### PR TITLE
hotfix: vpc change owners with wire

### DIFF
--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -1268,3 +1268,21 @@ func (vpc *SVpc) PerformPrivate(ctx context.Context, userCred mcclient.TokenCred
 	}
 	return vpc.SEnabledStatusInfrasResourceBase.PerformPrivate(ctx, userCred, query, input)
 }
+
+func (vpc *SVpc) PerformChangeOwner(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformChangeDomainOwnerInput) (jsonutils.JSONObject, error) {
+	_, err := vpc.SEnabledStatusInfrasResourceBase.PerformChangeOwner(ctx, userCred, query, input)
+	if err != nil {
+		return nil, errors.Wrap(err, "SEnabledStatusInfrasResourceBase.PerformChangeOwner")
+	}
+	wires := vpc.GetWires()
+	for i := range wires {
+		if wires[i].IsEmulated {
+			_, err := wires[i].PerformChangeOwner(ctx, userCred, query, input)
+			if err != nil {
+				return nil, errors.Wrap(err, "wires[i].PerformChangeOwner")
+			}
+		}
+	}
+
+	return nil, nil
+}

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -366,7 +366,7 @@ func (self *SWire) syncWithCloudWire(ctx context.Context, userCred mcclient.Toke
 		log.Errorf("syncWithCloudWire error %s", err)
 	}
 
-	if provider != nil {
+	if provider != nil && !self.IsEmulated {
 		SyncCloudDomain(userCred, self, provider.GetOwnerId())
 		self.SyncShareState(ctx, userCred, provider.getAccountShareInfo())
 	}
@@ -408,6 +408,9 @@ func (manager *SWireManager) newFromCloudWire(ctx context.Context, userCred mccl
 	}
 
 	wire.IsEmulated = extWire.IsEmulated()
+	wire.DomainId = vpc.DomainId
+	wire.IsPublic = vpc.IsPublic
+	wire.PublicScope = vpc.PublicScope
 
 	err = manager.TableSpec().Insert(ctx, &wire)
 	if err != nil {
@@ -415,10 +418,10 @@ func (manager *SWireManager) newFromCloudWire(ctx context.Context, userCred mccl
 		return nil, err
 	}
 
-	if provider != nil {
+	/*if provider != nil {
 		SyncCloudDomain(userCred, &wire, provider.GetOwnerId())
 		wire.SyncShareState(ctx, userCred, provider.getAccountShareInfo())
-	}
+	}*/
 
 	db.OpsLog.LogEvent(&wire, db.ACT_CREATE, wire.GetShortDesc(ctx), userCred)
 	return &wire, nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：vpc更改owner，设置共享属性时，同时设置其包含的wires的owner和共享属性
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area region
/cc @zexi 