### PR TITLE
fix: make old notify send SDK compatible

### DIFF
--- a/pkg/mcclient/modules/notify/mod_notification.go
+++ b/pkg/mcclient/modules/notify/mod_notification.go
@@ -40,7 +40,7 @@ type SNotifyMessage struct {
 }
 
 type SNotifyV2Message struct {
-	ReceiverIds []string `json:"receiver_ids"`
+	Receivers   []string `json:"receivers"`
 	ContactType string   `json:"contact_type"`
 	Topic       string   `json:"topic"`
 	Priority    string   `json:"priority"`
@@ -73,7 +73,7 @@ func (manager *NotificationManager) Send(s *mcclient.ClientSession, msg SNotifyM
 	receiverIds = append(receiverIds, msg.Uid...)
 
 	v2msg := SNotifyV2Message{
-		ReceiverIds: receiverIds,
+		Receivers:   receiverIds,
 		ContactType: string(msg.ContactType),
 		Topic:       msg.Topic,
 		Priority:    string(msg.Priority),


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. 为`notify-send`添加了一个 oldsdk 选项 以试用旧版的notify sdk接口。（用来测试旧版的兼容性）
2. 修复了发送失败的问题。

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area notify
/cc @zexi