### PR TITLE
fix: domain resource domain share to system when non_default_domain_projects off

### DIFF
--- a/pkg/cloudcommon/db/infraresource.go
+++ b/pkg/cloudcommon/db/infraresource.go
@@ -22,6 +22,7 @@ import (
 	"yunion.io/x/sqlchemy"
 
 	"yunion.io/x/onecloud/pkg/apis"
+	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
@@ -248,6 +249,15 @@ func (model *SInfrasResourceBase) SaveSharedInfo(src apis.TOwnerSource, ctx cont
 }
 
 func (model *SInfrasResourceBase) SyncShareState(ctx context.Context, userCred mcclient.TokenCredential, shareInfo apis.SAccountShareInfo) {
+	if !consts.GetNonDefaultDomainProjects() {
+		if model.PublicSrc != string(apis.OWNER_SOURCE_LOCAL) {
+			model.SaveSharedInfo(apis.OWNER_SOURCE_CLOUD, ctx, userCred, apis.SShareInfo{
+				IsPublic:    true,
+				PublicScope: rbacutils.ScopeSystem,
+			})
+		}
+		return
+	}
 	si := shareInfo.GetDomainShareInfo()
 	if model.PublicSrc != string(apis.OWNER_SOURCE_LOCAL) {
 		model.SaveSharedInfo(apis.OWNER_SOURCE_CLOUD, ctx, userCred, si)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：当三级权限关闭时，所有域资源默认全局共享

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area util