### PR TITLE
fix: image upload not clean pending usage

### DIFF
--- a/cmd/climc/shell/image/images.go
+++ b/cmd/climc/shell/image/images.go
@@ -252,7 +252,7 @@ func init() {
 	}
 
 	type ImageDeleteOptions struct {
-		ID                    []string `help:"Image ID or name"`
+		ID                    []string `help:"Image ID or name" json:"-"`
 		OverridePendingDelete *bool    `help:"Delete image directly instead of pending delete" short-token:"f"`
 	}
 	R(&ImageDeleteOptions{}, "image-delete", "Delete a image", func(s *mcclient.ClientSession, args *ImageDeleteOptions) error {

--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -538,7 +538,8 @@ func (self *SImage) PostCreate(ctx context.Context, userCred mcclient.TokenCrede
 	// if SImage belong to a guest image, pending quota will not be set.
 	if self.IsGuestImage.IsFalse() {
 		pendingUsage := SQuota{Image: 1}
-		keys := imageCreateInput2QuotaKeys(self.DiskFormat, ownerId)
+		inputDiskFormat, _ := data.GetString("disk_format")
+		keys := imageCreateInput2QuotaKeys(inputDiskFormat, ownerId)
 		pendingUsage.SetKeys(keys)
 		cancelUsage := SQuota{Image: 1}
 		keys = self.GetQuotaKeys()


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：镜像上传时为正确设置pending usage keys，导致清理pending usage失败

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2
- release/3.3

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi  @wanyaoqi 
/area image