### PR TITLE
fix: schedtag should be system resource

### DIFF
--- a/pkg/compute/policy/resources.go
+++ b/pkg/compute/policy/resources.go
@@ -34,6 +34,7 @@ var (
 		"loadbalanceragents",
 		// "reservedips",
 		"policy_definitions",
+		"schedtags",
 	}
 	computeDomainResources = []string{
 		"cloudaccounts",


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正: schedtags应该是系统资源

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2
- release/3.3

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area region
