### PR TITLE
fix: do not search response key if empty json returned

### DIFF
--- a/pkg/util/httputils/httputils.go
+++ b/pkg/util/httputils/httputils.go
@@ -615,8 +615,6 @@ func (client *JsonClient) Send(ctx context.Context, req JsonRequest, response Js
 			ce.Details = fmt.Sprintf("jsonutils.Parse(%s) error: %v", string(rbody), err)
 			return resp.Header, nil, ce
 		}
-	} else {
-		jrbody = jsonutils.NewDict()
 	}
 
 	if resp.StatusCode < 300 {
@@ -722,8 +720,6 @@ func ParseJSONResponse(reqBody string, resp *http.Response, err error, debug boo
 			// ignore the error
 			fmt.Fprintf(os.Stderr, "parsing json failed: %s", err)
 		}
-	} else {
-		jrbody = jsonutils.NewDict()
 	}
 
 	if resp.StatusCode < 300 {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：json请求返回空值时不应该报no key found的错误，修正ParseJSONRequest引入的兼容性问题

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
None

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area util