### PR TITLE
cloudcommon: remove unnecessary joint interface

### DIFF
--- a/pkg/cloudcommon/db/db_joint_dispatcher.go
+++ b/pkg/cloudcommon/db/db_joint_dispatcher.go
@@ -278,7 +278,7 @@ func (dispatcher *DBJointModelDispatcher) Detach(ctx context.Context, id1 string
 
 	obj, err := deleteItem(dispatcher.JointModelManager(), item, ctx, userCred, query, data)
 	if err == nil {
-		OpsLog.LogDetachEvent(ctx, item.Master(), item.Slave(), userCred, jsonutils.Marshal(item))
+		OpsLog.LogDetachEvent(ctx, JointMaster(item), JointSlave(item), userCred, jsonutils.Marshal(item))
 	}
 	return obj, err
 }
@@ -290,7 +290,7 @@ func DetachJoint(ctx context.Context, userCred mcclient.TokenCredential, item IJ
 	}
 	err = item.Delete(ctx, userCred)
 	if err == nil {
-		OpsLog.LogDetachEvent(ctx, item.Master(), item.Slave(), userCred, item.GetShortDesc(ctx))
+		OpsLog.LogDetachEvent(ctx, JointMaster(item), JointSlave(item), userCred, item.GetShortDesc(ctx))
 	}
 	return err
 }

--- a/pkg/cloudcommon/db/interface.go
+++ b/pkg/cloudcommon/db/interface.go
@@ -233,9 +233,6 @@ type IJointModel interface {
 
 	GetIJointModel() IJointModel
 
-	Master() IStandaloneModel
-	Slave() IStandaloneModel
-
 	AllowDetach(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) bool
 
 	Detach(ctx context.Context, userCred mcclient.TokenCredential) error

--- a/pkg/cloudcommon/db/jointbase.go
+++ b/pkg/cloudcommon/db/jointbase.go
@@ -107,11 +107,11 @@ func (manager *SJointResourceBaseManager) AllowAttach(ctx context.Context, userC
 
 func JointModelExtra(jointModel IJointModel) (string, string) {
 	masterName, slaveName := "", ""
-	master := jointModel.Master()
+	master := JointMaster(jointModel)
 	if master != nil {
 		masterName = master.GetName()
 	}
-	slave := jointModel.Slave()
+	slave := JointSlave(jointModel)
 	if slave != nil {
 		slaveName = slave.GetName()
 	}
@@ -175,16 +175,8 @@ func (joint *SJointResourceBase) GetIJointModel() IJointModel {
 	return joint.GetVirtualObject().(IJointModel)
 }
 
-func (joint *SJointResourceBase) Master() IStandaloneModel {
-	return nil
-}
-
-func (joint *SJointResourceBase) Slave() IStandaloneModel {
-	return nil
-}
-
 func (self *SJointResourceBase) AllowGetJointDetails(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, item IJointModel) bool {
-	master := item.Master()
+	master := JointMaster(item)
 	switch master.(type) {
 	case IVirtualModel:
 		return master.(IVirtualModel).IsOwner(userCred) || IsAllowGet(rbacutils.ScopeSystem, userCred, master)
@@ -194,7 +186,7 @@ func (self *SJointResourceBase) AllowGetJointDetails(ctx context.Context, userCr
 }
 
 func (self *SJointResourceBase) AllowUpdateJointItem(ctx context.Context, userCred mcclient.TokenCredential, item IJointModel) bool {
-	master := item.Master()
+	master := JointMaster(item)
 	switch master.(type) {
 	case IVirtualModel:
 		return master.(IVirtualModel).IsOwner(userCred) || IsAllowUpdate(rbacutils.ScopeSystem, userCred, master)

--- a/pkg/cloudcommon/db/rbac.go
+++ b/pkg/cloudcommon/db/rbac.go
@@ -76,8 +76,8 @@ func isObjectRbacAllowed(model IModel, userCred mcclient.TokenCredential, action
 }
 
 func isJointObjectRbacAllowed(item IJointModel, userCred mcclient.TokenCredential, action string, extra ...string) error {
-	err1 := isObjectRbacAllowed(item.Master(), userCred, action, extra...)
-	err2 := isObjectRbacAllowed(item.Slave(), userCred, action, extra...)
+	err1 := isObjectRbacAllowed(JointMaster(item), userCred, action, extra...)
+	err2 := isObjectRbacAllowed(JointSlave(item), userCred, action, extra...)
 	if err1 == nil || err2 == nil {
 		return nil
 	}

--- a/pkg/cloudcommon/db/tablespec.go
+++ b/pkg/cloudcommon/db/tablespec.go
@@ -70,8 +70,8 @@ func (ts *sTableSpec) newInformerModel(dt interface{}) (*informer.ModelObject, e
 	}
 	jointObj, isJoint := obj.(IJointModel)
 	if isJoint {
-		mObj := jointObj.Master()
-		sObj := jointObj.Slave()
+		mObj := JointMaster(jointObj)
+		sObj := JointSlave(jointObj)
 		return informer.NewJointModel(jointObj, jointObj.KeywordPlural(), mObj.GetId(), sObj.GetId()), nil
 	}
 	return informer.NewModel(obj, obj.KeywordPlural(), obj.GetId()), nil

--- a/pkg/cloudcommon/db/virtualjointbase.go
+++ b/pkg/cloudcommon/db/virtualjointbase.go
@@ -75,16 +75,6 @@ func (manager *SVirtualJointResourceBaseManager) AllowAttach(ctx context.Context
 	return false
 }
 
-func (self *SVirtualJointResourceBase) AllowGetDetails(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {
-	masterVirtual := self.Master().(IVirtualModel)
-	return masterVirtual.IsOwner(userCred) || IsAllowGet(rbacutils.ScopeSystem, userCred, self)
-}
-
-func (self *SVirtualJointResourceBase) AllowUpdateItem(ctx context.Context, userCred mcclient.TokenCredential) bool {
-	masterVirtual := self.Master().(IVirtualModel)
-	return masterVirtual.IsOwner(userCred) || IsAllowUpdate(rbacutils.ScopeSystem, userCred, self)
-}
-
 func (manager *SVirtualJointResourceBaseManager) FilterByOwner(q *sqlchemy.SQuery, owner mcclient.IIdentityProvider, scope rbacutils.TRbacScope) *sqlchemy.SQuery {
 	if owner != nil {
 		masterQ := manager.GetMasterManager().Query("id")

--- a/pkg/cloudid/models/cloudgroup_policies.go
+++ b/pkg/cloudid/models/cloudgroup_policies.go
@@ -85,14 +85,6 @@ func (self *SCloudgroupPolicy) ValidateUpdateData(ctx context.Context, userCred 
 	return nil, httperrors.NewNotSupportedError("Not Supported")
 }
 
-func (joint *SCloudgroupPolicy) Master() db.IStandaloneModel {
-	return db.JointMaster(joint)
-}
-
-func (joint *SCloudgroupPolicy) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 // 用户组中权限详情
 func (self *SCloudgroupPolicy) GetExtraDetails(
 	ctx context.Context,

--- a/pkg/cloudid/models/cloudgroup_users.go
+++ b/pkg/cloudid/models/cloudgroup_users.go
@@ -86,14 +86,6 @@ func (self *SCloudgroupUser) ValidateUpdateData(ctx context.Context, userCred mc
 	return nil, httperrors.NewNotSupportedError("Not Supported")
 }
 
-func (joint *SCloudgroupUser) Master() db.IStandaloneModel {
-	return db.JointMaster(joint)
-}
-
-func (joint *SCloudgroupUser) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 // 获取用户组中用户详情
 func (self *SCloudgroupUser) GetExtraDetails(
 	ctx context.Context,

--- a/pkg/cloudid/models/clouduser_policies.go
+++ b/pkg/cloudid/models/clouduser_policies.go
@@ -90,14 +90,6 @@ func (self *SClouduserPolicy) ValidateUpdateData(ctx context.Context, userCred m
 	return nil, httperrors.NewNotSupportedError("Not Supported")
 }
 
-func (joint *SClouduserPolicy) Master() db.IStandaloneModel {
-	return db.JointMaster(joint)
-}
-
-func (joint *SClouduserPolicy) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 // 获取公有云用户权限详情
 func (self *SClouduserPolicy) GetExtraDetails(
 	ctx context.Context,

--- a/pkg/compute/models/cloudproviderregions.go
+++ b/pkg/compute/models/cloudproviderregions.go
@@ -94,14 +94,6 @@ func (manager *SCloudproviderregionManager) GetSlaveFieldName() string {
 	return "cloudregion_id"
 }
 
-func (joint *SCloudproviderregion) Master() db.IStandaloneModel {
-	return db.JointMaster(joint)
-}
-
-func (joint *SCloudproviderregion) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 func (self *SCloudproviderregion) GetProvider() *SCloudprovider {
 	providerObj, err := CloudproviderManager.FetchById(self.CloudproviderId)
 	if err != nil {

--- a/pkg/compute/models/dbinstancenetworks.go
+++ b/pkg/compute/models/dbinstancenetworks.go
@@ -65,14 +65,6 @@ func (manager *SDBInstanceNetworkManager) GetSlaveFieldName() string {
 	return "network_id"
 }
 
-func (joint *SDBInstanceNetwork) Master() db.IStandaloneModel {
-	return db.JointMaster(joint)
-}
-
-func (joint *SDBInstanceNetwork) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 func (self *SDBInstanceNetwork) Detach(ctx context.Context, userCred mcclient.TokenCredential) error {
 	return db.DetachJoint(ctx, userCred, self)
 }

--- a/pkg/compute/models/groupguests.go
+++ b/pkg/compute/models/groupguests.go
@@ -62,14 +62,6 @@ func (manager *SGroupguestManager) GetSlaveFieldName() string {
 	return "guest_id"
 }
 
-func (joint *SGroupguest) Master() db.IStandaloneModel {
-	return db.JointMaster(joint)
-}
-
-func (joint *SGroupguest) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 func (self *SGroupguest) GetExtraDetails(
 	ctx context.Context,
 	userCred mcclient.TokenCredential,

--- a/pkg/compute/models/groupnetworks.go
+++ b/pkg/compute/models/groupnetworks.go
@@ -67,14 +67,6 @@ func (manager *SGroupnetworkManager) GetSlaveFieldName() string {
 	return "network_id"
 }
 
-func (joint *SGroupnetwork) Master() db.IStandaloneModel {
-	return db.JointMaster(joint)
-}
-
-func (joint *SGroupnetwork) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 func (self *SGroupnetwork) GetExtraDetails(
 	ctx context.Context,
 	userCred mcclient.TokenCredential,

--- a/pkg/compute/models/guestdisks.go
+++ b/pkg/compute/models/guestdisks.go
@@ -107,14 +107,6 @@ func (self *SGuestdisk) ValidateUpdateData(ctx context.Context, userCred mcclien
 	return input, nil
 }
 
-func (joint *SGuestdisk) Master() db.IStandaloneModel {
-	return db.JointMaster(joint)
-}
-
-func (joint *SGuestdisk) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 func (self *SGuestdisk) GetExtraDetails(
 	ctx context.Context,
 	userCred mcclient.TokenCredential,

--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -108,14 +108,6 @@ func (manager *SGuestnetworkManager) GetSlaveFieldName() string {
 	return "network_id"
 }
 
-func (joint *SGuestnetwork) Master() db.IStandaloneModel {
-	return db.JointMaster(joint)
-}
-
-func (joint *SGuestnetwork) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 func (self *SGuestnetwork) GetExtraDetails(
 	ctx context.Context,
 	userCred mcclient.TokenCredential,

--- a/pkg/compute/models/hostnetworks.go
+++ b/pkg/compute/models/hostnetworks.go
@@ -72,14 +72,6 @@ func (manager *SHostnetworkManager) GetSlaveFieldName() string {
 	return "network_id"
 }
 
-func (bn *SHostnetwork) Master() db.IStandaloneModel {
-	return db.JointMaster(bn)
-}
-
-func (bn *SHostnetwork) Slave() db.IStandaloneModel {
-	return db.JointSlave(bn)
-}
-
 func (bn *SHostnetwork) GetExtraDetails(
 	ctx context.Context,
 	userCred mcclient.TokenCredential,

--- a/pkg/compute/models/hostschedtags.go
+++ b/pkg/compute/models/hostschedtags.go
@@ -61,20 +61,6 @@ func (manager *SHostschedtagManager) GetSlaveFieldName() string {
 	return "host_id"
 }
 
-func (self *SHostschedtag) GetHost() *SHost {
-	return self.Master().(*SHost)
-}
-
-func (self *SHostschedtag) GetHosts() ([]SHost, error) {
-	hosts := []SHost{}
-	err := self.GetSchedtag().GetObjects(&hosts)
-	return hosts, err
-}
-
-func (self *SHostschedtag) Master() db.IStandaloneModel {
-	return self.SSchedtagJointsBase.master(self)
-}
-
 func (self *SHostschedtag) GetExtraDetails(
 	ctx context.Context,
 	userCred mcclient.TokenCredential,

--- a/pkg/compute/models/hoststorages.go
+++ b/pkg/compute/models/hoststorages.go
@@ -83,14 +83,6 @@ func (manager *SHoststorageManager) GetSlaveFieldName() string {
 	return "storage_id"
 }
 
-func (joint *SHoststorage) Master() db.IStandaloneModel {
-	return db.JointMaster(joint)
-}
-
-func (joint *SHoststorage) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 func (self *SHoststorage) GetExtraDetails(
 	ctx context.Context,
 	userCred mcclient.TokenCredential,

--- a/pkg/compute/models/hostwires.go
+++ b/pkg/compute/models/hostwires.go
@@ -77,14 +77,6 @@ func (manager *SHostwireManager) GetSlaveFieldName() string {
 	return "wire_id"
 }
 
-func (joint *SHostwire) Master() db.IStandaloneModel {
-	return db.JointMaster(joint)
-}
-
-func (joint *SHostwire) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 func (self *SHostwire) GetExtraDetails(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, isList bool) (api.HostwireDetails, error) {
 	return api.HostwireDetails{}, nil
 }

--- a/pkg/compute/models/loadbalancernetworks.go
+++ b/pkg/compute/models/loadbalancernetworks.go
@@ -203,16 +203,6 @@ func (ln *SLoadbalancerNetwork) Delete(ctx context.Context, userCred mcclient.To
 	return db.DeleteModel(ctx, userCred, ln)
 }
 
-// Master implements db.IJointModel interface
-func (ln *SLoadbalancerNetwork) Master() db.IStandaloneModel {
-	return db.JointMaster(ln)
-}
-
-// Slave implements db.IJointModel interface
-func (ln *SLoadbalancerNetwork) Slave() db.IStandaloneModel {
-	return db.JointSlave(ln)
-}
-
 // Detach implements db.IJointModel interface
 func (ln *SLoadbalancerNetwork) Detach(ctx context.Context, userCred mcclient.TokenCredential) error {
 	return db.DetachJoint(ctx, userCred, ln)

--- a/pkg/compute/models/networkinterfacenetwork.go
+++ b/pkg/compute/models/networkinterfacenetwork.go
@@ -69,14 +69,6 @@ func (manager *SNetworkinterfacenetworkManager) GetSlaveFieldName() string {
 	return "network_id"
 }
 
-func (joint *SNetworkinterfacenetwork) Master() db.IStandaloneModel {
-	return db.JointMaster(joint)
-}
-
-func (joint *SNetworkinterfacenetwork) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 func (manager *SNetworkinterfacenetworkManager) AllowListItems(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {
 	return db.IsAdminAllowList(userCred, manager)
 }

--- a/pkg/compute/models/networkschedtags.go
+++ b/pkg/compute/models/networkschedtags.go
@@ -61,20 +61,6 @@ func (manager *SNetworkschedtagManager) GetSlaveFieldName() string {
 	return "network_id"
 }
 
-func (s *SNetworkschedtag) GetNetwork() *SNetwork {
-	return s.Master().(*SNetwork)
-}
-
-func (s *SNetworkschedtag) GetNetworks() ([]SNetwork, error) {
-	nets := []SNetwork{}
-	err := s.GetSchedtag().GetObjects(&nets)
-	return nets, err
-}
-
-func (s *SNetworkschedtag) Master() db.IStandaloneModel {
-	return s.SSchedtagJointsBase.master(s)
-}
-
 func (s *SNetworkschedtag) GetExtraDetails(
 	ctx context.Context,
 	userCred mcclient.TokenCredential,

--- a/pkg/compute/models/scalinggroup_guest.go
+++ b/pkg/compute/models/scalinggroup_guest.go
@@ -102,15 +102,6 @@ func (sgg *SScalingGroupGuest) SetGuestStatus(status string) error {
 	return err
 }
 
-func (sgg *SScalingGroupGuest) Master() db.IStandaloneModel {
-	return sgg.getGuest()
-}
-
-func (sgg *SScalingGroupGuest) Slave() db.IStandaloneModel {
-	sg, _ := ScalingGroupManager.FetchById(sgg.ScalingGroupId)
-	return sg.(*SScalingGroup)
-}
-
 func (sggm *SScalingGroupGuestManager) Query(fields ...string) *sqlchemy.SQuery {
 	return sggm.SVirtualJointResourceBaseManager.Query(fields...).NotEquals("guest_status",
 		compute.SG_GUEST_STATUS_PENDING_REMOVE)

--- a/pkg/compute/models/schedtagjoint.go
+++ b/pkg/compute/models/schedtagjoint.go
@@ -142,18 +142,6 @@ func (joint *SSchedtagJointsBase) GetSchedtagId() string {
 	return joint.SchedtagId
 }
 
-func (joint *SSchedtagJointsBase) master(obj db.IJointModel) db.IStandaloneModel {
-	return db.JointMaster(obj)
-}
-
-func (joint *SSchedtagJointsBase) GetSchedtag() *SSchedtag {
-	return joint.Slave().(*SSchedtag)
-}
-
-func (joint *SSchedtagJointsBase) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 func (joint *SSchedtagJointsBase) GetExtraDetails(
 	obj db.IJointModel,
 	ctx context.Context,

--- a/pkg/compute/models/storagecachedimages.go
+++ b/pkg/compute/models/storagecachedimages.go
@@ -90,14 +90,6 @@ func (manager *SStoragecachedimageManager) GetSlaveFieldName() string {
 	return "cachedimage_id"
 }
 
-func (joint *SStoragecachedimage) Master() db.IStandaloneModel {
-	return db.JointMaster(joint)
-}
-
-func (joint *SStoragecachedimage) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 func (self *SStoragecachedimageManager) AllowListItems(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {
 	return db.IsAdminAllowList(userCred, self)
 }

--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -1583,7 +1583,7 @@ func (storage *SStorage) PerformForceDetachHost(ctx context.Context, userCred mc
 	hostStorage.SetModelManager(HoststorageManager, hostStorage)
 	err = hostStorage.Delete(ctx, userCred)
 	if err == nil {
-		db.OpsLog.LogDetachEvent(ctx, hostStorage.Master(), hostStorage.Slave(), userCred, jsonutils.NewString("force detach"))
+		db.OpsLog.LogDetachEvent(ctx, db.JointMaster(hostStorage), db.JointSlave(hostStorage), userCred, jsonutils.NewString("force detach"))
 	}
 	return nil, err
 }

--- a/pkg/compute/models/storageschedtags.go
+++ b/pkg/compute/models/storageschedtags.go
@@ -61,20 +61,6 @@ func (manager *SStorageschedtagManager) GetSlaveFieldName() string {
 	return "storage_id"
 }
 
-func (s *SStorageschedtag) GetStorage() *SStorage {
-	return s.Master().(*SStorage)
-}
-
-func (s *SStorageschedtag) GetStorages() ([]SStorage, error) {
-	storages := []SStorage{}
-	err := s.GetSchedtag().GetObjects(&storages)
-	return storages, err
-}
-
-func (joint *SStorageschedtag) Master() db.IStandaloneModel {
-	return joint.SSchedtagJointsBase.master(joint)
-}
-
 func (joint *SStorageschedtag) GetExtraDetails(
 	ctx context.Context,
 	userCred mcclient.TokenCredential,

--- a/pkg/monitor/models/alertnotification.go
+++ b/pkg/monitor/models/alertnotification.go
@@ -170,14 +170,6 @@ func (joint *SAlertnotification) DoSave(ctx context.Context, userCred mcclient.T
 	return nil
 }
 
-func (joint *SAlertnotification) Master() db.IStandaloneModel {
-	return db.JointMaster(joint)
-}
-
-func (joint *SAlertnotification) Slave() db.IStandaloneModel {
-	return db.JointSlave(joint)
-}
-
 func (joint *SAlertnotification) GetNotification() (*SNotification, error) {
 	noti, err := NotificationManager.GetNotification(joint.NotificationId)
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

IJointModel 里面的 Master(), Slave() interface 其实是不需要的，直接调用 db.JointMaster/JointSlave 就可以了，每个 joint model 各自实现是有问题的

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
- NONE

/cc @swordqiu @ioito @rainzm @wanyaoqi 