### PR TITLE
fix: use json to store task error message

### DIFF
--- a/pkg/cloudcommon/db/taskman/interface.go
+++ b/pkg/cloudcommon/db/taskman/interface.go
@@ -37,7 +37,7 @@ type ITask interface {
 	GetTaskRequestHeader() http.Header
 
 	SetStageComplete(ctx context.Context, data *jsonutils.JSONDict)
-	SetStageFailed(ctx context.Context, reason string)
+	SetStageFailed(ctx context.Context, reason jsonutils.JSONObject)
 
 	GetPendingUsage(quota quotas.IQuota, index int) error
 	ClearPendingUsage(index int) error

--- a/pkg/cloudcommon/db/taskman/tasks.go
+++ b/pkg/cloudcommon/db/taskman/tasks.go
@@ -398,18 +398,29 @@ func execITask(taskValue reflect.Value, task *STask, odata jsonutils.JSONObject,
 
 	taskFailed := false
 
-	data := odata
-	if data != nil {
-		taskStatus, _ := data.GetString("__status__")
-		if len(taskStatus) > 0 && taskStatus != "OK" {
-			taskFailed = true
-			if vdata, ok := data.(*jsonutils.JSONDict); ok {
-				reason, err := vdata.Get("__reason__") // only dict support Get
-				if err != nil {
-					reason = jsonutils.NewString(fmt.Sprintf("Task failed due to unknown remote errors! %s", odata))
-					vdata.Set("__reason__", reason)
+	var data jsonutils.JSONObject
+	if odata != nil {
+		switch dictdata := odata.(type) {
+		case *jsonutils.JSONDict:
+			taskStatus, _ := data.GetString("__status__")
+			if len(taskStatus) > 0 && taskStatus != "OK" {
+				taskFailed = true
+				dictdata.Set("__stage__", jsonutils.NewString(task.Stage))
+				if !dictdata.Contains("__reason__") {
+					reasonJson := dictdata.CopyExcludes("__status__", "__stage__")
+					dictdata.Set("__reason__", reasonJson)
 				}
+				/*if vdata, ok := data.(*jsonutils.JSONDict); ok {
+					reason, err := vdata.Get("__reason__") // only dict support Get
+					if err != nil {
+						reason = jsonutils.NewString(fmt.Sprintf("Task failed due to unknown remote errors! %s", odata))
+						vdata.Set("__reason__", reason)
+					}
+				}*/
 			}
+			data = dictdata
+		default:
+			data = odata
 		}
 	} else {
 		data = jsonutils.NewDict()
@@ -441,7 +452,7 @@ func execITask(taskValue reflect.Value, task *STask, odata jsonutils.JSONObject,
 			} else {
 				log.Errorf(msg)
 			}
-			task.SetStageFailed(ctx, msg)
+			task.SetStageFailed(ctx, jsonutils.NewString(msg))
 			task.SaveRequestContext(&ctxData)
 			return
 		}
@@ -451,16 +462,16 @@ func execITask(taskValue reflect.Value, task *STask, odata jsonutils.JSONObject,
 	if objManager == nil {
 		msg := fmt.Sprintf("model %s not found??? ...", task.ObjName)
 		log.Errorf(msg)
-		task.SetStageFailed(ctx, msg)
+		task.SetStageFailed(ctx, jsonutils.NewString(msg))
 		task.SaveRequestContext(&ctxData)
 		return
 	}
 	// log.Debugf("objManager: %s", objManager)
 	objResManager, ok := objManager.(db.IStandaloneModelManager)
 	if !ok {
-		msg := fmt.Sprintf("mode %s is not a resource??? ...", task.ObjName)
+		msg := fmt.Sprintf("model %s is not a resource??? ...", task.ObjName)
 		log.Errorf(msg)
-		task.SetStageFailed(ctx, msg)
+		task.SetStageFailed(ctx, jsonutils.NewString(msg))
 		task.SaveRequestContext(&ctxData)
 		return
 	}
@@ -476,7 +487,7 @@ func execITask(taskValue reflect.Value, task *STask, odata jsonutils.JSONObject,
 			if err != nil {
 				msg := fmt.Sprintf("fail to find %s object %s", task.ObjName, objId)
 				log.Errorf(msg)
-				task.SetStageFailed(ctx, msg)
+				task.SetStageFailed(ctx, jsonutils.NewString(msg))
 				task.SaveRequestContext(&ctxData)
 				return
 			}
@@ -493,7 +504,7 @@ func execITask(taskValue reflect.Value, task *STask, odata jsonutils.JSONObject,
 		if err != nil {
 			msg := fmt.Sprintf("fail to find %s object %s", task.ObjName, task.ObjId)
 			log.Errorf(msg)
-			task.SetStageFailed(ctx, msg)
+			task.SetStageFailed(ctx, jsonutils.NewString(msg))
 			task.SaveRequestContext(&ctxData)
 			return
 		}
@@ -637,18 +648,30 @@ func (self *STask) SetStageComplete(ctx context.Context, data *jsonutils.JSONDic
 	self.NotifyParentTaskComplete(ctx, data, false)
 }
 
-func (self *STask) SetStageFailed(ctx context.Context, reason string) {
+func (self *STask) SetStageFailed(ctx context.Context, reason jsonutils.JSONObject) {
 	if self.Stage == TASK_STAGE_FAILED {
 		log.Warningf("Task %s has been failed", self.TaskName)
 		return
 	}
 	log.Infof("XXX TASK %s failed: %s on stage %s", self.TaskName, reason, self.Stage)
-	prevFailed, _ := self.Params.GetString("__failed_reason")
-	if len(prevFailed) > 0 {
-		reason = prevFailed + ";" + reason
+	reasonDict := jsonutils.NewDict()
+	reasonDict.Add(jsonutils.NewString(self.Stage), "stage")
+	if reason != nil {
+		reasonDict.Add(reason, "reason")
+	}
+	reason = reasonDict
+	prevFailed, _ := self.Params.Get("__failed_reason")
+	if prevFailed != nil {
+		switch prevFailed.(type) {
+		case *jsonutils.JSONArray:
+			prevFailed.(*jsonutils.JSONArray).Add(reason)
+			reason = prevFailed
+		default:
+			reason = jsonutils.NewArray(prevFailed, reason)
+		}
 	}
 	data := jsonutils.NewDict()
-	data.Add(jsonutils.NewString(reason), "__failed_reason")
+	data.Add(reason, "__failed_reason")
 	self.SetStage(TASK_STAGE_FAILED, data)
 	self.NotifyParentTaskFailure(ctx, reason)
 }
@@ -700,10 +723,11 @@ func notifyRemoteTask(ctx context.Context, notifyUrl string, taskid string, body
 	log.Infof("Notify remote URL %s(%s) get acked: %s!", notifyUrl, taskid, body.String())
 }
 
-func (self *STask) NotifyParentTaskFailure(ctx context.Context, reason string) {
+func (self *STask) NotifyParentTaskFailure(ctx context.Context, reason jsonutils.JSONObject) {
 	body := jsonutils.NewDict()
 	body.Add(jsonutils.NewString("error"), "__status__")
-	body.Add(jsonutils.NewString(fmt.Sprintf("Subtask %s failed: %s", self.TaskName, reason)), "__reason__")
+	body.Add(jsonutils.NewString(self.TaskName), "__task_name__")
+	body.Add(reason, "__reason__")
 	self.NotifyParentTaskComplete(ctx, body, true)
 }
 

--- a/pkg/cloudevent/tasks/cloudevent_sync_task.go
+++ b/pkg/cloudevent/tasks/cloudevent_sync_task.go
@@ -38,9 +38,9 @@ func init() {
 	taskman.RegisterTask(CloudeventSyncTask{})
 }
 
-func (self *CloudeventSyncTask) taskFailed(ctx context.Context, cloudprovider *models.SCloudprovider, err error) {
+func (self *CloudeventSyncTask) taskFailed(ctx context.Context, cloudprovider *models.SCloudprovider, err jsonutils.JSONObject) {
 	cloudprovider.MarkEndSync(self.UserCred)
-	self.SetStageFailed(ctx, err.Error())
+	self.SetStageFailed(ctx, err)
 }
 
 func (self *CloudeventSyncTask) taskComplete(ctx context.Context, cloudprovider *models.SCloudprovider) {
@@ -53,19 +53,19 @@ func (self *CloudeventSyncTask) OnInit(ctx context.Context, obj db.IStandaloneMo
 
 	factory, err := provider.GetProviderFactory()
 	if err != nil {
-		self.taskFailed(ctx, provider, errors.Wrap(err, "cloudprovider.GetProviderFactory"))
+		self.taskFailed(ctx, provider, jsonutils.NewString(errors.Wrap(err, "cloudprovider.GetProviderFactory").Error()))
 		return
 	}
 
 	iProvider, err := provider.GetProvider()
 	if err != nil {
-		self.taskFailed(ctx, provider, errors.Wrap(err, "cloudprovider.GetProvider"))
+		self.taskFailed(ctx, provider, jsonutils.NewString(errors.Wrap(err, "cloudprovider.GetProvider").Error()))
 		return
 	}
 
 	start, end, err := provider.GetNextTimeRange()
 	if err != nil {
-		self.taskFailed(ctx, provider, errors.Wrap(err, "provider.GetNextTimeRange"))
+		self.taskFailed(ctx, provider, jsonutils.NewString(errors.Wrap(err, "provider.GetNextTimeRange").Error()))
 		return
 	}
 
@@ -87,7 +87,7 @@ func (self *CloudeventSyncTask) OnInit(ctx context.Context, obj db.IStandaloneMo
 					if err == cloudprovider.ErrNotSupported {
 						continue
 					}
-					self.taskFailed(ctx, provider, errors.Wrapf(err, "regions[%d].GetICloudEvents", i))
+					self.taskFailed(ctx, provider, jsonutils.NewString(errors.Wrapf(err, "regions[%d].GetICloudEvents", i).Error()))
 					return
 				}
 				events = append(events, _events...)

--- a/pkg/cloudid/tasks/cloudgroupcache_delete_task.go
+++ b/pkg/cloudid/tasks/cloudgroupcache_delete_task.go
@@ -36,10 +36,10 @@ func init() {
 	taskman.RegisterTask(CloudgroupcacheDeleteTask{})
 }
 
-func (self *CloudgroupcacheDeleteTask) taskFailed(ctx context.Context, cache *models.SCloudgroupcache, err error) {
-	cache.SetStatus(self.GetUserCred(), api.CLOUD_GROUP_STATUS_DELETE_FAILED, err.Error())
+func (self *CloudgroupcacheDeleteTask) taskFailed(ctx context.Context, cache *models.SCloudgroupcache, err jsonutils.JSONObject) {
+	cache.SetStatus(self.GetUserCred(), api.CLOUD_GROUP_STATUS_DELETE_FAILED, err.String())
 	logclient.AddActionLogWithStartable(self, cache, logclient.ACT_DELETE, err, self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	self.SetStageFailed(ctx, err)
 }
 
 func (self *CloudgroupcacheDeleteTask) taskComplete(ctx context.Context, cache *models.SCloudgroupcache) {
@@ -60,12 +60,12 @@ func (self *CloudgroupcacheDeleteTask) OnInit(ctx context.Context, obj db.IStand
 			self.taskComplete(ctx, cache)
 			return
 		}
-		self.taskFailed(ctx, cache, errors.Wrap(err, "GetICloudgroup"))
+		self.taskFailed(ctx, cache, jsonutils.NewString(errors.Wrap(err, "GetICloudgroup").Error()))
 		return
 	}
 	err = iGroup.Delete()
 	if err != nil {
-		self.taskFailed(ctx, cache, errors.Wrap(err, "iGroup.Delete"))
+		self.taskFailed(ctx, cache, jsonutils.NewString(errors.Wrap(err, "iGroup.Delete").Error()))
 		return
 	}
 	self.taskComplete(ctx, cache)

--- a/pkg/cloudid/tasks/cloudgroupcache_sync_status_task.go
+++ b/pkg/cloudid/tasks/cloudgroupcache_sync_status_task.go
@@ -35,17 +35,17 @@ func init() {
 	taskman.RegisterTask(CloudgroupcacheSyncstatusTask{})
 }
 
-func (self *CloudgroupcacheSyncstatusTask) taskFailed(ctx context.Context, cache *models.SCloudgroupcache, err error) {
-	cache.SetStatus(self.GetUserCred(), api.CLOUD_GROUP_CACHE_STATUS_UNKNOWN, err.Error())
+func (self *CloudgroupcacheSyncstatusTask) taskFailed(ctx context.Context, cache *models.SCloudgroupcache, err jsonutils.JSONObject) {
+	cache.SetStatus(self.GetUserCred(), api.CLOUD_GROUP_CACHE_STATUS_UNKNOWN, err.String())
 	logclient.AddActionLogWithStartable(self, cache, logclient.ACT_SYNC_STATUS, err, self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	self.SetStageFailed(ctx, err)
 }
 
 func (self *CloudgroupcacheSyncstatusTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
 	cache := obj.(*models.SCloudgroupcache)
 	_, err := cache.GetICloudgroup()
 	if err != nil {
-		self.taskFailed(ctx, cache, errors.Wrap(err, "GetICloudgroup"))
+		self.taskFailed(ctx, cache, jsonutils.NewString(errors.Wrap(err, "GetICloudgroup").Error()))
 		return
 	}
 	self.SetStageComplete(ctx, nil)

--- a/pkg/cloudid/tasks/clouduser_delete_task.go
+++ b/pkg/cloudid/tasks/clouduser_delete_task.go
@@ -36,10 +36,10 @@ func init() {
 	taskman.RegisterTask(ClouduserDeleteTask{})
 }
 
-func (self *ClouduserDeleteTask) taskFailed(ctx context.Context, clouduser *models.SClouduser, err error) {
-	clouduser.SetStatus(self.GetUserCred(), api.CLOUD_USER_STATUS_DELETE_FAILED, err.Error())
+func (self *ClouduserDeleteTask) taskFailed(ctx context.Context, clouduser *models.SClouduser, err jsonutils.JSONObject) {
+	clouduser.SetStatus(self.GetUserCred(), api.CLOUD_USER_STATUS_DELETE_FAILED, err.String())
 	logclient.AddActionLogWithStartable(self, clouduser, logclient.ACT_DELETE, err, self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	self.SetStageFailed(ctx, err)
 }
 
 func (self *ClouduserDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
@@ -58,13 +58,13 @@ func (self *ClouduserDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneM
 			self.SetStageComplete(ctx, nil)
 			return
 		}
-		self.taskFailed(ctx, clouduser, errors.Wrap(err, "GetIClouduser"))
+		self.taskFailed(ctx, clouduser, jsonutils.NewString(errors.Wrap(err, "GetIClouduser").Error()))
 		return
 	}
 
 	err = iUser.Delete()
 	if err != nil {
-		self.taskFailed(ctx, clouduser, errors.Wrap(err, "user.Delete"))
+		self.taskFailed(ctx, clouduser, jsonutils.NewString(errors.Wrap(err, "user.Delete").Error()))
 		return
 	}
 	clouduser.RealDelete(ctx, self.GetUserCred())

--- a/pkg/cloudid/tasks/clouduser_sync_task.go
+++ b/pkg/cloudid/tasks/clouduser_sync_task.go
@@ -34,9 +34,9 @@ func init() {
 	taskman.RegisterTask(ClouduserSyncTask{})
 }
 
-func (self *ClouduserSyncTask) taskFailed(ctx context.Context, clouduser *models.SClouduser, err error) {
-	clouduser.SetStatus(self.GetUserCred(), api.CLOUD_USER_STATUS_SYNC_FAILED, err.Error())
-	self.SetStageFailed(ctx, err.Error())
+func (self *ClouduserSyncTask) taskFailed(ctx context.Context, clouduser *models.SClouduser, err jsonutils.JSONObject) {
+	clouduser.SetStatus(self.GetUserCred(), api.CLOUD_USER_STATUS_SYNC_FAILED, err.String())
+	self.SetStageFailed(ctx, err)
 }
 
 func (self *ClouduserSyncTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
@@ -49,12 +49,12 @@ func (self *ClouduserSyncTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 func (self *ClouduserSyncTask) OnSyncCloudpoliciesComplete(ctx context.Context, user *models.SClouduser, body jsonutils.JSONObject) {
 	account, err := user.GetCloudaccount()
 	if err != nil {
-		self.taskFailed(ctx, user, errors.Wrap(err, "user.GetCloudaccount"))
+		self.taskFailed(ctx, user, jsonutils.NewString(errors.Wrap(err, "user.GetCloudaccount").Error()))
 		return
 	}
 	factory, err := account.GetProviderFactory()
 	if err != nil {
-		self.taskFailed(ctx, user, errors.Wrap(err, "GetProviderFactory"))
+		self.taskFailed(ctx, user, jsonutils.NewString(errors.Wrap(err, "GetProviderFactory").Error()))
 		return
 	}
 
@@ -69,7 +69,7 @@ func (self *ClouduserSyncTask) OnSyncCloudpoliciesComplete(ctx context.Context, 
 }
 
 func (self *ClouduserSyncTask) OnSyncCloudpoliciesCompleteFailed(ctx context.Context, user *models.SClouduser, data jsonutils.JSONObject) {
-	self.taskFailed(ctx, user, errors.Error(data.String()))
+	self.taskFailed(ctx, user, data)
 }
 
 func (self *ClouduserSyncTask) OnSyncCloudgroupsComplete(ctx context.Context, user *models.SClouduser, body jsonutils.JSONObject) {
@@ -78,5 +78,5 @@ func (self *ClouduserSyncTask) OnSyncCloudgroupsComplete(ctx context.Context, us
 }
 
 func (self *ClouduserSyncTask) OnSyncCloudgroupsCompleteFailed(ctx context.Context, user *models.SClouduser, data jsonutils.JSONObject) {
-	self.taskFailed(ctx, user, errors.Error(data.String()))
+	self.taskFailed(ctx, user, data)
 }

--- a/pkg/cloudid/tasks/clouduser_syncstatus_task.go
+++ b/pkg/cloudid/tasks/clouduser_syncstatus_task.go
@@ -34,9 +34,9 @@ func init() {
 	taskman.RegisterTask(ClouduserSyncstatusTask{})
 }
 
-func (self *ClouduserSyncstatusTask) taskFailed(ctx context.Context, clouduser *models.SClouduser, err error) {
-	clouduser.SetStatus(self.GetUserCred(), api.CLOUD_USER_STATUS_UNKNOWN, err.Error())
-	self.SetStageFailed(ctx, err.Error())
+func (self *ClouduserSyncstatusTask) taskFailed(ctx context.Context, clouduser *models.SClouduser, err jsonutils.JSONObject) {
+	clouduser.SetStatus(self.GetUserCred(), api.CLOUD_USER_STATUS_UNKNOWN, err.String())
+	self.SetStageFailed(ctx, err)
 }
 
 func (self *ClouduserSyncstatusTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
@@ -44,7 +44,7 @@ func (self *ClouduserSyncstatusTask) OnInit(ctx context.Context, obj db.IStandal
 
 	_, err := clouduser.GetIClouduser()
 	if err != nil {
-		self.taskFailed(ctx, clouduser, errors.Wrap(err, "GetIClouduser"))
+		self.taskFailed(ctx, clouduser, jsonutils.NewString(errors.Wrap(err, "GetIClouduser").Error()))
 		return
 	}
 

--- a/pkg/cloudid/tasks/sync_cloudpolicies_task.go
+++ b/pkg/cloudid/tasks/sync_cloudpolicies_task.go
@@ -34,8 +34,8 @@ func init() {
 	taskman.RegisterTask(SyncCloudIdResourcesTask{})
 }
 
-func (self *SyncCloudIdResourcesTask) taskFailed(ctx context.Context, cloudaccount *models.SCloudaccount, err error) {
-	self.SetStageFailed(ctx, err.Error())
+func (self *SyncCloudIdResourcesTask) taskFailed(ctx context.Context, cloudaccount *models.SCloudaccount, err jsonutils.JSONObject) {
+	self.SetStageFailed(ctx, err)
 }
 
 func (self *SyncCloudIdResourcesTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
@@ -43,7 +43,7 @@ func (self *SyncCloudIdResourcesTask) OnInit(ctx context.Context, obj db.IStanda
 
 	provider, err := account.GetProvider()
 	if err != nil {
-		self.taskFailed(ctx, account, errors.Wrap(err, "GetProvider"))
+		self.taskFailed(ctx, account, jsonutils.NewString(errors.Wrap(err, "GetProvider").Error()))
 		return
 	}
 
@@ -73,5 +73,5 @@ func (self *SyncCloudIdResourcesTask) OnSyncCloudusersComplete(ctx context.Conte
 }
 
 func (self *SyncCloudIdResourcesTask) OnClouduserSyncCompleteFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }

--- a/pkg/cloudid/tasks/sync_cloudusers_task.go
+++ b/pkg/cloudid/tasks/sync_cloudusers_task.go
@@ -121,5 +121,5 @@ func (self *SyncCloudusersTask) OnClouduserSyncComplete(ctx context.Context, obj
 }
 
 func (self *SyncCloudusersTask) OnClouduserSyncCompleteFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }

--- a/pkg/compute/tasks/baremetal_cdrom_task.go
+++ b/pkg/compute/tasks/baremetal_cdrom_task.go
@@ -47,16 +47,16 @@ func (self *BaremetalCdromTask) OnInit(ctx context.Context, obj db.IStandaloneMo
 	self.SetStage("OnSyncConfigComplete", nil)
 	_, err := baremetal.BaremetalSyncRequest(ctx, "POST", url, headers, self.Params)
 	if err != nil {
-		self.OnFailure(ctx, baremetal, err.Error())
+		self.OnFailure(ctx, baremetal, jsonutils.Marshal(err))
 	}
 }
 
-func (self *BaremetalCdromTask) OnFailure(ctx context.Context, baremetal *models.SHost, reason string) {
+func (self *BaremetalCdromTask) OnFailure(ctx context.Context, baremetal *models.SHost, reason jsonutils.JSONObject) {
 	action, _ := self.Params.GetString("action")
 	if action == api.BAREMETAL_CDROM_ACTION_INSERT {
-		baremetal.SetStatus(self.UserCred, api.BAREMETAL_INSERT_FAIL, reason)
+		baremetal.SetStatus(self.UserCred, api.BAREMETAL_INSERT_FAIL, reason.String())
 	} else {
-		baremetal.SetStatus(self.UserCred, api.BAREMETAL_EJECT_FAIL, reason)
+		baremetal.SetStatus(self.UserCred, api.BAREMETAL_EJECT_FAIL, reason.String())
 	}
 	self.SetStageFailed(ctx, reason)
 }
@@ -66,6 +66,5 @@ func (self *BaremetalCdromTask) OnSyncConfigComplete(ctx context.Context, bareme
 }
 
 func (self *BaremetalCdromTask) OnSyncConfigCompleteFailed(ctx context.Context, baremetal *models.SHost, body jsonutils.JSONObject) {
-	reason, _ := body.GetString("__reason__")
-	self.OnFailure(ctx, baremetal, reason)
+	self.OnFailure(ctx, baremetal, body)
 }

--- a/pkg/compute/tasks/baremetal_convert_hypervisor_task.go
+++ b/pkg/compute/tasks/baremetal_convert_hypervisor_task.go
@@ -60,7 +60,7 @@ func (self *BaremetalConvertHypervisorTask) OnInit(ctx context.Context, obj db.I
 	paramsDict := params.(*jsonutils.JSONDict)
 	input, err := cmdline.FetchServerCreateInputByJSON(paramsDict)
 	if err != nil {
-		self.SetStageFailed(ctx, err.Error())
+		self.SetStageFailed(ctx, jsonutils.Marshal(err))
 		return
 	}
 	input.ParentTaskId = self.GetTaskId()
@@ -74,7 +74,7 @@ func (self *BaremetalConvertHypervisorTask) OnGuestDeployComplete(ctx context.Co
 	hypervisor := self.getHypervisor()
 	driver := models.GetHostDriver(hypervisor)
 	if driver == nil {
-		self.SetStageFailed(ctx, fmt.Sprintf("Get Host Driver error %s", hypervisor))
+		self.SetStageFailed(ctx, jsonutils.NewString(fmt.Sprintf("Get Host Driver error %s", hypervisor)))
 	}
 	err := driver.FinishConvert(self.UserCred, baremetal, guest, driver.GetHostType())
 	if err != nil {
@@ -105,5 +105,5 @@ func (self *BaremetalConvertHypervisorTask) OnGuestDeleteComplete(ctx context.Co
 }
 
 func (self *BaremetalConvertHypervisorTask) OnFailedSyncstatusComplete(ctx context.Context, baremetal *models.SHost, body jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, "convert failed")
+	self.SetStageFailed(ctx, body)
 }

--- a/pkg/compute/tasks/baremetal_delete_task.go
+++ b/pkg/compute/tasks/baremetal_delete_task.go
@@ -67,6 +67,6 @@ func (self *BaremetalDeleteTask) OnDeleteBaremetalCompleteFailed(ctx context.Con
 }
 
 func (self *BaremetalDeleteTask) OnFailure(ctx context.Context, baremetal *models.SHost, body jsonutils.JSONObject) {
-	baremetal.SetStatus(self.UserCred, api.BAREMETAL_DELETE_FAIL, "")
-	self.SetStageFailed(ctx, "")
+	baremetal.SetStatus(self.UserCred, api.BAREMETAL_DELETE_FAIL, body.String())
+	self.SetStageFailed(ctx, body)
 }

--- a/pkg/compute/tasks/baremetal_ipmi_probe_task.go
+++ b/pkg/compute/tasks/baremetal_ipmi_probe_task.go
@@ -43,13 +43,13 @@ func (self *BaremetalIpmiProbeTask) OnInit(ctx context.Context, obj db.IStandalo
 	self.SetStage("OnSyncConfigComplete", nil)
 	_, err := baremetal.BaremetalSyncRequest(ctx, "POST", url, headers, self.Params)
 	if err != nil {
-		self.OnFailure(ctx, baremetal, err.Error())
+		self.OnFailure(ctx, baremetal, jsonutils.Marshal(err))
 	}
 }
 
-func (self *BaremetalIpmiProbeTask) OnFailure(ctx context.Context, baremetal *models.SHost, reason string) {
+func (self *BaremetalIpmiProbeTask) OnFailure(ctx context.Context, baremetal *models.SHost, reason jsonutils.JSONObject) {
 	logclient.AddActionLogWithStartable(self, baremetal, logclient.ACT_PROBE, reason, self.UserCred, false)
-	baremetal.SetStatus(self.UserCred, api.BAREMETAL_PROBE_FAIL, reason)
+	baremetal.SetStatus(self.UserCred, api.BAREMETAL_PROBE_FAIL, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -59,6 +59,5 @@ func (self *BaremetalIpmiProbeTask) OnSyncConfigComplete(ctx context.Context, ba
 }
 
 func (self *BaremetalIpmiProbeTask) OnSyncConfigCompleteFailed(ctx context.Context, baremetal *models.SHost, body jsonutils.JSONObject) {
-	reason, _ := body.GetString("__reason__")
-	self.OnFailure(ctx, baremetal, reason)
+	self.OnFailure(ctx, baremetal, body)
 }

--- a/pkg/compute/tasks/baremetal_maintenance_task.go
+++ b/pkg/compute/tasks/baremetal_maintenance_task.go
@@ -73,7 +73,7 @@ func (self *BaremetalMaintenanceTask) OnEnterMaintenantModeSucc(ctx context.Cont
 }
 
 func (self *BaremetalMaintenanceTask) OnEnterMaintenantModeSuccFailed(ctx context.Context, baremetal *models.SHost, body jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, body.String())
+	self.SetStageFailed(ctx, body)
 	baremetal.StartSyncstatus(ctx, self.UserCred, "")
 	guest := baremetal.GetBaremetalServer()
 	if guest != nil {
@@ -81,6 +81,6 @@ func (self *BaremetalMaintenanceTask) OnEnterMaintenantModeSuccFailed(ctx contex
 	}
 	action := self.Action()
 	if len(action) > 0 {
-		logclient.AddActionLogWithStartable(self, baremetal, action, body.String(), self.UserCred, false)
+		logclient.AddActionLogWithStartable(self, baremetal, action, body, self.UserCred, false)
 	}
 }

--- a/pkg/compute/tasks/baremetal_prepare_task.go
+++ b/pkg/compute/tasks/baremetal_prepare_task.go
@@ -41,12 +41,12 @@ func (self *BaremetalPrepareTask) OnInit(ctx context.Context, obj db.IStandalone
 	self.SetStage("OnSyncConfigComplete", nil)
 	_, err := baremetal.BaremetalSyncRequest(ctx, "POST", url, headers, self.Params)
 	if err != nil {
-		self.OnFailure(ctx, baremetal, err.Error())
+		self.OnFailure(ctx, baremetal, jsonutils.Marshal(err))
 	}
 }
 
-func (self *BaremetalPrepareTask) OnFailure(ctx context.Context, baremetal *models.SHost, reason string) {
-	baremetal.SetStatus(self.UserCred, api.BAREMETAL_PREPARE_FAIL, reason)
+func (self *BaremetalPrepareTask) OnFailure(ctx context.Context, baremetal *models.SHost, reason jsonutils.JSONObject) {
+	baremetal.SetStatus(self.UserCred, api.BAREMETAL_PREPARE_FAIL, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -56,6 +56,5 @@ func (self *BaremetalPrepareTask) OnSyncConfigComplete(ctx context.Context, bare
 }
 
 func (self *BaremetalPrepareTask) OnSyncConfigCompleteFailed(ctx context.Context, baremetal *models.SHost, body jsonutils.JSONObject) {
-	reason, _ := body.GetString("__reason__")
-	self.OnFailure(ctx, baremetal, reason)
+	self.OnFailure(ctx, baremetal, body)
 }

--- a/pkg/compute/tasks/baremetal_server_reset_task.go
+++ b/pkg/compute/tasks/baremetal_server_reset_task.go
@@ -33,7 +33,7 @@ func (self *BaremetalServerResetTask) OnInit(ctx context.Context, obj db.IStanda
 	guest := obj.(*models.SGuest)
 	baremetal := guest.GetHost()
 	if baremetal == nil {
-		self.SetStageFailed(ctx, "Baremetal is None")
+		self.SetStageFailed(ctx, jsonutils.NewString("Baremetal is not found"))
 		return
 	}
 	url := fmt.Sprintf("/baremetals/%s/servers/%s/reset", baremetal.Id, guest.Id)
@@ -41,7 +41,7 @@ func (self *BaremetalServerResetTask) OnInit(ctx context.Context, obj db.IStanda
 	_, err := baremetal.BaremetalSyncRequest(ctx, "POST", url, headers, nil)
 	if err != nil {
 		log.Errorln(err)
-		self.SetStageFailed(ctx, err.Error())
+		self.SetStageFailed(ctx, jsonutils.Marshal(err))
 	} else {
 		self.SetStageComplete(ctx, nil)
 	}

--- a/pkg/compute/tasks/baremetal_server_start_task.go
+++ b/pkg/compute/tasks/baremetal_server_start_task.go
@@ -65,10 +65,9 @@ func (self *BaremetalServerStartTask) OnStartComplete(ctx context.Context, guest
 }
 
 func (self *BaremetalServerStartTask) OnStartCompleteFailed(ctx context.Context, guest *models.SGuest, body jsonutils.JSONObject) {
-	reason := body.String()
-	guest.SetStatus(self.UserCred, api.VM_START_FAILED, reason)
-	db.OpsLog.LogEvent(guest, db.ACT_START_FAIL, reason, self.UserCred)
+	guest.SetStatus(self.UserCred, api.VM_START_FAILED, body.String())
+	db.OpsLog.LogEvent(guest, db.ACT_START_FAIL, body, self.UserCred)
 	baremetal := guest.GetHost()
-	baremetal.SetStatus(self.UserCred, api.BAREMETAL_START_FAIL, reason)
-	self.SetStageFailed(ctx, reason)
+	baremetal.SetStatus(self.UserCred, api.BAREMETAL_START_FAIL, body.String())
+	self.SetStageFailed(ctx, body)
 }

--- a/pkg/compute/tasks/baremetal_server_stop_task.go
+++ b/pkg/compute/tasks/baremetal_server_stop_task.go
@@ -80,10 +80,10 @@ func (self *BaremetalServerStopTask) OnGuestStopTaskComplete(ctx context.Context
 
 func (self *BaremetalServerStopTask) OnGuestStopTaskCompleteFailed(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {
 	guest.SetStatus(self.UserCred, db.ACT_STOP_FAIL, data.String())
-	db.OpsLog.LogEvent(guest, db.ACT_STOP_FAIL, data.String(), self.UserCred)
+	db.OpsLog.LogEvent(guest, db.ACT_STOP_FAIL, data, self.UserCred)
 	baremetal := guest.GetHost()
-	baremetal.SetStatus(self.UserCred, api.BAREMETAL_READY, "")
-	self.SetStageFailed(ctx, data.String())
+	baremetal.SetStatus(self.UserCred, api.BAREMETAL_READY, data.String())
+	self.SetStageFailed(ctx, data)
 }
 
 func (self *BaremetalServerStopTask) OnStopGuestFail(ctx context.Context, guest *models.SGuest, reason string) {

--- a/pkg/compute/tasks/baremetal_sync_config_task.go
+++ b/pkg/compute/tasks/baremetal_sync_config_task.go
@@ -49,7 +49,7 @@ func (self *BaremetalSyncConfigTask) DoSyncConfig(ctx context.Context, baremetal
 	headers := self.GetTaskRequestHeader()
 	_, err := baremetal.BaremetalSyncRequest(ctx, "POST", url, headers, nil)
 	if err != nil {
-		self.SetStageFailed(ctx, err.Error())
+		self.SetStageFailed(ctx, jsonutils.Marshal(err))
 	}
 }
 

--- a/pkg/compute/tasks/baremetal_sync_status_task.go
+++ b/pkg/compute/tasks/baremetal_sync_status_task.go
@@ -47,7 +47,7 @@ func (self *BaremetalSyncStatusTask) DoSyncStatus(ctx context.Context, baremetal
 	headers := self.GetTaskRequestHeader()
 	_, err := baremetal.BaremetalSyncRequest(ctx, "POST", url, headers, nil)
 	if err != nil {
-		self.SetStageFailed(ctx, err.Error())
+		self.SetStageFailed(ctx, jsonutils.Marshal(err))
 	}
 }
 

--- a/pkg/compute/tasks/baremetal_unconvert_hypervisor_task.go
+++ b/pkg/compute/tasks/baremetal_unconvert_hypervisor_task.go
@@ -40,7 +40,7 @@ func (self *BaremetalUnconvertHypervisorTask) OnInit(ctx context.Context, obj db
 	baremetal.SetStatus(self.UserCred, api.BAREMETAL_CONVERTING, "")
 	guests := baremetal.GetGuests()
 	if len(guests) > 1 {
-		self.SetStageFailed(ctx, "Host guest conut > 1")
+		self.SetStageFailed(ctx, jsonutils.NewString("Host guest conut > 1"))
 	}
 	if len(guests) == 1 {
 		guest := guests[0]
@@ -68,7 +68,7 @@ func (self *BaremetalUnconvertHypervisorTask) OnGuestDeleteCompleteFailed(ctx co
 	db.OpsLog.LogEvent(baremetal, db.ACT_UNCONVERT_FAIL, body, self.UserCred)
 	self.SetStage("OnFailSyncstatusComplete", nil)
 	baremetal.StartSyncstatus(ctx, self.UserCred, self.GetTaskId())
-	logclient.AddActionLogWithStartable(self, baremetal, logclient.ACT_BM_UNCONVERT_HYPER, nil, self.UserCred, false)
+	logclient.AddActionLogWithStartable(self, baremetal, logclient.ACT_BM_UNCONVERT_HYPER, body, self.UserCred, false)
 }
 
 func (self *BaremetalUnconvertHypervisorTask) OnPrepareComplete(ctx context.Context, baremetal *models.SHost, body jsonutils.JSONObject) {
@@ -76,5 +76,5 @@ func (self *BaremetalUnconvertHypervisorTask) OnPrepareComplete(ctx context.Cont
 }
 
 func (self *BaremetalUnconvertHypervisorTask) OnFailSyncstatusComplete(ctx context.Context, baremetal *models.SHost, body jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, "Delete server failed")
+	self.SetStageFailed(ctx, jsonutils.NewString("Delete server failed"))
 }

--- a/pkg/compute/tasks/baremetal_unmaintenance_task.go
+++ b/pkg/compute/tasks/baremetal_unmaintenance_task.go
@@ -43,10 +43,9 @@ func (self *BaremetalUnmaintenanceTask) OnInit(ctx context.Context, obj db.IStan
 	_, err := baremetal.BaremetalSyncRequest(ctx, "POST", url, headers, self.Params)
 	if err != nil {
 		if len(action) > 0 {
-			msg := fmt.Sprintf("unmaintenance error %s", err.Error())
-			logclient.AddActionLogWithStartable(self, baremetal, action, msg, self.UserCred, false)
+			logclient.AddActionLogWithStartable(self, baremetal, action, err, self.UserCred, false)
 		}
-		self.SetStageFailed(ctx, err.Error())
+		self.SetStageFailed(ctx, jsonutils.Marshal(err))
 	} else {
 		if len(action) > 0 {
 			logclient.AddActionLogWithStartable(self, baremetal, action, "", self.UserCred, true)

--- a/pkg/compute/tasks/bucket_create_task.go
+++ b/pkg/compute/tasks/bucket_create_task.go
@@ -36,9 +36,9 @@ func init() {
 
 func (task *BucketCreateTask) taskFailed(ctx context.Context, bucket *models.SBucket, err error) {
 	bucket.SetStatus(task.UserCred, api.BUCKET_STATUS_CREATE_FAIL, err.Error())
-	db.OpsLog.LogEvent(bucket, db.ACT_ALLOCATE_FAIL, err.Error(), task.UserCred)
-	logclient.AddActionLogWithStartable(task, bucket, logclient.ACT_ALLOCATE, err.Error(), task.UserCred, false)
-	task.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(bucket, db.ACT_ALLOCATE_FAIL, err, task.UserCred)
+	logclient.AddActionLogWithStartable(task, bucket, logclient.ACT_ALLOCATE, err, task.UserCred, false)
+	task.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (task *BucketCreateTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {

--- a/pkg/compute/tasks/bucket_delete_task.go
+++ b/pkg/compute/tasks/bucket_delete_task.go
@@ -38,7 +38,7 @@ func (task *BucketDeleteTask) taskFailed(ctx context.Context, bucket *models.SBu
 	bucket.SetStatus(task.UserCred, api.VPC_STATUS_DELETE_FAILED, err.Error())
 	db.OpsLog.LogEvent(bucket, db.ACT_DELOCATE_FAIL, err.Error(), task.UserCred)
 	logclient.AddActionLogWithStartable(task, bucket, logclient.ACT_DELETE, err.Error(), task.UserCred, false)
-	task.SetStageFailed(ctx, err.Error())
+	task.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (task *BucketDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {

--- a/pkg/compute/tasks/bucket_syncstatus_task.go
+++ b/pkg/compute/tasks/bucket_syncstatus_task.go
@@ -38,7 +38,7 @@ func init() {
 
 func (self *BucketSyncstatusTask) taskFailed(ctx context.Context, bucket *models.SBucket, err error) {
 	bucket.SetStatus(self.GetUserCred(), api.BUCKET_STATUS_UNKNOWN, err.Error())
-	self.SetStageFailed(ctx, err.Error())
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 	db.OpsLog.LogEvent(bucket, db.ACT_SYNC_STATUS, bucket.GetShortDesc(ctx), self.GetUserCred())
 	logclient.AddActionLogWithContext(ctx, bucket, logclient.ACT_SYNC_STATUS, err, self.UserCred, false)
 }

--- a/pkg/compute/tasks/cloud_account_delete_task.go
+++ b/pkg/compute/tasks/cloud_account_delete_task.go
@@ -53,7 +53,7 @@ func (self *CloudAccountDeleteTask) OnInit(ctx context.Context, obj db.IStandalo
 		if err != nil {
 			// very unlikely
 			account.SetStatus(self.UserCred, api.CLOUD_PROVIDER_DELETE_FAILED, err.Error())
-			self.SetStageFailed(ctx, err.Error())
+			self.SetStageFailed(ctx, jsonutils.Marshal(err))
 			return
 		}
 	}
@@ -73,7 +73,7 @@ func (self *CloudAccountDeleteTask) OnAllCloudProviderDeleteCompleteFailed(ctx c
 	account := obj.(*models.SCloudaccount)
 
 	account.SetStatus(self.UserCred, api.CLOUD_PROVIDER_DELETE_FAILED, body.String())
-	self.SetStageFailed(ctx, body.String())
+	self.SetStageFailed(ctx, body)
 
 	logclient.AddActionLogWithStartable(self, account, logclient.ACT_DELETE, body, self.UserCred, false)
 }

--- a/pkg/compute/tasks/cloud_account_sync_skus_task.go
+++ b/pkg/compute/tasks/cloud_account_sync_skus_task.go
@@ -41,8 +41,8 @@ func init() {
 func (self *CloudAccountSyncSkusTask) taskFailed(ctx context.Context, account *models.SCloudaccount, err error) {
 	account.SetStatus(self.UserCred, api.CLOUD_PROVIDER_SYNC_STATUS_ERROR, err.Error())
 	db.OpsLog.LogEvent(account, db.ACT_SYNC_CLOUD_SKUS, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, account, logclient.ACT_CLOUD_SYNC, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	logclient.AddActionLogWithStartable(self, account, logclient.ACT_CLOUD_SYNC, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *CloudAccountSyncSkusTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {

--- a/pkg/compute/tasks/cloud_account_sync_task.go
+++ b/pkg/compute/tasks/cloud_account_sync_task.go
@@ -64,7 +64,7 @@ func (self *CloudAccountSyncInfoTask) OnInit(ctx context.Context, obj db.IStanda
 func (self *CloudAccountSyncInfoTask) OnCloudaccountSyncReadyFailed(ctx context.Context, obj db.IStandaloneModel, err jsonutils.JSONObject) {
 	cloudaccount := obj.(*models.SCloudaccount)
 	db.OpsLog.LogEvent(cloudaccount, db.ACT_SYNC_HOST_FAILED, err, self.UserCred)
-	self.SetStageFailed(ctx, err.String())
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 	logclient.AddActionLogWithStartable(self, cloudaccount, logclient.ACT_CLOUD_SYNC, err, self.UserCred, false)
 }
 
@@ -75,7 +75,7 @@ func (self *CloudAccountSyncInfoTask) OnCloudaccountSyncReady(ctx context.Contex
 	if err != nil {
 		cloudaccount.MarkEndSyncWithLock(ctx, self.UserCred)
 		db.OpsLog.LogEvent(cloudaccount, db.ACT_SYNC_HOST_FAILED, err, self.UserCred)
-		self.SetStageFailed(ctx, err.Error())
+		self.SetStageFailed(ctx, jsonutils.Marshal(err))
 		logclient.AddActionLogWithStartable(self, cloudaccount, logclient.ACT_CLOUD_SYNC, err, self.UserCred, false)
 		return
 	}
@@ -129,6 +129,6 @@ func (self *CloudAccountSyncInfoTask) OnCloudaccountSyncCompleteFailed(ctx conte
 	cloudaccount := obj.(*models.SCloudaccount)
 	cloudaccount.MarkEndSyncWithLock(ctx, self.UserCred)
 	db.OpsLog.LogEvent(cloudaccount, db.ACT_SYNC_HOST_FAILED, err, self.UserCred)
-	self.SetStageFailed(ctx, err.String())
+	self.SetStageFailed(ctx, err)
 	logclient.AddActionLogWithStartable(self, cloudaccount, logclient.ACT_CLOUD_SYNC, err, self.UserCred, false)
 }

--- a/pkg/compute/tasks/cloud_provider_delete_task.go
+++ b/pkg/compute/tasks/cloud_provider_delete_task.go
@@ -42,8 +42,8 @@ func (self *CloudProviderDeleteTask) OnInit(ctx context.Context, obj db.IStandal
 	err := provider.RealDelete(ctx, self.UserCred)
 	if err != nil {
 		provider.SetStatus(self.UserCred, api.CLOUD_PROVIDER_DELETE_FAILED, "StartDiskCloudproviderTask")
-		self.SetStageFailed(ctx, err.Error())
-		logclient.AddActionLogWithStartable(self, provider, logclient.ACT_DELETE, err.Error(), self.UserCred, false)
+		self.SetStageFailed(ctx, jsonutils.Marshal(err))
+		logclient.AddActionLogWithStartable(self, provider, logclient.ACT_DELETE, err, self.UserCred, false)
 		return
 	}
 

--- a/pkg/compute/tasks/cloud_provider_sync_info_task.go
+++ b/pkg/compute/tasks/cloud_provider_sync_info_task.go
@@ -58,11 +58,6 @@ func getAction(params *jsonutils.JSONDict) string {
 	return action
 }
 
-func taskFail(ctx context.Context, task *CloudProviderSyncInfoTask, provider *models.SCloudprovider, reason string) {
-	logclient.AddActionLogWithStartable(task, provider, getAction(task.Params), reason, task.UserCred, false)
-	task.SetStageFailed(ctx, reason)
-}
-
 func (self *CloudProviderSyncInfoTask) GetSyncRange() models.SSyncRange {
 	syncRange := models.SSyncRange{}
 	syncRangeJson, _ := self.Params.Get("sync_range")

--- a/pkg/compute/tasks/dbinstance_account_create_task.go
+++ b/pkg/compute/tasks/dbinstance_account_create_task.go
@@ -40,8 +40,8 @@ func init() {
 func (self *DBInstanceAccountCreateTask) taskFailed(ctx context.Context, account *models.SDBInstanceAccount, err error) {
 	account.SetStatus(self.UserCred, api.DBINSTANCE_USER_CREATE_FAILED, err.Error())
 	db.OpsLog.LogEvent(account, db.ACT_CREATE, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, account, logclient.ACT_CREATE, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	logclient.AddActionLogWithStartable(self, account, logclient.ACT_CREATE, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceAccountCreateTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_account_delete_task.go
+++ b/pkg/compute/tasks/dbinstance_account_delete_task.go
@@ -38,8 +38,8 @@ func init() {
 func (self *DBInstanceAccountDeleteTask) taskFailed(ctx context.Context, account *models.SDBInstanceAccount, err error) {
 	account.SetStatus(self.UserCred, api.DBINSTANCE_USER_DELETE_FAILED, err.Error())
 	db.OpsLog.LogEvent(account, db.ACT_DELETE, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, account, logclient.ACT_DELETE, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	logclient.AddActionLogWithStartable(self, account, logclient.ACT_DELETE, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceAccountDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_account_grant_privilege_task.go
+++ b/pkg/compute/tasks/dbinstance_account_grant_privilege_task.go
@@ -40,8 +40,8 @@ func init() {
 func (self *DBInstanceAccountGrantPrivilegeTask) taskFailed(ctx context.Context, account *models.SDBInstanceAccount, err error) {
 	account.SetStatus(self.UserCred, api.DBINSTANCE_USER_AVAILABLE, err.Error())
 	db.OpsLog.LogEvent(account, db.ACT_GRANT_PRIVILEGE, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, account, logclient.ACT_GRANT_PRIVILEGE, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	logclient.AddActionLogWithStartable(self, account, logclient.ACT_GRANT_PRIVILEGE, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceAccountGrantPrivilegeTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_account_reset_password_task.go
+++ b/pkg/compute/tasks/dbinstance_account_reset_password_task.go
@@ -37,9 +37,9 @@ func init() {
 
 func (self *DBInstanceAccountResetPasswordTask) taskFailed(ctx context.Context, account *models.SDBInstanceAccount, err error) {
 	account.SetStatus(self.UserCred, api.DBINSTANCE_USER_RESET_PASSWD_FAILED, err.Error())
-	db.OpsLog.LogEvent(account, db.ACT_RESET_PASSWORD, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, account, logclient.ACT_RESET_PASSWORD, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(account, db.ACT_RESET_PASSWORD, err, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, account, logclient.ACT_RESET_PASSWORD, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceAccountResetPasswordTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_account_revoke_privilege_task.go
+++ b/pkg/compute/tasks/dbinstance_account_revoke_privilege_task.go
@@ -39,9 +39,9 @@ func init() {
 
 func (self *DBInstanceAccountRevokePrivilegeTask) taskFailed(ctx context.Context, account *models.SDBInstanceAccount, err error) {
 	account.SetStatus(self.UserCred, api.DBINSTANCE_USER_AVAILABLE, err.Error())
-	db.OpsLog.LogEvent(account, db.ACT_REVOKE_PRIVILEGE, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, account, logclient.ACT_REVOKE_PRIVILEGE, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(account, db.ACT_REVOKE_PRIVILEGE, err, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, account, logclient.ACT_REVOKE_PRIVILEGE, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceAccountRevokePrivilegeTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_account_set_privileges_task.go
+++ b/pkg/compute/tasks/dbinstance_account_set_privileges_task.go
@@ -40,9 +40,9 @@ func init() {
 
 func (self *DBInstanceAccountSetPrivilegesTask) taskFailed(ctx context.Context, account *models.SDBInstanceAccount, err error) {
 	account.SetStatus(self.UserCred, api.DBINSTANCE_USER_AVAILABLE, err.Error())
-	db.OpsLog.LogEvent(account, db.ACT_SET_PRIVILEGES, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, account, logclient.ACT_SET_PRIVILEGES, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(account, db.ACT_SET_PRIVILEGES, err, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, account, logclient.ACT_SET_PRIVILEGES, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceAccountSetPrivilegesTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_backup_create_task.go
+++ b/pkg/compute/tasks/dbinstance_backup_create_task.go
@@ -38,13 +38,13 @@ func init() {
 
 func (self *DBInstanceBackupCreateTask) taskFailed(ctx context.Context, backup *models.SDBInstanceBackup, err error) {
 	backup.SetStatus(self.UserCred, api.DBINSTANCE_BACKUP_CREATE_FAILED, err.Error())
-	db.OpsLog.LogEvent(backup, db.ACT_CREATE, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, backup, logclient.ACT_CREATE, err.Error(), self.UserCred, false)
+	db.OpsLog.LogEvent(backup, db.ACT_CREATE, err, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, backup, logclient.ACT_CREATE, err, self.UserCred, false)
 	instance, _ := backup.GetDBInstance()
 	if instance != nil {
 		instance.SetStatus(self.UserCred, api.DBINSTANCE_BACKING_UP_FAILED, err.Error())
 	}
-	self.SetStageFailed(ctx, err.Error())
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceBackupCreateTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_backup_delete.go
+++ b/pkg/compute/tasks/dbinstance_backup_delete.go
@@ -38,9 +38,9 @@ func init() {
 
 func (self *DBInstanceBackupDeleteTask) taskFailed(ctx context.Context, backup *models.SDBInstanceBackup, err error) {
 	backup.SetStatus(self.UserCred, api.DBINSTANCE_BACKUP_DELETE_FAILED, err.Error())
-	db.OpsLog.LogEvent(backup, db.ACT_DELETE, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, backup, logclient.ACT_DELETE, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(backup, db.ACT_DELETE, err, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, backup, logclient.ACT_DELETE, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceBackupDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_backup_syncstatus_task.go
+++ b/pkg/compute/tasks/dbinstance_backup_syncstatus_task.go
@@ -38,7 +38,7 @@ func init() {
 
 func (self *DBInstanceBackupSyncstatusTask) taskFailed(ctx context.Context, backup *models.SDBInstanceBackup, err error) {
 	backup.SetStatus(self.GetUserCred(), api.DBINSTANCE_BACKUP_UNKNOWN, err.Error())
-	self.SetStageFailed(ctx, err.Error())
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 	db.OpsLog.LogEvent(backup, db.ACT_SYNC_STATUS, backup.GetShortDesc(ctx), self.GetUserCred())
 	logclient.AddActionLogWithContext(ctx, backup, logclient.ACT_SYNC_STATUS, err, self.UserCred, false)
 }

--- a/pkg/compute/tasks/dbinstance_change_config.go
+++ b/pkg/compute/tasks/dbinstance_change_config.go
@@ -37,9 +37,9 @@ func init() {
 
 func (self *DBInstanceChangeConfigTask) taskFailed(ctx context.Context, dbinstance *models.SDBInstance, err error) {
 	dbinstance.SetStatus(self.UserCred, api.DBINSTANCE_CHANGE_CONFIG_FAILED, err.Error())
-	db.OpsLog.LogEvent(dbinstance, db.ACT_CHANGE_CONFIG, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, dbinstance, logclient.ACT_CHANGE_CONFIG, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(dbinstance, db.ACT_CHANGE_CONFIG, err, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, dbinstance, logclient.ACT_CHANGE_CONFIG, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceChangeConfigTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
@@ -70,5 +70,5 @@ func (self *DBInstanceChangeConfigTask) OnSyncDBInstanceStatusComplete(ctx conte
 }
 
 func (self *DBInstanceChangeConfigTask) OnSyncDBInstanceStatusCompleteFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }

--- a/pkg/compute/tasks/dbinstance_create_task.go
+++ b/pkg/compute/tasks/dbinstance_create_task.go
@@ -38,9 +38,9 @@ func init() {
 
 func (self *DBInstanceCreateTask) taskFailed(ctx context.Context, dbinstance *models.SDBInstance, err error) {
 	dbinstance.SetStatus(self.UserCred, api.DBINSTANCE_CREATE_FAILED, err.Error())
-	db.OpsLog.LogEvent(dbinstance, db.ACT_CREATE, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, dbinstance, logclient.ACT_CREATE, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(dbinstance, db.ACT_CREATE, err, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, dbinstance, logclient.ACT_CREATE, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceCreateTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
@@ -105,5 +105,5 @@ func (self *DBInstanceCreateTask) OnSyncDBInstanceStatusComplete(ctx context.Con
 }
 
 func (self *DBInstanceCreateTask) OnSyncDBInstanceStatusCompleteFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }

--- a/pkg/compute/tasks/dbinstance_database_create_task.go
+++ b/pkg/compute/tasks/dbinstance_database_create_task.go
@@ -39,9 +39,9 @@ func init() {
 
 func (self *DBInstanceDatabaseCreateTask) taskFailed(ctx context.Context, database *models.SDBInstanceDatabase, err error) {
 	database.SetStatus(self.UserCred, api.DBINSTANCE_DATABASE_CREATE_FAILE, err.Error())
-	db.OpsLog.LogEvent(database, db.ACT_CREATE, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, database, logclient.ACT_CREATE, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(database, db.ACT_CREATE, err, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, database, logclient.ACT_CREATE, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceDatabaseCreateTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_database_delete_task.go
+++ b/pkg/compute/tasks/dbinstance_database_delete_task.go
@@ -37,9 +37,9 @@ func init() {
 
 func (self *DBInstanceDatabaseDeleteTask) taskFailed(ctx context.Context, database *models.SDBInstanceDatabase, err error) {
 	database.SetStatus(self.UserCred, api.DBINSTANCE_DATABASE_DELETE_FAILED, err.Error())
-	db.OpsLog.LogEvent(database, db.ACT_DELETE, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, database, logclient.ACT_DELETE, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(database, db.ACT_DELETE, err, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, database, logclient.ACT_DELETE, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceDatabaseDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_delete_task.go
+++ b/pkg/compute/tasks/dbinstance_delete_task.go
@@ -38,9 +38,9 @@ func init() {
 
 func (self *DBInstanceDeleteTask) taskFailed(ctx context.Context, dbinstance *models.SDBInstance, err error) {
 	dbinstance.SetStatus(self.UserCred, api.DBINSTANCE_DELETE_FAILED, err.Error())
-	db.OpsLog.LogEvent(dbinstance, db.ACT_DELETE, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, dbinstance, logclient.ACT_DELETE, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(dbinstance, db.ACT_DELETE, err, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, dbinstance, logclient.ACT_DELETE, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_public_connection_task.go
+++ b/pkg/compute/tasks/dbinstance_public_connection_task.go
@@ -47,8 +47,8 @@ func (self *DBInstancePublicConnectionTask) getAction() string {
 
 func (self *DBInstancePublicConnectionTask) taskFailed(ctx context.Context, dbinstance *models.SDBInstance, err error) {
 	dbinstance.SetStatus(self.UserCred, api.DBINSTANCE_FAILE, err.Error())
-	logclient.AddActionLogWithStartable(self, dbinstance, self.getAction(), err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	logclient.AddActionLogWithStartable(self, dbinstance, self.getAction(), err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstancePublicConnectionTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_reboot_task.go
+++ b/pkg/compute/tasks/dbinstance_reboot_task.go
@@ -39,9 +39,9 @@ func init() {
 
 func (self *DBInstanceRebootTask) taskFailed(ctx context.Context, dbinstance *models.SDBInstance, err error) {
 	dbinstance.SetStatus(self.UserCred, api.DBINSTANCE_REBOOT_FAILED, err.Error())
-	db.OpsLog.LogEvent(dbinstance, db.ACT_REBOOT, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, dbinstance, logclient.ACT_REBOOT, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(dbinstance, db.ACT_REBOOT, err, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, dbinstance, logclient.ACT_REBOOT, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceRebootTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_recovery_task.go
+++ b/pkg/compute/tasks/dbinstance_recovery_task.go
@@ -39,9 +39,9 @@ func init() {
 
 func (self *DBInstanceRecoveryTask) taskFailed(ctx context.Context, instance *models.SDBInstance, err error) {
 	instance.SetStatus(self.UserCred, api.DBINSTANCE_RESTORE_FAILED, err.Error())
-	db.OpsLog.LogEvent(instance, db.ACT_RESTORE, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, instance, logclient.ACT_RESTORE, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(instance, db.ACT_RESTORE, err, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, instance, logclient.ACT_RESTORE, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceRecoveryTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_renew_task.go
+++ b/pkg/compute/tasks/dbinstance_renew_task.go
@@ -45,12 +45,12 @@ func (self *DBInstanceRenewTask) OnInit(ctx context.Context, obj db.IStandaloneM
 
 	exp, err := instance.GetRegion().GetDriver().RequestRenewDBInstance(instance, bc)
 	if err != nil {
-		msg := fmt.Sprintf("RequestRenewDBInstance failed %s", err)
-		log.Errorf(msg)
-		db.OpsLog.LogEvent(instance, db.ACT_REW_FAIL, msg, self.UserCred)
-		logclient.AddActionLogWithStartable(self, instance, logclient.ACT_RENEW, msg, self.UserCred, false)
-		instance.SetStatus(self.GetUserCred(), api.DBINSTANCE_RENEW_FAILED, msg)
-		self.SetStageFailed(ctx, msg)
+		// msg := fmt.Sprintf("RequestRenewDBInstance failed %s", err)
+		// log.Errorf(msg)
+		db.OpsLog.LogEvent(instance, db.ACT_REW_FAIL, err, self.UserCred)
+		logclient.AddActionLogWithStartable(self, instance, logclient.ACT_RENEW, err, self.UserCred, false)
+		instance.SetStatus(self.GetUserCred(), api.DBINSTANCE_RENEW_FAILED, err.Error())
+		self.SetStageFailed(ctx, jsonutils.Marshal(err))
 		return
 	}
 
@@ -58,7 +58,7 @@ func (self *DBInstanceRenewTask) OnInit(ctx context.Context, obj db.IStandaloneM
 	if err != nil {
 		msg := fmt.Sprintf("SaveRenewInfo fail %s", err)
 		log.Errorf(msg)
-		self.SetStageFailed(ctx, msg)
+		self.SetStageFailed(ctx, jsonutils.NewString(msg))
 		return
 	}
 

--- a/pkg/compute/tasks/dbinstance_sync_status_task.go
+++ b/pkg/compute/tasks/dbinstance_sync_status_task.go
@@ -37,9 +37,9 @@ func init() {
 
 func (self *DBInstanceSyncStatusTask) taskFailed(ctx context.Context, dbinstance *models.SDBInstance, err error) {
 	dbinstance.SetStatus(self.UserCred, api.DBINSTANCE_UNKNOWN, err.Error())
-	db.OpsLog.LogEvent(dbinstance, db.ACT_SYNC_STATUS, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, dbinstance, logclient.ACT_SYNC_STATUS, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(dbinstance, db.ACT_SYNC_STATUS, err, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, dbinstance, logclient.ACT_SYNC_STATUS, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceSyncStatusTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/dbinstance_sync_task.go
+++ b/pkg/compute/tasks/dbinstance_sync_task.go
@@ -37,9 +37,9 @@ func init() {
 
 func (self *DBInstanceSyncTask) taskFailed(ctx context.Context, dbinstance *models.SDBInstance, err error) {
 	dbinstance.SetStatus(self.UserCred, api.DBINSTANCE_UNKNOWN, err.Error())
-	db.OpsLog.LogEvent(dbinstance, db.ACT_SYNC_CONF, err.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, dbinstance, logclient.ACT_SYNC_CONF, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	db.OpsLog.LogEvent(dbinstance, db.ACT_SYNC_CONF, err, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, dbinstance, logclient.ACT_SYNC_CONF, err, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }
 
 func (self *DBInstanceSyncTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/disk_base_task.go
+++ b/pkg/compute/tasks/disk_base_task.go
@@ -17,6 +17,8 @@ package tasks
 import (
 	"context"
 
+	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/quotas"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/compute/models"
@@ -31,7 +33,7 @@ func (self *SDiskBaseTask) getDisk() *models.SDisk {
 	return obj.(*models.SDisk)
 }
 
-func (self *SDiskBaseTask) SetStageFailed(ctx context.Context, reason string) {
+func (self *SDiskBaseTask) SetStageFailed(ctx context.Context, reason jsonutils.JSONObject) {
 	self.finalReleasePendingUsage(ctx)
 	self.STask.SetStageFailed(ctx, reason)
 }

--- a/pkg/compute/tasks/disk_batch_create_task.go
+++ b/pkg/compute/tasks/disk_batch_create_task.go
@@ -103,7 +103,7 @@ func (self *DiskBatchCreateTask) GetFirstDisk() (*api.DiskConfig, error) {
 	return disks[0], nil
 }
 
-func (self *DiskBatchCreateTask) OnScheduleFailCallback(ctx context.Context, obj IScheduleModel, reason string) {
+func (self *DiskBatchCreateTask) OnScheduleFailCallback(ctx context.Context, obj IScheduleModel, reason jsonutils.JSONObject) {
 	self.SSchedTask.OnScheduleFailCallback(ctx, obj, reason)
 	disk := obj.(*models.SDisk)
 	log.Errorf("Schedule disk %s failed", disk.Name)
@@ -127,7 +127,7 @@ func (self *DiskBatchCreateTask) SaveScheduleResult(ctx context.Context, obj ISc
 	onError := func(err error) {
 		self.clearPendingUsage(ctx, disk)
 		disk.SetStatus(self.UserCred, api.DISK_ALLOC_FAILED, err.Error())
-		self.SetStageFailed(ctx, err.Error())
+		self.SetStageFailed(ctx, jsonutils.Marshal(err))
 		db.OpsLog.LogEvent(disk, db.ACT_ALLOCATE_FAIL, err, self.UserCred)
 		notifyclient.NotifySystemError(disk.Id, disk.Name, api.DISK_ALLOC_FAILED, err.Error())
 	}

--- a/pkg/compute/tasks/disk_create_task.go
+++ b/pkg/compute/tasks/disk_create_task.go
@@ -71,7 +71,7 @@ func (self *DiskCreateTask) OnStorageCacheImageComplete(ctx context.Context, dis
 func (self *DiskCreateTask) OnStartAllocateFailed(ctx context.Context, disk *models.SDisk, data jsonutils.JSONObject) {
 	disk.SetStatus(self.UserCred, api.DISK_ALLOC_FAILED, data.String())
 	logclient.AddActionLogWithStartable(self, disk, logclient.ACT_ALLOCATE, data, self.UserCred, false)
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }
 
 func (self *DiskCreateTask) OnDiskReady(ctx context.Context, disk *models.SDisk, data jsonutils.JSONObject) {
@@ -106,7 +106,7 @@ func (self *DiskCreateTask) OnDiskReady(ctx context.Context, disk *models.SDisk,
 func (self *DiskCreateTask) OnDiskReadyFailed(ctx context.Context, disk *models.SDisk, data jsonutils.JSONObject) {
 	disk.SetStatus(self.UserCred, api.DISK_ALLOC_FAILED, data.String())
 	logclient.AddActionLogWithStartable(self, disk, logclient.ACT_ALLOCATE, data, self.UserCred, false)
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }
 
 func init() {

--- a/pkg/compute/tasks/disk_delete_task.go
+++ b/pkg/compute/tasks/disk_delete_task.go
@@ -44,13 +44,13 @@ func (self *DiskDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneModel,
 	cnt, err := disk.GetGuestDiskCount()
 	if err != nil {
 		reason := "Disk GetGuestDiskCount fail: " + err.Error()
-		self.SetStageFailed(ctx, reason)
+		self.SetStageFailed(ctx, jsonutils.NewString(reason))
 		db.OpsLog.LogEvent(disk, db.ACT_DELOCATE_FAIL, reason, self.UserCred)
 		return
 	}
 	if cnt > 0 {
 		reason := "Disk has been attached to server"
-		self.SetStageFailed(ctx, reason)
+		self.SetStageFailed(ctx, jsonutils.NewString(reason))
 		db.OpsLog.LogEvent(disk, db.ACT_DELOCATE_FAIL, reason, self.UserCred)
 		return
 	}
@@ -179,7 +179,7 @@ func (self *DiskDeleteTask) OnGuestDiskDeleteComplete(ctx context.Context, obj d
 
 func (self *DiskDeleteTask) OnGuestDiskDeleteCompleteFailed(ctx context.Context, disk *models.SDisk, reason jsonutils.JSONObject) {
 	disk.SetStatus(self.GetUserCred(), api.DISK_DEALLOC_FAILED, reason.String())
-	self.SetStageFailed(ctx, reason.String())
+	self.SetStageFailed(ctx, reason)
 	db.OpsLog.LogEvent(disk, db.ACT_DELOCATE_FAIL, disk.GetShortDesc(ctx), self.GetUserCred())
 	logclient.AddActionLogWithContext(ctx, disk, logclient.ACT_DELOCATE, reason, self.UserCred, false)
 }

--- a/pkg/compute/tasks/disk_resize_task.go
+++ b/pkg/compute/tasks/disk_resize_task.go
@@ -60,7 +60,7 @@ func (self *DiskResizeTask) OnInit(ctx context.Context, obj db.IStandaloneModel,
 	reason := "Cannot find host for disk"
 	if host == nil || host.HostStatus != api.HOST_ONLINE {
 		self.SetDiskReady(ctx, disk, self.GetUserCred(), reason)
-		self.SetStageFailed(ctx, reason)
+		self.SetStageFailed(ctx, jsonutils.NewString(reason))
 		db.OpsLog.LogEvent(disk, db.ACT_RESIZE_FAIL, reason, self.GetUserCred())
 		logclient.AddActionLogWithStartable(self, disk, logclient.ACT_RESIZE, reason, self.UserCred, false)
 		return
@@ -88,9 +88,9 @@ func (self *DiskResizeTask) OnStartResizeDiskSucc(ctx context.Context, disk *mod
 
 func (self *DiskResizeTask) OnStartResizeDiskFailed(ctx context.Context, disk *models.SDisk, reason error) {
 	self.SetDiskReady(ctx, disk, self.GetUserCred(), reason.Error())
-	self.SetStageFailed(ctx, reason.Error())
-	db.OpsLog.LogEvent(disk, db.ACT_RESIZE_FAIL, reason.Error(), self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, disk, logclient.ACT_RESIZE, reason.Error(), self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.Marshal(reason))
+	db.OpsLog.LogEvent(disk, db.ACT_RESIZE_FAIL, reason, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, disk, logclient.ACT_RESIZE, reason, self.UserCred, false)
 }
 
 func (self *DiskResizeTask) OnDiskResizeComplete(ctx context.Context, disk *models.SDisk, data jsonutils.JSONObject) {
@@ -150,6 +150,6 @@ func (self *DiskResizeTask) OnDiskResized(ctx context.Context, disk *models.SDis
 func (self *DiskResizeTask) OnDiskResizeCompleteFailed(ctx context.Context, disk *models.SDisk, data jsonutils.JSONObject) {
 	self.SetDiskReady(ctx, disk, self.GetUserCred(), data.String())
 	db.OpsLog.LogEvent(disk, db.ACT_RESIZE_FAIL, disk.GetShortDesc(ctx), self.UserCred)
-	logclient.AddActionLogWithStartable(self, disk, logclient.ACT_RESIZE, data.String(), self.UserCred, false)
-	self.SetStageFailed(ctx, data.String())
+	logclient.AddActionLogWithStartable(self, disk, logclient.ACT_RESIZE, data, self.UserCred, false)
+	self.SetStageFailed(ctx, data)
 }

--- a/pkg/compute/tasks/disk_syncstatus_task.go
+++ b/pkg/compute/tasks/disk_syncstatus_task.go
@@ -38,7 +38,7 @@ func init() {
 
 func (self *DiskSyncstatusTask) taskFailed(ctx context.Context, disk *models.SDisk, err error) {
 	disk.SetStatus(self.GetUserCred(), api.DISK_UNKNOWN, err.Error())
-	self.SetStageFailed(ctx, err.Error())
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 	db.OpsLog.LogEvent(disk, db.ACT_SYNC_STATUS, disk.GetShortDesc(ctx), self.GetUserCred())
 	logclient.AddActionLogWithContext(ctx, disk, logclient.ACT_SYNC_STATUS, err, self.UserCred, false)
 }

--- a/pkg/compute/tasks/eip_change_bandwidth_task.go
+++ b/pkg/compute/tasks/eip_change_bandwidth_task.go
@@ -35,8 +35,8 @@ func init() {
 	taskman.RegisterTask(EipChangeBandwidthTask{})
 }
 
-func (self *EipChangeBandwidthTask) TaskFail(ctx context.Context, eip *models.SElasticip, msg string) {
-	eip.SetStatus(self.UserCred, api.EIP_STATUS_READY, msg)
+func (self *EipChangeBandwidthTask) TaskFail(ctx context.Context, eip *models.SElasticip, msg jsonutils.JSONObject) {
+	eip.SetStatus(self.UserCred, api.EIP_STATUS_READY, msg.String())
 	db.OpsLog.LogEvent(eip, db.ACT_CHANGE_BANDWIDTH, msg, self.GetUserCred())
 	logclient.AddActionLogWithStartable(self, eip, logclient.ACT_CHANGE_BANDWIDTH, msg, self.UserCred, false)
 	self.SetStageFailed(ctx, msg)
@@ -47,7 +47,7 @@ func (self *EipChangeBandwidthTask) OnInit(ctx context.Context, obj db.IStandalo
 	bandwidth, _ := self.Params.Int("bandwidth")
 	if bandwidth <= 0 {
 		msg := fmt.Sprintf("invalid bandwidth %d", bandwidth)
-		self.TaskFail(ctx, eip, msg)
+		self.TaskFail(ctx, eip, jsonutils.NewString(msg))
 		return
 	}
 
@@ -55,7 +55,7 @@ func (self *EipChangeBandwidthTask) OnInit(ctx context.Context, obj db.IStandalo
 		extEip, err := eip.GetIEip()
 		if err != nil {
 			msg := fmt.Sprintf("fail to find iEip %s", err)
-			self.TaskFail(ctx, eip, msg)
+			self.TaskFail(ctx, eip, jsonutils.NewString(msg))
 			return
 		}
 
@@ -63,7 +63,7 @@ func (self *EipChangeBandwidthTask) OnInit(ctx context.Context, obj db.IStandalo
 
 		if err != nil {
 			msg := fmt.Sprintf("fail to find iEip %s", err)
-			self.TaskFail(ctx, eip, msg)
+			self.TaskFail(ctx, eip, jsonutils.NewString(msg))
 			return
 		}
 
@@ -71,7 +71,7 @@ func (self *EipChangeBandwidthTask) OnInit(ctx context.Context, obj db.IStandalo
 
 	if err := eip.DoChangeBandwidth(self.UserCred, int(bandwidth)); err != nil {
 		msg := fmt.Sprintf("fail to synchronize iEip bandwidth %s", err)
-		self.TaskFail(ctx, eip, msg)
+		self.TaskFail(ctx, eip, jsonutils.NewString(msg))
 		return
 	}
 	logclient.AddActionLogWithStartable(self, eip, logclient.ACT_CHANGE_BANDWIDTH, nil, self.UserCred, true)

--- a/pkg/compute/tasks/eip_deallocate_task.go
+++ b/pkg/compute/tasks/eip_deallocate_task.go
@@ -37,8 +37,8 @@ func init() {
 	taskman.RegisterTask(EipDeallocateTask{})
 }
 
-func (self *EipDeallocateTask) taskFail(ctx context.Context, eip *models.SElasticip, msg string) {
-	eip.SetStatus(self.UserCred, api.EIP_STATUS_DEALLOCATE_FAIL, msg)
+func (self *EipDeallocateTask) taskFail(ctx context.Context, eip *models.SElasticip, msg jsonutils.JSONObject) {
+	eip.SetStatus(self.UserCred, api.EIP_STATUS_DEALLOCATE_FAIL, msg.String())
 	db.OpsLog.LogEvent(eip, db.ACT_DELOCATE, msg, self.GetUserCred())
 	logclient.AddActionLogWithStartable(self, eip, logclient.ACT_DELETE, msg, self.UserCred, false)
 	self.SetStageFailed(ctx, msg)
@@ -53,14 +53,14 @@ func (self *EipDeallocateTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 		if err != nil {
 			if errors.Cause(err) != cloudprovider.ErrNotFound && errors.Cause(err) != cloudprovider.ErrInvalidProvider {
 				msg := fmt.Sprintf("fail to find iEIP for eip %s", err)
-				self.taskFail(ctx, eip, msg)
+				self.taskFail(ctx, eip, jsonutils.NewString(msg))
 				return
 			}
 		} else {
 			err = expEip.Delete()
 			if err != nil {
 				msg := fmt.Sprintf("fail to delete iEIP %s", err)
-				self.taskFail(ctx, eip, msg)
+				self.taskFail(ctx, eip, jsonutils.NewString(msg))
 				return
 			}
 		}
@@ -73,7 +73,7 @@ func (self *EipDeallocateTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 	err := eip.RealDelete(ctx, self.UserCred)
 	if err != nil {
 		msg := fmt.Sprintf("fail to delete EIP %s", err)
-		self.taskFail(ctx, eip, msg)
+		self.taskFail(ctx, eip, jsonutils.NewString(msg))
 		return
 	}
 

--- a/pkg/compute/tasks/eip_syncstatus_task.go
+++ b/pkg/compute/tasks/eip_syncstatus_task.go
@@ -35,8 +35,8 @@ func init() {
 	taskman.RegisterTask(EipSyncstatusTask{})
 }
 
-func (self *EipSyncstatusTask) taskFail(ctx context.Context, eip *models.SElasticip, msg string) {
-	eip.SetStatus(self.UserCred, api.EIP_STATUS_UNKNOWN, msg)
+func (self *EipSyncstatusTask) taskFail(ctx context.Context, eip *models.SElasticip, msg jsonutils.JSONObject) {
+	eip.SetStatus(self.UserCred, api.EIP_STATUS_UNKNOWN, msg.String())
 	db.OpsLog.LogEvent(eip, db.ACT_SYNC_STATUS, msg, self.GetUserCred())
 	logclient.AddActionLogWithStartable(self, eip, logclient.ACT_SYNC_STATUS, msg, self.UserCred, false)
 	self.SetStageFailed(ctx, msg)
@@ -48,28 +48,28 @@ func (self *EipSyncstatusTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 	extEip, err := eip.GetIEip()
 	if err != nil {
 		msg := fmt.Sprintf("fail to find ieip for eip %s", err)
-		self.taskFail(ctx, eip, msg)
+		self.taskFail(ctx, eip, jsonutils.NewString(msg))
 		return
 	}
 
 	err = extEip.Refresh()
 	if err != nil {
 		msg := fmt.Sprintf("fail to refresh eip status %s", err)
-		self.taskFail(ctx, eip, msg)
+		self.taskFail(ctx, eip, jsonutils.NewString(msg))
 		return
 	}
 
 	err = eip.SyncWithCloudEip(ctx, self.UserCred, eip.GetCloudprovider(), extEip, nil)
 	if err != nil {
 		msg := fmt.Sprintf("fail to sync eip status %s", err)
-		self.taskFail(ctx, eip, msg)
+		self.taskFail(ctx, eip, jsonutils.NewString(msg))
 		return
 	}
 
 	err = eip.SyncInstanceWithCloudEip(ctx, self.UserCred, extEip)
 	if err != nil {
 		msg := fmt.Sprintf("fail to sync eip status %s", err)
-		self.taskFail(ctx, eip, msg)
+		self.taskFail(ctx, eip, jsonutils.NewString(msg))
 		return
 	}
 

--- a/pkg/compute/tasks/elasticcache_account_delete_task.go
+++ b/pkg/compute/tasks/elasticcache_account_delete_task.go
@@ -36,11 +36,11 @@ func init() {
 	taskman.RegisterTask(ElasticcacheAccountDeleteTask{})
 }
 
-func (self *ElasticcacheAccountDeleteTask) taskFail(ctx context.Context, ea *models.SElasticcacheAccount, reason string) {
-	ea.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_ACCOUNT_STATUS_DELETE_FAILED, reason)
+func (self *ElasticcacheAccountDeleteTask) taskFail(ctx context.Context, ea *models.SElasticcacheAccount, reason jsonutils.JSONObject) {
+	ea.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_ACCOUNT_STATUS_DELETE_FAILED, reason.String())
 	db.OpsLog.LogEvent(ea, db.ACT_DELETE_FAIL, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, ea, logclient.ACT_DELETE, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(ea.Id, ea.Name, api.ELASTIC_CACHE_ACCOUNT_STATUS_DELETE_FAILED, reason)
+	notifyclient.NotifySystemError(ea.Id, ea.Name, api.ELASTIC_CACHE_ACCOUNT_STATUS_DELETE_FAILED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -48,18 +48,18 @@ func (self *ElasticcacheAccountDeleteTask) OnInit(ctx context.Context, obj db.IS
 	ea := obj.(*models.SElasticcacheAccount)
 	region := ea.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, ea, fmt.Sprintf("failed to find region for elastic cache account %s", ea.GetName()))
+		self.taskFail(ctx, ea, jsonutils.NewString(fmt.Sprintf("failed to find region for elastic cache account %s", ea.GetName())))
 		return
 	}
 
 	self.SetStage("OnElasticcacheAccountDeleteComplete", nil)
 	if err := region.GetDriver().RequestDeleteElasticcacheAccount(ctx, self.GetUserCred(), ea, self); err != nil {
-		self.taskFail(ctx, ea, err.Error())
+		self.taskFail(ctx, ea, jsonutils.Marshal(err))
 		return
 	} else {
 		err = db.DeleteModel(ctx, self.GetUserCred(), ea)
 		if err != nil {
-			self.taskFail(ctx, ea, err.Error())
+			self.taskFail(ctx, ea, jsonutils.NewString(err.Error()))
 			return
 		}
 

--- a/pkg/compute/tasks/elasticcache_account_reset_password_task.go
+++ b/pkg/compute/tasks/elasticcache_account_reset_password_task.go
@@ -36,15 +36,15 @@ func init() {
 	taskman.RegisterTask(ElasticcacheAccountResetPasswordTask{})
 }
 
-func (self *ElasticcacheAccountResetPasswordTask) taskFail(ctx context.Context, ea *models.SElasticcacheAccount, reason string) {
-	ea.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason)
+func (self *ElasticcacheAccountResetPasswordTask) taskFail(ctx context.Context, ea *models.SElasticcacheAccount, reason jsonutils.JSONObject) {
+	ea.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason.String())
 	ec, err := db.FetchById(models.ElasticcacheManager, ea.ElasticcacheId)
 	if err == nil {
-		ec.(*models.SElasticcache).SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason)
+		ec.(*models.SElasticcache).SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason.String())
 	}
 	db.OpsLog.LogEvent(ea, db.ACT_RESET_PASSWORD, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, ea, logclient.ACT_RESET_PASSWORD, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(ea.Id, ea.Name, api.ELASTIC_CACHE_STATUS_CREATE_FAILED, reason)
+	notifyclient.NotifySystemError(ea.Id, ea.Name, api.ELASTIC_CACHE_STATUS_CREATE_FAILED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -52,13 +52,13 @@ func (self *ElasticcacheAccountResetPasswordTask) OnInit(ctx context.Context, ob
 	ea := obj.(*models.SElasticcacheAccount)
 	region := ea.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, ea, fmt.Sprintf("failed to find region for elastic cache account %s", ea.GetName()))
+		self.taskFail(ctx, ea, jsonutils.NewString(fmt.Sprintf("failed to find region for elastic cache account %s", ea.GetName())))
 		return
 	}
 
 	self.SetStage("OnElasticcacheAccountResetPasswordComplete", nil)
 	if err := region.GetDriver().RequestElasticcacheAccountResetPassword(ctx, self.GetUserCred(), ea, self); err != nil {
-		self.taskFail(ctx, ea, err.Error())
+		self.taskFail(ctx, ea, jsonutils.Marshal(err))
 		return
 	} else {
 		logclient.AddActionLogWithStartable(self, ea, logclient.ACT_RESET_PASSWORD, nil, self.UserCred, true)

--- a/pkg/compute/tasks/elasticcache_acl_create_task.go
+++ b/pkg/compute/tasks/elasticcache_acl_create_task.go
@@ -36,11 +36,11 @@ func init() {
 	taskman.RegisterTask(ElasticcacheAclCreateTask{})
 }
 
-func (self *ElasticcacheAclCreateTask) taskFail(ctx context.Context, ea *models.SElasticcacheAcl, reason string) {
-	ea.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_ACL_STATUS_CREATE_FAILED, reason)
+func (self *ElasticcacheAclCreateTask) taskFail(ctx context.Context, ea *models.SElasticcacheAcl, reason jsonutils.JSONObject) {
+	ea.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_ACL_STATUS_CREATE_FAILED, reason.String())
 	db.OpsLog.LogEvent(ea, db.ACT_ALLOCATE_FAIL, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, ea, logclient.ACT_CREATE, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(ea.Id, ea.Name, api.ELASTIC_CACHE_ACL_STATUS_CREATE_FAILED, reason)
+	notifyclient.NotifySystemError(ea.Id, ea.Name, api.ELASTIC_CACHE_ACL_STATUS_CREATE_FAILED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -48,13 +48,13 @@ func (self *ElasticcacheAclCreateTask) OnInit(ctx context.Context, obj db.IStand
 	ea := obj.(*models.SElasticcacheAcl)
 	region := ea.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, ea, fmt.Sprintf("failed to find region for elastic cache backup %s", ea.GetName()))
+		self.taskFail(ctx, ea, jsonutils.NewString(fmt.Sprintf("failed to find region for elastic cache backup %s", ea.GetName())))
 		return
 	}
 
 	self.SetStage("OnElasticcacheAclCreateComplete", nil)
 	if err := region.GetDriver().RequestCreateElasticcacheAcl(ctx, self.GetUserCred(), ea, self); err != nil {
-		self.taskFail(ctx, ea, err.Error())
+		self.taskFail(ctx, ea, jsonutils.Marshal(err))
 		return
 	}
 }
@@ -65,5 +65,5 @@ func (self *ElasticcacheAclCreateTask) OnElasticcacheAclCreateComplete(ctx conte
 }
 
 func (self *ElasticcacheAclCreateTask) OnElasticcacheAclCreateCompleteFailed(ctx context.Context, ea *models.SElasticcacheAcl, data jsonutils.JSONObject) {
-	self.taskFail(ctx, ea, data.String())
+	self.taskFail(ctx, ea, data)
 }

--- a/pkg/compute/tasks/elasticcache_backup_restore_instance_task.go
+++ b/pkg/compute/tasks/elasticcache_backup_restore_instance_task.go
@@ -36,11 +36,11 @@ func init() {
 	taskman.RegisterTask(ElasticcacheBackupRestoreInstanceTask{})
 }
 
-func (self *ElasticcacheBackupRestoreInstanceTask) taskFail(ctx context.Context, eb *models.SElasticcacheBackup, reason string) {
-	eb.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CREATE_FAILED, reason)
+func (self *ElasticcacheBackupRestoreInstanceTask) taskFail(ctx context.Context, eb *models.SElasticcacheBackup, reason jsonutils.JSONObject) {
+	eb.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CREATE_FAILED, reason.String())
 	db.OpsLog.LogEvent(eb, db.ACT_CONVERT_FAIL, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, eb, logclient.ACT_RESTORE, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(eb.Id, eb.Name, api.ELASTIC_CACHE_STATUS_CREATE_FAILED, reason)
+	notifyclient.NotifySystemError(eb.Id, eb.Name, api.ELASTIC_CACHE_STATUS_CREATE_FAILED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -48,13 +48,13 @@ func (self *ElasticcacheBackupRestoreInstanceTask) OnInit(ctx context.Context, o
 	eb := obj.(*models.SElasticcacheBackup)
 	region := eb.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, eb, fmt.Sprintf("failed to find region for elastic cache backup %s", eb.GetName()))
+		self.taskFail(ctx, eb, jsonutils.NewString(fmt.Sprintf("failed to find region for elastic cache backup %s", eb.GetName())))
 		return
 	}
 
 	self.SetStage("OnElasticcacheBackupRestoreInstanceComplete", nil)
 	if err := region.GetDriver().RequestElasticcacheBackupRestoreInstance(ctx, self.GetUserCred(), eb, self); err != nil {
-		self.OnElasticcacheBackupRestoreInstanceCompleteFailed(ctx, eb, err.Error())
+		self.OnElasticcacheBackupRestoreInstanceCompleteFailed(ctx, eb, jsonutils.Marshal(err))
 		return
 	}
 
@@ -68,6 +68,6 @@ func (self *ElasticcacheBackupRestoreInstanceTask) OnElasticcacheBackupRestoreIn
 	self.SetStageComplete(ctx, nil)
 }
 
-func (self *ElasticcacheBackupRestoreInstanceTask) OnElasticcacheBackupRestoreInstanceCompleteFailed(ctx context.Context, eb *models.SElasticcacheBackup, reason string) {
+func (self *ElasticcacheBackupRestoreInstanceTask) OnElasticcacheBackupRestoreInstanceCompleteFailed(ctx context.Context, eb *models.SElasticcacheBackup, reason jsonutils.JSONObject) {
 	self.taskFail(ctx, eb, reason)
 }

--- a/pkg/compute/tasks/elasticcache_create_task.go
+++ b/pkg/compute/tasks/elasticcache_create_task.go
@@ -36,11 +36,11 @@ func init() {
 	taskman.RegisterTask(ElasticcacheCreateTask{})
 }
 
-func (self *ElasticcacheCreateTask) taskFail(ctx context.Context, elasticcache *models.SElasticcache, reason string) {
-	elasticcache.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CREATE_FAILED, reason)
+func (self *ElasticcacheCreateTask) taskFail(ctx context.Context, elasticcache *models.SElasticcache, reason jsonutils.JSONObject) {
+	elasticcache.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CREATE_FAILED, reason.String())
 	db.OpsLog.LogEvent(elasticcache, db.ACT_ALLOCATE_FAIL, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, elasticcache, logclient.ACT_CREATE, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(elasticcache.Id, elasticcache.Name, api.ELASTIC_CACHE_STATUS_CREATE_FAILED, reason)
+	notifyclient.NotifySystemError(elasticcache.Id, elasticcache.Name, api.ELASTIC_CACHE_STATUS_CREATE_FAILED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -48,7 +48,7 @@ func (self *ElasticcacheCreateTask) OnInit(ctx context.Context, obj db.IStandalo
 	elasticcache := obj.(*models.SElasticcache)
 	region := elasticcache.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, elasticcache, fmt.Sprintf("failed to find region for elastic cache %s", elasticcache.GetName()))
+		self.taskFail(ctx, elasticcache, jsonutils.NewString(fmt.Sprintf("failed to find region for elastic cache %s", elasticcache.GetName())))
 		return
 	}
 
@@ -61,7 +61,7 @@ func (self *ElasticcacheCreateTask) OnSyncSecurityGroupComplete(ctx context.Cont
 	region := elasticcache.GetRegion()
 	self.SetStage("OnElasticcacheCreateComplete", nil)
 	if err := region.GetDriver().RequestCreateElasticcache(ctx, self.GetUserCred(), elasticcache, self); err != nil {
-		self.taskFail(ctx, elasticcache, err.Error())
+		self.taskFail(ctx, elasticcache, jsonutils.Marshal(err))
 		return
 	}
 }
@@ -73,5 +73,5 @@ func (self *ElasticcacheCreateTask) OnElasticcacheCreateComplete(ctx context.Con
 }
 
 func (self *ElasticcacheCreateTask) OnElasticcacheCreateCompleteFailed(ctx context.Context, elasticcache *models.SElasticcache, reason jsonutils.JSONObject) {
-	self.taskFail(ctx, elasticcache, reason.String())
+	self.taskFail(ctx, elasticcache, reason)
 }

--- a/pkg/compute/tasks/elasticcache_delete_task.go
+++ b/pkg/compute/tasks/elasticcache_delete_task.go
@@ -36,11 +36,11 @@ func init() {
 	taskman.RegisterTask(ElasticcacheDeleteTask{})
 }
 
-func (self *ElasticcacheDeleteTask) taskFail(ctx context.Context, elasticcache *models.SElasticcache, reason string) {
-	elasticcache.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_RELEASE_FAILED, reason)
+func (self *ElasticcacheDeleteTask) taskFail(ctx context.Context, elasticcache *models.SElasticcache, reason jsonutils.JSONObject) {
+	elasticcache.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_RELEASE_FAILED, reason.String())
 	db.OpsLog.LogEvent(elasticcache, db.ACT_DELOCATE_FAIL, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, elasticcache, logclient.ACT_DELETE, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(elasticcache.Id, elasticcache.Name, api.ELASTIC_CACHE_STATUS_RELEASE_FAILED, reason)
+	notifyclient.NotifySystemError(elasticcache.Id, elasticcache.Name, api.ELASTIC_CACHE_STATUS_RELEASE_FAILED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -48,13 +48,13 @@ func (self *ElasticcacheDeleteTask) OnInit(ctx context.Context, obj db.IStandalo
 	ec := obj.(*models.SElasticcache)
 	region := ec.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, ec, fmt.Sprintf("failed to find region for elastic cache %s", ec.GetName()))
+		self.taskFail(ctx, ec, jsonutils.NewString(fmt.Sprintf("failed to find region for elastic cache %s", ec.GetName())))
 		return
 	}
 
 	self.SetStage("OnElasticcacheDeleteComplete", nil)
 	if err := region.GetDriver().RequestDeleteElasticcache(ctx, self.GetUserCred(), ec, self); err != nil {
-		self.taskFail(ctx, ec, err.Error())
+		self.taskFail(ctx, ec, jsonutils.Marshal(err))
 		return
 	} else {
 		ec.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_RELEASED, "")

--- a/pkg/compute/tasks/elasticcache_flush_instance.go
+++ b/pkg/compute/tasks/elasticcache_flush_instance.go
@@ -36,11 +36,11 @@ func init() {
 	taskman.RegisterTask(ElasticcacheFlushInstanceTask{})
 }
 
-func (self *ElasticcacheFlushInstanceTask) taskFail(ctx context.Context, elasticcache *models.SElasticcache, reason string) {
-	elasticcache.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_FLUSHING_FAILED, reason)
+func (self *ElasticcacheFlushInstanceTask) taskFail(ctx context.Context, elasticcache *models.SElasticcache, reason jsonutils.JSONObject) {
+	elasticcache.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_FLUSHING_FAILED, reason.String())
 	db.OpsLog.LogEvent(elasticcache, db.ACT_FLUSH_INSTANCE_FAIL, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, elasticcache, logclient.ACT_FLUSH_INSTANCE, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(elasticcache.Id, elasticcache.Name, api.ELASTIC_CACHE_STATUS_FLUSHING_FAILED, reason)
+	notifyclient.NotifySystemError(elasticcache.Id, elasticcache.Name, api.ELASTIC_CACHE_STATUS_FLUSHING_FAILED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -48,13 +48,13 @@ func (self *ElasticcacheFlushInstanceTask) OnInit(ctx context.Context, obj db.IS
 	elasticcache := obj.(*models.SElasticcache)
 	region := elasticcache.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, elasticcache, fmt.Sprintf("failed to find region for elastic cache %s", elasticcache.GetName()))
+		self.taskFail(ctx, elasticcache, jsonutils.NewString(fmt.Sprintf("failed to find region for elastic cache %s", elasticcache.GetName())))
 		return
 	}
 
 	self.SetStage("OnElasticcacheFlushInstanceComplete", nil)
 	if err := region.GetDriver().RequestElasticcacheFlushInstance(ctx, self.GetUserCred(), elasticcache, self); err != nil {
-		self.OnElasticcacheFlushInstanceCompleteFailed(ctx, elasticcache, err.Error())
+		self.OnElasticcacheFlushInstanceCompleteFailed(ctx, elasticcache, jsonutils.Marshal(err))
 		return
 	}
 
@@ -68,6 +68,6 @@ func (self *ElasticcacheFlushInstanceTask) OnElasticcacheFlushInstanceComplete(c
 	self.SetStageComplete(ctx, nil)
 }
 
-func (self *ElasticcacheFlushInstanceTask) OnElasticcacheFlushInstanceCompleteFailed(ctx context.Context, elasticcache *models.SElasticcache, reason string) {
+func (self *ElasticcacheFlushInstanceTask) OnElasticcacheFlushInstanceCompleteFailed(ctx context.Context, elasticcache *models.SElasticcache, reason jsonutils.JSONObject) {
 	self.taskFail(ctx, elasticcache, reason)
 }

--- a/pkg/compute/tasks/elasticcache_set_maintain_time_task.go
+++ b/pkg/compute/tasks/elasticcache_set_maintain_time_task.go
@@ -36,11 +36,11 @@ func init() {
 	taskman.RegisterTask(ElasticcacheSetMaintainTimeTask{})
 }
 
-func (self *ElasticcacheSetMaintainTimeTask) taskFail(ctx context.Context, elasticcache *models.SElasticcache, reason string) {
-	elasticcache.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason)
+func (self *ElasticcacheSetMaintainTimeTask) taskFail(ctx context.Context, elasticcache *models.SElasticcache, reason jsonutils.JSONObject) {
+	elasticcache.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason.String())
 	db.OpsLog.LogEvent(elasticcache, db.ACT_UPDATE, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, elasticcache, logclient.ACT_UPDATE, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(elasticcache.Id, elasticcache.Name, api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason)
+	notifyclient.NotifySystemError(elasticcache.Id, elasticcache.Name, api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -48,13 +48,13 @@ func (self *ElasticcacheSetMaintainTimeTask) OnInit(ctx context.Context, obj db.
 	elasticcache := obj.(*models.SElasticcache)
 	region := elasticcache.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, elasticcache, fmt.Sprintf("failed to find region for elastic cache %s", elasticcache.GetName()))
+		self.taskFail(ctx, elasticcache, jsonutils.NewString(fmt.Sprintf("failed to find region for elastic cache %s", elasticcache.GetName())))
 		return
 	}
 
 	self.SetStage("OnElasticcacheSetMaintainTimeComplete", nil)
 	if err := region.GetDriver().RequestElasticcacheSetMaintainTime(ctx, self.GetUserCred(), elasticcache, self); err != nil {
-		self.OnElasticcacheSetMaintainTimeCompleteFailed(ctx, elasticcache, err.Error())
+		self.OnElasticcacheSetMaintainTimeCompleteFailed(ctx, elasticcache, jsonutils.Marshal(err))
 		return
 	}
 
@@ -68,6 +68,6 @@ func (self *ElasticcacheSetMaintainTimeTask) OnElasticcacheSetMaintainTimeComple
 	self.SetStageComplete(ctx, nil)
 }
 
-func (self *ElasticcacheSetMaintainTimeTask) OnElasticcacheSetMaintainTimeCompleteFailed(ctx context.Context, elasticcache *models.SElasticcache, reason string) {
+func (self *ElasticcacheSetMaintainTimeTask) OnElasticcacheSetMaintainTimeCompleteFailed(ctx context.Context, elasticcache *models.SElasticcache, reason jsonutils.JSONObject) {
 	self.taskFail(ctx, elasticcache, reason)
 }

--- a/pkg/compute/tasks/elasticcache_sync_task.go
+++ b/pkg/compute/tasks/elasticcache_sync_task.go
@@ -36,11 +36,11 @@ func init() {
 	taskman.RegisterTask(ElasticcacheSyncTask{})
 }
 
-func (self *ElasticcacheSyncTask) taskFail(ctx context.Context, elasticcache *models.SElasticcache, reason string) {
-	elasticcache.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_SYNC_FAILED, reason)
+func (self *ElasticcacheSyncTask) taskFail(ctx context.Context, elasticcache *models.SElasticcache, reason jsonutils.JSONObject) {
+	elasticcache.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_SYNC_FAILED, reason.String())
 	db.OpsLog.LogEvent(elasticcache, db.ACT_SYNC_CONF, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, elasticcache, logclient.ACT_SYNC_CONF, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(elasticcache.Id, elasticcache.Name, api.ELASTIC_CACHE_STATUS_SYNC_FAILED, reason)
+	notifyclient.NotifySystemError(elasticcache.Id, elasticcache.Name, api.ELASTIC_CACHE_STATUS_SYNC_FAILED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -48,13 +48,13 @@ func (self *ElasticcacheSyncTask) OnInit(ctx context.Context, obj db.IStandalone
 	ec := obj.(*models.SElasticcache)
 	region := ec.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, ec, fmt.Sprintf("failed to find region for elastic cache %s", ec.GetName()))
+		self.taskFail(ctx, ec, jsonutils.NewString(fmt.Sprintf("failed to find region for elastic cache %s", ec.GetName())))
 		return
 	}
 
 	self.SetStage("OnElasticcacheSyncComplete", nil)
 	if err := region.GetDriver().RequestSyncElasticcache(ctx, self.GetUserCred(), ec, self); err != nil {
-		self.taskFail(ctx, ec, err.Error())
+		self.taskFail(ctx, ec, jsonutils.Marshal(err))
 		return
 	} else {
 		logclient.AddActionLogWithStartable(self, ec, logclient.ACT_SYNC_CONF, "", self.UserCred, true)

--- a/pkg/compute/tasks/elasticcache_update_backup_policy_task.go
+++ b/pkg/compute/tasks/elasticcache_update_backup_policy_task.go
@@ -36,11 +36,11 @@ func init() {
 	taskman.RegisterTask(ElasticcacheUpdateBackupPolicyTask{})
 }
 
-func (self *ElasticcacheUpdateBackupPolicyTask) taskFail(ctx context.Context, elasticcache *models.SElasticcache, reason string) {
-	elasticcache.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason)
+func (self *ElasticcacheUpdateBackupPolicyTask) taskFail(ctx context.Context, elasticcache *models.SElasticcache, reason jsonutils.JSONObject) {
+	elasticcache.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason.String())
 	db.OpsLog.LogEvent(elasticcache, db.ACT_UPDATE, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, elasticcache, logclient.ACT_UPDATE, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(elasticcache.Id, elasticcache.Name, api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason)
+	notifyclient.NotifySystemError(elasticcache.Id, elasticcache.Name, api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -48,13 +48,13 @@ func (self *ElasticcacheUpdateBackupPolicyTask) OnInit(ctx context.Context, obj 
 	elasticcache := obj.(*models.SElasticcache)
 	region := elasticcache.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, elasticcache, fmt.Sprintf("failed to find region for elastic cache %s", elasticcache.GetName()))
+		self.taskFail(ctx, elasticcache, jsonutils.Marshal(fmt.Sprintf("failed to find region for elastic cache %s", elasticcache.GetName())))
 		return
 	}
 
 	self.SetStage("OnElasticcacheUpdateBackupPolicyComplete", nil)
 	if err := region.GetDriver().RequestElasticcacheUpdateBackupPolicy(ctx, self.GetUserCred(), elasticcache, self); err != nil {
-		self.OnElasticcacheUpdateBackupPolicyCompleteFailed(ctx, elasticcache, err.Error())
+		self.OnElasticcacheUpdateBackupPolicyCompleteFailed(ctx, elasticcache, jsonutils.Marshal(err))
 		return
 	}
 
@@ -68,6 +68,6 @@ func (self *ElasticcacheUpdateBackupPolicyTask) OnElasticcacheUpdateBackupPolicy
 	self.SetStageComplete(ctx, nil)
 }
 
-func (self *ElasticcacheUpdateBackupPolicyTask) OnElasticcacheUpdateBackupPolicyCompleteFailed(ctx context.Context, elasticcache *models.SElasticcache, reason string) {
+func (self *ElasticcacheUpdateBackupPolicyTask) OnElasticcacheUpdateBackupPolicyCompleteFailed(ctx context.Context, elasticcache *models.SElasticcache, reason jsonutils.JSONObject) {
 	self.taskFail(ctx, elasticcache, reason)
 }

--- a/pkg/compute/tasks/guest_base_task.go
+++ b/pkg/compute/tasks/guest_base_task.go
@@ -17,6 +17,8 @@ package tasks
 import (
 	"context"
 
+	"yunion.io/x/jsonutils"
+
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/quotas"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/compute/models"
@@ -31,7 +33,7 @@ func (self *SGuestBaseTask) getGuest() *models.SGuest {
 	return obj.(*models.SGuest)
 }
 
-func (self *SGuestBaseTask) SetStageFailed(ctx context.Context, reason string) {
+func (self *SGuestBaseTask) SetStageFailed(ctx context.Context, reason jsonutils.JSONObject) {
 	self.finalReleasePendingUsage(ctx)
 	self.STask.SetStageFailed(ctx, reason)
 }

--- a/pkg/compute/tasks/guest_batch_create_task.go
+++ b/pkg/compute/tasks/guest_batch_create_task.go
@@ -84,7 +84,7 @@ func (self *GuestBatchCreateTask) OnInit(ctx context.Context, objs []db.IStandal
 	StartScheduleObjects(ctx, self, objs)
 }
 
-func (self *GuestBatchCreateTask) OnScheduleFailCallback(ctx context.Context, obj IScheduleModel, reason string) {
+func (self *GuestBatchCreateTask) OnScheduleFailCallback(ctx context.Context, obj IScheduleModel, reason jsonutils.JSONObject) {
 	guest := obj.(*models.SGuest)
 	if guest.DisableDelete.IsTrue() {
 		guest.SetDisableDelete(self.UserCred, false)
@@ -276,9 +276,9 @@ func (self *GuestBatchCreateTask) SaveScheduleResult(ctx context.Context, obj IS
 	if err != nil {
 		self.clearPendingUsage(ctx, guest)
 		db.OpsLog.LogEvent(guest, db.ACT_ALLOCATE_FAIL, err, self.UserCred)
-		logclient.AddActionLogWithStartable(self, obj, logclient.ACT_ALLOCATE, err.Error(), self.GetUserCred(), false)
+		logclient.AddActionLogWithStartable(self, obj, logclient.ACT_ALLOCATE, err, self.GetUserCred(), false)
 		notifyclient.NotifySystemError(guest.Id, guest.Name, api.VM_CREATE_FAILED, err.Error())
-		self.SetStageFailed(ctx, err.Error())
+		self.SetStageFailed(ctx, jsonutils.Marshal(err))
 	}
 }
 

--- a/pkg/compute/tasks/guest_block_io_throttle_task.go
+++ b/pkg/compute/tasks/guest_block_io_throttle_task.go
@@ -86,8 +86,8 @@ func (self *GuestBlockIoThrottleTask) OnGuestSyncFailed(ctx context.Context, gue
 }
 
 func (self *GuestBlockIoThrottleTask) OnIoThrottleFailed(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {
-	db.OpsLog.LogEvent(guest, db.ACT_VM_IO_THROTTLE_FAIL, data.String(), self.UserCred)
-	logclient.AddActionLogWithContext(ctx, guest, logclient.ACT_VM_IO_THROTTLE, data.String(), self.UserCred, false)
+	db.OpsLog.LogEvent(guest, db.ACT_VM_IO_THROTTLE_FAIL, data, self.UserCred)
+	logclient.AddActionLogWithContext(ctx, guest, logclient.ACT_VM_IO_THROTTLE, data, self.UserCred, false)
 	guest.SetStatus(self.UserCred, api.VM_IO_THROTTLE_FAIL, data.String())
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }

--- a/pkg/compute/tasks/guest_change_config_task.go
+++ b/pkg/compute/tasks/guest_change_config_task.go
@@ -54,40 +54,40 @@ func (self *GuestChangeConfigTask) OnDisksResizeComplete(ctx context.Context, ob
 
 	iResizeDisks, err := self.Params.Get("resize")
 	if iResizeDisks == nil || err != nil {
-		self.markStageFailed(ctx, guest, err.Error())
+		self.markStageFailed(ctx, guest, jsonutils.NewString(err.Error()))
 		return
 	}
 	resizeDisks := iResizeDisks.(*jsonutils.JSONArray)
 	for i := 0; i < resizeDisks.Length(); i++ {
 		iResizeSet, err := resizeDisks.GetAt(i)
 		if err != nil {
-			self.markStageFailed(ctx, guest, fmt.Sprintf("resizeDisks.GetAt fail %s", err))
+			self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("resizeDisks.GetAt fail %s", err)))
 			return
 		}
 		resizeSet := iResizeSet.(*jsonutils.JSONArray)
 		diskId, err := resizeSet.GetAt(0)
 		if err != nil {
-			self.markStageFailed(ctx, guest, fmt.Sprintf("resizeSet.GetAt(0) fail %s", err))
+			self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("resizeSet.GetAt(0) fail %s", err)))
 			return
 		}
 		idStr, err := diskId.GetString()
 		if err != nil {
-			self.markStageFailed(ctx, guest, fmt.Sprintf("diskId.GetString fail %s", err))
+			self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("diskId.GetString fail %s", err)))
 			return
 		}
 		jSize, err := resizeSet.GetAt(1)
 		if err != nil {
-			self.markStageFailed(ctx, guest, fmt.Sprintf("resizeSet.GetAt(1) fail %s", err))
+			self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("resizeSet.GetAt(1) fail %s", err)))
 			return
 		}
 		size, err := jSize.Int()
 		if err != nil {
-			self.markStageFailed(ctx, guest, fmt.Sprintf("jSize.Int fail %s", err))
+			self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("jSize.Int fail %s", err)))
 			return
 		}
 		iDisk, err := models.DiskManager.FetchById(idStr)
 		if err != nil {
-			self.markStageFailed(ctx, guest, fmt.Sprintf("models.DiskManager.FetchById(idStr) fail %s", err))
+			self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("models.DiskManager.FetchById(idStr) fail %s", err)))
 			return
 		}
 		disk := iDisk.(*models.SDisk)
@@ -95,12 +95,12 @@ func (self *GuestChangeConfigTask) OnDisksResizeComplete(ctx context.Context, ob
 			var pendingUsage models.SQuota
 			err = self.GetPendingUsage(&pendingUsage, 0)
 			if err != nil {
-				self.markStageFailed(ctx, guest, fmt.Sprintf("self.GetPendingUsage(&pendingUsage) fail %s", err))
+				self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("self.GetPendingUsage(&pendingUsage) fail %s", err)))
 				return
 			}
 			err = guest.StartGuestDiskResizeTask(ctx, self.UserCred, disk.Id, size, self.GetTaskId(), &pendingUsage)
 			if err != nil {
-				self.markStageFailed(ctx, guest, fmt.Sprintf("guest.StartGuestDiskResizeTask fail %s", err))
+				self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("guest.StartGuestDiskResizeTask fail %s", err)))
 				return
 			}
 			return
@@ -123,7 +123,7 @@ func (self *GuestChangeConfigTask) DoCreateDisksTask(ctx context.Context, guest 
 
 func (self *GuestChangeConfigTask) OnCreateDisksCompleteFailed(ctx context.Context, obj db.IStandaloneModel, err jsonutils.JSONObject) {
 	guest := obj.(*models.SGuest)
-	self.markStageFailed(ctx, guest, fmt.Sprintf("OnCreateDisksCompleteFailed %s", err))
+	self.markStageFailed(ctx, guest, err)
 }
 
 func (self *GuestChangeConfigTask) OnCreateDisksComplete(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
@@ -138,7 +138,7 @@ func (self *GuestChangeConfigTask) OnCreateDisksComplete(ctx context.Context, ob
 			provider := guest.GetDriver().GetProvider()
 			sku, err := models.ServerSkuManager.FetchSkuByNameAndProvider(instanceType, provider, false)
 			if err != nil {
-				self.markStageFailed(ctx, guest, fmt.Sprintf("models.ServerSkuManager.FetchSkuByNameAndProvider error %s", err))
+				self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("models.ServerSkuManager.FetchSkuByNameAndProvider error %s", err)))
 				return
 			}
 			vcpuCount = int64(sku.CpuCoreCount)
@@ -160,7 +160,7 @@ func (self *GuestChangeConfigTask) OnCreateDisksComplete(ctx context.Context, ob
 func (self *GuestChangeConfigTask) startGuestChangeCpuMemSpec(ctx context.Context, guest *models.SGuest, instanceType string, vcpuCount int64, vmemSize int64) {
 	err := guest.GetDriver().RequestChangeVmConfig(ctx, guest, self, instanceType, vcpuCount, vmemSize)
 	if err != nil {
-		self.markStageFailed(ctx, guest, fmt.Sprintf("guest.GetDriver().RequestChangeVmConfig fail %s", err))
+		self.markStageFailed(ctx, guest, jsonutils.Marshal(err))
 		return
 	}
 }
@@ -195,7 +195,7 @@ func (self *GuestChangeConfigTask) OnGuestChangeCpuMemSpecComplete(ctx context.C
 		return nil
 	})
 	if err != nil {
-		self.markStageFailed(ctx, guest, fmt.Sprintf("Update fail %s", err))
+		self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("Update fail %s", err)))
 		return
 	}
 	changeConfigSpec := jsonutils.NewDict()
@@ -214,7 +214,7 @@ func (self *GuestChangeConfigTask) OnGuestChangeCpuMemSpecComplete(ctx context.C
 	var pendingUsage models.SQuota
 	err = self.GetPendingUsage(&pendingUsage, 0)
 	if err != nil {
-		self.markStageFailed(ctx, guest, fmt.Sprintf("GetPendingUsage %s", err))
+		self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("GetPendingUsage %s", err)))
 		return
 	}
 	var cancelUsage models.SQuota
@@ -232,7 +232,7 @@ func (self *GuestChangeConfigTask) OnGuestChangeCpuMemSpecComplete(ctx context.C
 
 	keys, err := guest.GetQuotaKeys()
 	if err != nil {
-		self.markStageFailed(ctx, guest, fmt.Sprintf("guest.GetQuotaKeys %s", err))
+		self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("guest.GetQuotaKeys %s", err)))
 		return
 	}
 	cancelUsage.SetKeys(keys)
@@ -244,12 +244,12 @@ func (self *GuestChangeConfigTask) OnGuestChangeCpuMemSpecComplete(ctx context.C
 	if !cancelUsage.IsEmpty() {
 		err = quotas.CancelPendingUsage(ctx, self.UserCred, &pendingUsage, &cancelUsage, true) // success
 		if err != nil {
-			self.markStageFailed(ctx, guest, fmt.Sprintf("CancelPendingUsage fail %s", err))
+			self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("CancelPendingUsage fail %s", err)))
 			return
 		}
 		err = self.SetPendingUsage(&pendingUsage, 0)
 		if err != nil {
-			self.markStageFailed(ctx, guest, fmt.Sprintf("SetPendingUsage fail %s", err))
+			self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("SetPendingUsage fail %s", err)))
 			return
 		}
 	}
@@ -265,7 +265,7 @@ func (self *GuestChangeConfigTask) OnGuestChangeCpuMemSpecCompleteFailed(ctx con
 	if err := guest.GetDriver().OnGuestChangeCpuMemFailed(ctx, guest, data.(*jsonutils.JSONDict), self); err != nil {
 		log.Errorln(err)
 	}
-	self.markStageFailed(ctx, guest, fmt.Sprintf("guest.GetDriver().RequestChangeVmConfig fail %s", data))
+	self.markStageFailed(ctx, guest, data)
 }
 
 func (self *GuestChangeConfigTask) OnGuestChangeCpuMemSpecFinish(ctx context.Context, guest *models.SGuest) {
@@ -273,7 +273,7 @@ func (self *GuestChangeConfigTask) OnGuestChangeCpuMemSpecFinish(ctx context.Con
 	self.SetStage("OnSyncConfigComplete", nil)
 	err := guest.StartSyncTaskWithoutSyncstatus(ctx, self.UserCred, false, self.GetTaskId())
 	if err != nil {
-		self.markStageFailed(ctx, guest, fmt.Sprintf("StartSyncstatus fail %s", err))
+		self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("StartSyncstatus fail %s", err)))
 		return
 	}
 }
@@ -284,7 +284,7 @@ func (self *GuestChangeConfigTask) OnSyncConfigComplete(ctx context.Context, obj
 	self.SetStage("on_sync_status_complete", nil)
 	err := guest.StartSyncstatus(ctx, self.UserCred, self.GetTaskId())
 	if err != nil {
-		self.markStageFailed(ctx, guest, fmt.Sprintf("StartSyncstatus fail %s", err))
+		self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("StartSyncstatus fail %s", err)))
 		return
 	}
 }
@@ -310,11 +310,11 @@ func (self *GuestChangeConfigTask) OnGuestStartComplete(ctx context.Context, obj
 }
 
 func (self *GuestChangeConfigTask) OnGuestStartCompleteFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }
 
-func (self *GuestChangeConfigTask) markStageFailed(ctx context.Context, guest *models.SGuest, reason string) {
-	guest.SetStatus(self.UserCred, api.VM_CHANGE_FLAVOR_FAIL, reason)
+func (self *GuestChangeConfigTask) markStageFailed(ctx context.Context, guest *models.SGuest, reason jsonutils.JSONObject) {
+	guest.SetStatus(self.UserCred, api.VM_CHANGE_FLAVOR_FAIL, reason.String())
 	db.OpsLog.LogEvent(guest, db.ACT_CHANGE_FLAVOR_FAIL, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_VM_CHANGE_FLAVOR, reason, self.UserCred, false)
 	self.SetStageFailed(ctx, reason)

--- a/pkg/compute/tasks/guest_create_task.go
+++ b/pkg/compute/tasks/guest_create_task.go
@@ -70,7 +70,7 @@ func (self *GuestCreateTask) OnDiskPreparedFailed(ctx context.Context, obj db.IS
 	db.OpsLog.LogEvent(guest, db.ACT_ALLOCATE_FAIL, data, self.UserCred)
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_ALLOCATE, data, self.UserCred, false)
 	notifyclient.NotifySystemError(guest.Id, guest.Name, api.VM_DISK_FAILED, data.String())
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }
 
 func (self *GuestCreateTask) OnDiskPrepared(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
@@ -99,7 +99,7 @@ func (self *GuestCreateTask) OnCdromPreparedFailed(ctx context.Context, obj db.I
 	db.OpsLog.LogEvent(guest, db.ACT_ALLOCATE_FAIL, data, self.UserCred)
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_ALLOCATE, data, self.UserCred, false)
 	notifyclient.NotifySystemError(guest.Id, guest.Name, api.VM_DISK_FAILED, fmt.Sprintf("cdrom_failed %s", data))
-	self.SetStageFailed(ctx, fmt.Sprintf("cdrom_failed %s", data))
+	self.SetStageFailed(ctx, data)
 }
 
 func (self *GuestCreateTask) StartDeployGuest(ctx context.Context, guest *models.SGuest) {
@@ -153,7 +153,7 @@ func (self *GuestCreateTask) OnDeployGuestDescCompleteFailed(ctx context.Context
 	db.OpsLog.LogEvent(guest, db.ACT_ALLOCATE_FAIL, data, self.UserCred)
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_ALLOCATE, data, self.UserCred, false)
 	notifyclient.NotifySystemError(guest.Id, guest.Name, api.VM_DEPLOY_FAILED, data.String())
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }
 
 func (self *GuestCreateTask) OnDeployEipComplete(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
@@ -194,7 +194,7 @@ func (self *GuestCreateTask) OnDeployEipCompleteFailed(ctx context.Context, obj 
 	db.OpsLog.LogEvent(guest, db.ACT_EIP_ATTACH, data, self.UserCred)
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_EIP_ASSOCIATE, data, self.UserCred, false)
 	notifyclient.NotifySystemError(guest.Id, guest.Name, api.VM_ASSOCIATE_EIP_FAILED, data.String())
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }
 
 func (self *GuestCreateTask) OnAutoStartGuest(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/guest_delete_task.go
+++ b/pkg/compute/tasks/guest_delete_task.go
@@ -285,7 +285,7 @@ func (self *GuestDeleteTask) OnFailed(ctx context.Context, guest *models.SGuest,
 	guest.SetStatus(self.UserCred, api.VM_DELETE_FAIL, err.String())
 	db.OpsLog.LogEvent(guest, db.ACT_DELOCATE_FAIL, err, self.UserCred)
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_DELOCATE, err, self.UserCred, false)
-	self.SetStageFailed(ctx, err.String())
+	self.SetStageFailed(ctx, err)
 }
 
 func (self *GuestDeleteTask) OnGuestDeleteCompleteFailed(ctx context.Context, obj db.IStandaloneModel, err jsonutils.JSONObject) {

--- a/pkg/compute/tasks/guest_deploy_task.go
+++ b/pkg/compute/tasks/guest_deploy_task.go
@@ -35,7 +35,7 @@ type GuestDeployTask struct {
 func (self *GuestDeployTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
 	guest := obj.(*models.SGuest)
 	if !guest.IsNetworkAllocated() {
-		self.SetStageFailed(ctx, fmt.Sprintf("Guest %s network not ready!!", guest.Name))
+		self.SetStageFailed(ctx, jsonutils.NewString(fmt.Sprintf("Guest %s network not ready!!", guest.Name)))
 	} else {
 		self.OnGuestNetworkReady(ctx, guest)
 	}
@@ -75,7 +75,7 @@ func (self *GuestDeployTask) DeployOnHost(ctx context.Context, guest *models.SGu
 
 func (self *GuestDeployTask) OnDeployGuestFail(ctx context.Context, guest *models.SGuest, err error) {
 	guest.SetStatus(self.UserCred, api.VM_DEPLOY_FAILED, err.Error())
-	self.SetStageFailed(ctx, err.Error())
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_VM_DEPLOY, err, self.UserCred, false)
 	db.OpsLog.LogEvent(guest, db.ACT_VM_DEPLOY_FAIL, err.Error(), self.UserCred)
 }
@@ -137,7 +137,7 @@ func (self *GuestDeployTask) OnDeployGuestCompleteFailed(ctx context.Context, ob
 		}
 	}
 	guest.SetStatus(self.UserCred, api.VM_DEPLOY_FAILED, data.String())
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_VM_DEPLOY, data, self.UserCred, false)
 	db.OpsLog.LogEvent(guest, db.ACT_VM_DEPLOY_FAIL, data, self.UserCred)
 }
@@ -147,7 +147,7 @@ func (self *GuestDeployTask) OnDeployStartGuestComplete(ctx context.Context, obj
 }
 
 func (self *GuestDeployTask) OnDeployStartGuestCompleteFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }
 
 func (self *GuestDeployTask) OnDeployGuestSyncstatusComplete(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
@@ -155,7 +155,7 @@ func (self *GuestDeployTask) OnDeployGuestSyncstatusComplete(ctx context.Context
 }
 
 func (self *GuestDeployTask) OnDeployGuestSyncstatusCompleteFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }
 
 func init() {

--- a/pkg/compute/tasks/guest_detach_all_disks_task.go
+++ b/pkg/compute/tasks/guest_detach_all_disks_task.go
@@ -41,7 +41,7 @@ func (self *GuestDetachAllDisksTask) OnDiskDeleteComplete(ctx context.Context, o
 	guest := obj.(*models.SGuest)
 	cnt, err := guest.DiskCount()
 	if err != nil {
-		self.SetStageFailed(ctx, err.Error())
+		self.SetStageFailed(ctx, jsonutils.NewString(err.Error()))
 		return
 	}
 	if cnt == 0 {
@@ -65,7 +65,7 @@ func (self *GuestDetachAllDisksTask) OnDiskDeleteComplete(ctx context.Context, o
 		taskData.Add(jsonutils.JSONFalse, "keep_disk")
 		task, err := taskman.TaskManager.NewTask(ctx, "GuestDetachDiskTask", guest, self.UserCred, taskData, self.GetTaskId(), "", nil)
 		if err != nil {
-			self.SetStageFailed(ctx, err.Error())
+			self.SetStageFailed(ctx, jsonutils.NewString(err.Error()))
 		} else {
 			task.ScheduleRun(nil)
 		}

--- a/pkg/compute/tasks/guest_insert_iso_task.go
+++ b/pkg/compute/tasks/guest_insert_iso_task.go
@@ -53,7 +53,7 @@ func (self *GuestInsertIsoTask) prepareIsoImage(ctx context.Context, obj db.ISta
 	} else {
 		guest.EjectIso(self.UserCred)
 		db.OpsLog.LogEvent(obj, db.ACT_ISO_PREPARE_FAIL, imageId, self.UserCred)
-		self.SetStageFailed(ctx, "host no local storage cache")
+		self.SetStageFailed(ctx, jsonutils.NewString("host no local storage cache"))
 	}
 }
 
@@ -62,14 +62,14 @@ func (self *GuestInsertIsoTask) OnIsoPrepareCompleteFailed(ctx context.Context, 
 	db.OpsLog.LogEvent(obj, db.ACT_ISO_PREPARE_FAIL, imageId, self.UserCred)
 	guest := obj.(*models.SGuest)
 	guest.EjectIso(self.UserCred)
-	self.SetStageFailed(ctx, "OnIsoPrepareCompleteFailed")
+	self.SetStageFailed(ctx, data)
 }
 
 func (self *GuestInsertIsoTask) OnIsoPrepareComplete(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
 	imageId, _ := data.GetString("image_id")
 	size, err := data.Int("size")
 	if err != nil {
-		self.SetStageFailed(ctx, err.Error())
+		self.SetStageFailed(ctx, jsonutils.NewString(err.Error()))
 		return
 	}
 	name, _ := data.GetString("name")
@@ -115,7 +115,7 @@ func (self *HaGuestInsertIsoTask) prepareIsoImage(ctx context.Context, obj db.IS
 	} else {
 		guest.EjectIso(self.UserCred)
 		db.OpsLog.LogEvent(obj, db.ACT_ISO_PREPARE_FAIL, imageId, self.UserCred)
-		self.SetStageFailed(ctx, "host no local storage cache")
+		self.SetStageFailed(ctx, jsonutils.NewString("host no local storage cache"))
 	}
 }
 

--- a/pkg/compute/tasks/guest_renew_task.go
+++ b/pkg/compute/tasks/guest_renew_task.go
@@ -48,10 +48,10 @@ func (self *GuestRenewTask) OnInit(ctx context.Context, obj db.IStandaloneModel,
 	if err != nil {
 		msg := fmt.Sprintf("RequestRenewInstance failed %s", err)
 		log.Errorf(msg)
-		db.OpsLog.LogEvent(guest, db.ACT_REW_FAIL, msg, self.UserCred)
-		logclient.AddActionLogWithStartable(self, guest, logclient.ACT_RENEW, msg, self.UserCred, false)
+		db.OpsLog.LogEvent(guest, db.ACT_REW_FAIL, err, self.UserCred)
+		logclient.AddActionLogWithStartable(self, guest, logclient.ACT_RENEW, err, self.UserCred, false)
 		guest.SetStatus(self.GetUserCred(), api.VM_RENEW_FAILED, msg)
-		self.SetStageFailed(ctx, msg)
+		self.SetStageFailed(ctx, jsonutils.Marshal(err))
 		return
 	}
 
@@ -59,7 +59,7 @@ func (self *GuestRenewTask) OnInit(ctx context.Context, obj db.IStandaloneModel,
 	if err != nil {
 		msg := fmt.Sprintf("SaveRenewInfo fail %s", err)
 		log.Errorf(msg)
-		self.SetStageFailed(ctx, msg)
+		self.SetStageFailed(ctx, jsonutils.NewString(msg))
 		return
 	}
 
@@ -83,7 +83,7 @@ func (self *PrepaidRecycleHostRenewTask) OnInit(ctx context.Context, obj db.ISta
 	if err != nil {
 		msg := fmt.Sprintf("host.GetIHost fail %s", err)
 		log.Errorf(msg)
-		self.SetStageFailed(ctx, msg)
+		self.SetStageFailed(ctx, jsonutils.NewString(msg))
 		return
 	}
 
@@ -91,7 +91,7 @@ func (self *PrepaidRecycleHostRenewTask) OnInit(ctx context.Context, obj db.ISta
 	if err != nil {
 		msg := fmt.Sprintf("ihost.GetIVMById fail %s", err)
 		log.Errorf(msg)
-		self.SetStageFailed(ctx, msg)
+		self.SetStageFailed(ctx, jsonutils.NewString(msg))
 		return
 	}
 
@@ -101,7 +101,7 @@ func (self *PrepaidRecycleHostRenewTask) OnInit(ctx context.Context, obj db.ISta
 	if err != nil {
 		msg := fmt.Sprintf("iVM.Renew fail %s", err)
 		log.Errorf(msg)
-		self.SetStageFailed(ctx, msg)
+		self.SetStageFailed(ctx, jsonutils.NewString(msg))
 		return
 	}
 
@@ -109,7 +109,7 @@ func (self *PrepaidRecycleHostRenewTask) OnInit(ctx context.Context, obj db.ISta
 	if err != nil {
 		msg := fmt.Sprintf("refresh after renew fail %s", err)
 		log.Errorf(msg)
-		self.SetStageFailed(ctx, msg)
+		self.SetStageFailed(ctx, jsonutils.NewString(msg))
 		return
 	}
 
@@ -121,7 +121,7 @@ func (self *PrepaidRecycleHostRenewTask) OnInit(ctx context.Context, obj db.ISta
 	if err != nil {
 		msg := fmt.Sprintf("SaveRenewInfo fail %s", err)
 		log.Errorf(msg)
-		self.SetStageFailed(ctx, msg)
+		self.SetStageFailed(ctx, jsonutils.NewString(msg))
 		return
 	}
 

--- a/pkg/compute/tasks/guest_reset_task.go
+++ b/pkg/compute/tasks/guest_reset_task.go
@@ -41,7 +41,7 @@ func (self *GuestSoftResetTask) OnInit(ctx context.Context, obj db.IStandaloneMo
 	if err == nil {
 		self.SetStageComplete(ctx, nil)
 	} else {
-		self.SetStageFailed(ctx, err.Error())
+		self.SetStageFailed(ctx, jsonutils.Marshal(err))
 	}
 }
 

--- a/pkg/compute/tasks/guest_resume_task.go
+++ b/pkg/compute/tasks/guest_resume_task.go
@@ -55,7 +55,7 @@ func (self *GuestResumeTask) OnResumeCompleteFailed(ctx context.Context, obj db.
 	guest := obj.(*models.SGuest)
 	guest.SetStatus(self.UserCred, api.VM_SUSPEND, "")
 	db.OpsLog.LogEvent(guest, db.ACT_RESUME_FAIL, err.String(), self.UserCred)
-	self.SetStageFailed(ctx, err.String())
+	self.SetStageFailed(ctx, err)
 }
 
 func (self *GuestResumeTask) OnResumeGuestFail(guest *models.SGuest, reason string) {

--- a/pkg/compute/tasks/guest_save_image_task.go
+++ b/pkg/compute/tasks/guest_save_image_task.go
@@ -49,7 +49,7 @@ func (self *GuestSaveImageTask) OnStopServerComplete(ctx context.Context, guest 
 	self.SetStage("OnSaveRootImageComplete", nil)
 	disks := guest.CategorizeDisks()
 	if err := disks.Root.StartDiskSaveTask(ctx, self.GetUserCred(), self.GetParams(), self.GetTaskId()); err != nil {
-		self.SetStageFailed(ctx, err.Error())
+		self.SetStageFailed(ctx, jsonutils.NewString(err.Error()))
 	}
 }
 
@@ -64,8 +64,8 @@ func (self *GuestSaveImageTask) OnSaveRootImageComplete(ctx context.Context, gue
 
 func (self *GuestSaveImageTask) OnSaveRootImageCompleteFailed(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {
 	log.Errorf("Guest save root image failed: %s", data.PrettyString())
-	guest.SetStatus(self.GetUserCred(), api.VM_SAVE_DISK_FAILED, data.PrettyString())
-	self.SetStageFailed(ctx, data.PrettyString())
+	guest.SetStatus(self.GetUserCred(), api.VM_SAVE_DISK_FAILED, data.String())
+	self.SetStageFailed(ctx, data)
 }
 
 func (self *GuestSaveImageTask) OnStartServerComplete(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {

--- a/pkg/compute/tasks/guest_save_template_task.go
+++ b/pkg/compute/tasks/guest_save_template_task.go
@@ -38,8 +38,8 @@ func init() {
 	taskman.RegisterTask(GuestSaveTemplateTask{})
 }
 
-func (self *GuestSaveTemplateTask) taskFailed(ctx context.Context, g *models.SGuest, reason string) {
-	g.SetStatus(self.UserCred, api.VM_TEMPLATE_SAVE_FAILED, reason)
+func (self *GuestSaveTemplateTask) taskFailed(ctx context.Context, g *models.SGuest, reason jsonutils.JSONObject) {
+	g.SetStatus(self.UserCred, api.VM_TEMPLATE_SAVE_FAILED, reason.String())
 	logclient.AddActionLogWithStartable(self, g, logclient.ACT_SAVE_TO_TEMPLATE, reason, self.UserCred, false)
 	self.SetStageFailed(ctx, reason)
 }
@@ -66,7 +66,7 @@ func (self *GuestSaveTemplateTask) OnInit(ctx context.Context, obj db.IStandalon
 	session := auth.GetSession(ctx, self.UserCred, "", "")
 	_, err := modules.GuestTemplate.Create(session, dict)
 	if err != nil {
-		self.taskFailed(ctx, g, err.Error())
+		self.taskFailed(ctx, g, jsonutils.NewString(err.Error()))
 		return
 	}
 	logclient.AddActionLogWithStartable(self, g, logclient.ACT_SAVE_TO_TEMPLATE, "", self.UserCred, true)

--- a/pkg/compute/tasks/guest_set_auto_renew_task.go
+++ b/pkg/compute/tasks/guest_set_auto_renew_task.go
@@ -16,7 +16,6 @@ package tasks
 
 import (
 	"context"
-	"fmt"
 
 	"yunion.io/x/jsonutils"
 
@@ -42,11 +41,11 @@ func (self *GuestSetAutoRenewTask) OnInit(ctx context.Context, obj db.IStandalon
 	autoRenew, _ := self.GetParams().Bool("auto_renew")
 	err := guest.GetDriver().RequestSetAutoRenewInstance(ctx, self.UserCred, guest, autoRenew, self)
 	if err != nil {
-		msg := fmt.Sprintf("RequestSetAutoRenewInstance failed %s", err)
-		db.OpsLog.LogEvent(guest, db.ACT_SET_AUTO_RENEW_FAIL, msg, self.UserCred)
-		logclient.AddActionLogWithStartable(self, guest, logclient.ACT_SET_AUTO_RENEW, msg, self.UserCred, false)
-		guest.SetStatus(self.GetUserCred(), api.VM_SET_AUTO_RENEW_FAILED, msg)
-		self.SetStageFailed(ctx, msg)
+		// msg := fmt.Sprintf("RequestSetAutoRenewInstance failed %s", err)
+		db.OpsLog.LogEvent(guest, db.ACT_SET_AUTO_RENEW_FAIL, err, self.UserCred)
+		logclient.AddActionLogWithStartable(self, guest, logclient.ACT_SET_AUTO_RENEW, err, self.UserCred, false)
+		guest.SetStatus(self.GetUserCred(), api.VM_SET_AUTO_RENEW_FAILED, err.Error())
+		self.SetStageFailed(ctx, jsonutils.Marshal(err))
 		return
 	}
 }
@@ -60,7 +59,7 @@ func (self *GuestSetAutoRenewTask) OnSetAutoRenewComplete(ctx context.Context, g
 func (self *GuestSetAutoRenewTask) OnSetAutoRenewCompleteFailed(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_SET_AUTO_RENEW, data, self.UserCred, false)
 	guest.SetStatus(self.GetUserCred(), api.VM_SET_AUTO_RENEW_FAILED, data.String())
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }
 
 func (self *GuestSetAutoRenewTask) OnGuestSyncstatusComplete(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {
@@ -68,5 +67,5 @@ func (self *GuestSetAutoRenewTask) OnGuestSyncstatusComplete(ctx context.Context
 }
 
 func (self *GuestSetAutoRenewTask) OnGuestSyncstatusCompleteFailed(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }

--- a/pkg/compute/tasks/guest_stop_task.go
+++ b/pkg/compute/tasks/guest_stop_task.go
@@ -77,6 +77,6 @@ func (self *GuestStopTask) OnGuestStopTaskCompleteFailed(ctx context.Context, gu
 		guest.SetStatus(self.UserCred, api.VM_STOP_FAILED, reason.String())
 	}
 	db.OpsLog.LogEvent(guest, db.ACT_STOP_FAIL, reason.String(), self.UserCred)
-	self.SetStageFailed(ctx, reason.String())
+	self.SetStageFailed(ctx, reason)
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_VM_STOP, reason.String(), self.UserCred, false)
 }

--- a/pkg/compute/tasks/guest_suspend_task.go
+++ b/pkg/compute/tasks/guest_suspend_task.go
@@ -55,7 +55,7 @@ func (self *GuestSuspendTask) OnSuspendCompleteFailed(ctx context.Context, obj d
 	guest := obj.(*models.SGuest)
 	guest.SetStatus(self.UserCred, api.VM_RUNNING, "")
 	db.OpsLog.LogEvent(guest, db.ACT_STOP_FAIL, err.String(), self.UserCred)
-	self.SetStageFailed(ctx, err.String())
+	self.SetStageFailed(ctx, err)
 }
 
 func (self *GuestSuspendTask) OnSuspendGuestFail(guest *models.SGuest, reason string) {

--- a/pkg/compute/tasks/guest_sync_task.go
+++ b/pkg/compute/tasks/guest_sync_task.go
@@ -39,12 +39,12 @@ func (self *GuestSyncConfTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 	guest := obj.(*models.SGuest)
 	db.OpsLog.LogEvent(guest, db.ACT_SYNC_CONF, nil, self.UserCred)
 	if host := guest.GetHost(); host == nil {
-		self.SetStageFailed(ctx, "No host for sync")
+		self.SetStageFailed(ctx, jsonutils.NewString("No host for sync"))
 		return
 	} else {
 		self.SetStage("on_sync_complete", nil)
 		if err := guest.GetDriver().RequestSyncConfigOnHost(ctx, guest, host, self); err != nil {
-			self.SetStageFailed(ctx, err.Error())
+			self.SetStageFailed(ctx, jsonutils.Marshal(err))
 			log.Errorf("SyncConfTask faled %v", err)
 		}
 	}
@@ -74,9 +74,9 @@ func (self *GuestSyncConfTask) OnDiskSyncComplete(ctx context.Context, guest *mo
 
 func (self *GuestSyncConfTask) OnDiskSyncCompleteFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
 	guest := obj.(*models.SGuest)
-	db.OpsLog.LogEvent(guest, db.ACT_SYNC_CONF_FAIL, data.String(), self.UserCred)
+	db.OpsLog.LogEvent(guest, db.ACT_SYNC_CONF_FAIL, data, self.UserCred)
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_VM_SYNC_CONF, data, self.UserCred, false)
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }
 
 func (self *GuestSyncConfTask) OnSyncCompleteFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
@@ -85,8 +85,8 @@ func (self *GuestSyncConfTask) OnSyncCompleteFailed(ctx context.Context, obj db.
 		guest.SetStatus(self.GetUserCred(), api.VM_SYNC_FAIL, data.String())
 	}
 	logclient.AddActionLogWithStartable(self, guest, logclient.ACT_VM_SYNC_CONF, data, self.UserCred, false)
-	db.OpsLog.LogEvent(guest, db.ACT_SYNC_CONF_FAIL, data.String(), self.UserCred)
-	self.SetStageFailed(ctx, data.String())
+	db.OpsLog.LogEvent(guest, db.ACT_SYNC_CONF_FAIL, data, self.UserCred)
+	self.SetStageFailed(ctx, data)
 }
 
 func (self *GuestSyncConfTask) OnSyncStatusComplete(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {
@@ -94,5 +94,5 @@ func (self *GuestSyncConfTask) OnSyncStatusComplete(ctx context.Context, guest *
 }
 
 func (self *GuestSyncConfTask) OnSyncStatusCompleteFailed(ctx context.Context, guest *models.SGuest, data jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }

--- a/pkg/compute/tasks/guest_undeploy_task.go
+++ b/pkg/compute/tasks/guest_undeploy_task.go
@@ -82,5 +82,5 @@ func (self *GuestUndeployTask) OnStartDeleteGuestFail(ctx context.Context, err e
 			return
 		}
 	}
-	self.SetStageFailed(ctx, err.Error())
+	self.SetStageFailed(ctx, jsonutils.Marshal(err))
 }

--- a/pkg/compute/tasks/ha_disk_create_task.go
+++ b/pkg/compute/tasks/ha_disk_create_task.go
@@ -73,7 +73,7 @@ func (self *HADiskCreateTask) OnDiskReady(
 
 func (self *HADiskCreateTask) OnBackupAllocateFailed(ctx context.Context, disk *models.SDisk, data jsonutils.JSONObject) {
 	disk.SetStatus(self.UserCred, api.DISK_BACKUP_ALLOC_FAILED, data.String())
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }
 
 func (self *HADiskCreateTask) OnSlaveDiskReady(

--- a/pkg/compute/tasks/host_guests_migrate_task.go
+++ b/pkg/compute/tasks/host_guests_migrate_task.go
@@ -38,7 +38,7 @@ func (self *HostGuestsMigrateTask) OnInit(ctx context.Context, obj db.IStandalon
 	guests := make([]*api.GuestBatchMigrateParams, 0)
 	err := self.Params.Unmarshal(&guests, "guests")
 	if err != nil {
-		self.SetStageFailed(ctx, err.Error())
+		self.SetStageFailed(ctx, jsonutils.NewString(err.Error()))
 		return
 	}
 	preferHostId, _ := self.Params.GetString("prefer_host_id")
@@ -73,7 +73,7 @@ func (self *HostGuestsMigrateTask) OnInit(ctx context.Context, obj db.IStandalon
 	}
 	if !guestMigrating {
 		if jsonutils.QueryBoolean(self.Params, "some_guest_migrate_failed", false) {
-			self.SetStageFailed(ctx, "some guest migrate failed")
+			self.SetStageFailed(ctx, jsonutils.NewString("some guest migrate failed"))
 		} else {
 			self.SetStageComplete(ctx, nil)
 		}

--- a/pkg/compute/tasks/host_maintenance_task.go
+++ b/pkg/compute/tasks/host_maintenance_task.go
@@ -46,7 +46,7 @@ func (self *HostMaintainTask) OnInit(ctx context.Context, obj db.IStandaloneMode
 	self.SetStage("OnGuestsMigrate", nil)
 	err := models.GuestManager.StartHostGuestsMigrateTask(ctx, self.UserCred, host, self.Params, self.Id)
 	if err != nil {
-		self.TaskFailed(ctx, host, err.Error())
+		self.TaskFailed(ctx, host, jsonutils.NewString(err.Error()))
 		return
 	}
 }
@@ -59,10 +59,10 @@ func (self *HostMaintainTask) OnGuestsMigrate(ctx context.Context, host *models.
 }
 
 func (self *HostMaintainTask) OnGuestsMigrateFailed(ctx context.Context, host *models.SHost, data jsonutils.JSONObject) {
-	self.TaskFailed(ctx, host, data.String())
+	self.TaskFailed(ctx, host, data)
 }
 
-func (self *HostMaintainTask) TaskFailed(ctx context.Context, host *models.SHost, reason string) {
+func (self *HostMaintainTask) TaskFailed(ctx context.Context, host *models.SHost, reason jsonutils.JSONObject) {
 	host.PerformDisable(ctx, self.UserCred, nil, apis.PerformDisableInput{})
 	host.SetStatus(self.UserCred, api.BAREMETAL_MAINTAIN_FAIL, "On host maintain task complete failed")
 	logclient.AddSimpleActionLog(host, logclient.ACT_HOST_MAINTAINING, reason, self.UserCred, false)

--- a/pkg/compute/tasks/host_storage_attach_task.go
+++ b/pkg/compute/tasks/host_storage_attach_task.go
@@ -34,7 +34,7 @@ func init() {
 	taskman.RegisterTask(HostStorageAttachTask{})
 }
 
-func (self *HostStorageAttachTask) taskFail(ctx context.Context, host *models.SHost, reason string) {
+func (self *HostStorageAttachTask) taskFail(ctx context.Context, host *models.SHost, reason jsonutils.JSONObject) {
 	if hoststorage := self.getHoststorage(host); hoststorage != nil {
 		storage := hoststorage.GetStorage()
 		hoststorage.Detach(ctx, self.GetUserCred())
@@ -60,14 +60,14 @@ func (self *HostStorageAttachTask) OnInit(ctx context.Context, obj db.IStandalon
 	host := obj.(*models.SHost)
 	hoststorage := self.getHoststorage(host)
 	if hoststorage == nil {
-		self.taskFail(ctx, host, "failed to find hoststorage")
+		self.taskFail(ctx, host, jsonutils.NewString("failed to find hoststorage"))
 		return
 	}
 	storage := hoststorage.GetStorage()
 	self.SetStage("OnAttachStorageComplete", nil)
 	err := host.GetHostDriver().RequestAttachStorage(ctx, hoststorage, host, storage, self)
 	if err != nil {
-		self.taskFail(ctx, host, err.Error())
+		self.taskFail(ctx, host, jsonutils.Marshal(err))
 	}
 }
 
@@ -83,5 +83,5 @@ func (self *HostStorageAttachTask) OnAttachStorageComplete(ctx context.Context, 
 }
 
 func (self *HostStorageAttachTask) OnAttachStorageCompleteFailed(ctx context.Context, host *models.SHost, reason jsonutils.JSONObject) {
-	self.taskFail(ctx, host, reason.String())
+	self.taskFail(ctx, host, reason)
 }

--- a/pkg/compute/tasks/instance_snapshot_and_clone_task.go
+++ b/pkg/compute/tasks/instance_snapshot_and_clone_task.go
@@ -38,9 +38,9 @@ func init() {
 }
 
 func (self *InstanceSnapshotAndCloneTask) taskFailed(
-	ctx context.Context, isp *models.SInstanceSnapshot, reason string) {
+	ctx context.Context, isp *models.SInstanceSnapshot, reason jsonutils.JSONObject) {
 	guest := models.GuestManager.FetchGuestById(isp.GuestId)
-	guest.SetStatus(self.UserCred, compute.VM_SNAPSHOT_AND_CLONE_FAILED, reason)
+	guest.SetStatus(self.UserCred, compute.VM_SNAPSHOT_AND_CLONE_FAILED, reason.String())
 	logclient.AddActionLogWithContext(
 		ctx, guest, logclient.ACT_VM_SNAPSHOT_AND_CLONE, reason, self.UserCred, false,
 	)
@@ -59,7 +59,7 @@ func (self *InstanceSnapshotAndCloneTask) taskComplete(
 	self.SetStageComplete(ctx, nil)
 }
 
-func (self *InstanceSnapshotAndCloneTask) SetStageFailed(ctx context.Context, reason string) {
+func (self *InstanceSnapshotAndCloneTask) SetStageFailed(ctx context.Context, reason jsonutils.JSONObject) {
 	self.finalReleasePendingUsage(ctx, false)
 	self.STask.SetStageFailed(ctx, reason)
 }
@@ -85,7 +85,7 @@ func (self *InstanceSnapshotAndCloneTask) OnInit(
 	self.SetStage("OnCreateInstanceSnapshot", nil)
 	err := isp.StartCreateInstanceSnapshotTask(ctx, self.UserCred, nil, self.Id)
 	if err != nil {
-		self.taskFailed(ctx, isp, err.Error())
+		self.taskFailed(ctx, isp, jsonutils.NewString(err.Error()))
 		return
 	}
 }
@@ -95,7 +95,7 @@ func (self *InstanceSnapshotAndCloneTask) OnCreateInstanceSnapshot(
 	// start create server
 	params, err := self.Params.Get("guest_params")
 	if err != nil {
-		self.taskFailed(ctx, isp, "Failed get new guest params")
+		self.taskFailed(ctx, isp, jsonutils.NewString("Failed get new guest params"))
 		return
 	}
 	count, _ := params.Int("count")
@@ -104,7 +104,7 @@ func (self *InstanceSnapshotAndCloneTask) OnCreateInstanceSnapshot(
 	}
 	err = self.doGuestCreate(ctx, isp, params, int(count))
 	if err != nil {
-		self.taskFailed(ctx, isp, err.Error())
+		self.taskFailed(ctx, isp, jsonutils.NewString(err.Error()))
 		return
 	}
 	self.taskComplete(ctx, isp, nil)
@@ -136,5 +136,5 @@ func (self *InstanceSnapshotAndCloneTask) doGuestCreate(
 
 func (self *InstanceSnapshotAndCloneTask) OnCreateInstanceSnapshotFailed(
 	ctx context.Context, isp *models.SInstanceSnapshot, data jsonutils.JSONObject) {
-	self.taskFailed(ctx, isp, data.String())
+	self.taskFailed(ctx, isp, data)
 }

--- a/pkg/compute/tasks/instance_snapshot_create_task.go
+++ b/pkg/compute/tasks/instance_snapshot_create_task.go
@@ -40,7 +40,7 @@ func init() {
 	taskman.RegisterTask(InstanceSnapshotCreateTask{})
 }
 
-func (self *InstanceSnapshotCreateTask) SetStageFailed(ctx context.Context, reason string) {
+func (self *InstanceSnapshotCreateTask) SetStageFailed(ctx context.Context, reason jsonutils.JSONObject) {
 	self.finalReleasePendingUsage(ctx)
 	self.STask.SetStageFailed(ctx, reason)
 }
@@ -54,17 +54,17 @@ func (self *InstanceSnapshotCreateTask) finalReleasePendingUsage(ctx context.Con
 }
 
 func (self *InstanceSnapshotCreateTask) taskFail(
-	ctx context.Context, isp *models.SInstanceSnapshot, guest *models.SGuest, reason string) {
+	ctx context.Context, isp *models.SInstanceSnapshot, guest *models.SGuest, reason jsonutils.JSONObject) {
 
 	if guest == nil {
 		guest = models.GuestManager.FetchGuestById(isp.GuestId)
 	}
-	isp.SetStatus(self.UserCred, compute.INSTANCE_SNAPSHOT_FAILED, reason)
-	guest.SetStatus(self.UserCred, compute.VM_INSTANCE_SNAPSHOT_FAILED, reason)
+	isp.SetStatus(self.UserCred, compute.INSTANCE_SNAPSHOT_FAILED, reason.String())
+	guest.SetStatus(self.UserCred, compute.VM_INSTANCE_SNAPSHOT_FAILED, reason.String())
 
 	db.OpsLog.LogEvent(isp, db.ACT_ALLOCATE_FAIL, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, isp, logclient.ACT_CREATE, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(isp.GetId(), isp.Name, compute.INSTANCE_SNAPSHOT_FAILED, reason)
+	notifyclient.NotifySystemError(isp.GetId(), isp.Name, compute.INSTANCE_SNAPSHOT_FAILED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -107,7 +107,7 @@ func (self *InstanceSnapshotCreateTask) GuestDiskCreateSnapshot(
 	snapshotName, err := db.GenerateName(models.SnapshotManager, self.UserCred,
 		fmt.Sprintf("%s-%s", isp.Name, rand.String(8)))
 	if err != nil {
-		self.taskFail(ctx, isp, guest, fmt.Sprintf("Generate snapshot name %s", err))
+		self.taskFail(ctx, isp, guest, jsonutils.NewString(fmt.Sprintf("Generate snapshot name %s", err)))
 		return
 	}
 
@@ -115,13 +115,13 @@ func (self *InstanceSnapshotCreateTask) GuestDiskCreateSnapshot(
 		ctx, self.UserCred, compute.SNAPSHOT_MANUAL, disks[diskIndex].DiskId,
 		guest.Id, "", snapshotName, -1)
 	if err != nil {
-		self.taskFail(ctx, isp, guest, err.Error())
+		self.taskFail(ctx, isp, guest, jsonutils.NewString(err.Error()))
 		return
 	}
 
 	err = models.InstanceSnapshotJointManager.CreateJoint(ctx, isp.Id, snapshot.Id, int8(diskIndex))
 	if err != nil {
-		self.taskFail(ctx, isp, guest, err.Error())
+		self.taskFail(ctx, isp, guest, jsonutils.NewString(err.Error()))
 		return
 	}
 
@@ -131,7 +131,7 @@ func (self *InstanceSnapshotCreateTask) GuestDiskCreateSnapshot(
 	self.SetStage("OnDiskSnapshot", params)
 
 	if err := snapshot.StartSnapshotCreateTask(ctx, self.UserCred, nil, self.Id); err != nil {
-		self.taskFail(ctx, isp, guest, err.Error())
+		self.taskFail(ctx, isp, guest, jsonutils.NewString(err.Error()))
 		return
 	}
 }
@@ -143,7 +143,7 @@ func (self *InstanceSnapshotCreateTask) OnDiskSnapshot(
 
 	diskIndex, err := self.Params.Int("disk_index")
 	if err != nil {
-		self.taskFail(ctx, isp, guest, err.Error())
+		self.taskFail(ctx, isp, guest, jsonutils.NewString(err.Error()))
 		return
 	}
 
@@ -152,5 +152,5 @@ func (self *InstanceSnapshotCreateTask) OnDiskSnapshot(
 
 func (self *InstanceSnapshotCreateTask) OnDiskSnapshotFailed(
 	ctx context.Context, isp *models.SInstanceSnapshot, data jsonutils.JSONObject) {
-	self.taskFail(ctx, isp, nil, data.String())
+	self.taskFail(ctx, isp, nil, data)
 }

--- a/pkg/compute/tasks/loadbalancer_acl_delete_task.go
+++ b/pkg/compute/tasks/loadbalancer_acl_delete_task.go
@@ -36,11 +36,11 @@ func init() {
 	taskman.RegisterTask(LoadbalancerAclDeleteTask{})
 }
 
-func (self *LoadbalancerAclDeleteTask) taskFail(ctx context.Context, lbacl *models.SCachedLoadbalancerAcl, reason string) {
-	lbacl.SetStatus(self.GetUserCred(), api.LB_STATUS_DELETE_FAILED, reason)
+func (self *LoadbalancerAclDeleteTask) taskFail(ctx context.Context, lbacl *models.SCachedLoadbalancerAcl, reason jsonutils.JSONObject) {
+	lbacl.SetStatus(self.GetUserCred(), api.LB_STATUS_DELETE_FAILED, reason.String())
 	db.OpsLog.LogEvent(lbacl, db.ACT_DELOCATE_FAIL, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, lbacl, logclient.ACT_DELOCATE, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(lbacl.Id, lbacl.Name, api.LB_STATUS_DELETE_FAILED, reason)
+	notifyclient.NotifySystemError(lbacl.Id, lbacl.Name, api.LB_STATUS_DELETE_FAILED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -48,12 +48,12 @@ func (self *LoadbalancerAclDeleteTask) OnInit(ctx context.Context, obj db.IStand
 	lbacl := obj.(*models.SCachedLoadbalancerAcl)
 	region := lbacl.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, lbacl, fmt.Sprintf("failed to find region for lbacl %s", lbacl.Name))
+		self.taskFail(ctx, lbacl, jsonutils.NewString(fmt.Sprintf("failed to find region for lbacl %s", lbacl.Name)))
 		return
 	}
 	self.SetStage("OnLoadbalancerAclDeleteComplete", nil)
 	if err := region.GetDriver().RequestDeleteLoadbalancerAcl(ctx, self.GetUserCred(), lbacl, self); err != nil {
-		self.taskFail(ctx, lbacl, err.Error())
+		self.taskFail(ctx, lbacl, jsonutils.Marshal(err))
 	}
 }
 
@@ -65,5 +65,5 @@ func (self *LoadbalancerAclDeleteTask) OnLoadbalancerAclDeleteComplete(ctx conte
 }
 
 func (self *LoadbalancerAclDeleteTask) OnLoadbalancerAclDeleteCompleteFailed(ctx context.Context, lbacl *models.SCachedLoadbalancerAcl, reason jsonutils.JSONObject) {
-	self.taskFail(ctx, lbacl, reason.String())
+	self.taskFail(ctx, lbacl, reason)
 }

--- a/pkg/compute/tasks/loadbalancer_acl_sync_task.go
+++ b/pkg/compute/tasks/loadbalancer_acl_sync_task.go
@@ -36,11 +36,11 @@ func init() {
 	taskman.RegisterTask(LoadbalancerAclSyncTask{})
 }
 
-func (self *LoadbalancerAclSyncTask) taskFail(ctx context.Context, lbacl *models.SCachedLoadbalancerAcl, reason string) {
-	lbacl.SetStatus(self.GetUserCred(), api.LB_SYNC_CONF_FAILED, reason)
+func (self *LoadbalancerAclSyncTask) taskFail(ctx context.Context, lbacl *models.SCachedLoadbalancerAcl, reason jsonutils.JSONObject) {
+	lbacl.SetStatus(self.GetUserCred(), api.LB_SYNC_CONF_FAILED, reason.String())
 	db.OpsLog.LogEvent(lbacl, db.ACT_SYNC_CONF, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, lbacl, logclient.ACT_SYNC_CONF, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(lbacl.Id, lbacl.Name, api.LB_SYNC_CONF_FAILED, reason)
+	notifyclient.NotifySystemError(lbacl.Id, lbacl.Name, api.LB_SYNC_CONF_FAILED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -48,12 +48,12 @@ func (self *LoadbalancerAclSyncTask) OnInit(ctx context.Context, obj db.IStandal
 	lbacl := obj.(*models.SCachedLoadbalancerAcl)
 	region := lbacl.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, lbacl, fmt.Sprintf("failed to find region for lbacl %s", lbacl.Name))
+		self.taskFail(ctx, lbacl, jsonutils.NewString(fmt.Sprintf("failed to find region for lbacl %s", lbacl.Name)))
 		return
 	}
 	self.SetStage("OnLoadbalancerAclSyncComplete", nil)
 	if err := region.GetDriver().RequestSyncLoadbalancerAcl(ctx, self.GetUserCred(), lbacl, self); err != nil {
-		self.taskFail(ctx, lbacl, err.Error())
+		self.taskFail(ctx, lbacl, jsonutils.Marshal(err))
 	}
 }
 
@@ -65,5 +65,5 @@ func (self *LoadbalancerAclSyncTask) OnLoadbalancerAclSyncComplete(ctx context.C
 }
 
 func (self *LoadbalancerAclSyncTask) OnLoadbalancerAclSyncCompleteFailed(ctx context.Context, lbacl *models.SCachedLoadbalancerAcl, reason jsonutils.JSONObject) {
-	self.taskFail(ctx, lbacl, reason.String())
+	self.taskFail(ctx, lbacl, reason)
 }

--- a/pkg/compute/tasks/loadbalancer_listener_rule_create_task.go
+++ b/pkg/compute/tasks/loadbalancer_listener_rule_create_task.go
@@ -55,13 +55,13 @@ func onPrepareLoadbalancerBackendgroup(ctx context.Context, region *models.SClou
 func onHuaiweiPrepareLoadbalancerBackendgroup(ctx context.Context, region *models.SCloudregion, lbr *models.SLoadbalancerListenerRule, data jsonutils.JSONObject, self *LoadbalancerListenerRuleCreateTask) {
 	lbbg := lbr.GetLoadbalancerBackendGroup()
 	if lbbg == nil {
-		self.taskFail(ctx, lbr, "huawei loadbalancer listener rule releated backend group not found")
+		self.taskFail(ctx, lbr, jsonutils.NewString("huawei loadbalancer listener rule releated backend group not found"))
 		return
 	}
 
 	lblis := lbr.GetLoadbalancerListener()
 	if lblis == nil {
-		self.taskFail(ctx, lbr, "huawei loadbalancer listener rule releated listener not found")
+		self.taskFail(ctx, lbr, jsonutils.NewString("huawei loadbalancer listener rule releated listener not found"))
 		return
 	}
 
@@ -71,19 +71,19 @@ func onHuaiweiPrepareLoadbalancerBackendgroup(ctx context.Context, region *model
 	if group != nil {
 		ilbbg, err := group.GetICloudLoadbalancerBackendGroup()
 		if err != nil {
-			self.taskFail(ctx, lbr, err.Error())
+			self.taskFail(ctx, lbr, jsonutils.NewString(err.Error()))
 			return
 		}
 
 		groupParams, err := lbbg.GetHuaweiBackendGroupParams(lblis, lbr)
 		if err != nil {
-			self.taskFail(ctx, lbr, err.Error())
+			self.taskFail(ctx, lbr, jsonutils.NewString(err.Error()))
 			return
 		}
 		groupParams.ListenerID = ""
 		// 服务器组已经存在，直接同步即可
 		if err := ilbbg.Sync(ctx, groupParams); err != nil {
-			self.taskFail(ctx, lbr, err.Error())
+			self.taskFail(ctx, lbr, jsonutils.NewString(err.Error()))
 			return
 		} else {
 			group.SetModelManager(models.HuaweiCachedLbbgManager, group)
@@ -92,7 +92,7 @@ func onHuaiweiPrepareLoadbalancerBackendgroup(ctx context.Context, region *model
 				group.AssociatedType = api.LB_ASSOCIATE_TYPE_RULE
 				return nil
 			}); err != nil {
-				self.taskFail(ctx, lbr, err.Error())
+				self.taskFail(ctx, lbr, jsonutils.NewString(err.Error()))
 				return
 			}
 
@@ -108,19 +108,19 @@ func onHuaiweiPrepareLoadbalancerBackendgroup(ctx context.Context, region *model
 func onAwsPrepareLoadbalancerBackendgroup(ctx context.Context, region *models.SCloudregion, lbr *models.SLoadbalancerListenerRule, data jsonutils.JSONObject, self *LoadbalancerListenerRuleCreateTask) {
 	lbbg := lbr.GetLoadbalancerBackendGroup()
 	if lbbg == nil {
-		self.taskFail(ctx, lbr, "aws loadbalancer listener rule releated backend group not found")
+		self.taskFail(ctx, lbr, jsonutils.NewString("aws loadbalancer listener rule releated backend group not found"))
 		return
 	}
 
 	lblis := lbr.GetLoadbalancerListener()
 	if lblis == nil {
-		self.taskFail(ctx, lbr, "aws loadbalancer listener rule releated listener not found")
+		self.taskFail(ctx, lbr, jsonutils.NewString("aws loadbalancer listener rule releated listener not found"))
 		return
 	}
 
 	params, err := lbbg.GetAwsBackendGroupParams(lblis, lbr)
 	if err != nil {
-		self.taskFail(ctx, lbr, err.Error())
+		self.taskFail(ctx, lbr, jsonutils.NewString(err.Error()))
 		return
 	}
 
@@ -128,13 +128,13 @@ func onAwsPrepareLoadbalancerBackendgroup(ctx context.Context, region *models.SC
 	if group != nil {
 		ilbbg, err := group.GetICloudLoadbalancerBackendGroup()
 		if err != nil {
-			self.taskFail(ctx, lbr, err.Error())
+			self.taskFail(ctx, lbr, jsonutils.NewString(err.Error()))
 			return
 		}
 
 		// 服务器组已经存在，直接同步即可
 		if err := ilbbg.Sync(ctx, params); err != nil {
-			self.taskFail(ctx, lbr, err.Error())
+			self.taskFail(ctx, lbr, jsonutils.NewString(err.Error()))
 			return
 		}
 
@@ -147,11 +147,11 @@ func onAwsPrepareLoadbalancerBackendgroup(ctx context.Context, region *models.SC
 	}
 }
 
-func (self *LoadbalancerListenerRuleCreateTask) taskFail(ctx context.Context, lbr *models.SLoadbalancerListenerRule, reason string) {
-	lbr.SetStatus(self.GetUserCred(), api.LB_CREATE_FAILED, reason)
+func (self *LoadbalancerListenerRuleCreateTask) taskFail(ctx context.Context, lbr *models.SLoadbalancerListenerRule, reason jsonutils.JSONObject) {
+	lbr.SetStatus(self.GetUserCred(), api.LB_CREATE_FAILED, reason.String())
 	db.OpsLog.LogEvent(lbr, db.ACT_ALLOCATE_FAIL, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, lbr, logclient.ACT_CREATE, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(lbr.Id, lbr.Name, api.LB_CREATE_FAILED, reason)
+	notifyclient.NotifySystemError(lbr.Id, lbr.Name, api.LB_CREATE_FAILED, reason.String())
 	lblis := lbr.GetLoadbalancerListener()
 	if lblis != nil {
 		logclient.AddActionLogWithStartable(self, lblis, logclient.ACT_LB_ADD_LISTENER_RULE, reason, self.UserCred, false)
@@ -163,7 +163,7 @@ func (self *LoadbalancerListenerRuleCreateTask) OnInit(ctx context.Context, obj 
 	lbr := obj.(*models.SLoadbalancerListenerRule)
 	region := lbr.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, lbr, fmt.Sprintf("failed to find region for lbr %s", lbr.Name))
+		self.taskFail(ctx, lbr, jsonutils.NewString(fmt.Sprintf("failed to find region for lbr %s", lbr.Name)))
 		return
 	}
 
@@ -178,17 +178,17 @@ func (self *LoadbalancerListenerRuleCreateTask) OnPrepareLoadbalancerBackendgrou
 func (self *LoadbalancerListenerRuleCreateTask) OnCreateLoadbalancerListenerRule(ctx context.Context, lbr *models.SLoadbalancerListenerRule, data jsonutils.JSONObject) {
 	region := lbr.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, lbr, fmt.Sprintf("failed to find region for lbr %s", lbr.Name))
+		self.taskFail(ctx, lbr, jsonutils.NewString(fmt.Sprintf("failed to find region for lbr %s", lbr.Name)))
 		return
 	}
 	self.SetStage("OnLoadbalancerListenerRuleCreateComplete", nil)
 	if err := region.GetDriver().RequestCreateLoadbalancerListenerRule(ctx, self.GetUserCred(), lbr, self); err != nil {
-		self.taskFail(ctx, lbr, err.Error())
+		self.taskFail(ctx, lbr, jsonutils.Marshal(err))
 	}
 }
 
 func (self *LoadbalancerListenerRuleCreateTask) OnCreateLoadbalancerListenerRuleFailed(ctx context.Context, lbr *models.SLoadbalancerListenerRule, reason jsonutils.JSONObject) {
-	self.taskFail(ctx, lbr, reason.String())
+	self.taskFail(ctx, lbr, reason)
 }
 
 func (self *LoadbalancerListenerRuleCreateTask) OnLoadbalancerListenerRuleCreateComplete(ctx context.Context, lbr *models.SLoadbalancerListenerRule, data jsonutils.JSONObject) {
@@ -203,5 +203,5 @@ func (self *LoadbalancerListenerRuleCreateTask) OnLoadbalancerListenerRuleCreate
 }
 
 func (self *LoadbalancerListenerRuleCreateTask) OnLoadbalancerListenerRuleCreateCompleteFailed(ctx context.Context, lbr *models.SLoadbalancerListenerRule, reason jsonutils.JSONObject) {
-	self.taskFail(ctx, lbr, reason.String())
+	self.taskFail(ctx, lbr, reason)
 }

--- a/pkg/compute/tasks/loadbalancer_start_task.go
+++ b/pkg/compute/tasks/loadbalancer_start_task.go
@@ -36,11 +36,11 @@ func init() {
 	taskman.RegisterTask(LoadbalancerStartTask{})
 }
 
-func (self *LoadbalancerStartTask) taskFail(ctx context.Context, lb *models.SLoadbalancer, reason string) {
-	lb.SetStatus(self.GetUserCred(), api.LB_STATUS_DISABLED, reason)
+func (self *LoadbalancerStartTask) taskFail(ctx context.Context, lb *models.SLoadbalancer, reason jsonutils.JSONObject) {
+	lb.SetStatus(self.GetUserCred(), api.LB_STATUS_DISABLED, reason.String())
 	db.OpsLog.LogEvent(lb, db.ACT_ENABLE, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, lb, logclient.ACT_ENABLE, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(lb.Id, lb.Name, api.LB_STATUS_DISABLED, reason)
+	notifyclient.NotifySystemError(lb.Id, lb.Name, api.LB_STATUS_DISABLED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -48,12 +48,12 @@ func (self *LoadbalancerStartTask) OnInit(ctx context.Context, obj db.IStandalon
 	lb := obj.(*models.SLoadbalancer)
 	region := lb.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, lb, fmt.Sprintf("failed to find region for lb %s", lb.Name))
+		self.taskFail(ctx, lb, jsonutils.NewString(fmt.Sprintf("failed to find region for lb %s", lb.Name)))
 		return
 	}
 	self.SetStage("OnLoadbalancerStartComplete", nil)
 	if err := region.GetDriver().RequestStartLoadbalancer(ctx, self.GetUserCred(), lb, self); err != nil {
-		self.taskFail(ctx, lb, err.Error())
+		self.taskFail(ctx, lb, jsonutils.Marshal(err))
 	}
 }
 
@@ -65,5 +65,5 @@ func (self *LoadbalancerStartTask) OnLoadbalancerStartComplete(ctx context.Conte
 }
 
 func (self *LoadbalancerStartTask) OnLoadbalancerStartCompleteFailed(ctx context.Context, lb *models.SLoadbalancer, reason jsonutils.JSONObject) {
-	self.taskFail(ctx, lb, reason.String())
+	self.taskFail(ctx, lb, reason)
 }

--- a/pkg/compute/tasks/loadbalancer_stop_task.go
+++ b/pkg/compute/tasks/loadbalancer_stop_task.go
@@ -36,11 +36,11 @@ func init() {
 	taskman.RegisterTask(LoadbalancerStopTask{})
 }
 
-func (self *LoadbalancerStopTask) taskFail(ctx context.Context, lb *models.SLoadbalancer, reason string) {
-	lb.SetStatus(self.GetUserCred(), api.LB_STATUS_ENABLED, reason)
+func (self *LoadbalancerStopTask) taskFail(ctx context.Context, lb *models.SLoadbalancer, reason jsonutils.JSONObject) {
+	lb.SetStatus(self.GetUserCred(), api.LB_STATUS_ENABLED, reason.String())
 	db.OpsLog.LogEvent(lb, db.ACT_DISABLE, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, lb, logclient.ACT_DISABLE, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(lb.Id, lb.Name, api.LB_STATUS_ENABLED, reason)
+	notifyclient.NotifySystemError(lb.Id, lb.Name, api.LB_STATUS_ENABLED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -48,12 +48,12 @@ func (self *LoadbalancerStopTask) OnInit(ctx context.Context, obj db.IStandalone
 	lb := obj.(*models.SLoadbalancer)
 	region := lb.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, lb, fmt.Sprintf("failed to find region for lb %s", lb.Name))
+		self.taskFail(ctx, lb, jsonutils.NewString(fmt.Sprintf("failed to find region for lb %s", lb.Name)))
 		return
 	}
 	self.SetStage("OnLoadbalancerStopComplete", nil)
 	if err := region.GetDriver().RequestStopLoadbalancer(ctx, self.GetUserCred(), lb, self); err != nil {
-		self.taskFail(ctx, lb, err.Error())
+		self.taskFail(ctx, lb, jsonutils.Marshal(err))
 	}
 }
 
@@ -65,5 +65,5 @@ func (self *LoadbalancerStopTask) OnLoadbalancerStopComplete(ctx context.Context
 }
 
 func (self *LoadbalancerStopTask) OnLoadbalancerStopCompleteFailed(ctx context.Context, lb *models.SLoadbalancer, reason jsonutils.JSONObject) {
-	self.taskFail(ctx, lb, reason.String())
+	self.taskFail(ctx, lb, reason)
 }

--- a/pkg/compute/tasks/loadbalancer_syncstatus_task.go
+++ b/pkg/compute/tasks/loadbalancer_syncstatus_task.go
@@ -36,11 +36,11 @@ func init() {
 	taskman.RegisterTask(LoadbalancerSyncstatusTask{})
 }
 
-func (self *LoadbalancerSyncstatusTask) taskFail(ctx context.Context, lb *models.SLoadbalancer, reason string) {
-	lb.SetStatus(self.GetUserCred(), api.LB_STATUS_UNKNOWN, reason)
+func (self *LoadbalancerSyncstatusTask) taskFail(ctx context.Context, lb *models.SLoadbalancer, reason jsonutils.JSONObject) {
+	lb.SetStatus(self.GetUserCred(), api.LB_STATUS_UNKNOWN, reason.String())
 	db.OpsLog.LogEvent(lb, db.ACT_SYNC_STATUS, reason, self.UserCred)
 	logclient.AddActionLogWithStartable(self, lb, logclient.ACT_SYNC_STATUS, reason, self.UserCred, false)
-	notifyclient.NotifySystemError(lb.Id, lb.Name, api.LB_SYNC_CONF_FAILED, reason)
+	notifyclient.NotifySystemError(lb.Id, lb.Name, api.LB_SYNC_CONF_FAILED, reason.String())
 	self.SetStageFailed(ctx, reason)
 }
 
@@ -48,12 +48,12 @@ func (self *LoadbalancerSyncstatusTask) OnInit(ctx context.Context, obj db.IStan
 	lb := obj.(*models.SLoadbalancer)
 	region := lb.GetRegion()
 	if region == nil {
-		self.taskFail(ctx, lb, fmt.Sprintf("failed to find region for lb %s", lb.Name))
+		self.taskFail(ctx, lb, jsonutils.NewString(fmt.Sprintf("failed to find region for lb %s", lb.Name)))
 		return
 	}
 	self.SetStage("OnLoadbalancerSyncstatusComplete", nil)
 	if err := region.GetDriver().RequestSyncstatusLoadbalancer(ctx, self.GetUserCred(), lb, self); err != nil {
-		self.taskFail(ctx, lb, err.Error())
+		self.taskFail(ctx, lb, jsonutils.Marshal(err))
 	}
 }
 
@@ -64,5 +64,5 @@ func (self *LoadbalancerSyncstatusTask) OnLoadbalancerSyncstatusComplete(ctx con
 }
 
 func (self *LoadbalancerSyncstatusTask) OnLoadbalancerSyncstatusCompleteFailed(ctx context.Context, lb *models.SLoadbalancer, reason jsonutils.JSONObject) {
-	self.taskFail(ctx, lb, reason.String())
+	self.taskFail(ctx, lb, reason)
 }

--- a/pkg/compute/tasks/network_create_task.go
+++ b/pkg/compute/tasks/network_create_task.go
@@ -39,11 +39,14 @@ func init() {
 }
 
 func (self *NetworkCreateTask) taskFailed(ctx context.Context, network *models.SNetwork, event string, err error) {
-	log.Errorf("network create task fail on %s: %s", event, err)
-	network.SetStatus(self.UserCred, api.NETWORK_STATUS_FAILED, err.Error())
-	db.OpsLog.LogEvent(network, db.ACT_ALLOCATE_FAIL, err.Error(), self.UserCred)
-	logclient.AddActionLogWithStartable(self, network, logclient.ACT_CREATE, event, self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+	log.Errorf("network create task fail on %s: %s", event, err.Error())
+	reason := jsonutils.NewDict()
+	reason.Set("event", jsonutils.NewString(event))
+	reason.Set("reason", jsonutils.NewString(err.Error()))
+	network.SetStatus(self.UserCred, api.NETWORK_STATUS_FAILED, reason.String())
+	db.OpsLog.LogEvent(network, db.ACT_ALLOCATE_FAIL, reason, self.UserCred)
+	logclient.AddActionLogWithStartable(self, network, logclient.ACT_CREATE, reason, self.UserCred, false)
+	self.SetStageFailed(ctx, reason)
 }
 
 func (self *NetworkCreateTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {

--- a/pkg/compute/tasks/network_delete_task.go
+++ b/pkg/compute/tasks/network_delete_task.go
@@ -36,12 +36,12 @@ func init() {
 	taskman.RegisterTask(NetworkDeleteTask{})
 }
 
-func (self *NetworkDeleteTask) taskFailed(ctx context.Context, network *models.SNetwork, err error) {
-	log.Errorf("network delete task fail: %s", err)
-	network.SetStatus(self.UserCred, api.NETWORK_STATUS_DELETE_FAILED, err.Error())
-	db.OpsLog.LogEvent(network, db.ACT_ALLOCATE_FAIL, err.Error(), self.UserCred)
-	logclient.AddActionLogWithStartable(self, network, logclient.ACT_DELETE, err.Error(), self.UserCred, false)
-	self.SetStageFailed(ctx, err.Error())
+func (self *NetworkDeleteTask) taskFailed(ctx context.Context, network *models.SNetwork, reason jsonutils.JSONObject) {
+	log.Errorf("network delete task fail: %s", reason)
+	network.SetStatus(self.UserCred, api.NETWORK_STATUS_DELETE_FAILED, reason.String())
+	db.OpsLog.LogEvent(network, db.ACT_ALLOCATE_FAIL, reason, self.UserCred)
+	logclient.AddActionLogWithStartable(self, network, logclient.ACT_DELETE, reason, self.UserCred, false)
+	self.SetStageFailed(ctx, reason)
 }
 
 func (self *NetworkDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
@@ -54,13 +54,13 @@ func (self *NetworkDeleteTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 	if inet != nil {
 		err = inet.Delete()
 		if err != nil {
-			self.taskFailed(ctx, network, err)
+			self.taskFailed(ctx, network, jsonutils.NewString(err.Error()))
 			return
 		}
 	} else if err == cloudprovider.ErrNotFound {
 		// already deleted, do nothing
 	} else {
-		self.taskFailed(ctx, network, err)
+		self.taskFailed(ctx, network, jsonutils.NewString(err.Error()))
 		return
 	}
 

--- a/pkg/compute/tasks/network_syncstatus_task.go
+++ b/pkg/compute/tasks/network_syncstatus_task.go
@@ -35,11 +35,11 @@ func init() {
 	taskman.RegisterTask(NetworkSyncstatusTask{})
 }
 
-func (self *NetworkSyncstatusTask) taskFail(ctx context.Context, net *models.SNetwork, msg string) {
-	net.SetStatus(self.UserCred, api.NETWORK_STATUS_UNKNOWN, msg)
-	db.OpsLog.LogEvent(net, db.ACT_SYNC_STATUS, msg, self.GetUserCred())
-	logclient.AddActionLogWithStartable(self, net, logclient.ACT_SYNC_STATUS, msg, self.UserCred, false)
-	self.SetStageFailed(ctx, msg)
+func (self *NetworkSyncstatusTask) taskFail(ctx context.Context, net *models.SNetwork, reason jsonutils.JSONObject) {
+	net.SetStatus(self.UserCred, api.NETWORK_STATUS_UNKNOWN, reason.String())
+	db.OpsLog.LogEvent(net, db.ACT_SYNC_STATUS, reason, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, net, logclient.ACT_SYNC_STATUS, reason, self.UserCred, false)
+	self.SetStageFailed(ctx, reason)
 }
 
 func (self *NetworkSyncstatusTask) OnInit(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
@@ -48,21 +48,21 @@ func (self *NetworkSyncstatusTask) OnInit(ctx context.Context, obj db.IStandalon
 	extNet, err := net.GetINetwork()
 	if err != nil {
 		msg := fmt.Sprintf("fail to find ICloudNetwork for network %s", err)
-		self.taskFail(ctx, net, msg)
+		self.taskFail(ctx, net, jsonutils.NewString(msg))
 		return
 	}
 
 	err = extNet.Refresh()
 	if err != nil {
 		msg := fmt.Sprintf("fail to refresh ICloudNetwork status %s", err)
-		self.taskFail(ctx, net, msg)
+		self.taskFail(ctx, net, jsonutils.NewString(msg))
 		return
 	}
 
 	err = net.SyncWithCloudNetwork(ctx, self.UserCred, extNet, nil, nil)
 	if err != nil {
 		msg := fmt.Sprintf("fail to sync network status %s", err)
-		self.taskFail(ctx, net, msg)
+		self.taskFail(ctx, net, jsonutils.NewString(msg))
 		return
 	}
 

--- a/pkg/compute/tasks/secgroup_group_cache_task.go
+++ b/pkg/compute/tasks/secgroup_group_cache_task.go
@@ -34,8 +34,8 @@ func init() {
 	taskman.RegisterTask(SecurityGroupCacheTask{})
 }
 
-func (self *SecurityGroupCacheTask) taskFailed(ctx context.Context, secgroup *models.SSecurityGroup, err error) {
-	self.SetStageFailed(ctx, err.Error())
+func (self *SecurityGroupCacheTask) taskFailed(ctx context.Context, secgroup *models.SSecurityGroup, reason jsonutils.JSONObject) {
+	self.SetStageFailed(ctx, reason)
 }
 
 func (self *SecurityGroupCacheTask) getVpc() (*models.SVpc, error) {
@@ -55,13 +55,13 @@ func (self *SecurityGroupCacheTask) OnInit(ctx context.Context, obj db.IStandalo
 
 	vpc, err := self.getVpc()
 	if err != nil {
-		self.taskFailed(ctx, secgroup, errors.Wrap(err, "self.getVpc()"))
+		self.taskFailed(ctx, secgroup, jsonutils.NewString(errors.Wrap(err, "self.getVpc()").Error()))
 		return
 	}
 
 	region, err := vpc.GetRegion()
 	if err != nil {
-		self.taskFailed(ctx, secgroup, errors.Wrap(err, "vpc.GetRegion"))
+		self.taskFailed(ctx, secgroup, jsonutils.NewString(errors.Wrap(err, "vpc.GetRegion").Error()))
 		return
 	}
 
@@ -71,7 +71,7 @@ func (self *SecurityGroupCacheTask) OnInit(ctx context.Context, obj db.IStandalo
 
 	err = region.GetDriver().RequestCacheSecurityGroup(ctx, self.UserCred, region, vpc, secgroup, classic, self)
 	if err != nil {
-		self.taskFailed(ctx, secgroup, errors.Wrap(err, "RequestCacheSecgroup"))
+		self.taskFailed(ctx, secgroup, jsonutils.Marshal(err))
 		return
 	}
 }
@@ -81,5 +81,5 @@ func (self *SecurityGroupCacheTask) OnCacheSecurityGroupComplete(ctx context.Con
 }
 
 func (self *SecurityGroupCacheTask) OnCacheSecurityGroupCompleteFailed(ctx context.Context, obj db.IStandaloneModel, err jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, err.String())
+	self.SetStageFailed(ctx, err)
 }

--- a/pkg/compute/tasks/security_group_cache_delete_task.go
+++ b/pkg/compute/tasks/security_group_cache_delete_task.go
@@ -37,13 +37,13 @@ func init() {
 	taskman.RegisterTask(SecurityGroupCacheDeleteTask{})
 }
 
-func (self *SecurityGroupCacheDeleteTask) taskFailed(ctx context.Context, cache *models.SSecurityGroupCache, err error) {
-	cache.SetStatus(self.UserCred, api.SECGROUP_CACHE_STATUS_DELETE_FAILED, err.Error())
+func (self *SecurityGroupCacheDeleteTask) taskFailed(ctx context.Context, cache *models.SSecurityGroupCache, err jsonutils.JSONObject) {
+	cache.SetStatus(self.UserCred, api.SECGROUP_CACHE_STATUS_DELETE_FAILED, err.String())
 	secgroup, _ := cache.GetSecgroup()
 	if secgroup != nil {
 		logclient.AddActionLogWithStartable(self, secgroup, logclient.ACT_DELETE, err, self.UserCred, false)
 	}
-	self.SetStageFailed(ctx, err.Error())
+	self.SetStageFailed(ctx, err)
 }
 
 func (self *SecurityGroupCacheDeleteTask) taskComplete(ctx context.Context, cache *models.SSecurityGroupCache) {
@@ -71,7 +71,7 @@ func (self *SecurityGroupCacheDeleteTask) OnInit(ctx context.Context, obj db.ISt
 			self.taskComplete(ctx, cache)
 			return
 		}
-		self.taskFailed(ctx, cache, errors.Wrap(err, "cache.GetIRegion"))
+		self.taskFailed(ctx, cache, jsonutils.NewString(errors.Wrap(err, "cache.GetIRegion").Error()))
 		return
 	}
 	iSecgroup, err := iRegion.GetISecurityGroupById(cache.ExternalId)
@@ -80,12 +80,12 @@ func (self *SecurityGroupCacheDeleteTask) OnInit(ctx context.Context, obj db.ISt
 			self.taskComplete(ctx, cache)
 			return
 		}
-		self.taskFailed(ctx, cache, errors.Wrap(err, "iRegion.GetIStoragecacheById"))
+		self.taskFailed(ctx, cache, jsonutils.NewString(errors.Wrap(err, "iRegion.GetIStoragecacheById").Error()))
 		return
 	}
 	err = iSecgroup.Delete()
 	if err != nil {
-		self.taskFailed(ctx, cache, err)
+		self.taskFailed(ctx, cache, jsonutils.NewString(err.Error()))
 		return
 	}
 	self.taskComplete(ctx, cache)

--- a/pkg/compute/tasks/server_sku_cache_task.go
+++ b/pkg/compute/tasks/server_sku_cache_task.go
@@ -34,8 +34,8 @@ func init() {
 	taskman.RegisterTask(ServerSkuCacheTask{})
 }
 
-func (self *ServerSkuCacheTask) taskFailed(ctx context.Context, sku *models.SServerSku, err error) {
-	self.SetStageFailed(ctx, err.Error())
+func (self *ServerSkuCacheTask) taskFailed(ctx context.Context, sku *models.SServerSku, err jsonutils.JSONObject) {
+	self.SetStageFailed(ctx, err)
 }
 
 func (self *ServerSkuCacheTask) getCloudregion() (*models.SCloudregion, error) {
@@ -55,30 +55,30 @@ func (self *ServerSkuCacheTask) OnInit(ctx context.Context, obj db.IStandaloneMo
 
 	cloudregion, err := self.getCloudregion()
 	if err != nil {
-		self.taskFailed(ctx, sku, errors.Wrap(err, "self.getCloudregion()"))
+		self.taskFailed(ctx, sku, jsonutils.NewString(errors.Wrap(err, "self.getCloudregion()").Error()))
 		return
 	}
 
 	cloudprovider := cloudregion.GetCloudprovider()
 	if cloudprovider == nil {
-		self.taskFailed(ctx, sku, fmt.Errorf("failed to found cloudprovider for cloudregion %s(%s)", cloudregion.Name, cloudregion.Id))
+		self.taskFailed(ctx, sku, jsonutils.NewString(fmt.Sprintf("failed to found cloudprovider for cloudregion %s(%s)", cloudregion.Name, cloudregion.Id)))
 		return
 	}
 
 	provider, err := cloudprovider.GetProvider()
 	if err != nil {
-		self.taskFailed(ctx, sku, errors.Wrap(err, "cloudprovider.GetProvider"))
+		self.taskFailed(ctx, sku, jsonutils.NewString(errors.Wrap(err, "cloudprovider.GetProvider").Error()))
 		return
 	}
 	iRegion, err := provider.GetIRegionById(cloudregion.ExternalId)
 	if err != nil {
-		self.taskFailed(ctx, sku, errors.Wrap(err, "provider.GetIRegionById"))
+		self.taskFailed(ctx, sku, jsonutils.NewString(errors.Wrap(err, "provider.GetIRegionById").Error()))
 		return
 	}
 
 	iskus, err := iRegion.GetISkus()
 	if err != nil {
-		self.taskFailed(ctx, sku, errors.Wrap(err, "provider.GetIRegionById"))
+		self.taskFailed(ctx, sku, jsonutils.NewString(errors.Wrap(err, "provider.GetIRegionById").Error()))
 		return
 	}
 
@@ -91,7 +91,7 @@ func (self *ServerSkuCacheTask) OnInit(ctx context.Context, obj db.IStandaloneMo
 
 	err = iRegion.CreateISku(sku.Name, sku.CpuCoreCount, sku.MemorySizeMB)
 	if err != nil {
-		self.taskFailed(ctx, sku, errors.Wrap(err, "provider.GetIRegionById"))
+		self.taskFailed(ctx, sku, jsonutils.NewString(errors.Wrap(err, "provider.GetIRegionById").Error()))
 		return
 	}
 	self.SetStageComplete(ctx, nil)

--- a/pkg/compute/tasks/snapshot_policy_cache_delete_task.go
+++ b/pkg/compute/tasks/snapshot_policy_cache_delete_task.go
@@ -34,10 +34,10 @@ func init() {
 }
 
 func (self *SnapshotPolicyCacheDeleteTask) taskFailed(ctx context.Context, cache *models.SSnapshotPolicyCache,
-	err error) {
+	err jsonutils.JSONObject) {
 
-	cache.SetStatus(self.UserCred, api.SNAPSHOT_POLICY_CACHE_STATUS_DELETE_FAILED, err.Error())
-	self.SetStageFailed(ctx, err.Error())
+	cache.SetStatus(self.UserCred, api.SNAPSHOT_POLICY_CACHE_STATUS_DELETE_FAILED, err.String())
+	self.SetStageFailed(ctx, err)
 }
 
 func (self *SnapshotPolicyCacheDeleteTask) taskComplete(ctx context.Context, cache *models.SSnapshotPolicyCache) {
@@ -57,7 +57,7 @@ func (self *SnapshotPolicyCacheDeleteTask) OnInit(ctx context.Context, obj db.IS
 
 	err := cache.DeleteCloudSnapshotPolicy()
 	if err != nil {
-		self.taskFailed(ctx, cache, err)
+		self.taskFailed(ctx, cache, jsonutils.NewString(err.Error()))
 		return
 	}
 	self.taskComplete(ctx, cache)

--- a/pkg/compute/tasks/storage_cache_image_task.go
+++ b/pkg/compute/tasks/storage_cache_image_task.go
@@ -16,7 +16,6 @@ package tasks
 
 import (
 	"context"
-	"fmt"
 
 	"yunion.io/x/jsonutils"
 
@@ -91,25 +90,24 @@ func (self *StorageCacheImageTask) OnImageCacheCompleteFailed(ctx context.Contex
 	storageCache := obj.(*models.SStoragecache)
 	imageId, _ := self.Params.GetString("image_id")
 	scimg := models.StoragecachedimageManager.Register(ctx, self.UserCred, storageCache.Id, imageId, "")
-	err := fmt.Errorf(data.String())
 	extImgId, _ := data.GetString("image_id")
-	self.OnCacheFailed(ctx, storageCache, imageId, scimg, err, extImgId)
+	self.OnCacheFailed(ctx, storageCache, imageId, scimg, data, extImgId)
 }
 
-func (self *StorageCacheImageTask) OnCacheFailed(ctx context.Context, cache *models.SStoragecache, imageId string, scimg *models.SStoragecachedimage, err error, extImgId string) {
-	scimg.SetStatus(self.UserCred, api.CACHED_IMAGE_STATUS_CACHE_FAILED, err.Error())
+func (self *StorageCacheImageTask) OnCacheFailed(ctx context.Context, cache *models.SStoragecache, imageId string, scimg *models.SStoragecachedimage, reason jsonutils.JSONObject, extImgId string) {
+	scimg.SetStatus(self.UserCred, api.CACHED_IMAGE_STATUS_CACHE_FAILED, reason.String())
 	if len(extImgId) > 0 && scimg.ExternalId != extImgId {
 		scimg.SetExternalId(extImgId)
 	}
 	body := jsonutils.NewDict()
-	body.Add(jsonutils.NewString(err.Error()), "reason")
+	body.Add(reason, "reason")
 	body.Add(jsonutils.NewString(imageId), "image_id")
 	db.OpsLog.LogEvent(cache, db.ACT_CACHE_IMAGE_FAIL, body, self.UserCred)
 	ci := scimg.GetCachedimage()
 	if ci != nil {
 		logclient.AddActionLogWithStartable(self, ci, logclient.ACT_CACHED_IMAGE, body, self.UserCred, false)
 	}
-	self.SetStageFailed(ctx, err.Error())
+	self.SetStageFailed(ctx, body)
 }
 
 func (self *StorageCacheImageTask) OnCacheSucc(ctx context.Context, cache *models.SStoragecache, data *jsonutils.JSONDict) {

--- a/pkg/compute/tasks/storage_update_task.go
+++ b/pkg/compute/tasks/storage_update_task.go
@@ -44,7 +44,7 @@ func (self *StorageUpdateTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 	if dirver != nil {
 		err := dirver.DoStorageUpdateTask(ctx, self.UserCred, storage, self)
 		if err != nil {
-			self.SetStageFailed(ctx, err.Error())
+			self.SetStageFailed(ctx, jsonutils.NewString(err.Error()))
 		}
 	}
 	self.SetStageComplete(ctx, nil)
@@ -55,7 +55,7 @@ func (self *StorageUpdateTask) OnStorageUpdate(ctx context.Context, obj db.IStan
 }
 
 func (self *StorageUpdateTask) OnStorageUpdateFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }
 
 type RbdStorageUpdateTask struct {

--- a/pkg/compute/tasks/vpc_syncstatus_task.go
+++ b/pkg/compute/tasks/vpc_syncstatus_task.go
@@ -35,8 +35,8 @@ func init() {
 	taskman.RegisterTask(VpcSyncstatusTask{})
 }
 
-func (self *VpcSyncstatusTask) taskFail(ctx context.Context, vpc *models.SVpc, msg string) {
-	vpc.SetStatus(self.UserCred, api.VPC_STATUS_UNKNOWN, msg)
+func (self *VpcSyncstatusTask) taskFail(ctx context.Context, vpc *models.SVpc, msg jsonutils.JSONObject) {
+	vpc.SetStatus(self.UserCred, api.VPC_STATUS_UNKNOWN, msg.String())
 	db.OpsLog.LogEvent(vpc, db.ACT_SYNC_STATUS, msg, self.GetUserCred())
 	logclient.AddActionLogWithStartable(self, vpc, logclient.ACT_SYNC_STATUS, msg, self.UserCred, false)
 	self.SetStageFailed(ctx, msg)
@@ -48,21 +48,21 @@ func (self *VpcSyncstatusTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 	extVpc, err := vpc.GetIVpc()
 	if err != nil {
 		msg := fmt.Sprintf("fail to find ICloudVpc for vpc %s", err)
-		self.taskFail(ctx, vpc, msg)
+		self.taskFail(ctx, vpc, jsonutils.NewString(msg))
 		return
 	}
 
 	err = extVpc.Refresh()
 	if err != nil {
 		msg := fmt.Sprintf("fail to refresh ICloudVpc status %s", err)
-		self.taskFail(ctx, vpc, msg)
+		self.taskFail(ctx, vpc, jsonutils.NewString(msg))
 		return
 	}
 
 	err = vpc.SyncWithCloudVpc(ctx, self.UserCred, extVpc, nil)
 	if err != nil {
 		msg := fmt.Sprintf("fail to sync vpc status %s", err)
-		self.taskFail(ctx, vpc, msg)
+		self.taskFail(ctx, vpc, jsonutils.NewString(msg))
 		return
 	}
 

--- a/pkg/devtool/tasks/template_binding_servers.go
+++ b/pkg/devtool/tasks/template_binding_servers.go
@@ -30,7 +30,6 @@ package tasks
 
 import (
 	"context"
-	"fmt"
 
 	"yunion.io/x/jsonutils"
 
@@ -52,7 +51,7 @@ func (self *TemplateBindingServers) OnInit(ctx context.Context, obj db.IStandalo
 	template := obj.(*models.SDevtoolTemplate)
 	_, err := template.Binding(ctx, self.UserCred, nil, self.Params)
 	if err != nil {
-		self.SetStageFailed(ctx, fmt.Sprintf("TemplateUpdate failed %s", err))
+		self.SetStageFailed(ctx, jsonutils.Marshal(err))
 	} else {
 		self.SetStageComplete(ctx, nil)
 	}

--- a/pkg/devtool/tasks/template_unbinding_servers.go
+++ b/pkg/devtool/tasks/template_unbinding_servers.go
@@ -52,7 +52,7 @@ func (self *TemplateUnbindingServers) OnInit(ctx context.Context, obj db.IStanda
 	template := obj.(*models.SDevtoolTemplate)
 	_, err := template.Unbinding(ctx, self.UserCred, nil, self.Params)
 	if err != nil {
-		self.SetStageFailed(ctx, fmt.Sprintf("TemplateUnBindingServers failed %s", err))
+		self.SetStageFailed(ctx, jsonutils.NewString(fmt.Sprintf("TemplateUnBindingServers failed %s", err)))
 	} else {
 		self.SetStageComplete(ctx, nil)
 	}

--- a/pkg/devtool/tasks/template_update.go
+++ b/pkg/devtool/tasks/template_update.go
@@ -52,7 +52,7 @@ func (self *TemplateUpdate) OnInit(ctx context.Context, obj db.IStandaloneModel,
 	template := obj.(*models.SDevtoolTemplate)
 	_, err := template.TaskUpdate(ctx, self.UserCred, nil, self.Params)
 	if err != nil {
-		self.SetStageFailed(ctx, fmt.Sprintf("TemplateUpdate failed %s", err))
+		self.SetStageFailed(ctx, jsonutils.NewString(fmt.Sprintf("TemplateUpdate failed %s", err)))
 	} else {
 		self.SetStageComplete(ctx, nil)
 	}

--- a/pkg/image/tasks/image_check_task.go
+++ b/pkg/image/tasks/image_check_task.go
@@ -50,5 +50,5 @@ func (self *ImageCheckTask) OnCheckComplete(ctx context.Context, obj db.IStandal
 }
 
 func (self *ImageCheckTask) OnCheckCompleteFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }

--- a/pkg/image/tasks/image_convert_task.go
+++ b/pkg/image/tasks/image_convert_task.go
@@ -73,5 +73,5 @@ func (self *ImageConvertTask) OnConvertComplete(ctx context.Context, obj db.ISta
 }
 
 func (self *ImageConvertTask) OnConvertCompleteFailed(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
-	self.SetStageFailed(ctx, data.String())
+	self.SetStageFailed(ctx, data)
 }

--- a/pkg/image/tasks/image_copy_from_url_task.go
+++ b/pkg/image/tasks/image_copy_from_url_task.go
@@ -16,7 +16,6 @@ package tasks
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"yunion.io/x/jsonutils"
@@ -80,7 +79,9 @@ func (self *ImageCopyFromUrlTask) OnImageImportComplete(ctx context.Context, obj
 func (self *ImageCopyFromUrlTask) OnImageImportCompleteFailed(ctx context.Context, obj db.IStandaloneModel, err jsonutils.JSONObject) {
 	image := obj.(*models.SImage)
 	copyFrom, _ := self.Params.GetString("copy_from")
-	msg := fmt.Sprintf("copy from url %s request fail %s", copyFrom, err)
+	msg := jsonutils.NewDict()
+	msg.Add(err, "reason")
+	msg.Add(jsonutils.NewString(copyFrom), "copy_from")
 	image.OnSaveTaskFailed(self, self.UserCred, msg)
 	self.SetStageFailed(ctx, msg)
 }

--- a/pkg/image/tasks/image_delete_task.go
+++ b/pkg/image/tasks/image_delete_task.go
@@ -66,7 +66,7 @@ func (self *ImageDeleteTask) startDeleteImage(ctx context.Context, image *models
 	if err != nil {
 		msg := fmt.Sprintf("fail to remove %s %s", image.GetPath(""), err)
 		log.Errorf(msg)
-		self.SetStageFailed(ctx, msg)
+		self.SetStageFailed(ctx, jsonutils.NewString(msg))
 		return
 	}
 

--- a/pkg/image/tasks/image_probe_task.go
+++ b/pkg/image/tasks/image_probe_task.go
@@ -50,11 +50,11 @@ func (self *ImageProbeTask) OnInit(ctx context.Context, obj db.IStandaloneModel,
 	}
 	if e := self.updateImageMetadata(ctx, image); e != nil {
 		image.SetStatus(self.UserCred, api.IMAGE_STATUS_KILLED, fmt.Sprintf("Image update failed %s", e))
-		self.SetStageFailed(ctx, e.Error())
+		self.SetStageFailed(ctx, jsonutils.NewString(e.Error()))
 		return
 	}
 	if err != nil {
-		self.OnProbeFailed(ctx, image, err.Error())
+		self.OnProbeFailed(ctx, image, jsonutils.NewString(err.Error()))
 	} else {
 		self.OnProbeSuccess(ctx, image)
 	}
@@ -68,14 +68,14 @@ func (self *ImageProbeTask) StartImageProbe(ctx context.Context, image *models.S
 	if err := self.updateImageMetadata(ctx, image); err != nil {
 		image.SetStatus(self.UserCred, api.IMAGE_STATUS_KILLED,
 			fmt.Sprintf("Image update failed after probe %s", err))
-		self.SetStageFailed(ctx, err.Error())
+		self.SetStageFailed(ctx, jsonutils.NewString(err.Error()))
 		return
 	}
 
 	if probeErr == nil {
 		self.OnProbeSuccess(ctx, image)
 	} else {
-		self.OnProbeFailed(ctx, image, probeErr.Error())
+		self.OnProbeFailed(ctx, image, jsonutils.NewString(probeErr.Error()))
 	}
 }
 
@@ -164,7 +164,7 @@ type sImageInfo struct {
 	IsInstalledCloudInit  bool
 }
 
-func (self *ImageProbeTask) OnProbeFailed(ctx context.Context, image *models.SImage, reason string) {
+func (self *ImageProbeTask) OnProbeFailed(ctx context.Context, image *models.SImage, reason jsonutils.JSONObject) {
 	log.Infof("Image %s Probe Failed: %s", image.Name, reason)
 	db.OpsLog.LogEvent(image, db.ACT_PROBE_FAIL, reason, self.UserCred)
 	logclient.AddActionLogWithContext(ctx, image, logclient.ACT_IMAGE_PROBE, reason, self.UserCred, false)
@@ -173,7 +173,7 @@ func (self *ImageProbeTask) OnProbeFailed(ctx context.Context, image *models.SIm
 		self.SetStage("OnConvertComplete", nil)
 		if err := image.StartImageConvertTask(ctx, self.UserCred, self.GetId()); err != nil {
 			image.SetStatus(self.UserCred, api.IMAGE_STATUS_ACTIVE, "")
-			self.SetStageFailed(ctx, err.Error())
+			self.SetStageFailed(ctx, jsonutils.NewString(err.Error()))
 		}
 	} else {
 		image.SetStatus(self.UserCred, api.IMAGE_STATUS_ACTIVE, "")
@@ -191,7 +191,7 @@ func (self *ImageProbeTask) OnProbeSuccess(ctx context.Context, image *models.SI
 		self.SetStage("OnConvertComplete", nil)
 		if err := image.StartImageConvertTask(ctx, self.UserCred, self.GetId()); err != nil {
 			image.SetStatus(self.UserCred, api.IMAGE_STATUS_ACTIVE, "")
-			self.SetStageFailed(ctx, err.Error())
+			self.SetStageFailed(ctx, jsonutils.NewString(err.Error()))
 		}
 	} else {
 		image.SetStatus(self.UserCred, api.IMAGE_STATUS_ACTIVE, "")

--- a/pkg/keystone/driver/cas/cas.go
+++ b/pkg/keystone/driver/cas/cas.go
@@ -87,7 +87,7 @@ func (self *SCASDriver) request(ctx context.Context, method httputils.THttpMetho
 	cli := httputils.GetDefaultClient()
 	urlStr := httputils.JoinPath(self.casConfig.CASServerURL, path)
 	resp, err := httputils.Request(cli, ctx, method, urlStr, nil, nil, self.isDebug)
-	_, body, err := httputils.ParseResponse(resp, err, self.isDebug)
+	_, body, err := httputils.ParseResponse("", resp, err, self.isDebug)
 	return body, err
 }
 

--- a/pkg/keystone/tasks/identity_provider_delete_task.go
+++ b/pkg/keystone/tasks/identity_provider_delete_task.go
@@ -41,7 +41,7 @@ func (self *IdentityProviderDeleteTask) OnInit(ctx context.Context, obj db.IStan
 	err := idp.Purge(ctx, self.UserCred)
 	if err != nil {
 		idp.SetStatus(self.UserCred, api.IdentityDriverStatusDeleteFailed, err.Error())
-		self.SetStageFailed(ctx, fmt.Sprintf("purge failed %s", err))
+		self.SetStageFailed(ctx, jsonutils.NewString(fmt.Sprintf("purge failed %s", err)))
 		logclient.AddActionLogWithStartable(self, idp, logclient.ACT_DELETE, err, self.UserCred, false)
 		return
 	}

--- a/pkg/mcclient/modules/mod_buckets.go
+++ b/pkg/mcclient/modules/mod_buckets.go
@@ -56,7 +56,7 @@ func (manager *SBucketManager) Upload(s *mcclient.ClientSession, bucketId string
 		return errors.Wrap(err, "rawRequest")
 	}
 
-	_, _, err = s.ParseJSONResponse(resp, err)
+	_, _, err = s.ParseJSONResponse("", resp, err)
 	if err != nil {
 		return err
 	}

--- a/pkg/mcclient/modules/mod_images.go
+++ b/pkg/mcclient/modules/mod_images.go
@@ -466,7 +466,7 @@ func (this *ImageManager) _create(s *mcclient.ClientSession, params jsonutils.JS
 		}
 	}
 	resp, err := modulebase.RawRequest(this.ResourceManager, s, method, path, headers, body)
-	_, json, err := s.ParseJSONResponse(resp, err)
+	_, json, err := s.ParseJSONResponse("", resp, err)
 	if err != nil {
 		return nil, err
 	}
@@ -506,7 +506,7 @@ func (this *ImageManager) _update(s *mcclient.ClientSession, id string, params j
 	}
 	path := fmt.Sprintf("/%s/%s", this.URLPath(), url.PathEscape(id))
 	resp, err := modulebase.RawRequest(this.ResourceManager, s, "PUT", path, headers, body)
-	_, json, err := s.ParseJSONResponse(resp, err)
+	_, json, err := s.ParseJSONResponse("", resp, err)
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +560,7 @@ func (this *ImageManager) Download(s *mcclient.ClientSession, id string, format 
 		}
 		return FetchImageMeta(resp.Header), resp.Body, sizeBytes, nil
 	} else {
-		_, _, err = s.ParseJSONResponse(resp, err)
+		_, _, err = s.ParseJSONResponse("", resp, err)
 		return nil, nil, -1, err
 	}
 }

--- a/pkg/mcclient/modules/mod_infos.go
+++ b/pkg/mcclient/modules/mod_infos.go
@@ -36,7 +36,7 @@ var (
 func (this *InfoManager) Update(s *mcclient.ClientSession, header http.Header, body io.Reader) (jsonutils.JSONObject, error) {
 	path := fmt.Sprintf("/%s", this.URLPath())
 	resp, err := modulebase.RawRequest(this.ResourceManager, s, "POST", path, header, body)
-	_, json, err := s.ParseJSONResponse(resp, err)
+	_, json, err := s.ParseJSONResponse("", resp, err)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mcclient/modules/mod_itsm_process_instances.go
+++ b/pkg/mcclient/modules/mod_itsm_process_instances.go
@@ -36,7 +36,7 @@ var (
 func (self *ProcessInstanceManager) Upload(s *mcclient.ClientSession, header http.Header, body io.Reader) (jsonutils.JSONObject, error) {
 	path := fmt.Sprintf("/%s", self.URLPath())
 	resp, err := modulebase.RawRequest(self.ResourceManager, s, "POST", path, header, body)
-	_, json, err := s.ParseJSONResponse(resp, err)
+	_, json, err := s.ParseJSONResponse("", resp, err)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mcclient/modules/mod_license.go
+++ b/pkg/mcclient/modules/mod_license.go
@@ -36,7 +36,7 @@ var (
 func (this *LicenseManager) Upload(s *mcclient.ClientSession, header http.Header, body io.Reader) (jsonutils.JSONObject, error) {
 	path := fmt.Sprintf("/%s", this.URLPath())
 	resp, err := modulebase.RawRequest(this.ResourceManager, s, "POST", path, header, body)
-	_, json, err := s.ParseJSONResponse(resp, err)
+	_, json, err := s.ParseJSONResponse("", resp, err)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mcclient/session.go
+++ b/pkg/mcclient/session.go
@@ -258,8 +258,8 @@ func (this *ClientSession) JSONRequest(service, endpointType string, method http
 	return this.JSONVersionRequest(service, endpointType, method, url, headers, body, "")
 }
 
-func (this *ClientSession) ParseJSONResponse(resp *http.Response, err error) (http.Header, jsonutils.JSONObject, error) {
-	return httputils.ParseJSONResponse(resp, err, this.client.debug)
+func (this *ClientSession) ParseJSONResponse(reqBody string, resp *http.Response, err error) (http.Header, jsonutils.JSONObject, error) {
+	return httputils.ParseJSONResponse(reqBody, resp, err, this.client.debug)
 }
 
 func (this *ClientSession) HasSystemAdminPrivilege() bool {

--- a/pkg/monitor/tasks/resolve_bucket_acl_task.go
+++ b/pkg/monitor/tasks/resolve_bucket_acl_task.go
@@ -26,14 +26,14 @@ func (self *ResoleBucketAclTask) OnInit(ctx context.Context, obj db.IStandaloneM
 	err := suggestSysAlert.GetDriver().Resolve(suggestSysAlert)
 	if err != nil {
 		msg := fmt.Sprintf("fail to change bucket acl: %s", err)
-		self.taskFail(ctx, suggestSysAlert, msg)
+		self.taskFail(ctx, suggestSysAlert, jsonutils.NewString(msg))
 		return
 	}
 	suggestSysAlert.SetStatus(self.UserCred, api.SUGGEST_ALERT_DELETING, "")
 	err = suggestSysAlert.RealDelete(ctx, self.UserCred)
 	if err != nil {
 		msg := fmt.Sprintf("fail to delete SSuggestSysAlert %s", err)
-		self.taskFail(ctx, suggestSysAlert, msg)
+		self.taskFail(ctx, suggestSysAlert, jsonutils.NewString(msg))
 		return
 	}
 	db.OpsLog.LogEvent(suggestSysAlert, db.ACT_DELETE, nil, self.GetUserCred())
@@ -41,8 +41,8 @@ func (self *ResoleBucketAclTask) OnInit(ctx context.Context, obj db.IStandaloneM
 	self.SetStageComplete(ctx, nil)
 }
 
-func (self *ResoleBucketAclTask) taskFail(ctx context.Context, alert *models.SSuggestSysAlert, msg string) {
-	alert.SetStatus(self.UserCred, api.SUGGEST_ALERT_DELETE_FAIL, msg)
+func (self *ResoleBucketAclTask) taskFail(ctx context.Context, alert *models.SSuggestSysAlert, msg jsonutils.JSONObject) {
+	alert.SetStatus(self.UserCred, api.SUGGEST_ALERT_DELETE_FAIL, msg.String())
 	db.OpsLog.LogEvent(alert, db.ACT_DELETE, msg, self.GetUserCred())
 	logclient.AddActionLogWithStartable(self, alert, logclient.ACT_DELETE, msg, self.UserCred, false)
 	self.SetStageFailed(ctx, msg)

--- a/pkg/monitor/tasks/resolve_unused_task.go
+++ b/pkg/monitor/tasks/resolve_unused_task.go
@@ -40,14 +40,14 @@ func (self *ResolveUnusedTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 	err := suggestSysAlert.GetDriver().Resolve(suggestSysAlert)
 	if err != nil {
 		msg := fmt.Sprintf("fail to delete %s", err)
-		self.taskFail(ctx, suggestSysAlert, msg)
+		self.taskFail(ctx, suggestSysAlert, jsonutils.NewString(msg))
 		return
 	}
 	suggestSysAlert.SetStatus(self.UserCred, api.SUGGEST_ALERT_DELETING, "")
 	err = suggestSysAlert.RealDelete(ctx, self.UserCred)
 	if err != nil {
 		msg := fmt.Sprintf("fail to delete SSuggestSysAlert %s", err)
-		self.taskFail(ctx, suggestSysAlert, msg)
+		self.taskFail(ctx, suggestSysAlert, jsonutils.NewString(msg))
 		return
 	}
 	db.OpsLog.LogEvent(suggestSysAlert, db.ACT_DELETE, nil, self.GetUserCred())
@@ -55,8 +55,8 @@ func (self *ResolveUnusedTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 	self.SetStageComplete(ctx, nil)
 }
 
-func (self *ResolveUnusedTask) taskFail(ctx context.Context, alert *models.SSuggestSysAlert, msg string) {
-	alert.SetStatus(self.UserCred, api.SUGGEST_ALERT_DELETE_FAIL, msg)
+func (self *ResolveUnusedTask) taskFail(ctx context.Context, alert *models.SSuggestSysAlert, msg jsonutils.JSONObject) {
+	alert.SetStatus(self.UserCred, api.SUGGEST_ALERT_DELETE_FAIL, msg.String())
 	db.OpsLog.LogEvent(alert, db.ACT_DELETE, msg, self.GetUserCred())
 	logclient.AddActionLogWithStartable(self, alert, logclient.ACT_DELETE, msg, self.UserCred, false)
 	self.SetStageFailed(ctx, msg)

--- a/pkg/multicloud/ctyun/ctyun.go
+++ b/pkg/multicloud/ctyun/ctyun.go
@@ -200,6 +200,7 @@ func formRequest(client *SCtyunClient, method httputils.THttpMethod, apiName str
 		header.Set("platform", "3")
 	}
 
+	var reqbody string
 	ioData := strings.NewReader("")
 	if method == httputils.GET {
 		for k, v := range queries {
@@ -212,7 +213,8 @@ func formRequest(client *SCtyunClient, method httputils.THttpMethod, apiName str
 			datas.Add(k, c)
 		}
 
-		ioData = strings.NewReader(datas.Encode())
+		reqbody = datas.Encode()
+		ioData = strings.NewReader(reqbody)
 	}
 
 	header.Set("Content-Length", strconv.FormatInt(int64(ioData.Len()), 10))
@@ -233,7 +235,7 @@ func formRequest(client *SCtyunClient, method httputils.THttpMethod, apiName str
 			ioData,
 			client.debug)
 
-		_, jsonResp, err := httputils.ParseJSONResponse(resp, err, client.debug)
+		_, jsonResp, err := httputils.ParseJSONResponse(reqbody, resp, err, client.debug)
 		if err == nil {
 			if code, _ := jsonResp.Int("statusCode"); code != 800 {
 				if strings.Contains(jsonResp.String(), "NotFound") {

--- a/pkg/multicloud/objectstore/ceph/adminapi.go
+++ b/pkg/multicloud/objectstore/ceph/adminapi.go
@@ -85,7 +85,11 @@ func (api *SCephAdminApi) jsonRequest(ctx context.Context, method httputils.THtt
 
 	resp, err := api.client.Do(newReq)
 
-	return httputils.ParseJSONResponse(resp, err, api.debug)
+	var bodyStr string
+	if body != nil {
+		bodyStr = body.String()
+	}
+	return httputils.ParseJSONResponse(bodyStr, resp, err, api.debug)
 }
 
 func (api *SCephAdminApi) GetUsage(ctx context.Context, uid string) (jsonutils.JSONObject, error) {

--- a/pkg/multicloud/objectstore/xsky/adminapi.go
+++ b/pkg/multicloud/objectstore/xsky/adminapi.go
@@ -87,7 +87,11 @@ func (api *SXskyAdminApi) jsonRequest(ctx context.Context, method httputils.THtt
 	}
 	resp, err := api.client.Do(req)
 
-	return httputils.ParseJSONResponse(resp, err, api.debug)
+	var bodyStr string
+	if body != nil {
+		bodyStr = body.String()
+	}
+	return httputils.ParseJSONResponse(bodyStr, resp, err, api.debug)
 }
 
 type sLoginResponse struct {

--- a/pkg/multicloud/ucloud/ufile.go
+++ b/pkg/multicloud/ucloud/ufile.go
@@ -196,7 +196,7 @@ func doRequest(req *http.Request) (jsonutils.JSONObject, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "httpclient Do")
 	}
-	_, body, err := httputils.ParseJSONResponse(res, err, false)
+	_, body, err := httputils.ParseJSONResponse("", res, err, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "ParseJSONResponse")
 	}

--- a/pkg/multicloud/zstack/zstack.go
+++ b/pkg/multicloud/zstack/zstack.go
@@ -430,7 +430,7 @@ func (cli *SZStackClient) wait(header http.Header, action string, requestURL str
 		if err != nil {
 			return nil, errors.Wrap(err, fmt.Sprintf("wait location %s", location))
 		}
-		_, result, err := httputils.ParseJSONResponse(resp, err, cli.debug)
+		_, result, err := httputils.ParseJSONResponse("", resp, err, cli.debug)
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
 				return nil, cloudprovider.ErrNotFound

--- a/pkg/util/influxdb/influxdb.go
+++ b/pkg/util/influxdb/influxdb.go
@@ -163,7 +163,7 @@ func JSONRequest(client *http.Client, ctx context.Context, method httputils.THtt
 	header.Set("Content-Length", strconv.FormatInt(int64(len(bodystr)), 10))
 	header.Set("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := httputils.Request(client, ctx, method, urlStr, header, jbody, debug)
-	return httputils.ParseJSONResponse(resp, err, debug)
+	return httputils.ParseJSONResponse(bodystr, resp, err, debug)
 }
 
 func (db *SInfluxdb) SetDatabase(dbName string) error {

--- a/pkg/util/oidcutils/client/client.go
+++ b/pkg/util/oidcutils/client/client.go
@@ -110,7 +110,7 @@ func (cli *SOIDCClient) request(ctx context.Context, method httputils.THttpMetho
 	header.Set("Accept", "application/json")
 	reqbody := strings.NewReader(data.QueryString())
 	resp, err := httputils.Request(cli.httpclient, ctx, method, urlStr, header, reqbody, cli.isDebug)
-	_, body, err := httputils.ParseJSONResponse(resp, err, cli.isDebug)
+	_, body, err := httputils.ParseJSONResponse(data.QueryString(), resp, err, cli.isDebug)
 	return body, err
 }
 

--- a/pkg/util/redfish/bmconsole/bmconsole.go
+++ b/pkg/util/redfish/bmconsole/bmconsole.go
@@ -65,7 +65,11 @@ func (r *SBMCConsole) RawRequest(ctx context.Context, method httputils.THttpMeth
 	header.Set("Connection", "Close")
 	header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:69.0) Gecko/20100101 Firefox/69.0")
 	resp, err := httputils.Request(r.client, ctx, method, urlStr, header, bytes.NewReader(body), r.isDebug)
-	hdr, rspBody, err := httputils.ParseResponse(resp, err, r.isDebug)
+	var bodyStr string
+	if body != nil {
+		bodyStr = string(body)
+	}
+	hdr, rspBody, err := httputils.ParseResponse(bodyStr, resp, err, r.isDebug)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "httputils.Request")
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：丰富task错误信息，使用json存储task的错误信息
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @yousong 
/area util