### PR TITLE
修复监控报警规则删除的问题

### DIFF
--- a/pkg/monitor/models/commonalert.go
+++ b/pkg/monitor/models/commonalert.go
@@ -639,7 +639,8 @@ func (alert *SCommonAlert) customizeDeleteNotis(
 
 func (alert *SCommonAlert) Delete(ctx context.Context, userCred mcclient.TokenCredential) error {
 	CommonAlertManager.DeleteSubscriptionAlert(alert)
-	return alert.SetStatus(userCred, monitor.ALERT_STATUS_DELETED, "")
+
+	return alert.SAlert.Delete(ctx, userCred)
 }
 
 func (self *SCommonAlertManager) GetSystemAlerts() ([]SCommonAlert, error) {


### PR DESCRIPTION
**是否需要 backport 到之前的 release 分支**:
release/3.3

