### PR TITLE
aws elb listener&rule name too long fix

### DIFF
--- a/pkg/multicloud/aws/loadbalancerlistener.go
+++ b/pkg/multicloud/aws/loadbalancerlistener.go
@@ -60,7 +60,8 @@ func (self *SElbListener) GetId() string {
 }
 
 func (self *SElbListener) GetName() string {
-	return self.ListenerArn
+	segs := strings.Split(self.ListenerArn, "/")
+	return segs[len(segs)-1]
 }
 
 func (self *SElbListener) GetGlobalId() string {

--- a/pkg/multicloud/aws/loadbalancerlistenerrule.go
+++ b/pkg/multicloud/aws/loadbalancerlistenerrule.go
@@ -80,7 +80,8 @@ func (self *SElbListenerRule) GetId() string {
 }
 
 func (self *SElbListenerRule) GetName() string {
-	return self.RuleArn
+	segs := strings.Split(self.RuleArn, "/")
+	return segs[len(segs)-1]
 }
 
 func (self *SElbListenerRule) GetGlobalId() string {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
* aws elb listener&rule name too long fix

**是否需要 backport 到之前的 release 分支**:
- release/3.3
- release/3.2
- release/3.1
- release/3.0

/area region
/cc @swordqiu @zexi 
