### PR TITLE
fix: oidc auth callback url not complete

### DIFF
--- a/pkg/apigateway/handler/oidc.go
+++ b/pkg/apigateway/handler/oidc.go
@@ -74,7 +74,11 @@ func handleOIDCAuth(ctx context.Context, w http.ResponseWriter, req *http.Reques
 	if err != nil {
 		// redirect to login page
 		qs := jsonutils.NewDict()
-		qs.Set(getLoginCallbackParam(), jsonutils.NewString(req.URL.String()))
+		oUrl := req.URL.String()
+		if !strings.HasPrefix(oUrl, "http") {
+			oUrl = httputils.JoinPath(options.Options.ApiServer, oUrl)
+		}
+		qs.Set(getLoginCallbackParam(), jsonutils.NewString(oUrl))
 		loginUrl := addQuery(getSsoAuthCallbackUrl(), qs)
 		appsrv.SendRedirect(w, loginUrl)
 		return


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：OIDC认证回调地址不正确，未包含host部分信息

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area apigateway