### PR TITLE
[3.3] region: lbagents: skip tls check for default influxdb endpoint url

### DIFF
--- a/pkg/compute/models/loadbalanceragents.go
+++ b/pkg/compute/models/loadbalanceragents.go
@@ -273,6 +273,7 @@ func (p *SLoadbalancerAgentParamsTelegraf) initDefault(data *jsonutils.JSONDict)
 		u, _ := auth.GetServiceURL("influxdb", baseOpts.Region, "",
 			identity_apis.EndpointInterfacePublic)
 		p.InfluxDbOutputUrl = u
+		p.InfluxDbOutputUnsafeSsl = true
 	}
 	if p.HaproxyInputInterval == 0 {
 		p.HaproxyInputInterval = 5


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
region: lbagents: skip tls check for default influxdb endpoint url
```

A chery-pick from master, see #7220

**是否需要 backport 到之前的 release 分支**:

NONE

/area region
/cc @swordqiu @zexi @ioito 
