### PR TITLE
fix guest template health check

### DIFF
--- a/cmd/climc/shell/compute/guest_template.go
+++ b/cmd/climc/shell/compute/guest_template.go
@@ -145,6 +145,15 @@ func init() {
 		},
 	)
 
+	R(&GuestTemplateOptions{}, "server-template-inspect", "Inspect server template", func(s *mcclient.ClientSession, opts *GuestTemplateOptions) error {
+		tem, err := modules.GuestTemplate.PerformAction(s, opts.ID, "inspect", jsonutils.JSONNull)
+		if err != nil {
+			return err
+		}
+		printObject(tem)
+		return nil
+	})
+
 	type GuestTemplatePublicOptions struct {
 		ID          string `help:"ID or Name of server template"`
 		PublicScope string `help:"public scope"`

--- a/pkg/util/logclient/consts.go
+++ b/pkg/util/logclient/consts.go
@@ -146,6 +146,8 @@ const (
 
 	ACT_AUTHENTICATE = "认证登录"
 
+	ACT_HEALTH_CHECK = "健康检查"
+
 	ACT_RECYCLE_PREPAID      = "池化预付费主机"
 	ACT_UNDO_RECYCLE_PREPAID = "取消池化预付费主机"
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. 主机模板健康状态检查对image进行一次refresh的检查，如果镜像近期被删除，就可以检查出来
2. 提供一个手动触发检查的接口以及climc命令
3. 增加一个健康状态检查的日志

- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @zexi @ioito 