### PR TITLE
Automated cherry pick of #7324: fix: schedtag should be system resource

### DIFF
--- a/pkg/compute/policy/resources.go
+++ b/pkg/compute/policy/resources.go
@@ -34,6 +34,7 @@ var (
 		"loadbalanceragents",
 		// "reservedips",
 		"policy_definitions",
+		"schedtags",
 	}
 	computeDomainResources = []string{
 		"cloudaccounts",


### PR DESCRIPTION
Cherry pick of #7324 on release/3.3.

#7324: fix: schedtag should be system resource