### PR TITLE
fix: GetDefaultClient always return a new http client instance

### DIFF
--- a/pkg/cloudcommon/informer/etcd.go
+++ b/pkg/cloudcommon/informer/etcd.go
@@ -215,7 +215,7 @@ func (b *EtcdBackend) shouldDeleteWatchedResource(ctx context.Context, keywordPl
 	clientsKey := fmt.Sprintf("/%s/%s", keywordPlural, EtcdInformerClientsKey)
 	pairs, err := b.client.List(ctx, clientsKey)
 	if err != nil {
-		log.Errorf("list clientsKey %s error: %v", err)
+		log.Errorf("list clientsKey %s error: %v", clientsKey, err)
 		return false
 	}
 	return len(pairs) == 0

--- a/pkg/util/httputils/httputils.go
+++ b/pkg/util/httputils/httputils.go
@@ -411,11 +411,11 @@ func GetAdaptiveTimeoutClient() *http.Client {
 var defaultHttpClient *http.Client
 
 func init() {
-	defaultHttpClient = GetClient(true, time.Second*15)
+	defaultHttpClient = GetDefaultClient()
 }
 
 func GetDefaultClient() *http.Client {
-	return defaultHttpClient
+	return GetClient(true, time.Second*15)
 }
 
 func Request(client *http.Client, ctx context.Context, method THttpMethod, urlStr string, header http.Header, body io.Reader, debug bool) (*http.Response, error) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：GetDefaultClient改为总是返回一个新的instance，避免出现一个地方修改client（例如设置proxy）影响另外一个地方的情况

Con：增加了内存消耗
Pro：隔离了不同client实例，降低代码耦合度

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @yousong @wanyaoqi 
/area util