### PR TITLE
fix: idp deletel logic cleanup

### DIFF
--- a/cmd/climc/shell/identity/domains.go
+++ b/cmd/climc/shell/identity/domains.go
@@ -25,6 +25,7 @@ import (
 func init() {
 	type DomainListOptions struct {
 		options.BaseListOptions
+		IdpId string `help:"filter by idp_id"`
 	}
 	R(&DomainListOptions{}, "domain-list", "List domains", func(s *mcclient.ClientSession, args *DomainListOptions) error {
 		params, err := options.ListStructToParams(args)

--- a/cmd/climc/shell/identity/groups.go
+++ b/cmd/climc/shell/identity/groups.go
@@ -28,6 +28,7 @@ func init() {
 		options.BaseListOptions
 		Name          string `help:"Filter by name"`
 		OrderByDomain string `help:"order by domain name" choices:"asc|desc"`
+		IdpId         string `help:"filter by idp_id"`
 	}
 	R(&GroupListOptions{}, "group-list", "List groups", func(s *mcclient.ClientSession, args *GroupListOptions) error {
 		params, err := options.ListStructToParams(args)

--- a/cmd/climc/shell/identity/users.go
+++ b/cmd/climc/shell/identity/users.go
@@ -30,6 +30,7 @@ func init() {
 		Name          string `help:"Filter by name"`
 		OrderByDomain string `help:"order by domain name" choices:"asc|desc"`
 		Role          string `help:"Filter by role"`
+		IdpId         string `help:"filter by idp_id"`
 	}
 	R(&UserListOptions{}, "user-list", "List users", func(s *mcclient.ClientSession, args *UserListOptions) error {
 		params, err := options.ListStructToParams(args)

--- a/pkg/apis/identity/input.go
+++ b/pkg/apis/identity/input.go
@@ -144,6 +144,9 @@ type GroupListInput struct {
 
 	// 名称过滤
 	Displayname string `json:"displayname"`
+
+	// 按IDP过滤
+	IdpId string `json:"idp_id"`
 }
 
 type ProjectListInput struct {
@@ -160,6 +163,9 @@ type DomainListInput struct {
 	apis.StandaloneResourceListInput
 
 	Enabled *bool `json:"enabled"`
+
+	// 按IDP过滤
+	IdpId string `json:"idp_id"`
 }
 
 type UserListInput struct {
@@ -181,6 +187,9 @@ type UserListInput struct {
 
 	// 是否开启MFA认证
 	EnableMfa *bool `json:"enable_mfa"`
+
+	// 关联IDP
+	IdpId string `json:"idp_id"`
 }
 
 type EndpointListInput struct {

--- a/pkg/apis/identity/user.go
+++ b/pkg/apis/identity/user.go
@@ -33,5 +33,7 @@ type UserDetails struct {
 
 	Idps []IdpResourceInfo `json:"idps"`
 
+	IsLocal bool `json:"is_local"`
+
 	ExternalResourceInfo
 }

--- a/pkg/apis/identity/usrext.go
+++ b/pkg/apis/identity/usrext.go
@@ -35,7 +35,7 @@ type SUserExtended struct {
 	LocalName     string
 	DomainName    string
 	DomainEnabled bool
-	// IsLocal       bool
+	IsLocal       bool
 	// IdpId         string
 	// IdpName       string
 }

--- a/pkg/keystone/driver/ldap/sync.go
+++ b/pkg/keystone/driver/ldap/sync.go
@@ -236,13 +236,13 @@ func (self *SLDAPDriver) syncUserDB(ctx context.Context, ui SUserInfo, domainId 
 		// } else {
 		//	user.Enabled = tristate.False
 		// }
-		if val, ok := ui.Extra["email"]; ok && len(val) > 0 {
+		if val, ok := ui.Extra["email"]; ok && len(val) > 0 && len(user.Email) > 0 {
 			user.Email = val
 		}
-		if val, ok := ui.Extra["displayname"]; ok && len(val) > 0 {
+		if val, ok := ui.Extra["displayname"]; ok && len(val) > 0 && len(user.Displayname) > 0 {
 			user.Displayname = val
 		}
-		if val, ok := ui.Extra["mobile"]; ok && len(val) > 0 {
+		if val, ok := ui.Extra["mobile"]; ok && len(val) > 0 && len(user.Mobile) > 0 {
 			user.Mobile = val
 		}
 	})

--- a/pkg/keystone/models/groups.go
+++ b/pkg/keystone/models/groups.go
@@ -121,6 +121,19 @@ func (manager *SGroupManager) ListItemFilter(
 		q = q.In("id", subq.SubQuery())
 	}
 
+	if len(query.IdpId) > 0 {
+		idpObj, err := IdentityProviderManager.FetchByIdOrName(userCred, query.IdpId)
+		if err != nil {
+			if errors.Cause(err) == sql.ErrNoRows {
+				return nil, errors.Wrapf(httperrors.ErrResourceNotFound, "%s %s", IdentityProviderManager.Keyword(), query.IdpId)
+			} else {
+				return nil, errors.Wrap(err, "IdentityProviderManager.FetchByIdOrName")
+			}
+		}
+		subq := IdmappingManager.FetchPublicIdsExcludesQuery(idpObj.GetId(), api.IdMappingEntityGroup, nil)
+		q = q.In("id", subq.SubQuery())
+	}
+
 	return q, nil
 }
 

--- a/pkg/keystone/models/id_mappings.go
+++ b/pkg/keystone/models/id_mappings.go
@@ -197,10 +197,17 @@ func (manager *SIdmappingManager) deleteAny(idpId string, entityType string, pub
 	return nil
 }
 
-func (manager *SIdmappingManager) FetchPublicIdsExcludes(idpId string, entityType string, excludes []string) ([]string, error) {
+func (manager *SIdmappingManager) FetchPublicIdsExcludesQuery(idpId string, entityType string, excludes []string) *sqlchemy.SQuery {
 	q := manager.Query("public_id").Equals("domain_id", idpId)
 	q = q.Equals("entity_type", entityType)
-	q = q.NotIn("public_id", excludes)
+	if len(excludes) > 0 {
+		q = q.NotIn("public_id", excludes)
+	}
+	return q
+}
+
+func (manager *SIdmappingManager) FetchPublicIdsExcludes(idpId string, entityType string, excludes []string) ([]string, error) {
+	q := manager.FetchPublicIdsExcludesQuery(idpId, entityType, excludes)
 	rows, err := q.Rows()
 	if err != nil && err != sql.ErrNoRows {
 		return nil, errors.Wrap(err, "q.Rows")

--- a/pkg/mcclient/modules/mod_identityproviders.go
+++ b/pkg/mcclient/modules/mod_identityproviders.go
@@ -29,7 +29,7 @@ func init() {
 		NewIdentityV3Manager("identity_provider",
 			"identity_providers",
 			[]string{},
-			[]string{"ID", "Name", "Driver", "Template", "Enabled", "Status", "Sync_Status", "Error_count", "Sync_Interval_Seconds"}),
+			[]string{"ID", "Name", "Driver", "Template", "auto_create_user", "Enabled", "Status", "Sync_Status", "Error_count", "Sync_Interval_Seconds", "target_domain_id"}),
 	}
 
 	register(&IdentityProviders)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：整理了idp删除逻辑，对于不新建用户的IDP，删除IDP只解除关联，否则，删除IDP同时也删除关联资源（用户，组，域等）

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area keystone
/cc @zexi 