### PR TITLE
iproute2: address: make Exact idempotent

### DIFF
--- a/pkg/util/iproute2/address_test.go
+++ b/pkg/util/iproute2/address_test.go
@@ -19,24 +19,24 @@ import (
 )
 
 func TestAddress(t *testing.T) {
-	ifname := genDummyName(t)
-	dum := addDummy(t, ifname)
-	defer delDummy(t, dum)
-
-	emptyT := func(t *testing.T) {
-		l := NewAddress(ifname)
-		l.Exact()
-		if err := l.Err(); err != nil {
-			t.Fatalf("got err: %v", err)
-		}
-		if ipnets, err := l.List4(); err != nil {
-			t.Fatalf("list4 err: %v", err)
-		} else if len(ipnets) > 0 {
-			t.Fatalf("want empty, got %#v", ipnets)
-		}
-	}
-
 	t.Run("exact some", func(t *testing.T) {
+		ifname := genDummyName(t)
+		dum := addDummy(t, ifname)
+		defer delDummy(t, dum)
+
+		emptyT := func(t *testing.T) {
+			l := NewAddress(ifname)
+			l.Exact()
+			if err := l.Err(); err != nil {
+				t.Fatalf("got err: %v", err)
+			}
+			if ipnets, err := l.List4(); err != nil {
+				t.Fatalf("list4 err: %v", err)
+			} else if len(ipnets) > 0 {
+				t.Fatalf("want empty, got %#v", ipnets)
+			}
+		}
+
 		want := "10.168.222.236/24"
 		l := NewAddress(ifname, want, "fe80::222:d5ff:fe9e:28d1/64")
 		l.Exact()
@@ -54,6 +54,35 @@ func TestAddress(t *testing.T) {
 		t.Run("empty empty", emptyT)
 	})
 
+	t.Run("exact indempotent", func(t *testing.T) {
+		ifname := genDummyName(t)
+		dum := addDummy(t, ifname)
+		defer delDummy(t, dum)
+
+		surprise := "10.127.190.240/32"
+		{
+			l := NewAddress(ifname, "10.127.190.217/24", surprise)
+			l.Exact()
+			if err := l.Err(); err != nil {
+				t.Fatalf("got err: %v", err)
+			}
+		}
+		{
+			l := NewAddress(ifname)
+			l.testcb = func() {
+				if err := NewAddress(ifname, surprise).Del().Err(); err != nil {
+					t.Fatalf("sneak failed: %v", err)
+				}
+			}
+			if addrs, _ := l.List4(); len(addrs) == 0 {
+				t.Fatalf("expect at least 1 v4 addr")
+			}
+			l.Exact()
+			if err := l.Err(); err != nil {
+				t.Fatalf("got err: %v", err)
+			}
+		}
+	})
 }
 
 func TestAddress_nopriv(t *testing.T) {


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:

```
Idempotence against address not available for Exact is not a bad idea if
we look at the name of that func

This should accomodate the race condition where keepalived will remove
vips should the primary address used for vrrp comms is removed, causing
later addr del to fail with "cannot assign requested address"
```

See yunionio/onecloud#4836

- [x] 冒烟测试

**是否需要 backport 到之前的 release 分支**:

- release/3.1

/area host
/area util
/cc @swordqiu @wanyaoqi @zexi 