### PR TITLE
Automated cherry pick of #7158: iproute2: address: make Exact idempotent

### DIFF
--- a/pkg/util/iproute2/address.go
+++ b/pkg/util/iproute2/address.go
@@ -2,6 +2,7 @@ package iproute2
 
 import (
 	"net"
+	"syscall"
 
 	"github.com/vishvananda/netlink"
 )
@@ -11,12 +12,17 @@ type Address struct {
 
 	addrBad bool
 	addrs   []*netlink.Addr
+
+	testcb func()
 }
+
+func nop() {}
 
 func NewAddress(ifname string, addresses ...string) *Address {
 	l := NewLink(ifname)
 	r := &Address{
-		Link: l,
+		Link:   l,
+		testcb: nop,
 	}
 
 	addrs := make([]*netlink.Addr, len(addresses))
@@ -62,6 +68,7 @@ func (address *Address) Exact() *Address {
 	if err != nil {
 		address.addErr(err, "Exact: AddrList")
 	}
+	address.testcb()
 	for _, oldAddr := range oldAddrs {
 		del := true
 		for _, addr := range address.addrs {
@@ -73,6 +80,13 @@ func (address *Address) Exact() *Address {
 		if del {
 			err := netlink.AddrDel(link, &oldAddr)
 			if err != nil {
+				if errno, ok := err.(syscall.Errno); ok {
+					switch errno {
+					case syscall.EADDRNOTAVAIL:
+						// "cannot assign requested address"
+						continue
+					}
+				}
 				address.addErr(err, "Exact: AddrDel %s", oldAddr)
 			}
 		}


### PR DESCRIPTION
Cherry pick of #7158 on release/3.1.

#7158: iproute2: address: make Exact idempotent