### PR TITLE
fix: preserve state while doing sso redirect

### DIFF
--- a/pkg/keystone/models/identity_provider.go
+++ b/pkg/keystone/models/identity_provider.go
@@ -1194,15 +1194,18 @@ func fetchAttributes(attrs map[string][]string, key string) []string {
 }
 
 func (idp *SIdentityProvider) TryUserJoinProject(attrConf api.SIdpAttributeOptions, ctx context.Context, usr *SUser, domainId string, attrs map[string][]string) {
+	if idp.AutoCreateUser.IsFalse() {
+		return
+	}
 	// update user attributes
 	_, err := db.Update(usr, func() error {
-		if v, ok := attrs[attrConf.UserDisplaynameAttribtue]; ok && len(v) > 0 {
+		if v, ok := attrs[attrConf.UserDisplaynameAttribtue]; ok && len(v) > 0 && len(v[0]) > 0 {
 			usr.Displayname = v[0]
 		}
-		if v, ok := attrs[attrConf.UserEmailAttribute]; ok && len(v) > 0 {
+		if v, ok := attrs[attrConf.UserEmailAttribute]; ok && len(v) > 0 && len(v[0]) > 0 {
 			usr.Email = v[0]
 		}
-		if v, ok := attrs[attrConf.UserMobileAttribute]; ok && len(v) > 0 {
+		if v, ok := attrs[attrConf.UserMobileAttribute]; ok && len(v) > 0 && len(v[0]) > 0 {
 			usr.Mobile = v[0]
 		}
 		return nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：sso登录用state保留登录前的querystring

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
None

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area apigateway
/cc @zexi 