### PR TITLE
fix: elasticcache_account_reset_password_task.go cherry pick build fail

### DIFF
--- a/pkg/compute/tasks/elasticcache_account_reset_password_task.go
+++ b/pkg/compute/tasks/elasticcache_account_reset_password_task.go
@@ -40,7 +40,7 @@ func (self *ElasticcacheAccountResetPasswordTask) taskFail(ctx context.Context, 
 	ea.SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason)
 	ec, err := db.FetchById(models.ElasticcacheManager, ea.ElasticcacheId)
 	if err == nil {
-		ec.(*models.SElasticcache).SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason.String())
+		ec.(*models.SElasticcache).SetStatus(self.GetUserCred(), api.ELASTIC_CACHE_STATUS_CHANGE_FAILED, reason)
 		logclient.AddActionLogWithStartable(self, ec, logclient.ACT_RESET_PASSWORD, reason, self.UserCred, false)
 	}
 	db.OpsLog.LogEvent(ea, db.ACT_RESET_PASSWORD, reason, self.UserCred)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：cherrypick 3.3导致编译失败

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area region