### PR TITLE
fix: change owner should check required domain list

### DIFF
--- a/cmd/climc/shell/compute/globalvpcs.go
+++ b/cmd/climc/shell/compute/globalvpcs.go
@@ -15,6 +15,8 @@
 package compute
 
 import (
+	"fmt"
+
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -76,6 +78,32 @@ func init() {
 			return err
 		}
 		printObject(result)
+		return nil
+	})
+
+	R(&GlobalVpcShowOptions{}, "global-vpc-change-owner-candidate-domains", "Show candiate domains of a global vpc for changing owner", func(s *mcclient.ClientSession, args *GlobalVpcShowOptions) error {
+		result, err := modules.GlobalVpcs.GetSpecific(s, args.ID, "change-owner-candidate-domains", nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
+	type GlobalVpcChangeOwnerOptions struct {
+		ID            string `help:"ID or name of vpc" json:"-"`
+		ProjectDomain string `json:"project_domain" help:"target domain"`
+	}
+	R(&GlobalVpcChangeOwnerOptions{}, "global-vpc-change-owner", "Change owner domain of a global vpc", func(s *mcclient.ClientSession, args *GlobalVpcChangeOwnerOptions) error {
+		if len(args.ProjectDomain) == 0 {
+			return fmt.Errorf("empty project_domain")
+		}
+		params := jsonutils.Marshal(args)
+		ret, err := modules.GlobalVpcs.PerformAction(s, args.ID, "change-owner", params)
+		if err != nil {
+			return err
+		}
+		printObject(ret)
 		return nil
 	})
 }

--- a/pkg/cloudcommon/db/domain.go
+++ b/pkg/cloudcommon/db/domain.go
@@ -77,6 +77,10 @@ func (model *SDomainizedResourceBase) GetChangeOwnerCandidateDomainIds() []strin
 	return nil
 }
 
+func (model *SDomainizedResourceBase) GetChangeOwnerRequiredDomainIds() []string {
+	return nil
+}
+
 func ValidateCreateDomainId(domainId string) error {
 	if !consts.GetNonDefaultDomainProjects() && domainId != identity.DEFAULT_DOMAIN_ID {
 		return httperrors.NewForbiddenError("project in non-default domain is prohibited")

--- a/pkg/cloudcommon/db/infraresource.go
+++ b/pkg/cloudcommon/db/infraresource.go
@@ -201,6 +201,9 @@ func (model *SInfrasResourceBase) PerformChangeOwner(
 	query jsonutils.JSONObject,
 	input apis.PerformChangeDomainOwnerInput,
 ) (jsonutils.JSONObject, error) {
+	if !consts.GetNonDefaultDomainProjects() {
+		return nil, errors.Wrap(httperrors.ErrForbidden, "not allow to change owner of domain resource if non_default_domain_projects is turned off")
+	}
 	if model.IsShared() {
 		return nil, errors.Wrap(httperrors.ErrInvalidStatus, "cannot change owner when shared!")
 	}

--- a/pkg/cloudcommon/db/managed.go
+++ b/pkg/cloudcommon/db/managed.go
@@ -22,6 +22,7 @@ import (
 
 type IOwnerResourceBaseModel interface {
 	GetChangeOwnerCandidateDomainIds() []string
+	GetChangeOwnerRequiredDomainIds() []string
 }
 
 type IManagedResourceBase interface {

--- a/pkg/compute/models/globalvpcs.go
+++ b/pkg/compute/models/globalvpcs.go
@@ -240,3 +240,12 @@ func (globalVpc *SGlobalVpc) GetRequiredSharedDomainIds() []string {
 	}
 	return db.ISharableMergeShareRequireDomainIds(requires...)
 }
+
+func (globalVpc *SGlobalVpc) GetChangeOwnerRequiredDomainIds() []string {
+	requires := stringutils2.SSortedStrings{}
+	vpcs, _ := globalVpc.GetVpcs()
+	for i := range vpcs {
+		requires = stringutils2.Append(requires, vpcs[i].DomainId)
+	}
+	return requires
+}

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -5275,6 +5275,15 @@ func (host *SHost) PerformChangeOwner(ctx context.Context, userCred mcclient.Tok
 	return ret, nil
 }
 
+func (host *SHost) GetChangeOwnerRequiredDomainIds() []string {
+	requires := stringutils2.SSortedStrings{}
+	guests := host.GetGuests()
+	for i := range guests {
+		requires = stringutils2.Append(requires, guests[i].DomainId)
+	}
+	return requires
+}
+
 func GetHostQuotaKeysFromCreateInput(input api.HostCreateInput) quotas.SDomainRegionalCloudResourceKeys {
 	ownerId := &db.SOwnerId{DomainId: input.ProjectDomain}
 	var zone *SZone

--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -1481,6 +1481,15 @@ func (storage *SStorage) performChangeOwnerInternal(ctx context.Context, userCre
 	return storage.SEnabledStatusInfrasResourceBase.PerformChangeOwner(ctx, userCred, query, input)
 }
 
+func (storage *SStorage) GetChangeOwnerRequiredDomainIds() []string {
+	requires := stringutils2.SSortedStrings{}
+	disks := storage.GetDisks()
+	for i := range disks {
+		requires = stringutils2.Append(requires, disks[i].DomainId)
+	}
+	return requires
+}
+
 func (storage *SStorage) PerformPublic(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPublicDomainInput) (jsonutils.JSONObject, error) {
 	// not allow to perform public for locally connected storage
 	if storage.IsLocal() {

--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -1135,6 +1135,15 @@ func (vpc *SVpc) GetChangeOwnerCandidateDomainIds() []string {
 	return db.ISharableMergeChangeOwnerCandidateDomainIds(vpc, candidates...)
 }
 
+func (vpc *SVpc) GetChangeOwnerRequiredDomainIds() []string {
+	requires := stringutils2.SSortedStrings{}
+	wires := vpc.GetWires()
+	for i := range wires {
+		requires = stringutils2.Append(requires, wires[i].DomainId)
+	}
+	return requires
+}
+
 func (vpc *SVpc) GetRequiredSharedDomainIds() []string {
 	wires := vpc.GetWires()
 	if len(wires) == 0 {

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -1036,6 +1036,15 @@ func (wire *SWire) GetChangeOwnerCandidateDomainIds() []string {
 	return db.ISharableMergeChangeOwnerCandidateDomainIds(wire, candidates...)
 }
 
+func (wire *SWire) GetChangeOwnerRequiredDomainIds() []string {
+	requires := stringutils2.SSortedStrings{}
+	networks, _ := wire.getNetworks(nil, rbacutils.ScopeNone)
+	for i := range networks {
+		requires = stringutils2.Append(requires, networks[i].DomainId)
+	}
+	return requires
+}
+
 func (wire *SWire) GetRequiredSharedDomainIds() []string {
 	networks, _ := wire.getNetworks(nil, rbacutils.ScopeNone)
 	if len(networks) == 0 {

--- a/pkg/mcclient/modules/mod_wires.go
+++ b/pkg/mcclient/modules/mod_wires.go
@@ -23,7 +23,9 @@ var (
 func init() {
 	Wires = NewComputeManager("wire", "wires",
 		[]string{"ID", "Name", "Bandwidth", "Zone_ID",
-			"Zone", "Networks", "VPC", "VPC_ID", "public_scope"},
+			"Zone", "Networks", "VPC", "VPC_ID", "public_scope",
+			"domain_id",
+		},
 		[]string{})
 
 	registerCompute(&Wires)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：将vpc、globalvpc更改owner时候，未检查下游资源（wire，vpc）的归属域情况

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2
- release/3.3

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area region

/hold