### PR TITLE
metric describe 接口

### DIFF
--- a/cmd/climc/shell/monitor/alertrecord.go
+++ b/cmd/climc/shell/monitor/alertrecord.go
@@ -7,8 +7,7 @@ import (
 )
 
 func init() {
-	cmd := shell.NewResourceCmd(modules.MetricManager)
-	cmd.List(new(options.MonitorMetricListOptions))
-	cmd.Update(new(options.MetricUpdateOptions))
-	cmd.Show(new(options.MetricShowOptions))
+	cmd := shell.NewResourceCmd(modules.AlertRecordManager)
+	cmd.List(new(options.AlertRecordListOptions))
+	cmd.Show(new(options.AlertRecordShowOptions))
 }

--- a/cmd/climc/shell/monitor/commonalertmetric.go
+++ b/cmd/climc/shell/monitor/commonalertmetric.go
@@ -1,0 +1,82 @@
+package monitor
+
+import (
+	monitorapi "yunion.io/x/onecloud/pkg/apis/monitor"
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modules"
+	"yunion.io/x/onecloud/pkg/mcclient/options"
+)
+
+func init() {
+	type MonitorMetricListOptions struct {
+		options.BaseListOptions
+		MeasurementName        []string `help:"name of Measurement"`
+		ResType                string   `help:"Resource properties of measurement e.g. guest/host/redis/oss/rds"`
+		MeasurementDisplayName string   `help:"The name of the measurement customization"`
+		FieldName              []string `help:"Name of Field"`
+		Unit                   string   `help:"Unit of Field " choices:"%|bps|Mbps|Bps|cps|count|ms|byte"`
+		FieldDisplayName       string   `help:"The name of the field customization"`
+	}
+	R(&MonitorMetricListOptions{}, "metric-describ-list", "list metric description info", func(s *mcclient.ClientSession,
+		args *MonitorMetricListOptions) error {
+		param, err := options.ListStructToParams(&(args.BaseListOptions))
+		if err != nil {
+			return err
+		}
+		metricInput := new(monitorapi.MetricListInput)
+		metricInput.Measurement.Names = args.MeasurementName
+		metricInput.Measurement.ResType = args.ResType
+		metricInput.Measurement.DisplayName = args.MeasurementDisplayName
+		metricInput.MetricFields.Names = args.FieldName
+		metricInput.MetricFields.Unit = args.Unit
+		metricInput.MetricFields.DisplayName = args.FieldDisplayName
+		listParam := metricInput.JSON(metricInput)
+		param.Update(listParam)
+		result, err := modules.MetricManager.List(s, param)
+		if err != nil {
+			return err
+		}
+		printList(result, modules.MetricManager.GetColumns(s))
+		return nil
+	})
+
+	type MetricUpdateOptions struct {
+		ID                     string `help:"ID of Metric " required:"true" positional:"true"`
+		ResType                string `help:"Resource properties of measurement e.g. guest/host/redis/oss/rds" required:"true"`
+		MeasurementDisplayName string `help:"The name of the measurement customization" required:"true"`
+		FieldName              string `help:"Name of Field" required:"true"`
+		FieldDisplayName       string `help:"The name of the field customization" required:"true"`
+		Unit                   string `help:"Unit of Field" choices:"%|bps|Mbps|Bps|cps|count|ms|byte" required:"true"`
+	}
+	R(&MetricUpdateOptions{}, "metric-describ-update", "update metric description info", func(s *mcclient.ClientSession,
+		args *MetricUpdateOptions) error {
+		updateInput := new(monitorapi.MetricUpdateInput)
+		updateInput.Measurement.DisplayName = args.MeasurementDisplayName
+		updateInput.Measurement.ResType = args.ResType
+		updateField := new(monitorapi.MetricFieldUpdateInput)
+		updateField.Name = args.FieldName
+		updateField.DisplayName = args.FieldDisplayName
+		updateField.Unit = args.Unit
+		updateInput.MetricFields = []monitorapi.MetricFieldUpdateInput{*updateField}
+		updateInput.Scope = "system"
+		result, err := modules.MetricManager.Update(s, args.ID, updateInput.JSON(updateInput))
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+
+	type MetricShowOptions struct {
+		ID string `help:"ID of Metric " json:"-"`
+	}
+	R(&MetricShowOptions{}, "metric-describ-show", "show metric description info", func(s *mcclient.ClientSession,
+		args *MetricShowOptions) error {
+		result, err := modules.MetricManager.Get(s, args.ID, nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
+}

--- a/pkg/apis/monitor/alert.go
+++ b/pkg/apis/monitor/alert.go
@@ -167,8 +167,10 @@ type ResultLogEntry struct {
 type EvalMatch struct {
 	Condition string            `json:"condition"`
 	Value     *float64          `json:"value"`
+	ValueStr  string            `json:"value_str"`
 	Metric    string            `json:"metric"`
 	Tags      map[string]string `json:"tags"`
+	Unit      string            `json:"unit"`
 }
 
 type AlertTestRunOutput struct {

--- a/pkg/apis/monitor/alertrecord.go
+++ b/pkg/apis/monitor/alertrecord.go
@@ -1,0 +1,32 @@
+package monitor
+
+import "yunion.io/x/onecloud/pkg/apis"
+
+type AlertRecordListInput struct {
+	apis.Meta
+
+	apis.ScopedResourceBaseListInput
+	apis.EnabledResourceBaseListInput
+	apis.StatusStandaloneResourceListInput
+
+	AlertId string `json:"alert_id"`
+	Level   string `json:"level"`
+	State   string `json:"state"`
+}
+
+type AlertRecordDetails struct {
+	apis.StatusStandaloneResourceDetails
+	apis.ScopedResourceBaseInfo
+
+	ResNum int64 `json:"res_num"`
+}
+
+type AlertRecordCreateInput struct {
+	apis.StandaloneResourceCreateInput
+
+	AlertId string `json:"alert_id"`
+	// 报警级别
+	Level    string       `json:"level"`
+	State    string       `json:"state"`
+	EvalData []*EvalMatch `json:"eval_data"`
+}

--- a/pkg/apis/monitor/commalert.go
+++ b/pkg/apis/monitor/commalert.go
@@ -103,11 +103,12 @@ type CommonAlertMetricDetails struct {
 	Comparator string  `json:"comparator"`
 	Threshold  float64 `json:"threshold"`
 	// metric points'value的运算方式
-	Reduce      string `json:"reduce"`
-	DB          string `json:"db"`
-	Measurement string `json:"measurement"`
-	Field       string `json:"field"`
-	Groupby     string `json:"groupby"`
-
-	FieldOpt string `json:"field_opt"`
+	Reduce                 string `json:"reduce"`
+	DB                     string `json:"db"`
+	Measurement            string `json:"measurement"`
+	MeasurementDisplayName string
+	Field                  string `json:"field"`
+	Groupby                string `json:"groupby"`
+	FieldDescription       MetricFieldDetail
+	FieldOpt               string `json:"field_opt"`
 }

--- a/pkg/apis/monitor/commalert.go
+++ b/pkg/apis/monitor/commalert.go
@@ -106,7 +106,8 @@ type CommonAlertMetricDetails struct {
 	Reduce                 string `json:"reduce"`
 	DB                     string `json:"db"`
 	Measurement            string `json:"measurement"`
-	MeasurementDisplayName string
+	MeasurementDisplayName string `json:"measurement_display_name"`
+	ResType                string `json:"res_type"`
 	Field                  string `json:"field"`
 	Groupby                string `json:"groupby"`
 	FieldDescription       MetricFieldDetail

--- a/pkg/apis/monitor/metric.go
+++ b/pkg/apis/monitor/metric.go
@@ -1,0 +1,110 @@
+package monitor
+
+import "yunion.io/x/onecloud/pkg/apis"
+
+const (
+	METRIC_RES_TYPE_GUEST = "guest"
+	METRIC_RES_TYPE_HOST  = "host"
+	METRIC_RES_TYPE_REDIS = "redis"
+	METRIC_RES_TYPE_OSS   = "oss"
+	METRIC_RES_TYPE_RDS   = "rds"
+
+	METRIC_UNIT_PERCENT = "%"
+	METRIC_UNIT_BPS     = "bps"
+	METRIC_UNIT_MBPS    = "Mbps"
+	METRIC_UNIT_BYTEPS  = "Bps"
+	METRIC_UNIT_CPS     = "cps"
+	METRIC_UNIT_COUNT   = "count"
+	METRIC_UNIT_MS      = "ms"
+	METRIC_UNIT_BYTE    = "byte"
+)
+
+var MetricResType = []string{METRIC_RES_TYPE_GUEST, METRIC_RES_TYPE_HOST, METRIC_RES_TYPE_REDIS, METRIC_RES_TYPE_OSS, METRIC_RES_TYPE_RDS}
+var MetricUnit = []string{"%", "bps", "Mbps", "Bps", "count/s", "count", "ms", "byte"}
+
+type MetricMeasurementCreateInput struct {
+	apis.StandaloneResourceCreateInput
+
+	ResType     string `json:"res_type"`
+	DisplayName string `json:"display_name"`
+	Database    string `json:"database"`
+}
+
+type MetricMeasurementUpdateInput struct {
+	apis.StandaloneResourceBaseUpdateInput
+
+	ResType     string `json:"res_type"`
+	DisplayName string `json:"display_name"`
+}
+
+type MetricMeasurementListInput struct {
+	apis.StatusStandaloneResourceListInput
+	apis.EnabledResourceBaseListInput
+	apis.ScopedResourceBaseListInput
+
+	ResType     string `json:"res_type"`
+	DisplayName string `json:"display_name"`
+}
+
+type MetricFieldCreateInput struct {
+	apis.StandaloneResourceCreateInput
+
+	DisplayName string `json:"display_name"`
+	Unit        string `json:"unit"`
+	ValueType   string `json:"value_type"`
+}
+
+type MetricFieldUpdateInput struct {
+	apis.StandaloneResourceBaseUpdateInput
+
+	Id          string
+	DisplayName string `json:"display_name"`
+	Unit        string `json:"unit"`
+	ValueType   string `json:"value_type"`
+}
+
+type MetricFieldListInput struct {
+	apis.StatusStandaloneResourceListInput
+	apis.EnabledResourceBaseListInput
+	apis.ScopedResourceBaseListInput
+
+	DisplayName string `json:"display_name"`
+	Unit        string `json:"unit"`
+	Scope       string `json:"scope"`
+}
+
+type MetricCreateInput struct {
+	Measurement  MetricMeasurementCreateInput `json:"measurement"`
+	MetricFields []MetricFieldCreateInput     `json:"metric_fields"`
+	Scope        string                       `json:"scope"`
+}
+
+type MetricUpdateInput struct {
+	apis.Meta
+
+	Measurement  MetricMeasurementUpdateInput `json:"measurement"`
+	MetricFields []MetricFieldUpdateInput     `json:"metric_fields"`
+	Scope        string                       `json:"scope"`
+}
+
+type MetricListInput struct {
+	apis.Meta
+
+	Measurement  MetricMeasurementListInput `json:"measurement"`
+	MetricFields MetricFieldListInput       `json:"metric_fields"`
+	Scope        string                     `json:"scope"`
+}
+
+type MetricDetails struct {
+	apis.StatusStandaloneResourceDetails
+	apis.ScopedResourceBaseInfo
+
+	MetricFields []MetricFieldDetail `json:"metric_fields"`
+}
+
+type MetricFieldDetail struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Unit        string `json:"unit"`
+	Id          string `json:"id"`
+}

--- a/pkg/apis/monitor/suggestsysrule.go
+++ b/pkg/apis/monitor/suggestsysrule.go
@@ -38,12 +38,15 @@ var METRIC_ATTRI = []string{METRIC_TAG, METRIC_FIELD}
 
 type InfluxMeasurement struct {
 	apis.Meta
-	Database    string
-	Measurement string
-	TagKey      []string
-	TagValue    map[string][]string
-	FieldKey    []string
-	Unit        []string
+	Database               string
+	Measurement            string
+	MeasurementDisplayName string
+	ResType                string
+	TagKey                 []string
+	TagValue               map[string][]string
+	FieldKey               []string
+	FieldDescriptions      map[string]MetricFieldDetail
+	Unit                   []string
 }
 
 type SuggestSysRuleListInput struct {

--- a/pkg/apis/monitor/template.go
+++ b/pkg/apis/monitor/template.go
@@ -31,4 +31,5 @@ type NotificationTemplateConfig struct {
 	Priority    string `json:"priority"`
 	Level       string `json:"level"`
 	IsRecovery  bool   `json:"is_recovery"`
+	WebUrl      string `json:"web_url"`
 }

--- a/pkg/apis/monitor/unifiedmonitor_const.go
+++ b/pkg/apis/monitor/unifiedmonitor_const.go
@@ -47,5 +47,7 @@ type MetricInputQuery struct {
 	From        string        `json:"from"`
 	To          string        `json:"to"`
 	Interval    string        `json:"interval"`
+	DomainId    string        `json:"domain_id"`
+	ProjectId   string        `json:"project_id"`
 	MetricQuery []*AlertQuery `json:"metric_query"`
 }

--- a/pkg/apis/monitor/unifiedmonitor_const.go
+++ b/pkg/apis/monitor/unifiedmonitor_const.go
@@ -13,15 +13,12 @@ var (
 	}
 
 	MEASUREMENT_TAG_KEYWORD = map[string]string{
-		"cpu":       "host",
-		"disk":      "device",
-		"mem":       "host",
-		"net":       "host",
-		"netstat":   "host",
-		"vm_cpu":    "vm_name",
-		"vm_diskio": "vm_name",
-		"vm_mem":    "vm_name",
-		"vm_netio":  "vm_name",
+		"host":         "host",
+		"guest":        "vm_name",
+		"redis":        "redis_name",
+		"rds":          "rds_name",
+		"oss":          "oss_name",
+		"cloudaccount": "cloudaccount_name",
 	}
 	AlertReduceFunc = map[string]string{
 		"avg":          "average value",

--- a/pkg/mcclient/modules/mod_alert_record.go
+++ b/pkg/mcclient/modules/mod_alert_record.go
@@ -1,0 +1,25 @@
+package modules
+
+import "yunion.io/x/onecloud/pkg/mcclient/modulebase"
+
+type SAlertRecordManager struct {
+	*modulebase.ResourceManager
+}
+
+var (
+	AlertRecordManager *SAlertRecordManager
+)
+
+func init() {
+	AlertRecordManager = NewAlertRecordManager()
+	register(AlertRecordManager)
+}
+
+func NewAlertRecordManager() *SAlertRecordManager {
+	man := NewMonitorV2Manager("alertrecord", "alertrecords",
+		[]string{"id", "alert_id", "level", "state", "eval_data"},
+		[]string{})
+	return &SAlertRecordManager{
+		ResourceManager: &man,
+	}
+}

--- a/pkg/mcclient/modules/mod_commonalert_metric.go
+++ b/pkg/mcclient/modules/mod_commonalert_metric.go
@@ -1,0 +1,25 @@
+package modules
+
+import "yunion.io/x/onecloud/pkg/mcclient/modulebase"
+
+type SMetricManager struct {
+	*modulebase.ResourceManager
+}
+
+var (
+	MetricManager *SMetricManager
+)
+
+func init() {
+	MetricManager = NewMetricManager()
+	register(MetricManager)
+}
+
+func NewMetricManager() *SMetricManager {
+	man := NewMonitorV2Manager("metricmeasurement", "metricmeasurements",
+		[]string{"id", "name", "display_name", "res_type", "metric_fields"},
+		[]string{})
+	return &SMetricManager{
+		ResourceManager: &man,
+	}
+}

--- a/pkg/mcclient/options/monitor/alertrecord.go
+++ b/pkg/mcclient/options/monitor/alertrecord.go
@@ -1,0 +1,31 @@
+package monitor
+
+import (
+	"yunion.io/x/jsonutils"
+
+	"yunion.io/x/onecloud/pkg/mcclient/options"
+)
+
+type AlertRecordListOptions struct {
+	options.BaseListOptions
+
+	AlertId string `help:"id of alert"`
+	Level   string `help:"alert level"`
+	State   string `help:"alert state"`
+}
+
+func (o *AlertRecordListOptions) Params() (jsonutils.JSONObject, error) {
+	return options.ListStructToParams(o)
+}
+
+type AlertRecordShowOptions struct {
+	ID string `help:"ID of Metric " json:"-"`
+}
+
+func (o *AlertRecordShowOptions) Params() (jsonutils.JSONObject, error) {
+	return options.StructToParams(o)
+}
+
+func (o *AlertRecordShowOptions) GetId() string {
+	return o.ID
+}

--- a/pkg/mcclient/options/monitor/commonalertmetric.go
+++ b/pkg/mcclient/options/monitor/commonalertmetric.go
@@ -1,0 +1,73 @@
+package monitor
+
+import (
+	"yunion.io/x/jsonutils"
+
+	monitorapi "yunion.io/x/onecloud/pkg/apis/monitor"
+	"yunion.io/x/onecloud/pkg/mcclient/options"
+)
+
+type MonitorMetricListOptions struct {
+	options.BaseListOptions
+	MeasurementName        []string `help:"name of Measurement"`
+	ResType                string   `help:"Resource properties of measurement e.g. guest/host/redis/oss/rds"`
+	MeasurementDisplayName string   `help:"The name of the measurement customization"`
+	FieldName              []string `help:"Name of Field"`
+	Unit                   string   `help:"Unit of Field " choices:"%|bps|Mbps|Bps|cps|count|ms|byte"`
+	FieldDisplayName       string   `help:"The name of the field customization"`
+}
+
+func (o *MonitorMetricListOptions) Params() (jsonutils.JSONObject, error) {
+	param, err := options.ListStructToParams(&(o.BaseListOptions))
+	if err != nil {
+		return nil, err
+	}
+	metricInput := new(monitorapi.MetricListInput)
+	metricInput.Measurement.Names = o.MeasurementName
+	metricInput.Measurement.ResType = o.ResType
+	metricInput.Measurement.DisplayName = o.MeasurementDisplayName
+	metricInput.MetricFields.Names = o.FieldName
+	metricInput.MetricFields.Unit = o.Unit
+	metricInput.MetricFields.DisplayName = o.FieldDisplayName
+	listParam := metricInput.JSON(metricInput)
+	param.Update(listParam)
+	return param, nil
+}
+
+type MetricUpdateOptions struct {
+	ID                     string `help:"ID of Metric " required:"true" positional:"true"`
+	ResType                string `help:"Resource properties of measurement e.g. guest/host/redis/oss/rds" required:"true"`
+	MeasurementDisplayName string `help:"The name of the measurement customization" required:"true"`
+	FieldName              string `help:"Name of Field" required:"true"`
+	FieldDisplayName       string `help:"The name of the field customization" required:"true"`
+	Unit                   string `help:"Unit of Field" choices:"%|bps|Mbps|Bps|cps|count|ms|byte" required:"true"`
+}
+
+func (o *MetricUpdateOptions) GetId() string {
+	return o.ID
+}
+
+func (o *MetricUpdateOptions) Params() (jsonutils.JSONObject, error) {
+	updateInput := new(monitorapi.MetricUpdateInput)
+	updateInput.Measurement.DisplayName = o.MeasurementDisplayName
+	updateInput.Measurement.ResType = o.ResType
+	updateField := new(monitorapi.MetricFieldUpdateInput)
+	updateField.Name = o.FieldName
+	updateField.DisplayName = o.FieldDisplayName
+	updateField.Unit = o.Unit
+	updateInput.MetricFields = []monitorapi.MetricFieldUpdateInput{*updateField}
+	updateInput.Scope = "system"
+	return updateInput.JSON(updateInput), nil
+}
+
+type MetricShowOptions struct {
+	ID string `help:"ID of Metric " json:"-"`
+}
+
+func (o *MetricShowOptions) Params() (jsonutils.JSONObject, error) {
+	return options.StructToParams(o)
+}
+
+func (o *MetricShowOptions) GetId() string {
+	return o.ID
+}

--- a/pkg/monitor/alerting/notifiers/templates/template.go
+++ b/pkg/monitor/alerting/notifiers/templates/template.go
@@ -28,51 +28,22 @@ func NewTemplateConfig(c monitor.NotificationTemplateConfig) *TemplateConfig {
 
 const DefaultMarkdownTemplate = `
 	## {{.Title}}
-
 	- 时间: {{.StartTime}}
 	- 级别: {{.Level}}
 
-	{{range .Matches}}
-
+	{{ range .Matches}}
 	- 指标: {{.Metric}}
-	- 当前值: {{.Value | FormateFloat}}
+	- 当前值: {{.ValueStr}}
 
 	### 触发条件:
-
-	- {{.Condition}}
+	- {{ $.Description}}
 
 	### 标签
-
-	{{range $key, $value := .Tags}}
-		> {{ $key }}: {{ $value}}
-	{{end}}
-	{{end}}
-`
-
-const EmailMarkdownTemplate = `
-<!DOCTYPE html>
-<html lang="en">
-	<head>
-	  <meta charset="UTF-8">
-	</head>
-	<body>
-		<p>## {{.Title}}</p>
-		<p>- 时间: {{.StartTime}}</p>
-		<p>- 级别: {{.Level}}</p>
-		<p>{{range .Matches}}</p>
-		<p>- 指标: {{.Metric}}</p>
-		<p>- 当前值: {{.Value | FormateFloat}}</p>
-		</br><p>## 触发条件:</p>
-		<p> {{.Condition}}</p>
-		</br><p>## 标签</p>
-		<p>
-			{{range $key, $value := .Tags}}
-				{{ $key }}: {{ $value}} </br>
-			{{end}}
-			{{end}}
-		</p>
-	</body>
-</html>
+	 > 名称: {{ GetValFromMap .Tags "name" }}
+	 > ip: {{ GetValFromMap .Tags "ip" }}
+	 > 平台: {{ GetValFromMap .Tags "brand" }}
+    ------
+	{{- end}}
 `
 
 func (c TemplateConfig) GenerateMarkdown() (string, error) {
@@ -82,3 +53,144 @@ func (c TemplateConfig) GenerateMarkdown() (string, error) {
 func (c TemplateConfig) GenerateEmailMarkdown() (string, error) {
 	return CompileTemplateFromMapHtml(EmailMarkdownTemplate, c)
 }
+
+const EmailMarkdownTemplate = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>{{.Title}}</title>
+</head>
+<style>
+  .title {
+    height: 40px;
+    line-height: 40px;
+    width: 960px;
+    background-color: #4da1ff;
+    color: #fff;
+    font-size: 16px;
+    text-align: center;
+    margin: 0 auto;
+  }
+  .table {
+    width: 960px;
+    margin: 0 auto;
+    padding: 10px 30px 0px 30px;
+    font-family:'微软雅黑',Helvetica,Arial,sans-serif;
+    font-size:14px;
+    background-color: #fbfbfb;
+  }
+  .tr-title {
+    height: 10px;
+    border-left: 5px solid #4da1ff;
+    margin-left: 10px;
+    padding: 3px 8px;
+    font-weight: bold;
+  }
+  .td {
+    width: 80px;
+    padding-left: 20px;
+    height: 35px;
+    font-weight: 400;
+  }
+  .link {
+    text-decoration: none;
+    color: #3591FF;
+  }
+  .thead-tr td {
+    border-left: 1px solid #d7d7d7;
+    border-top: 1px solid #d7d7d7;
+    height: 32px;
+    font-size: 14px;
+    background-color: #d7d7d7;
+    text-align: center;
+  }
+  .tbody-tr td {
+    border-left: 1px solid #d7d7d7;
+    border-top: 1px solid #d7d7d7;
+    height: 32px;
+    font-size: 14px;
+    font-weight: 400;
+    text-align: center;
+  }
+  .pb-3 {
+    padding-bottom: 30px;
+  }
+  .resouce-table {
+    width: 98%;
+    color: #717171;
+    border-right: 1px solid #d7d7d7;
+    border-bottom: 1px solid #d7d7d7;
+  }
+</style>
+<body>
+  <h3 class="title">报警提醒</h3>
+  <table border="0" cellspacing="0" cellpadding="0" class="table">
+    <tr><td colspan="4" class="tr-title">报警信息</td></tr>
+    <tr><td style="height: 10px;"></td></tr>
+    <tr>
+      <td class="td">报警策略：</td>
+      <td>{{.Name}}</td>
+    </tr>
+    <tr>
+      <td class="td">报警级别：</td>
+      <td>{{.Level}}</td>
+    </tr>
+    <tr>
+      <td class="td">报警时间：</td>
+      <td>{{.StartTime}}</td>
+    </tr>
+    <tr>
+      <td class="td">策略详情：</td>
+      <td>{{.Description}}</td>
+    </tr>
+  </table>
+  <table class="table" style="padding-top: 6px; padding-bottom: 10px;">
+    <tr>
+      <td style="padding-left: 20px; font-size: 14px;">若要查看详情信息，<a class="link" target="_blank" href="{{.WebUrl}}/commonalerts
+">请登录平台进行查看</a></td>
+    </tr>
+  </table>
+  <table border="0" cellspacing="0" cellpadding="0" class="table pb-3">
+    <tr><td colspan="4" class="tr-title">报警资源</td></tr>
+    <tr><td style="height: 10px;"></td></tr>
+    <tr>
+      <td colspan="4" style="padding: 10px 0 0 20px;">
+        <table cellspacing="0" cellpadding="0" class="resouce-table">
+          <thead>
+            <tr class="thead-tr">
+              <td>序号</td>
+	              <td>名称</td>
+              <td>IP</td>
+              <td>平台</td>
+              <td>当前值</td>
+            </tr>
+          </thead>
+          <tbody>
+			{{- range $i, $Matche := .Matches}}
+				<tr class="tbody-tr">
+				  <td>{{ Inc $i}}</td>
+				  <td>
+					{{- GetValFromMap .Tags "name"}}
+                  </td>
+				  <td>
+					{{ GetValFromMap .Tags "ip" }}
+                  </td>
+				  <td>
+				   	{{ GetValFromMap .Tags "brand" }}
+				  </td>
+				  <td>{{$Matche.ValueStr}}</td>
+				</tr>
+			{{end}}
+          </tbody>
+        </table>
+      </td>
+    </tr>
+    <tr><td style="height: 10px;"></td></tr>
+  </table>
+  <p style="width: 960px; height: 40px; line-height: 40px; margin: 0 auto; background-color: #4da1ff; color: #fff; font-size: 12px; text-align: center; ">本邮件由系统自动发送，请勿直接回复！</p>
+</body>
+</html>
+`

--- a/pkg/monitor/alerting/notifiers/templates/util.go
+++ b/pkg/monitor/alerting/notifiers/templates/util.go
@@ -16,7 +16,6 @@ package templates
 
 import (
 	"bytes"
-	"fmt"
 	"html/template"
 	t_template "text/template"
 )
@@ -25,7 +24,8 @@ func CompileTemplateFromMapHtml(tmplt string, configMap interface{}) (string, er
 	out := new(bytes.Buffer)
 	t := template.Must(template.New("commpiled_template").Funcs(
 		template.FuncMap{
-			"FormateFloat": FormateFloat,
+			"GetValFromMap": GetValFromMap,
+			"Inc":           Inc,
 		}).Parse(tmplt))
 	if err := t.Execute(out, configMap); err != nil {
 		return "", err
@@ -37,7 +37,8 @@ func CompileTEmplateFromMapText(tmplt string, configMap interface{}) (string, er
 	out := new(bytes.Buffer)
 	t := t_template.Must(t_template.New("commpiled_template").Funcs(
 		t_template.FuncMap{
-			"FormateFloat": FormateFloat,
+			"GetValFromMap": GetValFromMap,
+			"Inc":           Inc,
 		}).Parse(tmplt))
 	if err := t.Execute(out, configMap); err != nil {
 		return "", err
@@ -45,6 +46,10 @@ func CompileTEmplateFromMapText(tmplt string, configMap interface{}) (string, er
 	return out.String(), nil
 }
 
-func FormateFloat(f *float64) string {
-	return fmt.Sprintf("%f", *f)
+func GetValFromMap(valMap map[string]string, key string) string {
+	return valMap[key]
+}
+
+func Inc(i int) int {
+	return i + 1
 }

--- a/pkg/monitor/dbinit/doc.go
+++ b/pkg/monitor/dbinit/doc.go
@@ -1,0 +1,1 @@
+package dbinit // import "yunion.io/x/onecloud/pkg/monitor/dbinit"

--- a/pkg/monitor/dbinit/metric_dbinit.go
+++ b/pkg/monitor/dbinit/metric_dbinit.go
@@ -6,7 +6,8 @@ var MetricDescriptions = `
 		"measurement": {
 			"name": "cpu",
 			"display_name": "CPU usage",
-			"database":"telegraf"
+			"database":"telegraf",
+			"res_type":"host"
 		},
 		"metric_fields": [
 			{
@@ -60,7 +61,8 @@ var MetricDescriptions = `
 		"measurement": {
 			"name": "disk",
 			"display_name": "Disk usage",
-			"database":"telegraf"
+			"database":"telegraf",
+			"res_type":"host"
 		},
 		"metric_fields": [
 			{
@@ -71,7 +73,7 @@ var MetricDescriptions = `
 			{
 				"name":"inodes_free",
 				"display_name":"Available inode",
-				"unit":"byte"
+				"unit":"count"
 			},
 			{
 				"name":"inodes_total",
@@ -104,7 +106,8 @@ var MetricDescriptions = `
 		"measurement": {
 			"name": "diskio",
 			"display_name": "Disk traffic and timing",
-			"database":"telegraf"
+			"database":"telegraf",
+			"res_type":"host"
 		},
 		"metric_fields": [
 			{
@@ -173,7 +176,8 @@ var MetricDescriptions = `
 		"measurement": {
 			"name": "mem",
 			"display_name": "Memory",
-			"database":"telegraf"	
+			"database":"telegraf",
+			"res_type":"host"
 		},
 		"metric_fields": [
 			{
@@ -237,7 +241,8 @@ var MetricDescriptions = `
 		"measurement": {
 			"name": "net",
 			"display_name": "Network interface and protocol usage",
-			"database":"telegraf"
+			"database":"telegraf",
+			"res_type":"host"
 		},
 		"metric_fields": [
 			{

--- a/pkg/monitor/dbinit/metric_dbinit.go
+++ b/pkg/monitor/dbinit/metric_dbinit.go
@@ -1,0 +1,656 @@
+package dbinit
+
+var MetricDescriptions = `
+[
+	{
+		"measurement": {
+			"name": "cpu",
+			"display_name": "CPU usage",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"usage_active",
+				"display_name":"CPU active state utilization rate",
+				"unit":"%"
+			},
+			{
+				"name":"usage_guest",
+				"display_name":"CPU guest usage",
+				"unit":"%"
+			},
+			{
+				"name":"usage_idle",
+				"display_name":"CPU idle state utilization rate",
+				"unit":"%"
+			},
+			{
+				"name":"usage_iowait",
+				"display_name":"CPU IO usage",
+				"unit":"%"
+			},
+			{
+				"name":"usage_irq",
+				"display_name":"CPU IRQ usage",
+				"unit":"%"
+			},
+			{
+				"name":"usage_nice",
+				"display_name":"CPU priority switch utilization",
+				"unit":"%"
+			},
+			{
+				"name":"usage_softirq",
+				"display_name":"CPU softirq usage",
+				"unit":"%"
+			},
+			{
+				"name":"usage_system",
+				"display_name":"CPU system state utilization rate",
+				"unit":"%"
+			},
+			{
+				"name":"usage_user",
+				"display_name":"CPU user mode utilization rate",
+				"unit":"%"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "disk",
+			"display_name": "Disk usage",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"free",
+				"display_name":"Free space size",
+				"unit":"byte"
+			},
+			{
+				"name":"inodes_free",
+				"display_name":"Available inode",
+				"unit":"byte"
+			},
+			{
+				"name":"inodes_total",
+				"display_name":"Total inodes",
+				"unit":"count"
+			},
+			{
+				"name":"inodes_used",
+				"display_name":"Number of inodes used",
+				"unit":"count"
+			},
+			{
+				"name":"total",
+				"display_name":"Total disk size",
+				"unit":"byte"
+			},
+			{
+				"name":"used",
+				"display_name":"Used disk size",
+				"unit":"byte"
+			},
+			{
+				"name":"used_percent",
+				"display_name":"Percentage of used disks",
+				"unit":"%"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "diskio",
+			"display_name": "Disk traffic and timing",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"reads",
+				"display_name":"Number of reads",
+				"unit":"count"
+			},
+			{
+				"name":"writes",
+				"display_name":"Number of writes",
+				"unit":"count"
+			},
+			{
+				"name":"read_bytes",
+				"display_name":"Bytes read",
+				"unit":"byte"
+			},
+			{
+				"name":"write_bytes",
+				"display_name":"Bytes write",
+				"unit":"byte"
+			},
+			{
+				"name":"write_time",
+				"display_name":"Time to wait for write",
+				"unit":"ms"
+			},
+			{
+				"name":"io_time",
+				"display_name":"I / O request queuing time",
+				"unit":"ms"
+			},
+			{
+				"name":"weighted_io_time",
+				"display_name":"I / O request waiting time",
+				"unit":"ms"
+			},
+			{
+				"name":"iops_in_progress",
+				"display_name":"Number of I / O requests issued but not yet completed",
+				"unit":"count"
+			},
+			{
+				"name":"read_bps",
+				"display_name":"Disk read rate",
+				"unit":"bps"
+			},
+			{
+				"name":"write_bps",
+				"display_name":"Disk write rate",
+				"unit":"bps"
+			},
+			{
+				"name":"read_iops",
+				"display_name":"Disk read operate rate",
+				"unit":"count"
+			},
+			{
+				"name":"write_iops",
+				"display_name":"Disk write operate rate",
+				"unit":"count"
+			},
+		]
+	},
+	{
+		"measurement": {
+			"name": "mem",
+			"display_name": "Memory",
+			"database":"telegraf"	
+		},
+		"metric_fields": [
+			{
+				"name":"active",
+				"display_name":"The amount of active memory",
+				"unit":"byte"
+			},
+			{
+				"name":"available",
+				"display_name":"Available memory",
+				"unit":"byte"
+			},
+			{
+				"name":"available_percent",
+				"display_name":"Available memory rate",
+				"unit":"%"
+			},
+			{
+				"name":"buffered",
+				"display_name":"Buffer memory",
+				"unit":"byte"
+			},
+			{
+				"name":"cached",
+				"display_name":"Cache memory",
+				"unit":"byte"
+			},
+			{
+				"name":"free",
+				"display_name":"Free memory",
+				"unit":"byte"
+			},
+			{
+				"name":"inactive",
+				"display_name":"The amount of inactive memory",
+				"unit":"byte"
+			},
+			{
+				"name":"slab",
+				"display_name":"Number of kernel caches",
+				"unit":"byte"
+			},
+			{
+				"name":"total",
+				"display_name":"Total memory",
+				"unit":"byte"
+			},
+			{
+				"name":"used",
+				"display_name":"Used memory",
+				"unit":"byte"
+			},
+			{
+				"name":"used_percent",
+				"display_name":"Used memory rate",
+				"unit":"%"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "net",
+			"display_name": "Network interface and protocol usage",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"bytes_sent",
+				"display_name":"The total number of bytes sent by the network interface",
+				"unit":"byte"
+			},
+			{
+				"name":"bytes_recv",
+				"display_name":"The total number of bytes received by the network interface",
+				"unit":"byte"
+			},
+			{
+				"name":"packets_sent",
+				"display_name":"The total number of packets sent by the network interface",
+				"unit":"count"
+			},
+			{
+				"name":"packets_recv",
+				"display_name":"The total number of packets received by the network interface",
+				"unit":"count"
+			},
+			{
+				"name":"err_in",
+				"display_name":"The total number of receive errors detected by the network interface",
+				"unit":"count"
+			},
+			{
+				"name":"err_out",
+				"display_name":"The total number of transmission errors detected by the network interface",
+				"unit":"count"
+			},
+			{
+				"name":"drop_in",
+				"display_name":"The total number of received packets dropped by the network interface",
+				"unit":"byte"
+			},
+			{
+				"name":"drop_out",
+				"display_name":"The total number of transmission packets dropped by the network interface",
+				"unit":"byte"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "vm_cpu",
+			"display_name": "Guest CPU usage",
+			"res_type": "guest",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"cpu_count",
+				"display_name":"CPU cores",
+				"unit":"count"
+			},
+			{
+				"name":"cpu_time_system",
+				"display_name":"CPU system state time",
+				"unit":"ms"
+			},
+			{
+				"name":"cpu_time_user",
+				"display_name":"CPU user state time",
+				"unit":"ms"
+			},
+			{
+				"name":"cpu_usage_idle_pcore",
+				"display_name":"CPU idle rate per core",
+				"unit":"%"
+			},
+			{
+				"name":"cpu_usage_pcore",
+				"display_name":"CPU utilization rate per core",
+				"unit":"%"
+			},
+			{
+				"name":"thread_count",
+				"display_name":"The number of threads used by the process",
+				"unit":"count"
+			},
+			{
+				"name":"usage_active",
+				"display_name":"CPU active state utilization rate",
+				"unit":"%"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "vm_diskio",
+			"display_name": "Guest disk traffic",
+			"res_type": "guest",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"read_bps",
+				"display_name":"Disk read rate",
+				"unit":"Bps"
+			},
+			{
+				"name":"read_bytes",
+				"display_name":"Bytes read",
+				"unit":"byte"
+			},
+			{
+				"name":"read_iops",
+				"display_name":"Disk read operate rate",
+				"unit":"count"
+			},
+			{
+				"name":"write_bps",
+				"display_name":"Disk write rate",
+				"unit":"Bps"
+			},
+			{
+				"name":"write_bytes",
+				"display_name":"Bytes write",
+				"unit":"byte"
+			},
+			{
+				"name":"write_iops",
+				"display_name":"Disk write operate rate",
+				"unit":"count"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "vm_mem",
+			"display_name": "Guest memory",
+			"res_type": "guest",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"used_percent",
+				"display_name":"Used memory rate",
+				"unit":"%"
+			},
+			{
+				"name":"vms",
+				"display_name":"Virtual memory consumption",
+				"unit":"byte"
+			},
+			{
+				"name":"rss",
+				"display_name":"Actual use of physical memory",
+				"unit":"byte"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "oss_latency",
+			"display_name": "Object storage latency",
+			"res_type": "oss",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"req_late",
+				"display_name":"Request average E2E delay",
+				"unit":"ms"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "oss_netio",
+			"display_name": "Object storage network traffic",
+			"res_type": "oss",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"bps_recv",
+				"display_name":"Receive byte",
+				"unit":"byte"
+			},
+			{
+				"name":"bps_sent",
+				"display_name":"Send byte",
+				"unit":"byte"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "oss_req",
+			"display_name": "Object store request",
+			"res_type": "oss",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"req_count",
+				"display_name":"request count",
+				"unit":"count"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "rds_conn",
+			"display_name": "Rds connect",
+			"res_type": "rds",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"used_percent",
+				"display_name":"Connection usage",
+				"unit":"%"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "rds_cpu",
+			"display_name": "Rds CPU usage",
+			"res_type": "rds",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"usage_active",
+				"display_name":"CPU active state utilization rate",
+				"unit":"%"
+			},
+			{
+				"name":"used_percent",
+				"display_name":"Connection usage",
+				"unit":"%"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "rds_mem",
+			"display_name": "Rds memory",
+			"res_type": "rds",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"used_percent",
+				"display_name":"memory usage",
+				"unit":"%"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "rds_netio",
+			"display_name": "Rds network traffic",
+			"res_type": "rds",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"bps_recv",
+				"display_name":"Received traffic per second",
+				"unit":"bps"
+			},
+			{
+				"name":"bps_sent",
+				"display_name":"Send traffic per second",
+				"unit":"bps"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "rds_disk",
+			"display_name": "Rds disk usage",
+			"res_type": "rds",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"used_percent",
+				"display_name":"disk usage",
+				"unit":"%"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "dcs_cpu",
+			"display_name": "Redis CPU usage",
+			"res_type": "redis",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"usage_percent",
+				"display_name":"CPU active state utilization rate",
+				"unit":"%"
+			}
+		]	
+	},
+	{
+		"measurement": {
+			"name": "dcs_mem",
+			"display_name": "Redis memory",
+			"res_type": "redis",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"used_percent",
+				"display_name":"memory usage",
+				"unit":"%"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "dcs_netio",
+			"display_name": "Redis network traffic",
+			"res_type": "redis",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"bps_recv",
+				"display_name":"Received traffic per second",
+				"unit":"bps"
+			},
+			{
+				"name":"bps_sent",
+				"display_name":"Send traffic per second",
+				"unit":"bps"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "dcs_conn",
+			"display_name": "Redis connect",
+			"res_type": "redis",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"used_conn",
+				"display_name":"Connection usage",
+				"unit":"%"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "dcs_instantopt",
+			"display_name": "Redis operator",
+			"res_type": "redis",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"opt_sec",
+				"display_name":"Number of commands processed per second",
+				"unit":"count"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "dcs_cachekeys",
+			"display_name": "Redis keys",
+			"res_type": "redis",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"key_count",
+				"display_name":"Number of cache keys",
+				"unit":"count"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "dcs_datamem",
+			"display_name": "Redis data memory",
+			"res_type": "redis",
+			"database":"telegraf"
+		},
+		"metric_fields": [
+			{
+				"name":"used_byte",
+				"display_name":"Data node memory usage",
+				"unit":"byte"
+			}
+		]
+	},
+	{
+		"measurement": {
+			"name": "cloudaccount_balance",
+			"display_name": "Cloud account balance",
+			"res_type": "cloudaccount",
+			"database":"meter_db"
+		},
+		"metric_fields": [
+			{
+				"name":"balance",
+				"display_name":"balance",
+				"unit":"RMB"
+			}
+		]
+	}
+]
+`

--- a/pkg/monitor/models/alert.go
+++ b/pkg/monitor/models/alert.go
@@ -100,6 +100,7 @@ func (manager *SAlertManager) ListItemExportKeys(ctx context.Context, q *sqlchem
 func (man *SAlertManager) FetchAllAlerts() ([]SAlert, error) {
 	objs := make([]SAlert, 0)
 	q := man.Query()
+	q = q.IsTrue("enabled")
 	err := db.FetchModelObjects(man, q, &objs)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, errors.Wrap(err, "db.FetchModelObjects")

--- a/pkg/monitor/models/alertrecord.go
+++ b/pkg/monitor/models/alertrecord.go
@@ -1,0 +1,150 @@
+package models
+
+import (
+	"context"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/sqlchemy"
+
+	"yunion.io/x/onecloud/pkg/apis/monitor"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
+	"yunion.io/x/onecloud/pkg/util/stringutils2"
+)
+
+var (
+	AlertRecordManager *SAlertRecordManager
+)
+
+type SAlertRecordManager struct {
+	db.SEnabledResourceBaseManager
+	db.SStatusStandaloneResourceBaseManager
+	db.SScopedResourceBaseManager
+}
+
+type SAlertRecord struct {
+	//db.SVirtualResourceBase
+	db.SEnabledResourceBase
+	db.SStatusStandaloneResourceBase
+	db.SScopedResourceBase
+
+	AlertId  string               `width:"36" charset:"ascii" nullable:"false" list:"user" create:"required"`
+	Level    string               `charset:"ascii" width:"36" nullable:"false" default:"normal" list:"user" update:"user"`
+	State    string               `width:"36" charset:"ascii" nullable:"false" default:"unknown" list:"user" update:"user"`
+	EvalData jsonutils.JSONObject `list:"user" update:"user"`
+}
+
+func init() {
+	AlertRecordManager = &SAlertRecordManager{
+		SStatusStandaloneResourceBaseManager: db.NewStatusStandaloneResourceBaseManager(
+			SAlertRecord{},
+			"alertrecord_tbl",
+			"alertrecord",
+			"alertrecords",
+		),
+	}
+
+	AlertRecordManager.SetVirtualObject(AlertRecordManager)
+}
+
+func (manager *SAlertRecordManager) NamespaceScope() rbacutils.TRbacScope {
+	return rbacutils.ScopeSystem
+}
+
+func (manager *SAlertRecordManager) ListItemExportKeys(ctx context.Context, q *sqlchemy.SQuery, userCred mcclient.TokenCredential, keys stringutils2.SSortedStrings) (*sqlchemy.SQuery, error) {
+	q, err := manager.SStatusStandaloneResourceBaseManager.ListItemExportKeys(ctx, q, userCred, keys)
+	if err != nil {
+		return nil, errors.Wrap(err, "SStatusStandaloneResourceBaseManager.ListItemExportKeys")
+	}
+	q, err = manager.SScopedResourceBaseManager.ListItemExportKeys(ctx, q, userCred, keys)
+	if err != nil {
+		return nil, errors.Wrap(err, "SScopedResourceBaseManager.ListItemExportKeys")
+	}
+	return q, nil
+}
+
+func (manager *SAlertRecordManager) ListItemFilter(
+	ctx context.Context, q *sqlchemy.SQuery,
+	userCred mcclient.TokenCredential,
+	query monitor.AlertRecordListInput,
+) (*sqlchemy.SQuery, error) {
+	var err error
+
+	q, err = manager.SStandaloneResourceBaseManager.ListItemFilter(ctx, q, userCred, query.StandaloneResourceListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SStandaloneResourceBaseManager.ListItemFilter")
+	}
+	q, err = manager.SEnabledResourceBaseManager.ListItemFilter(ctx, q, userCred,
+		query.EnabledResourceBaseListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SEnabledResourceBaseManager.ListItemFilter")
+	}
+	q, err = manager.SScopedResourceBaseManager.ListItemFilter(ctx, q, userCred,
+		query.ScopedResourceBaseListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SScopedResourceBaseManager.ListItemFilter")
+	}
+	if len(query.Level) != 0 {
+		q = q.Equals("level", query.Level)
+	}
+	if len(query.State) != 0 {
+		q = q.Equals("state", query.State)
+	}
+	return q, nil
+}
+
+func (man *SAlertRecordManager) OrderByExtraFields(
+	ctx context.Context,
+	q *sqlchemy.SQuery,
+	userCred mcclient.TokenCredential,
+	input monitor.AlertRecordListInput,
+) (*sqlchemy.SQuery, error) {
+	var err error
+
+	q, err = man.SStatusStandaloneResourceBaseManager.OrderByExtraFields(ctx, q, userCred, input.StatusStandaloneResourceListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SStandaloneResourceBaseManager.OrderByExtraFields")
+	}
+	q, err = man.SScopedResourceBaseManager.OrderByExtraFields(ctx, q, userCred, input.ScopedResourceBaseListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SScopedResourceBaseManager.OrderByExtraFields")
+	}
+	return q, nil
+}
+
+func (man *SAlertRecordManager) FetchCustomizeColumns(
+	ctx context.Context,
+	userCred mcclient.TokenCredential,
+	query jsonutils.JSONObject,
+	objs []interface{},
+	fields stringutils2.SSortedStrings,
+	isList bool,
+) []monitor.AlertRecordDetails {
+	rows := make([]monitor.AlertRecordDetails, len(objs))
+	stdRows := man.SStatusStandaloneResourceBaseManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields, isList)
+	scopedRows := man.SScopedResourceBaseManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields, isList)
+	for i := range rows {
+		rows[i] = monitor.AlertRecordDetails{
+			StatusStandaloneResourceDetails: stdRows[i],
+			ScopedResourceBaseInfo:          scopedRows[i],
+		}
+		rows[i], _ = objs[i].(*SAlertRecord).GetMoreDetails(rows[i])
+	}
+	return rows
+}
+
+func (record *SAlertRecord) GetMoreDetails(out monitor.AlertRecordDetails) (monitor.AlertRecordDetails, error) {
+	evalMatchs := make([]monitor.EvalMatch, 0)
+	err := record.EvalData.Unmarshal(evalMatchs)
+	if err != nil {
+		return out, errors.Wrap(err, "record Unmarshal evalMatchs error")
+	}
+	out.ResNum = int64(len(evalMatchs))
+	return out, nil
+}
+
+func (man *SAlertRecordManager) ValidateCreateData(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, _ jsonutils.JSONObject, data monitor.AlertRecordCreateInput) (monitor.AlertRecordCreateInput, error) {
+	return data, nil
+}

--- a/pkg/monitor/models/commonalert.go
+++ b/pkg/monitor/models/commonalert.go
@@ -373,6 +373,16 @@ func (man *SCommonAlertManager) FetchCustomizeColumns(
 	return rows
 }
 
+func (alert *SCommonAlert) validateDeleteCondition(out *monitor.CommonAlertDetails) {
+	alert_type := alert.getAlertType()
+	switch alert_type {
+	case monitor.CommonAlertSystemAlertType:
+		out.CanDelete = false
+		out.DeleteFailReason = httperrors.NewInputParameterError("Cannot delete system alert").Error()
+	default:
+	}
+}
+
 func (alert *SCommonAlert) AllowDeleteItem(ctx context.Context, userCred mcclient.TokenCredential,
 	query jsonutils.JSONObject, data jsonutils.JSONObject) bool {
 	isForce, _ := data.Bool("force")
@@ -389,6 +399,8 @@ func (alert *SCommonAlert) AllowDeleteItem(ctx context.Context, userCred mcclien
 }
 
 func (alert *SCommonAlert) GetMoreDetails(out monitor.CommonAlertDetails) (monitor.CommonAlertDetails, error) {
+	alert.validateDeleteCondition(&out)
+
 	var err error
 	alertNotis, err := alert.GetNotifications()
 	if err != nil {
@@ -470,14 +482,46 @@ func (alert *SCommonAlert) getCommonAlertMetricDetails(out *monitor.CommonAlertD
 				break
 			}
 		}
-
 		metricDetails.Measurement = measurement
 		metricDetails.Field = field
 		metricDetails.DB = db
 		metricDetails.Groupby = groupby
+
+		//fill measurement\field desciption info
+		alert.getMetricDescriptionDetails(metricDetails)
+
 		out.CommonAlertMetricDetails[i] = metricDetails
 	}
 	return nil
+}
+
+func (alert *SCommonAlert) getMetricDescriptionDetails(metricDetails *monitor.CommonAlertMetricDetails) {
+	influxdbMeasurements := DataSourceManager.getMetricDescriptions([]monitor.InfluxMeasurement{monitor.
+		InfluxMeasurement{Measurement: metricDetails.Measurement}})
+	if len(influxdbMeasurements) == 0 {
+		return
+	}
+	if len(influxdbMeasurements[0].MeasurementDisplayName) != 0 {
+		metricDetails.MeasurementDisplayName = influxdbMeasurements[0].MeasurementDisplayName
+	}
+	fields := make([]string, 0)
+	if len(metricDetails.FieldOpt) != 0 {
+		fields = append(fields, strings.Split(metricDetails.Field, metricDetails.FieldOpt)...)
+	} else {
+		fields = append(fields, metricDetails.Field)
+	}
+	for _, field := range fields {
+		if influxdbMeasurements[0].FieldDescriptions == nil {
+			return
+		}
+		if fieldDes, ok := influxdbMeasurements[0].FieldDescriptions[field]; ok {
+			if len(metricDetails.FieldOpt) != 0 {
+				fieldDes.Name = metricDetails.Field
+				fieldDes.DisplayName = ""
+			}
+			metricDetails.FieldDescription = fieldDes
+		}
+	}
 }
 
 func getQueryEvalType(evalType string) string {
@@ -518,22 +562,26 @@ func (alert *SCommonAlert) ValidateUpdateData(
 	ctx context.Context,
 	userCred mcclient.TokenCredential,
 	query jsonutils.JSONObject,
-	data monitor.CommonAlertUpdateInput,
-) (monitor.CommonAlertUpdateInput, error) {
-
-	if data.Period == "" {
-		data.Period = "5m"
+	data *jsonutils.JSONDict,
+) (*jsonutils.JSONDict, error) {
+	updataInput := new(monitor.CommonAlertUpdateInput)
+	if period, _ := data.GetString("period"); len(period) > 0 {
+		if _, err := time.ParseDuration(period); err != nil {
+			return data, httperrors.NewInputParameterError("Invalid period format: %s", period)
+		}
+		if period != "" {
+			frep, _ := time.ParseDuration(period)
+			freqSpec := int64(frep / time.Second)
+			data.Set("frequency", jsonutils.NewInt(freqSpec))
+		}
 	}
-	if _, err := time.ParseDuration(data.Period); err != nil {
-		return data, httperrors.NewInputParameterError("Invalid period format: %s", data.Period)
-	}
-	if len(data.Recipients) == 0 {
-		return data, httperrors.NewInputParameterError("recipients is empty")
-	}
-	if len(data.CommonMetricInputQuery.MetricQuery) == 0 {
-		return data, httperrors.NewInputParameterError("metric_query is empty")
-	} else {
-		for _, query := range data.CommonMetricInputQuery.MetricQuery {
+	if metric_query, _ := data.GetArray("metric_query"); len(metric_query) > 0 {
+		for i, _ := range metric_query {
+			query := new(monitor.CommonAlertQuery)
+			err := metric_query[i].Unmarshal(query)
+			if err != nil {
+				return data, errors.Wrap(err, "metric_query Unmarshal error")
+			}
 			if !utils.IsInStringArray(getQueryEvalType(query.Comparator), validators.EvaluatorDefaultTypes) {
 				return data, httperrors.NewInputParameterError("the Comparator is illegal:", query.Comparator)
 			}
@@ -544,33 +592,35 @@ func (alert *SCommonAlert) ValidateUpdateData(
 				return data, httperrors.NewInputParameterError("threshold is meaningless")
 			}
 		}
-	}
+		metricQuery := new(monitor.CommonMetricInputQuery)
+		err := data.Unmarshal(metricQuery)
+		if err != nil {
+			return data, errors.Wrap(err, "metric_query Unmarshal error")
+		}
+		err = CommonAlertManager.ValidateMetricQuery(metricQuery)
+		if err != nil {
+			return data, errors.Wrap(err, "metric query error")
+		}
 
-	err := CommonAlertManager.ValidateMetricQuery(&data.CommonMetricInputQuery)
-	if err != nil {
-		return data, errors.Wrap(err, "metric query error")
-	}
-
-	if data.Period != "" {
-		frep, _ := time.ParseDuration(data.Period)
-		freqSpec := int64(frep / time.Second)
-		data.Frequency = &freqSpec
-	}
-
-	alertCreateInput := alert.getUpdateAlertInput(data)
-	alertCreateInput, err = AlertManager.ValidateCreateData(ctx, userCred, nil, query, alertCreateInput)
-	if err != nil {
-		return data, err
-	}
-	data.Settings = &alertCreateInput.Settings
-	data.AlertUpdateInput, err = alert.SAlert.ValidateUpdateData(ctx, userCred, query, data.AlertUpdateInput)
-	if err != nil {
-		return data, errors.Wrap(err, "SAlert.ValidateUpdateData")
-	}
-	if alert.getAlertType() == monitor.CommonAlertSystemAlertType {
-		tmp := data
-		tmp.Settings = nil
-		return tmp, nil
+		if alert.getAlertType() == monitor.CommonAlertSystemAlertType {
+			return data, nil
+		}
+		data.Update(jsonutils.Marshal(metricQuery))
+		err = data.Unmarshal(updataInput)
+		if err != nil {
+			return data, errors.Wrap(err, "updataInput Unmarshal err")
+		}
+		alertCreateInput := alert.getUpdateAlertInput(*updataInput)
+		alertCreateInput, err = AlertManager.ValidateCreateData(ctx, userCred, nil, query, alertCreateInput)
+		if err != nil {
+			return data, err
+		}
+		data.Set("settings", jsonutils.Marshal(&alertCreateInput.Settings))
+		updataInput.AlertUpdateInput, err = alert.SAlert.ValidateUpdateData(ctx, userCred, query, updataInput.AlertUpdateInput)
+		if err != nil {
+			return data, errors.Wrap(err, "SAlert.ValidateUpdateData")
+		}
+		data.Update(jsonutils.Marshal(updataInput))
 	}
 	return data, nil
 }
@@ -580,12 +630,14 @@ func (alert *SCommonAlert) PostUpdate(
 	query jsonutils.JSONObject, data jsonutils.JSONObject) {
 	updateInput := new(monitor.CommonAlertUpdateInput)
 	data.Unmarshal(updateInput)
-	if err := alert.UpdateNotification(ctx, userCred, query, data); err != nil {
-		log.Errorln("update notification", err)
-	}
-	_, err := alert.PerformSetScope(ctx, userCred, query, data)
-	if err != nil {
-		log.Errorln(errors.Wrap(err, "Alert PerformSetScope"))
+	if len(updateInput.Channel) != 0 {
+		if err := alert.UpdateNotification(ctx, userCred, query, data); err != nil {
+			log.Errorln("update notification", err)
+		}
+		_, err := alert.PerformSetScope(ctx, userCred, query, data)
+		if err != nil {
+			log.Errorln(errors.Wrap(err, "Alert PerformSetScope"))
+		}
 	}
 	CommonAlertManager.SetSubscriptionAlert(alert)
 }

--- a/pkg/monitor/models/metric.go
+++ b/pkg/monitor/models/metric.go
@@ -1,0 +1,578 @@
+package models
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/utils"
+	"yunion.io/x/sqlchemy"
+
+	"yunion.io/x/onecloud/pkg/apis/monitor"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/httperrors"
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/monitor/dbinit"
+	"yunion.io/x/onecloud/pkg/monitor/registry"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
+	"yunion.io/x/onecloud/pkg/util/stringutils2"
+)
+
+type SMetricMeasurementManager struct {
+	db.SEnabledResourceBaseManager
+	db.SStatusStandaloneResourceBaseManager
+	db.SScopedResourceBaseManager
+}
+
+type SMetricMeasurement struct {
+	//db.SVirtualResourceBase
+	db.SEnabledResourceBase
+	db.SStatusStandaloneResourceBase
+	db.SScopedResourceBase
+
+	ResType     string `width:"32" list:"user" update:"user"`
+	Database    string `width:"32" list:"user" update:"user"`
+	DisplayName string `width:"256" list:"user" update:"user"`
+}
+
+var MetricMeasurementManager *SMetricMeasurementManager
+
+func init() {
+	MetricMeasurementManager = &SMetricMeasurementManager{
+		SStatusStandaloneResourceBaseManager: db.NewStatusStandaloneResourceBaseManager(
+			SMetricMeasurement{},
+			"metricmeasurement_tbl",
+			"metricmeasurement",
+			"metricmeasurements",
+		),
+	}
+
+	MetricMeasurementManager.SetVirtualObject(MetricMeasurementManager)
+	registry.RegisterService(MetricMeasurementManager)
+}
+
+func (manager *SMetricMeasurementManager) NamespaceScope() rbacutils.TRbacScope {
+	return rbacutils.ScopeSystem
+}
+
+func (manager *SMetricMeasurementManager) ListItemExportKeys(ctx context.Context, q *sqlchemy.SQuery, userCred mcclient.TokenCredential, keys stringutils2.SSortedStrings) (*sqlchemy.SQuery, error) {
+	q, err := manager.SStatusStandaloneResourceBaseManager.ListItemExportKeys(ctx, q, userCred, keys)
+	if err != nil {
+		return nil, errors.Wrap(err, "SStatusStandaloneResourceBaseManager.ListItemExportKeys")
+	}
+	q, err = manager.SScopedResourceBaseManager.ListItemExportKeys(ctx, q, userCred, keys)
+	if err != nil {
+		return nil, errors.Wrap(err, "SScopedResourceBaseManager.ListItemExportKeys")
+	}
+	return q, nil
+}
+
+func (man *SMetricMeasurementManager) ValidateCreateData(
+	ctx context.Context, userCred mcclient.TokenCredential,
+	ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject,
+	data monitor.MetricCreateInput) (monitor.MetricMeasurementCreateInput, error) {
+	return data.Measurement, nil
+}
+
+func (measurement *SMetricMeasurement) CustomizeCreate(
+	ctx context.Context, userCred mcclient.TokenCredential,
+	ownerId mcclient.IIdentityProvider,
+	query jsonutils.JSONObject,
+	data jsonutils.JSONObject,
+) error {
+	err := measurement.SScopedResourceBase.CustomizeCreate(ctx, userCred, ownerId, query, data)
+	if err != nil {
+		return err
+	}
+	input := new(monitor.MetricCreateInput)
+	if err := data.Unmarshal(input); err != nil {
+		return err
+	}
+
+	for _, fieldInput := range input.MetricFields {
+		field, err := measurement.SaveMetricField(ctx, userCred, ownerId, fieldInput)
+		if err != nil {
+			return err
+		}
+		err = measurement.attachMetricField(ctx, userCred, field)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (measurement *SMetricMeasurement) attachMetricField(ctx context.Context, userCred mcclient.TokenCredential,
+	field *SMetricField) error {
+	count, err := measurement.isAttachMetricField(field)
+	if err != nil {
+		return err
+	}
+	if count {
+		return httperrors.ErrDuplicateName
+	}
+	metric := new(SMetric)
+	if len(measurement.GetId()) == 0 {
+		measurement.Id = db.DefaultUUIDGenerator()
+	}
+	metric.MeasurementId = measurement.GetId()
+	metric.FieldId = field.GetId()
+	return metric.DoSave(ctx)
+}
+
+func (measurement *SMetricMeasurement) isAttachMetricField(field *SMetricField) (bool, error) {
+	q := MetricManager.Query().Equals(MetricManager.GetMasterFieldName(), measurement.GetId()).Equals(MetricManager.
+		GetSlaveFieldName(), field.GetId())
+	count, err := q.CountWithError()
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+
+}
+
+func (measurement *SMetricMeasurement) SaveMetricField(ctx context.Context, userCred mcclient.TokenCredential,
+	ownerId mcclient.IIdentityProvider, fieldInput monitor.MetricFieldCreateInput) (*SMetricField, error) {
+	return MetricFieldManager.SaveMetricField(ctx, userCred, ownerId, fieldInput)
+}
+
+func (manager *SMetricMeasurementManager) ListItemFilter(
+	ctx context.Context, q *sqlchemy.SQuery,
+	userCred mcclient.TokenCredential,
+	query monitor.MetricListInput,
+) (*sqlchemy.SQuery, error) {
+	var err error
+	q, err = manager.SStandaloneResourceBaseManager.ListItemFilter(ctx, q, userCred, query.Measurement.StandaloneResourceListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SStandaloneResourceBaseManager.ListItemFilter")
+	}
+	q, err = manager.SEnabledResourceBaseManager.ListItemFilter(ctx, q, userCred,
+		query.Measurement.EnabledResourceBaseListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SEnabledResourceBaseManager.ListItemFilter")
+	}
+	q, err = manager.SScopedResourceBaseManager.ListItemFilter(ctx, q, userCred,
+		query.Measurement.ScopedResourceBaseListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SScopedResourceBaseManager.ListItemFilter")
+	}
+	if len(query.Measurement.ResType) != 0 {
+		q = q.Equals("res_type", query.Measurement.ResType)
+	}
+	if len(query.Measurement.DisplayName) != 0 {
+		q = q.Equals("display_name", query.Measurement.DisplayName)
+	}
+	joinQuery, err := manager.listFilterMetricField(ctx, userCred, query.MetricFields)
+	if err != nil {
+		return q, err
+	}
+	joinSubQuery := joinQuery.SubQuery()
+	q = q.Join(joinSubQuery, sqlchemy.Equals(q.Field("id"), joinSubQuery.Field(MetricManager.GetMasterFieldName())))
+	return q, nil
+}
+
+func (man *SMetricMeasurementManager) OrderByExtraFields(
+	ctx context.Context,
+	q *sqlchemy.SQuery,
+	userCred mcclient.TokenCredential,
+	input monitor.AlertListInput,
+) (*sqlchemy.SQuery, error) {
+	var err error
+
+	q, err = man.SStatusStandaloneResourceBaseManager.OrderByExtraFields(ctx, q, userCred, input.StatusStandaloneResourceListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SStandaloneResourceBaseManager.OrderByExtraFields")
+	}
+	q, err = man.SScopedResourceBaseManager.OrderByExtraFields(ctx, q, userCred, input.ScopedResourceBaseListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SScopedResourceBaseManager.OrderByExtraFields")
+	}
+	return q, nil
+}
+
+func (manager *SMetricMeasurementManager) listFilterMetricField(ctx context.Context, userCred mcclient.TokenCredential, query monitor.MetricFieldListInput) (*sqlchemy.SQuery, error) {
+	joinQuery := MetricManager.Query(MetricManager.GetMasterFieldName()).Distinct()
+
+	fieldQuery, err := MetricFieldManager.ListItemFilter(ctx, MetricFieldManager.Query(), userCred, query)
+	if err != nil {
+		return nil, err
+	}
+	fieldSubQuery := fieldQuery.SubQuery()
+	joinQuery = joinQuery.Join(fieldSubQuery, sqlchemy.Equals(joinQuery.Field(MetricManager.
+		GetSlaveFieldName()), fieldSubQuery.Field("id")))
+	return joinQuery, nil
+}
+
+func (man *SMetricMeasurementManager) FetchCustomizeColumns(
+	ctx context.Context,
+	userCred mcclient.TokenCredential,
+	query jsonutils.JSONObject,
+	objs []interface{},
+	fields stringutils2.SSortedStrings,
+	isList bool,
+) []monitor.MetricDetails {
+	rows := make([]monitor.MetricDetails, len(objs))
+	stdRows := man.SStatusStandaloneResourceBaseManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields, isList)
+	scopedRows := man.SScopedResourceBaseManager.FetchCustomizeColumns(ctx, userCred, query, objs, fields, isList)
+	for i := range rows {
+		rows[i] = monitor.MetricDetails{
+			StatusStandaloneResourceDetails: stdRows[i],
+			ScopedResourceBaseInfo:          scopedRows[i],
+		}
+		rows[i], _ = objs[i].(*SMetricMeasurement).GetMoreDetails(rows[i])
+	}
+	return rows
+}
+func (measurement *SMetricMeasurement) GetMoreDetails(out monitor.MetricDetails) (monitor.MetricDetails, error) {
+	fields, err := measurement.getFields()
+	if err != nil {
+		log.Errorln(err)
+		return out, err
+	}
+	fieldDetails := make([]monitor.MetricFieldDetail, 0)
+	for _, field := range fields {
+		fieldObj := jsonutils.Marshal(&field)
+		fieldDetail := new(monitor.MetricFieldDetail)
+		err := fieldObj.Unmarshal(fieldDetail)
+		if err != nil {
+			log.Errorln(err)
+			return out, err
+		}
+		fieldDetails = append(fieldDetails, *fieldDetail)
+	}
+	out.MetricFields = fieldDetails
+	return out, nil
+}
+
+func (measurement *SMetricMeasurement) ValidateUpdateData(
+	ctx context.Context,
+	userCred mcclient.TokenCredential,
+	query jsonutils.JSONObject,
+	data monitor.MetricUpdateInput,
+) (monitor.MetricMeasurementUpdateInput, error) {
+	if len(data.Measurement.ResType) == 0 {
+		return data.Measurement, errors.Wrap(httperrors.ErrNotEmpty, "res_type")
+	}
+	if !utils.IsInStringArray(data.Measurement.ResType, monitor.MetricResType) {
+		return data.Measurement, errors.Wrap(httperrors.ErrBadRequest, "res_type")
+	}
+	if len(data.Measurement.DisplayName) == 0 {
+		return data.Measurement, errors.Wrap(httperrors.ErrNotEmpty, "display_name")
+	}
+	return data.Measurement, nil
+}
+
+func (measurement *SMetricMeasurement) PreUpdate(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject,
+	data jsonutils.JSONObject) {
+	input := new(monitor.MetricUpdateInput)
+	if err := data.Unmarshal(input); err != nil {
+		return
+	}
+	for _, fieldUpdateInput := range input.MetricFields {
+		field, err := measurement.getMetricField(fieldUpdateInput.Name)
+		if err != nil {
+			log.Errorln(err, "metric measurement getMetricFields error")
+			continue
+		}
+		if field == nil {
+			log.Errorf("field:%s do not attach with measurement:%s", fieldUpdateInput.Name, measurement.Name)
+			continue
+		}
+		err = measurement.updateMetricField(ctx, userCred, field, fieldUpdateInput)
+		if err != nil {
+			log.Errorln(err, "measurement updateMetricField")
+		}
+	}
+}
+
+func (measurement *SMetricMeasurement) getMetricField(name string) (*SMetricField, error) {
+	fields := make([]SMetricField, 0)
+	q := measurement.getFieldsQuery()
+	q = q.Equals("name", name)
+	err := db.FetchModelObjects(MetricFieldManager, q, &fields)
+	if err != nil {
+		return nil, err
+	}
+	if len(fields) == 0 {
+		return nil, nil
+	}
+	if len(fields) != 1 {
+		return nil, errors.Wrapf(sqlchemy.ErrDuplicateEntry, "found %d, metric field name: %s", len(fields), name)
+	}
+	return &fields[0], nil
+}
+
+func (measurement *SMetricMeasurement) getFields() ([]SMetricField, error) {
+	fields := make([]SMetricField, 0)
+	q := measurement.getFieldsQuery()
+	err := db.FetchModelObjects(MetricFieldManager, q, &fields)
+	if err != nil {
+		return nil, err
+	}
+	return fields, nil
+}
+
+func (manager *SMetricMeasurementManager) getMeasurement(query *sqlchemy.SQuery) ([]SMetricMeasurement, error) {
+	measurements := make([]SMetricMeasurement, 0)
+	err := db.FetchModelObjects(MetricMeasurementManager, query, &measurements)
+	if err != nil {
+		return nil, err
+	}
+	return measurements, nil
+}
+
+func (manager *SMetricMeasurementManager) getInfluxdbMeasurements() (influxdbMeasurements []monitor.
+	InfluxMeasurement, err error) {
+	metric, err := manager.getMeasurement(manager.Query())
+	if err != nil {
+		return
+	}
+	for i, _ := range metric {
+		influxdbMeasurements = append(influxdbMeasurements, monitor.InfluxMeasurement{
+			Database:    metric[i].Database,
+			Measurement: metric[i].Name,
+		})
+	}
+	return
+
+}
+
+func (measurement *SMetricMeasurement) getFieldsQuery() *sqlchemy.SQuery {
+	metricJoinQuery := MetricManager.Query().Equals(MetricManager.GetMasterFieldName(), measurement.GetId()).SubQuery()
+	q := MetricFieldManager.Query()
+	q = q.Join(metricJoinQuery, sqlchemy.Equals(q.Field("id"), metricJoinQuery.Field(MetricManager.GetSlaveFieldName())))
+	return q
+}
+
+func (measurement *SMetricMeasurement) updateMetricField(ctx context.Context, userCred mcclient.TokenCredential,
+	field *SMetricField, input monitor.MetricFieldUpdateInput) error {
+	_, err := field.ValidateUpdateData(ctx, userCred, nil, input)
+	if err != nil {
+		return err
+	}
+	_, err = db.Update(field, func() error {
+		field.Unit = input.Unit
+		field.DisplayName = input.DisplayName
+		return nil
+	})
+	return err
+}
+
+func (manager *SMetricMeasurementManager) Init() error {
+	return nil
+}
+
+func (man *SMetricMeasurementManager) Run(ctx context.Context) error {
+
+	err := man.initJsonMetricInfo(ctx)
+	if err != nil {
+		return errors.Wrap(err, "init metric json error")
+	}
+	log.Infoln("========metric_measurement_field init finish==========")
+	return nil
+}
+
+func (manager *SMetricMeasurementManager) initMeasurementDatabase(ctx context.Context) (err error) {
+	databases, err := DataSourceManager.GetDatabases()
+	if err != nil {
+		return err
+	}
+	databaseArr, err := databases.GetArray("databases")
+	if err != nil {
+		return err
+	}
+	databaseGroup, _ := errgroup.WithContext(ctx)
+	for dIndex, _ := range databaseArr {
+		databaseTmp := databaseArr[dIndex]
+		databaseStr, _ := databaseTmp.GetString()
+		databaseGroup.Go(manager.getMeasurementAsyn(ctx, databaseStr))
+	}
+	err = databaseGroup.Wait()
+	return
+}
+
+func (manager *SMetricMeasurementManager) getMeasurementAsyn(ctx context.Context, database string) func() error {
+	return func() error {
+		query := jsonutils.NewDict()
+		query.Add(jsonutils.NewString(database), "database")
+
+		measurements, err := DataSourceManager.GetMeasurementsWithOutTimeFilter(query, "", "")
+		if err != nil {
+			return err
+		}
+		measurementArr, err := measurements.GetArray("measurements")
+		if err != nil {
+			return err
+		}
+		metrics := make([]monitor.MetricCreateInput, 0)
+		for mIndex, _ := range measurementArr {
+			measurementStr, _ := measurementArr[mIndex].GetString("measurement")
+			metric := monitor.MetricCreateInput{}
+			metricMea := monitor.MetricMeasurementCreateInput{}
+			metricMea.Name = measurementStr
+			metricMea.Database = database
+			metric.Measurement = metricMea
+			metric.MetricFields = make([]monitor.MetricFieldCreateInput, 0)
+			metrics = append(metrics, metric)
+		}
+		return manager.initMetrics(ctx, metrics)
+	}
+}
+
+func (manager *SMetricMeasurementManager) initJsonMetricInfo(ctx context.Context) error {
+	metricDescriptions, err := jsonutils.ParseString(dbinit.MetricDescriptions)
+	if err != nil {
+		return errors.Wrap(err, "SMetricMeasurementManager Parse MetricDescriptionstr error")
+	}
+	metrics := make([]monitor.MetricCreateInput, 0)
+	err = metricDescriptions.Unmarshal(&metrics)
+	if err != nil {
+		return errors.Wrap(err, "SMetricMeasurementManager Unmarshal MetricDescriptionstr error")
+	}
+	return manager.initMetrics(ctx, metrics)
+}
+
+func (manager *SMetricMeasurementManager) initMetrics(ctx context.Context, metrics []monitor.MetricCreateInput) (err error) {
+	measurementGroup, _ := errgroup.WithContext(ctx)
+	count := 1
+	for mIndex, _ := range metrics {
+
+		measurementTmp := metrics[mIndex]
+		if mIndex < len(metrics) && count < 10 {
+			count++
+			measurementGroup.Go(func() error {
+				return manager.initMeasurementAndFieldInfo(measurementTmp)
+			})
+		}
+		if count == 1 {
+			err := measurementGroup.Wait()
+			if err != nil {
+				return err
+			}
+			count = 1
+		}
+	}
+	err = measurementGroup.Wait()
+	return
+}
+
+func (manager *SMetricMeasurementManager) initMeasurementAndFieldInfo(createInput monitor.MetricCreateInput) error {
+	userCred := auth.AdminCredential()
+	listInput := new(monitor.MetricListInput)
+	listInput.Measurement.Names = []string{createInput.Measurement.Name}
+	measurements, err := manager.getMeasurementByName(userCred, *listInput)
+	if err != nil {
+		return errors.Wrap(err, "join query get  measurement error")
+	}
+	unInsertFields := createInput.MetricFields
+	updateFields := make([]monitor.MetricFieldCreateInput, 0)
+	if len(measurements) != 0 {
+		unInsertFields, updateFields = measurements[0].getInsertAndUpdateFields(userCred, createInput)
+	}
+	if len(measurements) == 0 {
+		_, err := db.DoCreate(manager, context.Background(), userCred, jsonutils.NewDict(),
+			jsonutils.Marshal(&createInput),
+			userCred)
+		if err != nil {
+			err = errors.Wrap(err, "create metricdescription error")
+		}
+		return err
+	}
+	createInput.MetricFields = unInsertFields
+	return measurements[0].insertOrUpdateMetric(userCred, createInput, updateFields)
+}
+
+func (manager *SMetricMeasurementManager) getMeasurementByName(userCred mcclient.TokenCredential,
+	listInput monitor.MetricListInput) ([]SMetricMeasurement, error) {
+	query, err := MetricMeasurementManager.ListItemFilter(context.Background(), MetricMeasurementManager.Query(), userCred,
+		listInput)
+	if err != nil {
+		return nil, err
+	}
+	return manager.getMeasurement(query)
+}
+
+func (self *SMetricMeasurement) getInsertAndUpdateFields(userCred mcclient.TokenCredential, input monitor.MetricCreateInput) (unInsertFields,
+	updateFields []monitor.MetricFieldCreateInput) {
+	measurementsIns := []interface{}{self}
+	details := MetricMeasurementManager.FetchCustomizeColumns(context.Background(), userCred, jsonutils.NewDict(), measurementsIns,
+		stringutils2.NewSortedStrings([]string{}), true)
+	unInsertFields, updateFields = getUnInsertFields(input.MetricFields, details[0])
+	return
+}
+
+func (self *SMetricMeasurement) insertOrUpdateMetric(userCred mcclient.TokenCredential,
+	createInput monitor.MetricCreateInput, updateFields []monitor.MetricFieldCreateInput) error {
+	_, err := db.Update(self, func() error {
+		if len(createInput.Measurement.DisplayName) != 0 {
+			self.DisplayName = createInput.Measurement.DisplayName
+		}
+		if len(createInput.Measurement.ResType) != 0 {
+			self.ResType = createInput.Measurement.ResType
+		}
+		if len(createInput.Measurement.Database) != 0 {
+			self.Database = createInput.Measurement.Database
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "update metric measurement error")
+	}
+
+	err = self.CustomizeCreate(context.Background(), userCred, userCred, jsonutils.NewDict(),
+		jsonutils.Marshal(&createInput))
+	if err != nil {
+		return errors.Wrap(err, "create metric field error")
+	}
+	dbFields, _ := self.getFields()
+	for i, _ := range dbFields {
+		for upIndex, _ := range updateFields {
+			if dbFields[i].Name == updateFields[upIndex].Name {
+				_, err := db.Update(&dbFields[i], func() error {
+					if len(updateFields[upIndex].DisplayName) != 0 {
+						dbFields[i].DisplayName = updateFields[upIndex].DisplayName
+					}
+					if len(updateFields[upIndex].Unit) != 0 {
+						dbFields[i].Unit = updateFields[upIndex].Unit
+					}
+					return nil
+				})
+				if err != nil {
+					return errors.Wrap(err, "update metric field error")
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func getUnInsertFields(searchFields []monitor.MetricFieldCreateInput,
+	dbFields monitor.MetricDetails) (unInsertFields, updateFields []monitor.
+	MetricFieldCreateInput) {
+	fieldCountMap := make(map[string]int)
+	fieldMap := make(map[string]monitor.MetricFieldCreateInput, 0)
+	for _, field := range searchFields {
+		fieldCountMap[field.Name]++
+		fieldMap[field.Name] = field
+	}
+
+	for _, dbField := range dbFields.MetricFields {
+		count, _ := fieldCountMap[dbField.Name]
+		if count == 1 {
+			if field, ok := fieldMap[dbField.Name]; ok {
+				updateFields = append(updateFields, field)
+			}
+			delete(fieldCountMap, dbField.Name)
+		}
+	}
+	for fieldName, _ := range fieldCountMap {
+		if field, ok := fieldMap[fieldName]; ok {
+			unInsertFields = append(unInsertFields, field)
+		}
+	}
+	return unInsertFields, updateFields
+}

--- a/pkg/monitor/models/metric.go
+++ b/pkg/monitor/models/metric.go
@@ -438,7 +438,7 @@ func (manager *SMetricMeasurementManager) initJsonMetricInfo(ctx context.Context
 
 func (manager *SMetricMeasurementManager) initMetrics(ctx context.Context, metrics []monitor.MetricCreateInput) (err error) {
 	measurementGroup, _ := errgroup.WithContext(ctx)
-	count := 1
+	count := 0
 	for mIndex, _ := range metrics {
 
 		measurementTmp := metrics[mIndex]
@@ -453,7 +453,7 @@ func (manager *SMetricMeasurementManager) initMetrics(ctx context.Context, metri
 			if err != nil {
 				return err
 			}
-			count = 1
+			count = 0
 		}
 	}
 	err = measurementGroup.Wait()

--- a/pkg/monitor/models/metric_field.go
+++ b/pkg/monitor/models/metric_field.go
@@ -1,0 +1,147 @@
+package models
+
+import (
+	"context"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/utils"
+	"yunion.io/x/sqlchemy"
+
+	"yunion.io/x/onecloud/pkg/apis/monitor"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/httperrors"
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
+	"yunion.io/x/onecloud/pkg/util/stringutils2"
+)
+
+type SMetricFieldManager struct {
+	db.SEnabledResourceBaseManager
+	db.SStatusStandaloneResourceBaseManager
+	db.SScopedResourceBaseManager
+}
+
+type SMetricField struct {
+	//db.SVirtualResourceBase
+	db.SEnabledResourceBase
+	db.SStatusStandaloneResourceBase
+	db.SScopedResourceBase
+
+	DisplayName string `width:"256" list:"user" update:"user"`
+	Unit        string `width:"32" list:"user" update:"user"`
+	ValueType   string `width:"32" list:"user" update:"user"`
+}
+
+var MetricFieldManager *SMetricFieldManager
+
+func init() {
+	MetricFieldManager = &SMetricFieldManager{
+		SStatusStandaloneResourceBaseManager: db.NewStatusStandaloneResourceBaseManager(
+			SMetricField{},
+			"metricfield_tbl",
+			"metricfield",
+			"metricfields",
+		),
+	}
+	MetricFieldManager.SetVirtualObject(MetricFieldManager)
+}
+
+func (manager *SMetricFieldManager) NamespaceScope() rbacutils.TRbacScope {
+	return rbacutils.ScopeSystem
+}
+
+func (manager *SMetricFieldManager) ListItemExportKeys(ctx context.Context, q *sqlchemy.SQuery,
+	userCred mcclient.TokenCredential, keys stringutils2.SSortedStrings) (*sqlchemy.SQuery, error) {
+	q, err := manager.SStatusStandaloneResourceBaseManager.ListItemExportKeys(ctx, q, userCred, keys)
+	if err != nil {
+		return nil, errors.Wrap(err, "SStatusStandaloneResourceBaseManager.ListItemExportKeys")
+	}
+	q, err = manager.SScopedResourceBaseManager.ListItemExportKeys(ctx, q, userCred, keys)
+	if err != nil {
+		return nil, errors.Wrap(err, "SScopedResourceBaseManager.ListItemExportKeys")
+	}
+	return q, nil
+}
+
+func (man *SMetricFieldManager) ValidateCreateData(
+	ctx context.Context, userCred mcclient.TokenCredential,
+	ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject,
+	data monitor.MetricFieldCreateInput) (monitor.MetricFieldCreateInput, error) {
+	return data, nil
+}
+
+func (field *SMetricField) ValidateUpdateData(
+	ctx context.Context,
+	userCred mcclient.TokenCredential,
+	query jsonutils.JSONObject,
+	data monitor.MetricFieldUpdateInput,
+) (monitor.MetricFieldUpdateInput, error) {
+	if len(data.DisplayName) == 0 {
+		return data, errors.Wrap(httperrors.ErrNotEmpty, "display_name")
+	}
+	if len(data.Unit) == 0 {
+		return data, errors.Wrap(httperrors.ErrNotEmpty, "unit")
+	}
+	if !utils.IsInStringArray(data.Unit, monitor.MetricUnit) {
+		return data, errors.Wrap(httperrors.ErrBadRequest, "unit")
+	}
+	return data, nil
+}
+
+func (manager *SMetricFieldManager) ListItemFilter(
+	ctx context.Context, q *sqlchemy.SQuery,
+	userCred mcclient.TokenCredential,
+	query monitor.MetricFieldListInput,
+) (*sqlchemy.SQuery, error) {
+	var err error
+	q, err = manager.SStandaloneResourceBaseManager.ListItemFilter(ctx, q, userCred, query.StandaloneResourceListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SStandaloneResourceBaseManager.ListItemFilter")
+	}
+	q, err = manager.SEnabledResourceBaseManager.ListItemFilter(ctx, q, userCred, query.EnabledResourceBaseListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SEnabledResourceBaseManager.ListItemFilter")
+	}
+	q, err = manager.SScopedResourceBaseManager.ListItemFilter(ctx, q, userCred,
+		query.ScopedResourceBaseListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SScopedResourceBaseManager.ListItemFilter")
+	}
+	if len(query.DisplayName) != 0 {
+		//q = q.Equals("display_name", query.DisplayName)
+		q = q.Filter(sqlchemy.Like(q.Field("display_name"), query.DisplayName))
+	}
+	if len(query.Unit) != 0 {
+		q = q.Equals("unit", query.Unit)
+	}
+	return q, nil
+}
+
+func (man *SMetricFieldManager) OrderByExtraFields(
+	ctx context.Context,
+	q *sqlchemy.SQuery,
+	userCred mcclient.TokenCredential,
+	input monitor.AlertListInput,
+) (*sqlchemy.SQuery, error) {
+	var err error
+
+	q, err = man.SStatusStandaloneResourceBaseManager.OrderByExtraFields(ctx, q, userCred, input.StatusStandaloneResourceListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SStandaloneResourceBaseManager.OrderByExtraFields")
+	}
+	q, err = man.SScopedResourceBaseManager.OrderByExtraFields(ctx, q, userCred, input.ScopedResourceBaseListInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "SScopedResourceBaseManager.OrderByExtraFields")
+	}
+	return q, nil
+}
+
+func (manager *SMetricFieldManager) SaveMetricField(ctx context.Context, userCred mcclient.TokenCredential,
+	ownerId mcclient.IIdentityProvider, fieldInput monitor.MetricFieldCreateInput) (*SMetricField, error) {
+	obj, err := db.DoCreate(manager, ctx, userCred, nil, fieldInput.JSON(&fieldInput), userCred)
+	if err != nil {
+		return nil, errors.Wrapf(err, "SaveMetricField error input: %s", fieldInput.JSON(&fieldInput))
+	}
+	return obj.(*SMetricField), nil
+}

--- a/pkg/monitor/models/metric_joint.go
+++ b/pkg/monitor/models/metric_joint.go
@@ -1,0 +1,50 @@
+package models
+
+import (
+	"context"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+)
+
+type SMetricManager struct {
+	db.SJointResourceBaseManager
+}
+
+type SMetric struct {
+	db.SVirtualJointResourceBase
+	MeasurementId string `width:"36" charset:"ascii" nullable:"false" list:"user" create:"required"`
+	FieldId       string `width:"36" charset:"ascii" nullable:"false" list:"user" create:"required"`
+}
+
+var MetricManager *SMetricManager
+
+func init() {
+	MetricManager = &SMetricManager{
+		SJointResourceBaseManager: db.NewJointResourceBaseManager(
+			SMetric{},
+			"metric_tbl",
+			"metric",
+			"metrics",
+			MetricMeasurementManager,
+			MetricFieldManager,
+		),
+	}
+	MetricManager.SetVirtualObject(MetricManager)
+	MetricManager.TableSpec().AddIndex(true, MetricManager.GetMasterFieldName(), MetricManager.GetSlaveFieldName())
+}
+
+func (man *SMetricManager) GetMasterFieldName() string {
+	return "measurement_id"
+}
+
+func (man *SMetricManager) GetSlaveFieldName() string {
+	return "field_id"
+}
+
+func (metric *SMetric) DoSave(ctx context.Context) error {
+	if err := MetricManager.TableSpec().Insert(ctx, metric); err != nil {
+		return err
+	}
+	metric.SetModelManager(MetricManager, metric)
+	return nil
+}

--- a/pkg/monitor/models/unifiedmonitor.go
+++ b/pkg/monitor/models/unifiedmonitor.go
@@ -71,7 +71,7 @@ func (self *SUnifiedMonitorManager) GetPropertyMeasurements(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	return DataSourceManager.GetMeasurements(query, "", filter)
+	return DataSourceManager.GetMeasurementsWithDescriptionInfos(query, "", filter)
 }
 
 func filterByScope(ctx context.Context, scope string, data jsonutils.JSONObject) (string, error) {
@@ -245,7 +245,7 @@ func doQuery(query monitor.MetricInputQuery) (*mq.Metrics, error) {
 
 func (self *SUnifiedMonitorManager) ValidateInputQuery(query *monitor.AlertQuery) error {
 	if query.From == "" {
-		query.From = "30m"
+		query.From = "1h"
 	}
 	if query.Model.Interval == "" {
 		query.Model.Interval = "5m"

--- a/pkg/monitor/service/handlers.go
+++ b/pkg/monitor/service/handlers.go
@@ -60,6 +60,7 @@ func InitHandlers(app *appsrv.Application) {
 		models.SuggestSysRuleConfigManager,
 		models.MetricMeasurementManager,
 		models.MetricFieldManager,
+		models.AlertRecordManager,
 	} {
 		db.RegisterModelManager(manager)
 		handler := db.NewModelHandler(manager)

--- a/pkg/monitor/service/handlers.go
+++ b/pkg/monitor/service/handlers.go
@@ -58,6 +58,8 @@ func InitHandlers(app *appsrv.Application) {
 		models.SuggestSysAlertManager,
 		models.CommonAlertManager,
 		models.SuggestSysRuleConfigManager,
+		models.MetricMeasurementManager,
+		models.MetricFieldManager,
 	} {
 		db.RegisterModelManager(manager)
 		handler := db.NewModelHandler(manager)
@@ -73,6 +75,7 @@ func InitHandlers(app *appsrv.Application) {
 
 	for _, manager := range []db.IJointModelManager{
 		models.AlertNotificationManager,
+		models.MetricManager,
 	} {
 		db.RegisterModelManager(manager)
 		handler := db.NewJointModelHandler(manager)

--- a/pkg/util/influxdb/influxdb.go
+++ b/pkg/util/influxdb/influxdb.go
@@ -85,8 +85,8 @@ func (db *SInfluxdb) Write(data string, precision string) error {
 }
 
 func (db *SInfluxdb) Query(sql string) ([][]dbResult, error) {
-	nurl := fmt.Sprintf("%s/query?q=%s", db.accessUrl, url.QueryEscape(sql))
-	_, body, err := httputils.JSONRequest(db.client, context.Background(), "POST", nurl, nil, nil, db.debug)
+	nurl := fmt.Sprintf("%s/query?db=%s&q=%s&epoch=ms", db.accessUrl, db.dbName, url.QueryEscape(sql))
+	_, body, err := httputils.JSONRequest(db.client, context.Background(), "GET", nurl, nil, nil, db.debug)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
1.初始化influxdb measurement和field到本地
2.更新measurement和field的display_name,以及unit等信息

3.模版调整：
 1）修改email template
 2）格式化消息结构中的报警value，增加单位，同时可以转换为合适的单位
 3）简化消息体中的tag信息：name，ip，brand，value

4.增加报警历史记录
 1）记录每条报警规则的，报警信息

**是否需要 backport 到之前的 release 分支**:
release/3.4

/area monitor
/cc @zexi 