### PR TITLE
bugfix: disable procutils print error info

### DIFF
--- a/pkg/util/procutils/procutils.go
+++ b/pkg/util/procutils/procutils.go
@@ -86,7 +86,7 @@ func (c *Command) Run() error {
 	log.Debugf("Exec command: %s %v", c.path, c.args)
 	err := c.cmd.Run()
 	if err != nil {
-		log.Errorf("Execute command %q , error: %v", c, err)
+		log.Debugf("Execute command %q , error: %v", c, err)
 	}
 	return err
 }
@@ -95,7 +95,7 @@ func (c *Command) Output() ([]byte, error) {
 	log.Debugf("Exec command: %s %v", c.path, c.args)
 	output, err := c.cmd.CombinedOutput()
 	if err != nil {
-		log.Errorf("Execute command %q , error: %v , output: %s", c, err, string(output))
+		log.Debugf("Execute command %q , error: %v , output: %s", c, err, string(output))
 	}
 	return output, err
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
```
- disable procutils print error info, should print by the caller
```

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/cc @zexi @swordqiu 
