### PR TITLE
fix: turn off some default project policies

### DIFF
--- a/pkg/compute/policy/defaults.go
+++ b/pkg/compute/policy/defaults.go
@@ -311,7 +311,7 @@ var (
 					Action:   PolicyActionList,
 					Result:   rbacutils.Allow,
 				},
-				{
+				/*{
 					Service:  api.SERVICE_TYPE,
 					Resource: "networks",
 					Action:   PolicyActionGet,
@@ -323,6 +323,7 @@ var (
 					Action:   PolicyActionList,
 					Result:   rbacutils.Allow,
 				},
+				*/
 			},
 		},
 	}

--- a/pkg/image/policy/defaults.go
+++ b/pkg/image/policy/defaults.go
@@ -44,7 +44,7 @@ var (
 					Action:   PolicyActionList,
 					Result:   rbacutils.Allow,
 				},
-				{
+				/*{
 					Service:  api.SERVICE_TYPE,
 					Resource: "images",
 					Action:   PolicyActionList,
@@ -68,6 +68,7 @@ var (
 					Action:   PolicyActionGet,
 					Result:   rbacutils.Allow,
 				},
+				*/
 			},
 		},
 		{


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：关闭network和image的默认项目权限

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area region image