### PR TITLE
nodealert bugfix：

### DIFF
--- a/pkg/monitor/models/nodealert.go
+++ b/pkg/monitor/models/nodealert.go
@@ -136,6 +136,9 @@ func (man *SNodeAlertManager) genName(ownerId mcclient.IIdentityProvider, resTyp
 	if err != nil {
 		return "", err
 	}
+	if name != nameHint {
+		return "", httperrors.NewDuplicateNameError(man.Keyword(), metric)
+	}
 	return name, nil
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1.重名判断：后端通过resType, nodeName, metric 限制前端可以创建相同metric的报警记录

- 冒烟测试

**是否需要 backport 到之前的 release 分支**:

- release/3.3

/cc @zexi 
/area monitor