### PR TITLE
fix: default vpc must be shared globally

### DIFF
--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -1197,6 +1197,9 @@ func (manager *SVpcManager) ListItemExportKeys(ctx context.Context,
 }
 
 func (vpc *SVpc) PerformPublic(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPublicDomainInput) (jsonutils.JSONObject, error) {
+	if rbacutils.String2ScopeDefault(input.Scope, rbacutils.ScopeSystem) != rbacutils.ScopeSystem {
+		return nil, httperrors.NewForbiddenError("For default vpc, only system level sharing can be set")
+	}
 	_, err := vpc.SEnabledStatusInfrasResourceBase.PerformPublic(ctx, userCred, query, input)
 	if err != nil {
 		return nil, errors.Wrap(err, "SEnabledStatusInfrasResourceBase.PerformPublic")
@@ -1215,6 +1218,9 @@ func (vpc *SVpc) PerformPublic(ctx context.Context, userCred mcclient.TokenCrede
 }
 
 func (vpc *SVpc) PerformPrivate(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPrivateInput) (jsonutils.JSONObject, error) {
+	if vpc.Id == "default" {
+		return nil, httperrors.NewForbiddenError("Prohibit making default vpc private")
+	}
 	// perform private for all emulated wires
 	emptyNets := true
 	wires := vpc.GetWires()


### PR DESCRIPTION
1. For default vpc, prohibit private operation.
2. For default vpc, prohibit public operation without scope 'system'.

原因：https://bug.yunion.io/zentao/bug-view-5214.html

- [x] 功能、bugfix描述
- [x] 冒烟测试

**这个 PR 实现什么功能/修复什么问题**:

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/cc @swordqiu @zexi 