### PR TITLE
feature: add is_auto_alloc flag to networks

### DIFF
--- a/cmd/climc/shell/compute/networks.go
+++ b/cmd/climc/shell/compute/networks.go
@@ -40,6 +40,9 @@ func init() {
 		ServerType string   `help:"search networks belongs to a ServerType" choices:"baremetal|container|eip|guest|ipmi|pxe"`
 		Schedtag   string   `help:"filter networks by schedtag"`
 
+		IsAutoAlloc *bool `help:"search network with is_auto_alloc"`
+		IsClassic   *bool `help:"search classic on-premise network"`
+
 		Status string `help:"filter by network status"`
 	}
 	R(&NetworkListOptions{}, "network-list", "List networks", func(s *mcclient.ClientSession, opts *NetworkListOptions) error {
@@ -79,6 +82,7 @@ func init() {
 		VlanId      int64  `help:"Vlan ID" default:"1"`
 		ExternalId  string `help:"External ID"`
 		AllocPolicy string `help:"Address allocation policy" choices:"none|stepdown|stepup|random"`
+		IsAutoAlloc *bool  `help:"Add network into auto-allocation pool" negative:"no_auto_alloc"`
 	}
 	R(&NetworkUpdateOptions{}, "network-update", "Update network", func(s *mcclient.ClientSession, args *NetworkUpdateOptions) error {
 		params := jsonutils.NewDict()
@@ -132,6 +136,9 @@ func init() {
 		}
 		if len(args.AllocPolicy) > 0 {
 			params.Add(jsonutils.NewString(args.AllocPolicy), "alloc_policy")
+		}
+		if args.IsAutoAlloc != nil {
+			params.Add(jsonutils.NewBool(*args.IsAutoAlloc), "is_auto_alloc")
 		}
 		if params.Size() == 0 {
 			return InvalidUpdateError()
@@ -228,6 +235,7 @@ func init() {
 		IfnameHint  string `help:"Hint for ifname generation"`
 		AllocPolicy string `help:"Address allocation policy" choices:"none|stepdown|stepup|random"`
 		ServerType  string `help:"Server type" choices:"baremetal|container|eip|guest|ipmi|pxe"`
+		IsAutoAlloc *bool  `help:"Auto allocation IP pool"`
 		Desc        string `help:"Description" metavar:"DESCRIPTION"`
 	}
 	R(&NetworkCreateOptions{}, "network-create", "Create a virtual network", func(s *mcclient.ClientSession, args *NetworkCreateOptions) error {
@@ -253,6 +261,9 @@ func init() {
 		}
 		if len(args.Desc) > 0 {
 			params.Add(jsonutils.NewString(args.Desc), "description")
+		}
+		if args.IsAutoAlloc != nil {
+			params.Add(jsonutils.NewBool(*args.IsAutoAlloc), "is_auto_alloc")
 		}
 		net, e := modules.Networks.CreateInContext(s, params, &modules.Wires, args.WIRE)
 		if e != nil {

--- a/pkg/apis/compute/network.go
+++ b/pkg/apis/compute/network.go
@@ -110,6 +110,10 @@ type NetworkListInput struct {
 	ServerType []string `json:"server_type"`
 	// 分配策略
 	AllocPolicy []string `json:"alloc_policy"`
+	// 是否加入自动分配地址池
+	IsAutoAlloc *bool `json:"is_auto_alloc"`
+	// 是否为基础网络（underlay）
+	IsClassic *bool `json:"is_classic"`
 }
 
 type NetworkResourceInfoBase struct {
@@ -177,6 +181,9 @@ type NetworkCreateInput struct {
 	// enum: guest,baremetal,pxe,ipmi
 	// default: guest
 	ServerType string `json:"server_type"`
+
+	// 是否加入自动分配地址池
+	IsAutoAlloc *bool `json:"is_auto_alloc"`
 }
 
 type NetworkDetails struct {
@@ -299,4 +306,7 @@ type NetworkUpdateInput struct {
 
 	// 分配策略
 	AllocPolicy string `json:"alloc_policy"`
+
+	// 是否加入自动分配地址池
+	IsAutoAlloc *bool `json:"is_auto_alloc"`
 }

--- a/pkg/baremetal/manager.go
+++ b/pkg/baremetal/manager.go
@@ -378,7 +378,7 @@ func (m *SBaremetalManager) checkNetworkFromIp(ip string) (string, error) {
 	params := jsonutils.NewDict()
 	params.Set("ip", jsonutils.NewString(ip))
 	params.Set("scope", jsonutils.NewString("system"))
-	params.Set("is_on_premise", jsonutils.JSONTrue)
+	params.Set("is_classic", jsonutils.JSONTrue)
 	res, err := modules.Networks.List(m.GetClientSession(), params)
 	if err != nil {
 		return "", fmt.Errorf("Fetch network by ip %s failed: %s", ip, err)
@@ -1041,7 +1041,7 @@ func (b *SBaremetalInstance) findAccessNetwork(accessIp string) (*types.SNetwork
 	params := jsonutils.NewDict()
 	params.Add(jsonutils.NewString(accessIp), "ip")
 	params.Add(jsonutils.NewString("system"), "scope")
-	params.Add(jsonutils.JSONTrue, "is_on_premise")
+	params.Add(jsonutils.JSONTrue, "is_classic")
 	session := b.manager.GetClientSession()
 	ret, err := modules.Networks.List(session, params)
 	if err != nil {

--- a/pkg/baremetal/pxe/dhcp.go
+++ b/pkg/baremetal/pxe/dhcp.go
@@ -271,7 +271,7 @@ func (req *dhcpRequest) findNetworkConf(session *mcclient.ClientSession, filterU
 			"filter.3")
 		params.Add(jsonutils.JSONTrue, "filter_any")
 	}
-	params.Add(jsonutils.JSONTrue, "is_on_premise")
+	params.Add(jsonutils.JSONTrue, "is_classic")
 	params.Add(jsonutils.NewString("system"), "scope")
 	ret, err := modules.Networks.List(session, params)
 	if err != nil {

--- a/pkg/baremetal/tasks/baseprepare.go
+++ b/pkg/baremetal/tasks/baseprepare.go
@@ -560,7 +560,7 @@ func (task *sBaremetalPrepareTask) getIPMIIPConfig(ipAddr string) (*ipmiIPConfig
 	params := jsonutils.NewDict()
 	params.Add(jsonutils.NewString(ipAddr), "ip")
 	params.Add(jsonutils.NewString("system"), "scope")
-	params.Add(jsonutils.JSONTrue, "is_on_premise")
+	params.Add(jsonutils.JSONTrue, "is_classic")
 	listRet, err := modules.Networks.List(task.getClientSession(), params)
 	if err != nil {
 		return nil, err

--- a/pkg/cloudcommon/agent/agent.go
+++ b/pkg/cloudcommon/agent/agent.go
@@ -201,7 +201,7 @@ func (agent *SBaseAgent) getZoneByIP(session *mcclient.ClientSession) (jsonutils
 		return nil, err
 	}
 	params.Add(jsonutils.NewString(listenIP.String()), "ip")
-	params.Add(jsonutils.JSONTrue, "is_on_premise")
+	params.Add(jsonutils.JSONTrue, "is_classic")
 	params.Add(jsonutils.NewString("system"), "scope")
 	networks, err := modules.Networks.List(session, params)
 	if err != nil {

--- a/pkg/compute/guestdrivers/baremetals.go
+++ b/pkg/compute/guestdrivers/baremetals.go
@@ -195,7 +195,7 @@ func (self *SBaremetalGuestDriver) Attach2RandomNetwork(guest *models.SGuest, ct
 		if netConfig.Private {
 			net, _ = wire.GetCandidatePrivateNetwork(userCred, models.NetworkManager.AllowScope(userCred), netConfig.Exit, netTypes)
 		} else {
-			net, _ = wire.GetCandidatePublicNetwork(userCred, models.NetworkManager.AllowScope(userCred), netConfig.Exit, netTypes)
+			net, _ = wire.GetCandidateAutoAllocNetwork(userCred, models.NetworkManager.AllowScope(userCred), netConfig.Exit, netTypes)
 		}
 		if net != nil {
 			netsAvaiable = append(netsAvaiable, *net)

--- a/pkg/compute/guestdrivers/virtualization.go
+++ b/pkg/compute/guestdrivers/virtualization.go
@@ -123,7 +123,7 @@ func (self *SVirtualizedGuestDriver) Attach2RandomNetwork(guest *models.SGuest, 
 		if netConfig.Private {
 			net, _ = wire.GetCandidatePrivateNetwork(userCred, models.NetworkManager.AllowScope(userCred), netConfig.Exit, netTypes)
 		} else {
-			net, _ = wire.GetCandidatePublicNetwork(userCred, models.NetworkManager.AllowScope(userCred), netConfig.Exit, netTypes)
+			net, _ = wire.GetCandidateAutoAllocNetwork(userCred, models.NetworkManager.AllowScope(userCred), netConfig.Exit, netTypes)
 		}
 		if net != nil {
 			netsAvaiable = append(netsAvaiable, *net)

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -4076,7 +4076,7 @@ func (self *SHost) EnableNetif(ctx context.Context, userCred mcclient.TokenCrede
 				return fmt.Errorf("fail to find private network %s", err)
 			}
 			if net == nil {
-				net, err = wire.GetCandidatePublicNetwork(userCred, NetworkManager.AllowScope(userCred), false, netTypes)
+				net, err = wire.GetCandidateAutoAllocNetwork(userCred, NetworkManager.AllowScope(userCred), false, netTypes)
 				if err != nil {
 					return fmt.Errorf("fail to find public network %s", err)
 				}

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -642,6 +642,17 @@ func (self *SWire) getGatewayNetworkQuery(ownerId mcclient.IIdentityProvider, sc
 	return q
 }
 
+func (self *SWire) getAutoAllocNetworks(ownerId mcclient.IIdentityProvider, scope rbacutils.TRbacScope) ([]SNetwork, error) {
+	q := self.getGatewayNetworkQuery(ownerId, scope)
+	q = q.IsTrue("is_auto_alloc")
+	nets := make([]SNetwork, 0)
+	err := db.FetchModelObjects(NetworkManager, q, &nets)
+	if err != nil {
+		return nil, err
+	}
+	return nets, nil
+}
+
 func (self *SWire) getPublicNetworks(ownerId mcclient.IIdentityProvider, scope rbacutils.TRbacScope) ([]SNetwork, error) {
 	q := self.getGatewayNetworkQuery(ownerId, scope)
 	q = q.IsTrue("is_public")
@@ -672,8 +683,8 @@ func (self *SWire) GetCandidatePrivateNetwork(ownerId mcclient.IIdentityProvider
 	return ChooseCandidateNetworks(nets, isExit, serverTypes), nil
 }
 
-func (self *SWire) GetCandidatePublicNetwork(ownerId mcclient.IIdentityProvider, scope rbacutils.TRbacScope, isExit bool, serverTypes []string) (*SNetwork, error) {
-	nets, err := self.getPublicNetworks(ownerId, scope)
+func (self *SWire) GetCandidateAutoAllocNetwork(ownerId mcclient.IIdentityProvider, scope rbacutils.TRbacScope, isExit bool, serverTypes []string) (*SNetwork, error) {
+	nets, err := self.getAutoAllocNetworks(ownerId, scope)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -776,7 +776,7 @@ func (h *SHostInfo) tryCreateNetworkOnWire() {
 	params := jsonutils.NewDict()
 	params.Set("ip", jsonutils.NewString(masterIp))
 	params.Set("mask", jsonutils.NewInt(int64(mask)))
-	params.Set("is_on_premise", jsonutils.JSONTrue)
+	params.Set("is_classic", jsonutils.JSONTrue)
 	params.Set("server_type", jsonutils.NewString(api.NETWORK_TYPE_BAREMETAL))
 	ret, err := modules.Networks.PerformClassAction(
 		hostutils.GetComputeSession(context.Background()),
@@ -802,7 +802,7 @@ func (h *SHostInfo) fetchAccessNetworkInfo() {
 	log.Debugf("Master ip %s to fetch wire", masterIp)
 	params := jsonutils.NewDict()
 	params.Set("ip", jsonutils.NewString(masterIp))
-	params.Set("is_on_premise", jsonutils.JSONTrue)
+	params.Set("is_classic", jsonutils.JSONTrue)
 	params.Set("scope", jsonutils.NewString("system"))
 	params.Set("limit", jsonutils.NewInt(0))
 	// use default vpc
@@ -1142,7 +1142,7 @@ func (h *SHostInfo) uploadNetworkInfo() {
 			if len(nic.Network) == 0 {
 				kwargs := jsonutils.NewDict()
 				kwargs.Set("ip", jsonutils.NewString(nic.Ip))
-				kwargs.Set("is_on_premise", jsonutils.JSONTrue)
+				kwargs.Set("is_classic", jsonutils.JSONTrue)
 				kwargs.Set("scope", jsonutils.NewString("system"))
 				kwargs.Set("limit", jsonutils.NewInt(0))
 

--- a/pkg/mcclient/modules/mod_networks.go
+++ b/pkg/mcclient/modules/mod_networks.go
@@ -27,7 +27,7 @@ func init() {
 			"wire_id", "wire", "is_public", "public_scope", "exit", "Ports",
 			"vnics", "guest_gateway",
 			"group_vnics", "bm_vnics", "reserve_vnics", "lb_vnics",
-			"server_type", "Status"},
+			"server_type", "Status", "is_auto_alloc"},
 		[]string{})
 
 	registerCompute(&Networks)

--- a/pkg/scheduler/algorithm/predicates/network_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/network_predicate.go
@@ -192,8 +192,8 @@ func (p *NetworkPredicate) Execute(u *core.Unit, c core.Candidater) (bool, []cor
 					})
 				}*/
 			} else {
-				if !n.IsPublic {
-					appendError(FailReason{Reason: fmt.Sprintf("Network %s is private", n.Name), Type: NetworkPrivate})
+				if n.IsAutoAlloc.IsFalse() {
+					appendError(FailReason{Reason: fmt.Sprintf("Network %s is not auto alloc", n.Name), Type: NetworkPrivate})
 				} /*else if rbacutils.TRbacScope(n.PublicScope) == rbacutils.ScopeDomain {
 					netDomain := n.DomainId
 					reqDomain := domain


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：
1. networks增加is_auto_alloc字段，指定该IP子网加入自动分配IP的地址池
2. 增加is_classic的过滤器，过滤出underlay的on_premise子网

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
None

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @yousong @wanyaoqi 
/area region