### PR TITLE
Automated cherry pick of #7426: baremetal: fix hpssactl split last LV size out of limit

### DIFF
--- a/pkg/baremetal/utils/raid/hpssactl/hpssactl.go
+++ b/pkg/baremetal/utils/raid/hpssactl/hpssactl.go
@@ -249,11 +249,17 @@ func (adapter *HPSARaidAdaptor) buildRaid(level string, devs []*baremetal.Bareme
 			return fmt.Errorf("getLastArray: %v", err)
 		}
 		cmds := []string{}
-		for _, sz := range conf.Size[1:] {
+		restSize := conf.Size[1:]
+		for idx, sz := range restSize {
+			isLast := idx == len(restSize)-1
+			sizeStr := fmt.Sprintf("size=%d", sz)
+			if isLast {
+				sizeStr = "size=max"
+			}
 			args = []string{"controller", fmt.Sprintf("slot=%d", adapter.index),
 				"array", array, "create", "type=ld",
 				fmt.Sprintf("raid=%s", level),
-				fmt.Sprintf("size=%d", sz),
+				sizeStr,
 			}
 			args = append(args, params...)
 			cmds = append(cmds, GetCommand(args...))


### PR DESCRIPTION
Cherry pick of #7426 on release/3.0.

#7426: baremetal: fix hpssactl split last LV size out of limit