### PR TITLE
fix(region): Don't allow address conflicts under vpc

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1459,12 +1459,12 @@ func (manager *SNetworkManager) ValidateCreateData(ctx context.Context, userCred
 		}
 	}
 	{
-		nets := manager.getAllNetworks(wire.Id, "")
-		if nets == nil {
-			return input, httperrors.NewInternalServerError("query all networks fail")
+		nets, err := vpc.GetNetworks()
+		if err != nil {
+			return input, httperrors.NewInternalServerError("fail to GetNetworks of vpc: %v", err)
 		}
 		if isOverlapNetworks(nets, ipStart, ipEnd) {
-			return input, httperrors.NewInputParameterError("Conflict address space with existing networks")
+			return input, httperrors.NewInputParameterError("Conflict address space with existing networks in vpc %q", vpc.GetName())
 		}
 	}
 

--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -226,6 +226,16 @@ func (self *SVpc) getNetworkQuery() *sqlchemy.SQuery {
 	return q
 }
 
+func (self *SVpc) GetNetworks() ([]SNetwork, error) {
+	q := self.getNetworkQuery()
+	nets := make([]SNetwork, 0, 5)
+	err := db.FetchModelObjects(NetworkManager, q, &nets)
+	if err != nil {
+		return nil, errors.Wrap(err, "db.FetchModelObjects")
+	}
+	return nets, nil
+}
+
 func (self *SVpc) GetNetworkCount() (int, error) {
 	q := self.getNetworkQuery()
 	return q.CountWithError()


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

之前保证上面的逻辑是：在创建network时，检查wire下的地址冲突。
但是default VPC（经典网络）具有多个wire，所以上述逻辑对它来说有些问题。

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3
- release/3.2
- release/3.1
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @swordqiu @yousong @zexi 