### PR TITLE
Automated cherry pick of #7447: aws elb listener&rule name too long fix

### DIFF
--- a/pkg/multicloud/aws/loadbalancerlistener.go
+++ b/pkg/multicloud/aws/loadbalancerlistener.go
@@ -60,7 +60,8 @@ func (self *SElbListener) GetId() string {
 }
 
 func (self *SElbListener) GetName() string {
-	return self.ListenerArn
+	segs := strings.Split(self.ListenerArn, "/")
+	return segs[len(segs)-1]
 }
 
 func (self *SElbListener) GetGlobalId() string {

--- a/pkg/multicloud/aws/loadbalancerlistenerrule.go
+++ b/pkg/multicloud/aws/loadbalancerlistenerrule.go
@@ -80,7 +80,8 @@ func (self *SElbListenerRule) GetId() string {
 }
 
 func (self *SElbListenerRule) GetName() string {
-	return self.RuleArn
+	segs := strings.Split(self.RuleArn, "/")
+	return segs[len(segs)-1]
 }
 
 func (self *SElbListenerRule) GetGlobalId() string {


### PR DESCRIPTION
Cherry pick of #7447 on release/3.3.

#7447: aws elb listener&rule name too long fix