### PR TITLE
fix: Merge the host network correctly when preparenet

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -650,15 +650,19 @@ func (manager *SCloudaccountManager) fetchEsxiZoneIds() ([]string, error) {
 // The suggested network mask is 24 and the gateway is x.x.x.1.
 // The suggests network is the smallest network segment that meets the above conditions.
 func (manager *SCloudaccountManager) suggestHostNetworks(ips []netutils.IPV4Addr) []api.CASimpleNetConf {
+	if len(ips) == 0 {
+		return nil
+	}
 	sort.Slice(ips, func(i, j int) bool {
 		return ips[i] < ips[j]
 	})
 	var (
-		mask       int8 = 24
-		consequent []netutils.IPV4Addr
-		ret        []api.CASimpleNetConf
+		mask        int8 = 24
+		lastnetAddr netutils.IPV4Addr
+		consequent  []netutils.IPV4Addr
+		ret         []api.CASimpleNetConf
 	)
-	lastnetAddr, _ := netutils.NewIPV4Addr("0.0.0.0")
+	lastnetAddr = ips[0].NetAddr(mask)
 	consequent = []netutils.IPV4Addr{ips[0]}
 	for i := 1; i < len(ips); i++ {
 		ip := ips[i]

--- a/pkg/compute/models/cloudaccounts_test.go
+++ b/pkg/compute/models/cloudaccounts_test.go
@@ -71,6 +71,21 @@ func TestSCloudaccount_suggestHostNetworks(t *testing.T) {
 				},
 			},
 		},
+		{
+			[]string{
+				"10.155.50.103",
+				"10.155.50.101",
+				"10.155.50.102",
+			},
+			[]api.CASimpleNetConf{
+				{
+					GuestIpStart: "10.155.50.101",
+					GuestIpEnd:   "10.155.50.103",
+					GuestIpMask:  24,
+					GuestGateway: "10.155.50.1",
+				},
+			},
+		},
 	}
 	for _, c := range cases {
 		ins := make([]netutils.IPV4Addr, len(c.in))


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

宿主机网络没有正确的合并

- [x] 功能、bugfix描述
- [x] 冒烟测试
- [x] 单元测试编写

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

- release/3.3

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
