### PR TITLE
opt(scheduler): better sort for hosts when selectHost

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -182,7 +182,7 @@ func newSchedResultByCtx(u *Unit, count int64, c Candidater) *SchedResultItem {
 		Count:             count,
 		Capacity:          u.GetCapacity(id),
 		Name:              c.Getter().Name(),
-		Score:             u.GetScore(id).String(),
+		Score:             u.GetScore(id),
 		Data:              u.GetFiltedData(id, count),
 		Candidater:        c,
 		AllocatedResource: u.GetAllocatedResource(id),
@@ -244,7 +244,7 @@ type SchedResultItem struct {
 	Count    int64                  `json:"count"`
 	Data     map[string]interface{} `json:"data"`
 	Capacity int64                  `json:"capacity"`
-	Score    string                 `json:"score"`
+	Score    Score                  `json:"score"`
 
 	CapacityDetails map[string]int64 `json:"capacity_details"`
 	ScoreDetails    string           `json:"score_details"`


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

在选择host之前对host的排序方法至关重要，现在按照优先级，分别是：
1. host已经分配的主虚拟机（备虚拟机）数量
2. host已经分配的虚拟机数量
3. 主机组允许的capacity
4. 由 priorities 给定的分数
5. 实时所能容纳此配置机器的数量

前两条代表的虚拟机数量仅是此次调度的数量

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area scheduler
/cc @zexi  @wanyaoqi  @swordqiu 