### PR TITLE
fix: change publicNetworkCount to autoAllocNetworkCount in Capability response

### DIFF
--- a/pkg/compute/models/capabilities.go
+++ b/pkg/compute/models/capabilities.go
@@ -58,10 +58,14 @@ type SCapabilities struct {
 	MaxDataDiskCount            int
 	SchedPolicySupport          bool
 	Usable                      bool
-	PublicNetworkCount          int
-	DBInstance                  map[string]map[string]map[string][]string //map[engine][engineVersion][category][]{storage_type}
-	Specs                       jsonutils.JSONObject
-	AvailableHostCount          int
+
+	// Deprecated
+	PublicNetworkCount int
+
+	AutoAllocNetworkCount int
+	DBInstance            map[string]map[string]map[string][]string //map[engine][engineVersion][category][]{storage_type}
+	Specs                 jsonutils.JSONObject
+	AvailableHostCount    int
 
 	StorageTypes2     map[string][]string                      `json:",allowempty"`
 	StorageTypes3     map[string]map[string]*SimpleStorageInfo `json:",allowempty"`
@@ -128,8 +132,9 @@ func GetCapabilities(ctx context.Context, userCred mcclient.TokenCredential, que
 	}
 	var err error
 	serverType := jsonutils.GetAnyString(query, []string{"host_type", "server_type"})
-	publicNetworkCount, _ := getAutoAllocNetworkCount(ownerId, scope, region, zone, serverType)
-	capa.PublicNetworkCount = publicNetworkCount
+	autoAllocNetworkCount, _ := getAutoAllocNetworkCount(ownerId, scope, region, zone, serverType)
+	capa.PublicNetworkCount = autoAllocNetworkCount
+	capa.AutoAllocNetworkCount = autoAllocNetworkCount
 	mans := []ISpecModelManager{HostManager, IsolatedDeviceManager}
 	capa.Specs, err = GetModelsSpecs(ctx, userCred, query.(*jsonutils.JSONDict), mans...)
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：将capability接口的publicNetworkCount字段名称改为autoAllocNetworkCount

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area region
/cc @zexi 