### PR TITLE
fix: oauth2 not support default_project_id and default_role_id

### DIFF
--- a/pkg/apis/identity/oauth2.go
+++ b/pkg/apis/identity/oauth2.go
@@ -18,4 +18,6 @@ package identity
 type SOAuth2IdpConfigOptions struct {
 	AppId  string `json:"app_id"`
 	Secret string `json:"secret"`
+
+	SIdpAttributeOptions
 }

--- a/pkg/apis/identity/oidc.go
+++ b/pkg/apis/identity/oidc.go
@@ -35,11 +35,15 @@ type SOIDCDexConfigOptions struct {
 	ClientId     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 	Endpoint     string `json:"endpoint"`
+
+	SIdpAttributeOptions
 }
 
 type SOIDCGithubConfigOptions struct {
 	ClientId     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
+
+	SIdpAttributeOptions
 }
 
 const (
@@ -52,4 +56,6 @@ type SOIDCAzureConfigOptions struct {
 	ClientSecret string `json:"client_secret"`
 	TenantId     string `json:"tenant_id"`
 	CloudEnv     string `json:"cloud_env"`
+
+	SIdpAttributeOptions
 }

--- a/pkg/apis/identity/saml.go
+++ b/pkg/apis/identity/saml.go
@@ -42,4 +42,36 @@ type SSAMLTestIdpConfigOptions struct {
 
 type SSAMLAzureADConfigOptions struct {
 	TenantId string `json:"tenant_id"`
+
+	SIdpAttributeOptions
+}
+
+func (a *SIdpAttributeOptions) Update(a2 SIdpAttributeOptions) {
+	if len(a2.UserNameAttribute) > 0 {
+		a.UserNameAttribute = a2.UserNameAttribute
+	}
+	if len(a2.UserIdAttribute) > 0 {
+		a.UserIdAttribute = a2.UserIdAttribute
+	}
+	if len(a2.UserDisplaynameAttribtue) > 0 {
+		a.UserDisplaynameAttribtue = a2.UserDisplaynameAttribtue
+	}
+	if len(a2.UserEmailAttribute) > 0 {
+		a.UserEmailAttribute = a2.UserEmailAttribute
+	}
+	if len(a2.UserMobileAttribute) > 0 {
+		a.UserMobileAttribute = a2.UserMobileAttribute
+	}
+	if len(a2.ProjectAttribute) > 0 {
+		a.ProjectAttribute = a2.ProjectAttribute
+	}
+	if len(a2.RolesAttribute) > 0 {
+		a.RolesAttribute = a2.RolesAttribute
+	}
+	if len(a2.DefaultProjectId) > 0 {
+		a.DefaultProjectId = a2.DefaultProjectId
+	}
+	if len(a2.DefaultRoleId) > 0 {
+		a.DefaultRoleId = a2.DefaultRoleId
+	}
 }

--- a/pkg/keystone/driver/oauth2/oauth2.go
+++ b/pkg/keystone/driver/oauth2/oauth2.go
@@ -79,7 +79,8 @@ func (self *SOAuth2Driver) Authenticate(ctx context.Context, ident mcclient.SAut
 	if factory == nil {
 		return nil, errors.Wrapf(httperrors.ErrNotSupported, "template %s not supported", self.Template)
 	}
-	options := factory.IdpAttributeOptions()
+	options := self.oauth2Config.SIdpAttributeOptions
+	options.Update(factory.IdpAttributeOptions())
 	driver := factory.NewDriver(self.oauth2Config.AppId, self.oauth2Config.Secret)
 	attrs, err := driver.Authenticate(ctx, ident.OAuth2.Code)
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：oauth2 IDP支持新建用户加入项目

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area keystone
/cc @zexi 