### PR TITLE
fix: prefetch image error when create guest with vmware template

### DIFF
--- a/pkg/compute/guestdrivers/esxi.go
+++ b/pkg/compute/guestdrivers/esxi.go
@@ -173,7 +173,7 @@ func (self *SESXiGuestDriver) GetJsonDescAtHost(ctx context.Context, userCred mc
 	if img.ImageType != cloudprovider.CachedImageTypeSystem {
 		return desc
 	}
-	sciSubQ := models.StoragecachedimageManager.Query("storagecache_id").Equals("cachedimage_id", templateId).SubQuery()
+	sciSubQ := models.StoragecachedimageManager.Query("storagecache_id").Equals("cachedimage_id", templateId).Equals("status", api.CACHED_IMAGE_STATUS_READY).SubQuery()
 	scQ := models.StoragecacheManager.Query().In("id", sciSubQ)
 	storageCaches := make([]models.SStoragecache, 0, 1)
 	err = db.FetchModelObjects(models.StoragecacheManager, scQ, &storageCaches)

--- a/pkg/hostman/storageman/imagecachemanager_agent.go
+++ b/pkg/hostman/storageman/imagecachemanager_agent.go
@@ -221,7 +221,11 @@ func (c *SAgentImageCacheManager) perfetchTemplateVMImageCache(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	_, err = host.GetTemplateVMById(data.ImageExternalId)
+	dc, err := host.GetDatacenter()
+	if err != nil {
+		return nil, errors.Wrap(err, "host.GetDatacenter")
+	}
+	_, err = dc.GetTemplateVMById(data.ImageExternalId)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/multicloud/esxi/datacenter.go
+++ b/pkg/multicloud/esxi/datacenter.go
@@ -364,3 +364,41 @@ func (dc *SDatacenter) GetNetworks() ([]IVMNetwork, error) {
 	}
 	return dc.inetworks, nil
 }
+
+func (dc *SDatacenter) GetTemplateVMs() ([]*SVirtualMachine, error) {
+	hosts, err := dc.GetIHosts()
+	if err != nil {
+		return nil, errors.Wrap(err, "SDatacenter.GetIHosts")
+	}
+	templateVms := make([]*SVirtualMachine, 5)
+	for _, ihost := range hosts {
+		host := ihost.(*SHost)
+		tvms, err := host.GetTemplateVMs()
+		if err != nil {
+			return nil, errors.Wrap(err, "host.GetTemplateVMs")
+		}
+		templateVms = append(templateVms, tvms...)
+	}
+	return templateVms, nil
+}
+
+func (dc *SDatacenter) GetTemplateVMById(id string) (*SVirtualMachine, error) {
+	id = dc.manager.getPrivateId(id)
+	hosts, err := dc.GetIHosts()
+	if err != nil {
+		return nil, errors.Wrap(err, "SDatacenter.GetIHosts")
+	}
+	for _, ihost := range hosts {
+		host := ihost.(*SHost)
+		tvms, err := host.GetTemplateVMs()
+		if err != nil {
+			return nil, errors.Wrap(err, "host.GetTemplateVMs")
+		}
+		for i := range tvms {
+			if tvms[i].GetGlobalId() == id {
+				return tvms[i], nil
+			}
+		}
+	}
+	return nil, cloudprovider.ErrNotFound
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. Only need the corresponding vmware template in the vcenter where the host is
located.
2. Chose storagecache which cacheimage is ready before deploying.

- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

- release/3.3
- release/3.2
- release/3.1

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area esxiagent
/cc @zexi @swordqiu 