### PR TITLE
fix: support AzureAD oidc in china area

### DIFF
--- a/pkg/apis/identity/oidc.go
+++ b/pkg/apis/identity/oidc.go
@@ -42,8 +42,14 @@ type SOIDCGithubConfigOptions struct {
 	ClientSecret string `json:"client_secret"`
 }
 
+const (
+	AZURE_CLOUD_ENV_CHINA  = "china"
+	AZURE_CLOUD_ENV_GLOBAL = "global"
+)
+
 type SOIDCAzureConfigOptions struct {
 	ClientId     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 	TenantId     string `json:"tenant_id"`
+	CloudEnv     string `json:"cloud_env"`
 }

--- a/pkg/keystone/driver/oidc/oidc.go
+++ b/pkg/keystone/driver/oidc/oidc.go
@@ -72,9 +72,17 @@ func (self *SOIDCDriver) prepareConfig() error {
 			if len(tenantId) == 0 {
 				tenantId = "common"
 			}
-			conf.AuthUrl = fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/", tenantId)
-			conf.TokenUrl = fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantId)
-			conf.UserinfoUrl = "https://graph.microsoft.com/oidc/userinfo"
+			cloudEnv, _ := confJson.GetString("cloud_env")
+			loginUrl := "https://login.microsoftonline.com"
+			graphUrl := "https://graph.microsoft.com"
+			switch cloudEnv {
+			case api.AZURE_CLOUD_ENV_CHINA:
+				loginUrl = "https://login.partner.microsoftonline.cn"
+				graphUrl = "https://microsoftgraph.chinacloudapi.cn"
+			}
+			conf.AuthUrl = fmt.Sprintf("%s/%s/oauth2/v2.0/", loginUrl, tenantId)
+			conf.TokenUrl = fmt.Sprintf("%s/%s/oauth2/v2.0/token", loginUrl, tenantId)
+			conf.UserinfoUrl = fmt.Sprintf("%s/oidc/userinfo", graphUrl)
 		}
 		err := confJson.Unmarshal(&conf)
 		if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：支持中国区Azure的 Azure AD OIDC认证源

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area keystone
/cc @zexi 