### PR TITLE
feature: use informer to update endpoint, policy and service configs

### DIFF
--- a/pkg/apigateway/clientman/clientman.go
+++ b/pkg/apigateway/clientman/clientman.go
@@ -20,22 +20,10 @@ import (
 	"github.com/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/apigateway/options"
-	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/util/seclib2"
 )
 
 func InitClient() error {
-	info := auth.NewAuthInfo(options.Options.AuthURL,
-		options.Options.AdminDomain,
-		options.Options.AdminUser,
-		options.Options.AdminPassword,
-		options.Options.AdminProject,
-		options.Options.AdminProjectDomain,
-	)
-
-	auth.Init(info, options.Options.DebugClient, true,
-		options.Options.SslCertfile, options.Options.SslKeyfile)
-
 	if options.Options.EnableSsl {
 		privData, err := ioutil.ReadFile(options.Options.SslKeyfile)
 		if err != nil {

--- a/pkg/apigateway/service/service.go
+++ b/pkg/apigateway/service/service.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"strconv"
 
-	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 
 	"yunion.io/x/onecloud/pkg/apigateway/app"
@@ -29,7 +28,6 @@ import (
 	app_common "yunion.io/x/onecloud/pkg/cloudcommon/app"
 	common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
 	"yunion.io/x/onecloud/pkg/mcclient"
-	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 )
 
 func StartService() {
@@ -55,9 +53,9 @@ func StartService() {
 	serviceApp := app.NewApp(app_common.InitApp(baseOpts, false))
 	serviceApp.InitHandlers().Bind()
 
-	mods, jmods := modulebase.GetRegisterdModules()
-	log.Infof("Modules: %s", jsonutils.Marshal(mods).PrettyString())
-	log.Infof("Modules: %s", jsonutils.Marshal(jmods).PrettyString())
+	// mods, jmods := modulebase.GetRegisterdModules()
+	// log.Infof("Modules: %s", jsonutils.Marshal(mods).PrettyString())
+	// log.Infof("Modules: %s", jsonutils.Marshal(jmods).PrettyString())
 
 	listenAddr := net.JoinHostPort(options.Options.Address, strconv.Itoa(options.Options.Port))
 	if opts.EnableSsl {

--- a/pkg/apis/const.go
+++ b/pkg/apis/const.go
@@ -37,5 +37,7 @@ const (
 	SERVICE_TYPE_SERVICETREE       = "servicetree"
 	SERVICE_TYPE_LOG               = "log"
 	SERVICE_TYPE_REGION            = "compute"
-	SERVICE_TYPE_INFLUXDB          = "influxdb"
+
+	SERVICE_TYPE_ETCD     = "etcd"
+	SERVICE_TYPE_INFLUXDB = "influxdb"
 )

--- a/pkg/cloudcommon/app/endpoint.go
+++ b/pkg/cloudcommon/app/endpoint.go
@@ -1,0 +1,48 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"time"
+
+	"yunion.io/x/jsonutils"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/syncman/watcher"
+	"yunion.io/x/onecloud/pkg/mcclient/auth"
+)
+
+type SEndpointChangeManager struct {
+	watcher.SInformerSyncManager
+}
+
+func newEndpointChangeManager() *SEndpointChangeManager {
+	man := &SEndpointChangeManager{}
+	man.InitSync(man)
+	return man
+}
+
+func (man *SEndpointChangeManager) DoSync(first bool) (time.Duration, error) {
+	// reauth to refresh endpoint list
+	auth.ReAuth()
+	return time.Hour * 2, nil
+}
+
+func (man *SEndpointChangeManager) NeedSync(dat *jsonutils.JSONDict) bool {
+	return true
+}
+
+func (man *SEndpointChangeManager) Name() string {
+	return "EndpointChangeManager"
+}

--- a/pkg/cloudcommon/db/lockman/base.go
+++ b/pkg/cloudcommon/db/lockman/base.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package lockman
 
 import "context"

--- a/pkg/cloudcommon/db/tablespec.go
+++ b/pkg/cloudcommon/db/tablespec.go
@@ -43,8 +43,8 @@ type ITableSpec interface {
 	SyncSQL() []string
 	DropForeignKeySQL() []string
 	AddIndex(unique bool, cols ...string) bool
-	Increment(diff interface{}, target interface{}) error
-	Decrement(diff interface{}, target interface{}) error
+	Increment(ctx context.Context, diff interface{}, target interface{}) error
+	Decrement(ctx context.Context, diff interface{}, target interface{}) error
 }
 
 type sTableSpec struct {
@@ -126,6 +126,26 @@ func (ts *sTableSpec) Update(ctx context.Context, dt interface{}, doUpdate func(
 		ts.informUpdate(ctx, dt, oldObj.(*jsonutils.JSONDict))
 	}
 	return diffs, nil
+}
+
+func (ts *sTableSpec) Increment(ctx context.Context, diff, target interface{}) error {
+	oldObj := jsonutils.Marshal(target)
+	err := ts.STableSpec.Increment(diff, target)
+	if err != nil {
+		return errors.Wrap(err, "Increment")
+	}
+	ts.informUpdate(ctx, target, oldObj.(*jsonutils.JSONDict))
+	return nil
+}
+
+func (ts *sTableSpec) Decrement(ctx context.Context, diff, target interface{}) error {
+	oldObj := jsonutils.Marshal(target)
+	err := ts.STableSpec.Decrement(diff, target)
+	if err != nil {
+		return err
+	}
+	ts.informUpdate(ctx, target, oldObj.(*jsonutils.JSONDict))
+	return nil
 }
 
 func (ts *sTableSpec) inform(ctx context.Context, dt interface{}, f func(ctx context.Context, obj *informer.ModelObject) error) {

--- a/pkg/cloudcommon/options/mergeconf.go
+++ b/pkg/cloudcommon/options/mergeconf.go
@@ -59,6 +59,7 @@ func getServiceConfig(s *mcclient.ClientSession, serviceId string) (jsonutils.JS
 type IServiceConfigSession interface {
 	Merge(opts interface{}, serviceType string, serviceVersion string) bool
 	Upload()
+	IsRemote() bool
 }
 
 type mcclientServiceConfigSession struct {
@@ -123,4 +124,8 @@ func (s *mcclientServiceConfigSession) Upload() {
 			log.Errorf("fail to save config: %s", err)
 		}
 	}
+}
+
+func (s *mcclientServiceConfigSession) IsRemote() bool {
+	return true
 }

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -70,10 +70,10 @@ type BaseOptions struct {
 
 	EnableRbac                       bool `help:"Switch on Role-based Access Control" default:"true"`
 	RbacDebug                        bool `help:"turn on rbac debug log" default:"false"`
-	RbacPolicySyncPeriodSeconds      int  `help:"policy sync interval in seconds, default 5 minutes" default:"300"`
+	RbacPolicySyncPeriodSeconds      int  `help:"policy sync interval in seconds, default 30 minutes" default:"1800"`
 	RbacPolicySyncFailedRetrySeconds int  `help:"seconds to wait after a failed sync, default 30 seconds" default:"30"`
 
-	ConfigSyncPeriodSeconds int `help:"service config sync interval in seconds, default 300 seconds/5 minutes" default:"300"`
+	ConfigSyncPeriodSeconds int `help:"service config sync interval in seconds, default 30 minutes" default:"1800"`
 
 	IsSlaveNode        bool `help:"Slave mode"`
 	CronJobWorkerCount int  `help:"Cron job worker count" default:"4"`
@@ -128,6 +128,7 @@ type DBOptions struct {
 	LockmanMethod string `help:"method for lock synchronization" choices:"inmemory|etcd" default:"inmemory"`
 
 	EtcdOptions
+
 	EtcdLockPrefix string `help:"prefix of etcd lock records" default:"/onecloud/lockman"`
 	EtcdLockTTL    int    `help:"ttl of etcd lock records" default:"5"`
 }

--- a/pkg/cloudcommon/syncman/doc.go
+++ b/pkg/cloudcommon/syncman/doc.go
@@ -12,27 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package identity
-
-import "yunion.io/x/onecloud/pkg/apis"
-
-type EndpointDetails struct {
-	apis.StandaloneResourceDetails
-	SEndpoint
-	CertificateDetails
-
-	// 服务名称,例如keystone, glance, region等
-	ServiceName string `json:"service_name"`
-
-	// 服务类型,例如identity, image, compute等
-	ServiceType string `json:"service_type"`
-}
-
-type CertificateDetails struct {
-	apis.SCertificateResourceBase
-	CertName string `json:"cert_name"`
-	CertId   string `json:"cert_id"`
-
-	CaCertificate string `json:"ca_certificate"`
-	CaPrivateKey  string `json:"ca_private_key"`
-}
+package syncman // import "yunion.io/x/onecloud/pkg/cloudcommon/syncman"

--- a/pkg/cloudcommon/syncman/sync.go
+++ b/pkg/cloudcommon/syncman/sync.go
@@ -1,0 +1,78 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncman
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
+
+	"yunion.io/x/onecloud/pkg/appsrv"
+)
+
+type ISyncClient interface {
+	DoSync(first bool) (time.Duration, error)
+	NeedSync(dat *jsonutils.JSONDict) bool
+	Name() string
+}
+
+type SSyncManager struct {
+	ISyncClient
+
+	lastSync  time.Time
+	syncTimer *time.Timer
+	syncOnce  int32
+
+	syncWorkerManager *appsrv.SWorkerManager
+}
+
+func (manager *SSyncManager) InitSync(client ISyncClient) {
+	manager.ISyncClient = client
+	manager.syncWorkerManager = appsrv.NewWorkerManagerIgnoreOverflow(fmt.Sprintf("(%s)sync_worker", client.Name()), 1, 1, true, true)
+}
+
+func (manager *SSyncManager) syncByInterval() error {
+	if manager.syncTimer != nil {
+		manager.syncTimer.Stop()
+		manager.syncTimer = nil
+	}
+	isFirst := false
+	if manager.lastSync.IsZero() {
+		isFirst = true
+	}
+	next, err := manager.DoSync(isFirst)
+	if err == nil {
+		manager.lastSync = time.Now()
+	}
+	manager.syncTimer = time.AfterFunc(next, manager.SyncOnce)
+	return err
+}
+
+func (manager *SSyncManager) SyncOnce() {
+	log.Debugf("[%s] SyncOnce", manager.Name())
+	if atomic.CompareAndSwapInt32(&manager.syncOnce, 0, 1) {
+		manager.syncWorkerManager.Run(func() {
+			atomic.StoreInt32(&manager.syncOnce, 0)
+			manager.syncByInterval()
+		}, nil, nil)
+	}
+}
+
+func (manager *SSyncManager) FirstSync() error {
+	return manager.syncByInterval()
+}

--- a/pkg/cloudcommon/syncman/watcher/doc.go
+++ b/pkg/cloudcommon/syncman/watcher/doc.go
@@ -12,27 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package identity
-
-import "yunion.io/x/onecloud/pkg/apis"
-
-type EndpointDetails struct {
-	apis.StandaloneResourceDetails
-	SEndpoint
-	CertificateDetails
-
-	// 服务名称,例如keystone, glance, region等
-	ServiceName string `json:"service_name"`
-
-	// 服务类型,例如identity, image, compute等
-	ServiceType string `json:"service_type"`
-}
-
-type CertificateDetails struct {
-	apis.SCertificateResourceBase
-	CertName string `json:"cert_name"`
-	CertId   string `json:"cert_id"`
-
-	CaCertificate string `json:"ca_certificate"`
-	CaPrivateKey  string `json:"ca_private_key"`
-}
+package watcher // import "yunion.io/x/onecloud/pkg/cloudcommon/syncman/watcher"

--- a/pkg/cloudcommon/syncman/watcher/watcher.go
+++ b/pkg/cloudcommon/syncman/watcher/watcher.go
@@ -1,0 +1,93 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watcher
+
+import (
+	"context"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+
+	"yunion.io/x/onecloud/pkg/apis"
+	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
+	"yunion.io/x/onecloud/pkg/cloudcommon/syncman"
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/auth"
+	"yunion.io/x/onecloud/pkg/mcclient/informer"
+)
+
+type SInformerSyncManager struct {
+	syncman.SSyncManager
+	resourceManager informer.IResourceManager
+	done            bool
+}
+
+func (manager *SInformerSyncManager) OnAdd(obj *jsonutils.JSONDict) {
+	log.Infof("[CREATED]: \n%s", obj.String())
+	if manager.NeedSync(obj) {
+		manager.SyncOnce()
+	}
+}
+
+func (manager *SInformerSyncManager) OnUpdate(oldObj, newObj *jsonutils.JSONDict) {
+	log.Infof("[UPDATED]: \n[NEW]: %s\n[OLD]: %s", newObj.String(), oldObj.String())
+	if manager.NeedSync(oldObj) || manager.NeedSync(newObj) {
+		manager.SyncOnce()
+	}
+}
+
+func (manager *SInformerSyncManager) OnDelete(obj *jsonutils.JSONDict) {
+	log.Infof("[DELETED]: \n%s", obj.String())
+	if manager.NeedSync(obj) {
+		manager.SyncOnce()
+	}
+}
+
+func (manager *SInformerSyncManager) OnServiceCatalogChange(catalog mcclient.IServiceCatalog) {
+	if manager.done {
+		return
+	}
+	url, _ := catalog.GetServiceURL(apis.SERVICE_TYPE_ETCD, consts.GetRegion(), "", "internal")
+	if len(url) == 0 {
+		log.Debugf("[%s] OnServiceCatalogChange: no etcd url found, retry", manager.Name())
+		return
+	}
+	err := manager.startWatcher()
+	if err != nil {
+		log.Errorf("[%s] watching resource errror %s", manager.Name(), err)
+		return
+	}
+	manager.done = true
+}
+
+func (manager *SInformerSyncManager) StartWatching(resMan informer.IResourceManager) {
+	manager.resourceManager = resMan
+	auth.RegisterCatalogListener(manager)
+}
+
+func (manager *SInformerSyncManager) startWatcher() error {
+	log.Infof("[%s] Start resource informer watcher for %s", manager.Name(), manager.resourceManager.GetKeyword())
+	ctx := context.Background()
+	s := auth.GetAdminSession(ctx, consts.GetRegion(), "v1")
+	watchMan, err := informer.NewWatchManagerBySession(s)
+	if err != nil {
+		return errors.Wrap(err, "NewWatchManagerBySession")
+	}
+	if err := watchMan.For(manager.resourceManager).AddEventHandler(ctx, manager); err != nil {
+		return errors.Wrapf(err, "watch resource %s", manager.resourceManager.GetKeyword())
+	}
+	return nil
+}

--- a/pkg/compute/service/service.go
+++ b/pkg/compute/service/service.go
@@ -79,10 +79,7 @@ func StartService() {
 
 	options.InitNameSyncResources()
 
-	err := setInfluxdbRetentionPolicy()
-	if err != nil {
-		log.Errorf("setInfluxdbRetentionPolicy fail: %s", err)
-	}
+	setInfluxdbRetentionPolicy()
 
 	models.InitSyncWorkers(options.Options.CloudSyncWorkerCount)
 

--- a/pkg/keystone/models/configs.go
+++ b/pkg/keystone/models/configs.go
@@ -425,6 +425,10 @@ func (s *dbServiceConfigSession) Upload() {
 	uploadConfig(s.service, s.config)
 }
 
+func (s *dbServiceConfigSession) IsRemote() bool {
+	return false
+}
+
 func uploadConfig(service *SService, config jsonutils.JSONObject) {
 	nconf := jsonutils.NewDict()
 	nconf.Add(config, "default")

--- a/pkg/keystone/models/endpoints.go
+++ b/pkg/keystone/models/endpoints.go
@@ -146,7 +146,7 @@ func (manager *SEndpointManager) IsEtcdInformerBackend(ep *SEndpoint) bool {
 	if svc == nil {
 		return false
 	}
-	if svc.GetName() != api.SERVICE_TYPE_ETCD {
+	if svc.GetName() != apis.SERVICE_TYPE_ETCD {
 		return false
 	}
 	epType := manager.getSessionEndpointType()
@@ -177,7 +177,7 @@ func (manager *SEndpointManager) fetchInformerEndpoint() (*SEndpoint, error) {
 		sqlchemy.IsTrue(endpoints.Field("enabled"))))
 	q = q.Filter(sqlchemy.AND(
 		sqlchemy.IsTrue(services.Field("enabled")),
-		sqlchemy.Equals(services.Field("type"), api.SERVICE_TYPE_ETCD)))
+		sqlchemy.Equals(services.Field("type"), apis.SERVICE_TYPE_ETCD)))
 
 	informerEp := new(SEndpoint)
 	if err := q.First(informerEp); err != nil {

--- a/pkg/mcclient/auth/auth.go
+++ b/pkg/mcclient/auth/auth.go
@@ -22,17 +22,19 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/cache"
 
 	"yunion.io/x/onecloud/pkg/apis/identity"
+	"yunion.io/x/onecloud/pkg/cloudcommon/syncman"
 	"yunion.io/x/onecloud/pkg/mcclient"
 )
 
 var (
-	manager            *authManager
-	defaultTimeout     int       = 600 // maybe time.Duration better
-	defaultCacheCount  int64     = 100000
-	initCh             chan bool = make(chan bool)
+	manager           *authManager
+	defaultTimeout    int   = 600 // maybe time.Duration better
+	defaultCacheCount int64 = 100000
+	// initCh             chan bool = make(chan bool)
 	globalEndpointType string
 )
 
@@ -134,6 +136,8 @@ func (c *TokenCacheVerify) Verify(ctx context.Context, cli *mcclient.Client, adm
 }
 
 type authManager struct {
+	syncman.SSyncManager
+
 	client           *mcclient.Client
 	info             *AuthInfo
 	adminCredential  mcclient.TokenCredential
@@ -142,12 +146,14 @@ type authManager struct {
 }
 
 func newAuthManager(cli *mcclient.Client, info *AuthInfo) *authManager {
-	return &authManager{
+	authm := &authManager{
 		client:           cli,
 		info:             info,
 		tokenCacheVerify: NewTokenCacheVerify(),
 		accessKeyCache:   newAccessKeyCache(),
 	}
+	authm.InitSync(authm)
+	return authm
 }
 
 func (a *authManager) verifyRequest(req http.Request, virtualHost bool) (mcclient.TokenCredential, error) {
@@ -190,19 +196,25 @@ func (a *authManager) authAdmin() error {
 	}
 }
 
-func (a *authManager) reAuth() {
-	redoSleepTime := 60 * time.Second
-	for {
-		err := a.authAdmin()
-		if err == nil {
-			break
-		}
-		log.Errorf("Reauth failed: %s, try it again after %v", err, redoSleepTime)
-		time.Sleep(redoSleepTime)
+func (a *authManager) DoSync(first bool) (time.Duration, error) {
+	err := a.authAdmin()
+	if err != nil {
+		return time.Minute, errors.Wrap(err, "authAdmin")
+	} else {
+		return a.adminCredential.GetExpires().Sub(time.Now()) / 2, nil
 	}
-	expire := a.adminCredential.GetExpires()
-	duration := expire.Sub(time.Now())
-	time.AfterFunc(time.Duration(duration.Nanoseconds()/2), a.reAuth)
+}
+
+func (a *authManager) NeedSync(dat *jsonutils.JSONDict) bool {
+	return true
+}
+
+func (a *authManager) Name() string {
+	return "AuthManager"
+}
+
+func (a *authManager) reAuth() {
+	a.SyncOnce()
 }
 
 func (a *authManager) GetServiceURL(service, region, zone, endpointType string) (string, error) {
@@ -235,19 +247,6 @@ func (a *authManager) isAuthed() bool {
 		return false
 	}
 	return true
-}
-
-func (a *authManager) init() error {
-	if err := a.authAdmin(); err != nil {
-		initCh <- false
-		log.Fatalf("Auth manager init err: %v", err)
-	}
-	log.Infof("Get token: %v", a.getTokenString())
-	expire := a.adminCredential.GetExpires()
-	duration := expire.Sub(time.Now())
-	time.AfterFunc(time.Duration(duration.Nanoseconds()/2), a.reAuth)
-	initCh <- true
-	return nil
 }
 
 func GetCatalogData(serviceTypes []string, region string) jsonutils.JSONObject {
@@ -290,6 +289,7 @@ func AdminCredential() mcclient.TokenCredential {
 	return manager.adminCredential
 }
 
+// Deprecated
 func AdminSession(ctx context.Context, region, zone, endpointType, apiVersion string) *mcclient.ClientSession {
 	cli := Client()
 	if cli == nil {
@@ -301,45 +301,31 @@ func AdminSession(ctx context.Context, region, zone, endpointType, apiVersion st
 	return cli.NewSession(ctx, region, zone, endpointType, AdminCredential(), apiVersion)
 }
 
+// Deprecated
 func AdminSessionWithInternal(ctx context.Context, region, zone, apiVersion string) *mcclient.ClientSession {
 	return AdminSession(ctx, region, zone, "internal", apiVersion)
 }
 
+// Deprecated
 func AdminSessionWithPublic(ctx context.Context, region, zone, apiVersion string) *mcclient.ClientSession {
 	return AdminSession(ctx, region, zone, "public", apiVersion)
 }
 
 type AuthCompletedCallback func()
 
-func (callback *AuthCompletedCallback) Run() {
-	f := *callback
-	for {
-		initOk := <-initCh
-		if initOk && manager.isAuthed() {
-			log.V(10).Infof("Auth completed, run callback: %v", *callback)
-			f()
-			return
-		}
-		log.Warningf("Auth manager not ready, check it again...")
-	}
-}
-
 func AsyncInit(info *AuthInfo, debug, insecure bool, certFile, keyFile string, callback AuthCompletedCallback) {
 	cli := mcclient.NewClient(info.AuthUrl, defaultTimeout, debug, insecure, certFile, keyFile)
 	manager = newAuthManager(cli, info)
-	go manager.init()
-	if callback != nil {
-		go callback.Run()
+	err := manager.FirstSync()
+	if err != nil {
+		log.Fatalf("Auth manager init err: %v", err)
+	} else if callback != nil {
+		callback()
 	}
 }
 
 func Init(info *AuthInfo, debug, insecure bool, certFile, keyFile string) {
-	done := make(chan bool, 1)
-	f := func() {
-		done <- true
-	}
-	AsyncInit(info, debug, insecure, certFile, keyFile, f)
-	<-done
+	AsyncInit(info, debug, insecure, certFile, keyFile, nil)
 }
 
 func ReAuth() {
@@ -392,4 +378,8 @@ func InitFromClientSession(session *mcclient.ClientSession) {
 	}
 
 	SetEndpointType(session.GetEndpointType())
+}
+
+func RegisterCatalogListener(listener mcclient.IServiceCatalogChangeListener) {
+	manager.client.RegisterCatalogListener(listener)
 }

--- a/pkg/mcclient/mcclient.go
+++ b/pkg/mcclient/mcclient.go
@@ -28,7 +28,9 @@ import (
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/gotypes"
 
+	"yunion.io/x/onecloud/pkg/apis"
 	api "yunion.io/x/onecloud/pkg/apis/identity"
+	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/util/httputils"
 	"yunion.io/x/onecloud/pkg/util/seclib2"
@@ -39,8 +41,11 @@ type Client struct {
 	timeout int
 	debug   bool
 
-	httpconn       *http.Client
-	serviceCatalog IServiceCatalog
+	httpconn        *http.Client
+	_serviceCatalog IServiceCatalog
+
+	catalogListeners []IServiceCatalogChangeListener
+	listenerWorker   *appsrv.SWorkerManager
 }
 
 func NewClient(authUrl string, timeout int, debug bool, insecure bool, certFile, keyFile string) *Client {
@@ -75,6 +80,8 @@ func NewClient(authUrl string, timeout int, debug bool, insecure bool, certFile,
 			}, // 不自动处理重定向请求
 		},
 	}
+
+	client.listenerWorker = appsrv.NewWorkerManager("client_catalog_listener_worker", 1, 2048, false)
 	return &client
 }
 
@@ -101,14 +108,6 @@ func (this *Client) AuthVersion() string {
 	} else {
 		return ""
 	}
-}
-
-func (this *Client) SetServiceCatalog(catalog IServiceCatalog) {
-	this.serviceCatalog = catalog
-}
-
-func (this *Client) GetServiceCatalog() IServiceCatalog {
-	return this.serviceCatalog
 }
 
 func (this *Client) NewAuthTokenCredential() TokenCredential {
@@ -259,7 +258,7 @@ func (this *Client) unmarshalV3Token(rbody jsonutils.JSONObject, tokenId string)
 	if cata == nil || cata.Len() == 0 {
 		log.Warningf("No service catalog avaiable")
 	} else {
-		this.serviceCatalog = cata
+		this.SetServiceCatalog(cata)
 	}
 	return
 }
@@ -276,7 +275,7 @@ func (this *Client) unmarshalV2Token(rbody jsonutils.JSONObject) (cred TokenCred
 		if cata == nil || cata.Len() == 0 {
 			log.Warningf("No srvice catalog avaiable")
 		} else {
-			this.serviceCatalog = cata
+			this.SetServiceCatalog(cata)
 		}
 		return
 	}
@@ -345,7 +344,7 @@ func (this *Client) GetCommonEtcdEndpoint(token TokenCredential, region, interfa
 		return nil, errors.Errorf("current version %s not support get internal etcd endpoint", this.AuthVersion())
 	}
 
-	_, err := this.GetServiceCatalog().GetServiceURL(api.SERVICE_TYPE_ETCD, region, "", interfaceType)
+	_, err := this.GetServiceCatalog().GetServiceURL(apis.SERVICE_TYPE_ETCD, region, "", interfaceType)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +352,7 @@ func (this *Client) GetCommonEtcdEndpoint(token TokenCredential, region, interfa
 	params := jsonutils.NewDict()
 	params.Add(jsonutils.NewString(interfaceType), "interface")
 	params.Add(jsonutils.JSONTrue, "enabled")
-	params.Add(jsonutils.NewString(api.SERVICE_TYPE_ETCD), "service")
+	params.Add(jsonutils.NewString(apis.SERVICE_TYPE_ETCD), "service")
 	params.Add(jsonutils.JSONTrue, "details")
 	params.Add(jsonutils.NewString(region), "region")
 
@@ -367,10 +366,10 @@ func (this *Client) GetCommonEtcdEndpoint(token TokenCredential, region, interfa
 		return nil, errors.Wrap(err, "get endpoints response")
 	}
 	if len(rets) == 0 {
-		return nil, errors.Wrapf(httperrors.ErrNotFound, "not found service %s %s endpoint", api.SERVICE_TYPE_ETCD, interfaceType)
+		return nil, errors.Wrapf(httperrors.ErrNotFound, "not found service %s %s endpoint", apis.SERVICE_TYPE_ETCD, interfaceType)
 	}
 	if len(rets) > 1 {
-		return nil, errors.Errorf("fond %d duplicate serivce %s %s endpoint", len(rets), api.SERVICE_TYPE_ETCD, interfaceType)
+		return nil, errors.Errorf("fond %d duplicate serivce %s %s endpoint", len(rets), apis.SERVICE_TYPE_ETCD, interfaceType)
 	}
 	endpoint := new(api.EndpointDetails)
 	if err := rets[0].Unmarshal(endpoint); err != nil {
@@ -391,11 +390,11 @@ func (this *Client) GetCommonEtcdTLSConfig(endpoint *api.EndpointDetails) (*tls.
 
 func (this *Client) NewSession(ctx context.Context, region, zone, endpointType string, token TokenCredential, apiVersion string) *ClientSession {
 	cata := token.GetServiceCatalog()
-	if this.serviceCatalog == nil {
+	if this.GetServiceCatalog() == nil {
 		if cata == nil || cata.Len() == 0 {
 			log.Warningf("Missing service catalog in token")
 		} else {
-			this.serviceCatalog = cata
+			this.SetServiceCatalog(cata)
 		}
 	}
 	if ctx == nil {

--- a/pkg/mcclient/session.go
+++ b/pkg/mcclient/session.go
@@ -136,16 +136,17 @@ func (this *ClientSession) GetServiceURL(service, endpointType string) (string, 
 	return this.GetServiceVersionURL(service, endpointType, this.getApiVersion(""))
 }
 
+func (this *ClientSession) GetServiceCatalog() IServiceCatalog {
+	return this.client.GetServiceCatalog()
+}
+
 func (this *ClientSession) GetServiceVersionURL(service, endpointType, apiVersion string) (string, error) {
 	if len(this.endpointType) > 0 {
 		// session specific endpoint type should override the input endpointType, which is supplied by manager
 		endpointType = this.endpointType
 	}
 	service = this.getServiceName(service, apiVersion)
-	url, err := this.token.GetServiceURL(service, this.region, this.zone, endpointType)
-	if err != nil && this.client.serviceCatalog != nil {
-		url, err = this.client.serviceCatalog.GetServiceURL(service, this.region, this.zone, endpointType)
-	}
+	url, err := this.GetServiceCatalog().GetServiceURL(service, this.region, this.zone, endpointType)
 	if err != nil && service == api.SERVICE_TYPE {
 		return this.client.authUrl, nil
 	}
@@ -167,10 +168,7 @@ func (this *ClientSession) GetServiceVersionURLs(service, endpointType, apiVersi
 		endpointType = this.endpointType
 	}
 	service = this.getServiceName(service, apiVersion)
-	urls, err := this.token.GetServiceURLs(service, this.region, this.zone, endpointType)
-	if err != nil && this.client.serviceCatalog != nil {
-		urls, err = this.client.serviceCatalog.GetServiceURLs(service, this.region, this.zone, endpointType)
-	}
+	urls, err := this.GetServiceCatalog().GetServiceURLs(service, this.region, this.zone, endpointType)
 	if err != nil && service == api.SERVICE_TYPE {
 		return []string{this.client.authUrl}, nil
 	}

--- a/pkg/multicloud/openstack/loadbalabcerpool.go
+++ b/pkg/multicloud/openstack/loadbalabcerpool.go
@@ -422,7 +422,7 @@ func (region *SRegion) UpdateLoadBalancerPool(poolId string, group *cloudprovide
 	}
 	_, err := region.lbUpdate(fmt.Sprintf("/v2/lbaas/pools/%s", poolId), jsonutils.Marshal(params))
 	if err != nil {
-		return errors.Wrap(err, `region.lbUpdate(fmt.Sprintf("/v2/lbaas/pools/%s", poolId), jsonutils.Marshal(params))`)
+		return errors.Wrapf(err, `region.lbUpdate("/v2/lbaas/pools/%s", jsonutils.Marshal(params))`, poolId)
 	}
 	return nil
 }

--- a/pkg/multicloud/openstack/loadbalancerlistener.go
+++ b/pkg/multicloud/openstack/loadbalancerlistener.go
@@ -587,7 +587,7 @@ func (listener *SLoadbalancerListener) GetILoadbalancerListenerRules() ([]cloudp
 func (region *SRegion) DeleteLoadbalancerListener(listenerId string) error {
 	_, err := region.lbDelete(fmt.Sprintf("/v2/lbaas/listeners/%s", listenerId))
 	if err != nil {
-		return errors.Wrapf(err, "region.lbDelete(fmt.Sprintf(/v2/lbaas/listeners/%s))", listenerId)
+		return errors.Wrapf(err, `region.lbDelete("/v2/lbaas/listeners/%s")`, listenerId)
 	}
 	return nil
 }

--- a/pkg/multicloud/openstack/loadbalbacer.go
+++ b/pkg/multicloud/openstack/loadbalbacer.go
@@ -371,7 +371,7 @@ func (lb *SLoadbalancer) GetLoadbalancerSpec() string {
 func (lb *SLoadbalancer) GetChargeType() string {
 	eip, err := lb.GetIEIP()
 	if err != nil {
-		log.Errorf("lb.GetIEIP():%s", err)
+		log.Errorf("lb.GetIEIP(): %s", err)
 	}
 	if err != nil {
 		return eip.GetInternetChargeType()


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：通过informer监听endpoints, policies和service变化，准实时获得endpoint, policies和service config的变化。服务启动时候，首先会启动一个timer获取etcd的endpoint，当etcd endpoint存在后，则启动endpoints, policies和service的informer client


<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @wanyaoqi @yousong 
/area keystone region apigateway
