### PR TITLE
baremetal: set zone when enable netif

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -4000,6 +4000,14 @@ func (self *SHost) EnableNetif(ctx context.Context, userCred mcclient.TokenCrede
 	if wire == nil {
 		return fmt.Errorf("No wire attached")
 	}
+	if self.ZoneId == "" {
+		if _, err := self.SaveUpdates(func() error {
+			self.ZoneId = wire.ZoneId
+			return nil
+		}); err != nil {
+			return errors.Wrapf(err, "set host zone_id %s by wire", wire.ZoneId)
+		}
+	}
 	hw, err := HostwireManager.FetchByHostIdAndMac(self.Id, netif.Mac)
 	if err != nil {
 		return err


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

预注册的物理机默认没有填 zone_id，在 pxe 启动 enable netif 的时候根据 wire 设置 baremetal 的 zone_id

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
- 3.2
/area region baremetal
/cc @swordqiu @wanyaoqi 