### PR TITLE
fix: add keystone sync user debug info

### DIFF
--- a/pkg/keystone/driver/ldap/class.go
+++ b/pkg/keystone/driver/ldap/class.go
@@ -83,16 +83,6 @@ func (self *SLDAPDriverClass) ValidateConfig(ctx context.Context, userCred mccli
 	if !unique {
 		return tconf, errors.Wrapf(httperrors.ErrDuplicateResource, "ldap URL %s has been registered", conf.Url)
 	}
-	nconf := make(map[string]jsonutils.JSONObject)
-	err = confJson.Unmarshal(&nconf)
-	if err != nil {
-		return tconf, errors.Wrap(err, "Unmarshal old config")
-	}
-	err = jsonutils.Marshal(conf).Unmarshal(&nconf)
-	if err != nil {
-		return tconf, errors.Wrap(err, "Unmarshal new config")
-	}
-	tconf[api.IdentityDriverLDAP] = nconf
 	return tconf, nil
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：LDAP配置加载时候引入了额外的冗余字段

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area keystone