### PR TITLE
fix GetOrCreateVpcForClassicNetwork

### DIFF
--- a/pkg/compute/models/elasticcache_instances.go
+++ b/pkg/compute/models/elasticcache_instances.go
@@ -588,7 +588,7 @@ func (manager *SElasticcacheManager) newFromCloudElasticcache(ctx context.Contex
 
 	instance.NetworkType = extInstance.GetNetworkType()
 	if instance.NetworkType == api.LB_NETWORK_TYPE_CLASSIC {
-		vpc, err := VpcManager.GetOrCreateVpcForClassicNetwork(ctx, region)
+		vpc, err := VpcManager.GetOrCreateVpcForClassicNetwork(ctx, provider, region)
 		if err != nil {
 			return nil, errors.Wrap(err, "NewVpcForClassicNetwork")
 		}

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -2733,7 +2733,8 @@ func getCloudNicNetwork(ctx context.Context, vnic cloudprovider.ICloudNic, host 
 	if vnet == nil {
 		if vnic.InClassicNetwork() {
 			region := host.GetRegion()
-			vpc, err := VpcManager.GetOrCreateVpcForClassicNetwork(ctx, region)
+			cloudprovider := region.GetCloudprovider()
+			vpc, err := VpcManager.GetOrCreateVpcForClassicNetwork(ctx, cloudprovider, region)
 			if err != nil {
 				return nil, errors.Wrap(err, "NewVpcForClassicNetwork")
 			}

--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -191,8 +191,7 @@ func (manager *SVpcManager) getVpcExternalIdForClassicNetwork(regionId, cloudpro
 	return fmt.Sprintf("%s-%s", regionId, cloudproviderId)
 }
 
-func (manager *SVpcManager) GetOrCreateVpcForClassicNetwork(ctx context.Context, region *SCloudregion) (*SVpc, error) {
-	cloudprovider := region.GetCloudprovider()
+func (manager *SVpcManager) GetOrCreateVpcForClassicNetwork(ctx context.Context, cloudprovider *SCloudprovider, region *SCloudregion) (*SVpc, error) {
 	externalId := manager.getVpcExternalIdForClassicNetwork(region.Id, cloudprovider.Id)
 	_vpc, err := db.FetchByExternalIdAndManagerId(manager, externalId, func(q *sqlchemy.SQuery) *sqlchemy.SQuery {
 		return q.Equals("manager_id", region.ManagerId)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
* 修复公有云region manager id为空，导致GetCloudprovider结果为nil的错误 

**是否需要 backport 到之前的 release 分支**:
- release/3.2
- release/3.3

/area region
/cc @ioito @yousong 
