### PR TITLE
fix(esxi): Select correct unitNumber for ide control when creating disk

### DIFF
--- a/pkg/multicloud/esxi/devtools.go
+++ b/pkg/multicloud/esxi/devtools.go
@@ -23,7 +23,7 @@ import (
 	"yunion.io/x/pkg/errors"
 )
 
-func NewDiskDev(sizeMb int64, templatePath string, uuid string, index int32, key int32, controlKey int32) *types.VirtualDisk {
+func NewDiskDev(sizeMb int64, templatePath string, uuid string, index int32, keyBase int32, controlKey int32, key int32) *types.VirtualDisk {
 	device := types.VirtualDisk{}
 
 	var backFile *types.VirtualDiskFlatVer2BackingInfo
@@ -48,7 +48,11 @@ func NewDiskDev(sizeMb int64, templatePath string, uuid string, index int32, key
 	}
 
 	device.ControllerKey = controlKey
-	device.Key = key + index
+	if key != 0 {
+		device.Key = key
+	} else {
+		device.Key = keyBase + index
+	}
 	device.UnitNumber = &index
 
 	return &device

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -762,6 +762,8 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 	var (
 		scsiIdx = 0
 		ideIdx  = 0
+		ide1un  = 0
+		ide2un  = 1
 		index   = 0
 		ctrlKey = 0
 	)
@@ -793,13 +795,18 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 				scsiIdx++
 			}
 		} else {
-			ctrlKey = 200 + ideIdx/2
-			index = ideIdx % 2
+			ideno := ideIdx % 2
+			if ideno == 0 {
+				index = ideIdx/2 + ide1un
+			} else {
+				index = ideIdx/2 + ide2un
+			}
+			ctrlKey = 200 + ideno
 			ideIdx += 1
 		}
 		log.Debugf("size: %d, image path: %s, uuid: %s, index: %d, ctrlKey: %d, driver: %s.", size, imagePath, uuid,
 			index, ctrlKey, disk.Driver)
-		spec := addDevSpec(NewDiskDev(size, imagePath, uuid, int32(index), 2000, int32(ctrlKey)))
+		spec := addDevSpec(NewDiskDev(size, imagePath, uuid, int32(index), 2000, int32(ctrlKey), 0))
 		spec.FileOperation = "create"
 		deviceChange = append(deviceChange, spec)
 	}
@@ -967,7 +974,7 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SData
 					size = 30 * 1024
 				}
 				uuid := params.Disks[i].DiskId
-				spec := addDevSpec(NewDiskDev(size, "", uuid, index, key, ctlKey))
+				spec := addDevSpec(NewDiskDev(size, "", uuid, index, key, ctlKey, 0))
 				spec.FileOperation = "create"
 				deviceChange = append(deviceChange, spec)
 			}

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -853,6 +853,16 @@ func (self *SVirtualMachine) FindDiskByDriver(drivers ...string) []SVirtualDisk 
 	return disks
 }
 
+func (self *SVirtualMachine) devNumWithCtrlKey(ctrlKey int32) int {
+	n := 0
+	for _, dev := range self.devs {
+		if dev.getControllerKey() == ctrlKey {
+			n++
+		}
+	}
+	return n
+}
+
 func (self *SVirtualMachine) CreateDisk(ctx context.Context, sizeMb int, uuid string, driver string) error {
 	if driver == "pvscsi" {
 		driver = "scsi"
@@ -864,29 +874,30 @@ func (self *SVirtualMachine) CreateDisk(ctx context.Context, sizeMb int, uuid st
 	if len(devs) == 0 {
 		return self.createDriverAndDisk(ctx, sizeMb, uuid, driver)
 	}
-	ctlKey := minDevKey(devs)
-	drivers := []string{driver}
-	if driver == "scsi" {
-		drivers = append(drivers, "pvscsi")
+	numDevBelowCtrl := make([]int, len(devs))
+	for i := range numDevBelowCtrl {
+		numDevBelowCtrl[i] = self.devNumWithCtrlKey(devs[i].getKey())
 	}
-	sameDisks := self.FindDiskByDriver(drivers...)
 
+	// find the min one
+	ctrlKey := devs[0].getKey()
+	unitNumber := numDevBelowCtrl[0]
+	for i := 1; i < len(numDevBelowCtrl); i++ {
+		if numDevBelowCtrl[i] >= unitNumber {
+			continue
+		}
+		ctrlKey = devs[i].getKey()
+		unitNumber = numDevBelowCtrl[i]
+	}
 	diskKey := self.FindMinDiffKey(2000)
-	if len(sameDisks) != 0 {
-		diskKey = minDiskKey(sameDisks)
-	}
-	index := len(sameDisks)
-	if driver == "ide" {
-		ctlKey += int32(index / 2)
-	}
 
 	// By default, the virtual SCSI controller is assigned to virtual device node (z:7),
 	// so that device node is unavailable for hard disks or other devices.
-	if index >= 7 && driver == "scsi" {
-		index++
+	if unitNumber >= 7 && driver == "scsi" {
+		unitNumber++
 	}
 
-	return self.createDiskInternal(ctx, sizeMb, uuid, int32(index), diskKey, ctlKey, "", true)
+	return self.createDiskInternal(ctx, sizeMb, uuid, int32(unitNumber), diskKey, ctrlKey, "", true)
 }
 
 // createDriverAndDisk will create a driver and disk associated with the driver
@@ -916,7 +927,7 @@ func (self *SVirtualMachine) createDiskWithDeviceChange(ctx context.Context,
 	deviceChange []types.BaseVirtualDeviceConfigSpec, sizeMb int,
 	uuid string, index int32, diskKey int32, ctlKey int32, imagePath string, check bool) error {
 
-	devSpec := NewDiskDev(int64(sizeMb), imagePath, uuid, index, diskKey, ctlKey)
+	devSpec := NewDiskDev(int64(sizeMb), imagePath, uuid, index, 0, ctlKey, diskKey)
 	spec := addDevSpec(devSpec)
 	spec.FileOperation = types.VirtualDeviceConfigSpecFileOperationCreate
 	configSpec := types.VirtualMachineConfigSpec{}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
对于windows机器，使用ide controller，创建多个磁盘的时候没有为设备选择正确的unitnumber，原因在于，有两个ide设备，挂载磁盘的时候尽量均分，但是ide设备上可能还有其他的设备。主要应该到创建机器和添加磁盘的时候。

解决bug：https://bug.yunion.io/zentao/bug-view-5258.html

- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

- release/3.3
- release/3.2
- release/3.1
- release/3.0

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area esxi
/cc @swordqiu @zexi 