### PR TITLE
Automated cherry pick of #7281: fix(esxi): Select correct unitNumber for ide control when creating disk

### DIFF
--- a/pkg/multicloud/esxi/devtools.go
+++ b/pkg/multicloud/esxi/devtools.go
@@ -23,7 +23,7 @@ import (
 	"yunion.io/x/pkg/errors"
 )
 
-func NewDiskDev(sizeMb int64, templatePath string, uuid string, index int32, key int32, controlKey int32) *types.VirtualDisk {
+func NewDiskDev(sizeMb int64, templatePath string, uuid string, index int32, keyBase int32, controlKey int32, key int32) *types.VirtualDisk {
 	device := types.VirtualDisk{}
 
 	var backFile *types.VirtualDiskFlatVer2BackingInfo
@@ -48,7 +48,11 @@ func NewDiskDev(sizeMb int64, templatePath string, uuid string, index int32, key
 	}
 
 	device.ControllerKey = controlKey
-	device.Key = key + index
+	if key != 0 {
+		device.Key = key
+	} else {
+		device.Key = keyBase + index
+	}
 	device.UnitNumber = &index
 
 	return &device

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -762,6 +762,8 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 	var (
 		scsiIdx = 0
 		ideIdx  = 0
+		ide1un  = 0
+		ide2un  = 1
 		index   = 0
 		ctrlKey = 0
 	)
@@ -793,13 +795,18 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 				scsiIdx++
 			}
 		} else {
-			ctrlKey = 200 + ideIdx/2
-			index = ideIdx % 2
+			ideno := ideIdx % 2
+			if ideno == 0 {
+				index = ideIdx/2 + ide1un
+			} else {
+				index = ideIdx/2 + ide2un
+			}
+			ctrlKey = 200 + ideno
 			ideIdx += 1
 		}
 		log.Debugf("size: %d, image path: %s, uuid: %s, index: %d, ctrlKey: %d, driver: %s.", size, imagePath, uuid,
 			index, ctrlKey, disk.Driver)
-		spec := addDevSpec(NewDiskDev(size, imagePath, uuid, int32(index), 2000, int32(ctrlKey)))
+		spec := addDevSpec(NewDiskDev(size, imagePath, uuid, int32(index), 2000, int32(ctrlKey), 0))
 		spec.FileOperation = "create"
 		deviceChange = append(deviceChange, spec)
 	}
@@ -967,7 +974,7 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SData
 					size = 30 * 1024
 				}
 				uuid := params.Disks[i].DiskId
-				spec := addDevSpec(NewDiskDev(size, "", uuid, index, key, ctlKey))
+				spec := addDevSpec(NewDiskDev(size, "", uuid, index, key, ctlKey, 0))
 				spec.FileOperation = "create"
 				deviceChange = append(deviceChange, spec)
 			}

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -857,6 +857,16 @@ func (self *SVirtualMachine) FindDiskByDriver(drivers ...string) []SVirtualDisk 
 	return disks
 }
 
+func (self *SVirtualMachine) devNumWithCtrlKey(ctrlKey int32) int {
+	n := 0
+	for _, dev := range self.devs {
+		if dev.getControllerKey() == ctrlKey {
+			n++
+		}
+	}
+	return n
+}
+
 func (self *SVirtualMachine) CreateDisk(ctx context.Context, sizeMb int, uuid string, driver string) error {
 	if driver == "pvscsi" {
 		driver = "scsi"
@@ -868,29 +878,30 @@ func (self *SVirtualMachine) CreateDisk(ctx context.Context, sizeMb int, uuid st
 	if len(devs) == 0 {
 		return self.createDriverAndDisk(ctx, sizeMb, uuid, driver)
 	}
-	ctlKey := minDevKey(devs)
-	drivers := []string{driver}
-	if driver == "scsi" {
-		drivers = append(drivers, "pvscsi")
+	numDevBelowCtrl := make([]int, len(devs))
+	for i := range numDevBelowCtrl {
+		numDevBelowCtrl[i] = self.devNumWithCtrlKey(devs[i].getKey())
 	}
-	sameDisks := self.FindDiskByDriver(drivers...)
 
+	// find the min one
+	ctrlKey := devs[0].getKey()
+	unitNumber := numDevBelowCtrl[0]
+	for i := 1; i < len(numDevBelowCtrl); i++ {
+		if numDevBelowCtrl[i] >= unitNumber {
+			continue
+		}
+		ctrlKey = devs[i].getKey()
+		unitNumber = numDevBelowCtrl[i]
+	}
 	diskKey := self.FindMinDiffKey(2000)
-	if len(sameDisks) != 0 {
-		diskKey = minDiskKey(sameDisks)
-	}
-	index := len(sameDisks)
-	if driver == "ide" {
-		ctlKey += int32(index / 2)
-	}
 
 	// By default, the virtual SCSI controller is assigned to virtual device node (z:7),
 	// so that device node is unavailable for hard disks or other devices.
-	if index >= 7 && driver == "scsi" {
-		index++
+	if unitNumber >= 7 && driver == "scsi" {
+		unitNumber++
 	}
 
-	return self.createDiskInternal(ctx, sizeMb, uuid, int32(index), diskKey, ctlKey, "", true)
+	return self.createDiskInternal(ctx, sizeMb, uuid, int32(unitNumber), diskKey, ctrlKey, "", true)
 }
 
 // createDriverAndDisk will create a driver and disk associated with the driver
@@ -920,7 +931,7 @@ func (self *SVirtualMachine) createDiskWithDeviceChange(ctx context.Context,
 	deviceChange []types.BaseVirtualDeviceConfigSpec, sizeMb int,
 	uuid string, index int32, diskKey int32, ctlKey int32, imagePath string, check bool) error {
 
-	devSpec := NewDiskDev(int64(sizeMb), imagePath, uuid, index, diskKey, ctlKey)
+	devSpec := NewDiskDev(int64(sizeMb), imagePath, uuid, index, 0, ctlKey, diskKey)
 	spec := addDevSpec(devSpec)
 	spec.FileOperation = types.VirtualDeviceConfigSpecFileOperationCreate
 	configSpec := types.VirtualMachineConfigSpec{}


### PR DESCRIPTION
Cherry pick of #7281 on release/3.3.

#7281: fix(esxi): Select correct unitNumber for ide control when creating disk