### PR TITLE
fix: init wire domain_id for local vpc

### DIFF
--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -1062,6 +1062,11 @@ func (self *SVpc) initWire(ctx context.Context, zone *SZone) (*SWire, error) {
 	wire.ZoneId = zone.Id
 	wire.IsEmulated = true
 	wire.Name = fmt.Sprintf("vpc-%s", self.Name)
+
+	wire.DomainId = self.DomainId
+	wire.IsPublic = self.IsPublic
+	wire.PublicScope = self.PublicScope
+
 	wire.SetModelManager(WireManager, wire)
 	err := WireManager.TableSpec().Insert(ctx, wire)
 	if err != nil {
@@ -1216,7 +1221,7 @@ func (manager *SVpcManager) ListItemExportKeys(ctx context.Context,
 }
 
 func (vpc *SVpc) PerformPublic(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPublicDomainInput) (jsonutils.JSONObject, error) {
-	if rbacutils.String2ScopeDefault(input.Scope, rbacutils.ScopeSystem) != rbacutils.ScopeSystem {
+	if vpc.Id == api.DEFAULT_VPC_ID && rbacutils.String2ScopeDefault(input.Scope, rbacutils.ScopeSystem) != rbacutils.ScopeSystem {
 		return nil, httperrors.NewForbiddenError("For default vpc, only system level sharing can be set")
 	}
 	_, err := vpc.SEnabledStatusInfrasResourceBase.PerformPublic(ctx, userCred, query, input)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：1. 本地vpc的wire domain_id未设置正确
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.2
- release/3.3

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi  @yousong 
/area region