### PR TITLE
vpcagent: ignore network without wire ids

### DIFF
--- a/pkg/vpcagent/models/modelset.go
+++ b/pkg/vpcagent/models/modelset.go
@@ -84,9 +84,11 @@ func (ms Vpcs) joinNetworks(subEntries Networks) bool {
 	for subId, subEntry := range subEntries {
 		wire := subEntry.Wire
 		if wire == nil {
-			// ensured by vpcs.joinWires
+			// let it go.  By the time the subnet has externalId or
+			// managerId set, we will not receive updates from them
+			// anymore
 			log.Warningf("network %s(%s) has no wire", subEntry.Name, subEntry.Id)
-			correct = false
+			delete(subEntries, subId)
 			continue
 		}
 		id := wire.VpcId


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
vpcagent: ignore network without wire ids
```

**是否需要 backport 到之前的 release 分支**:

- release/3.3

/cc @wanyaoqi @swordqiu @ioito @lvyangyang 