### PR TITLE
fix: vmware esxi host detects vnic portgroup info

### DIFF
--- a/pkg/cloudprovider/resources.go
+++ b/pkg/cloudprovider/resources.go
@@ -487,6 +487,7 @@ type ICloudHostNetInterface interface {
 	GetIpAddr() string
 	GetMtu() int32
 	GetNicType() string
+	GetBridge() string
 }
 
 type ICloudLoadbalancer interface {

--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -4616,7 +4616,15 @@ func (host *SHost) SyncHostExternalNics(ctx context.Context, userCred mcclient.T
 						enables = append(enables, extNics[i])
 					}
 				} else {
-					// do nothing, in sync
+					// in sync, sync interface and bridge
+					hw := host.getHostwireOfIdAndMac(netIfs[i].WireId, netIfs[i].Mac)
+					if hw != nil && (hw.Bridge != extNics[i].GetBridge() || hw.Interface != extNics[i].GetDevice()) {
+						db.Update(hw, func() error {
+							hw.Interface = extNics[i].GetDevice()
+							hw.Bridge = extNics[i].GetBridge()
+							return nil
+						})
+					}
 				}
 			} else {
 				reserveIp := false
@@ -4667,7 +4675,7 @@ func (host *SHost) SyncHostExternalNics(ctx context.Context, userCred mcclient.T
 		// always try reserved pool
 		extNic := adds[i].netif
 		err = host.addNetif(ctx, userCred, extNic.GetMac(), "", extNic.GetIpAddr(), 0, extNic.GetNicType(), extNic.GetIndex(),
-			extNic.IsLinkUp(), int16(extNic.GetMtu()), false, "", "", true, true)
+			extNic.IsLinkUp(), int16(extNic.GetMtu()), false, extNic.GetDevice(), extNic.GetBridge(), true, true)
 		if err != nil {
 			result.AddError(err)
 		} else {

--- a/pkg/multicloud/esxi/hostnic.go
+++ b/pkg/multicloud/esxi/hostnic.go
@@ -25,8 +25,14 @@ type SHostNicInfo struct {
 	Index   int8
 	LinkUp  bool
 	IpAddr  string
+	IpAddr6 string
 	Mtu     int32
 	NicType string
+
+	DVPortGroup string
+
+	IpAddrPrefixLen  int8
+	IpAddr6PrefixLen int8
 }
 
 func (nic *SHostNicInfo) GetDevice() string {
@@ -56,10 +62,30 @@ func (nic *SHostNicInfo) GetIpAddr() string {
 	return nic.IpAddr
 }
 
+func (nic *SHostNicInfo) GetIpAddrPrefixLen() int8 {
+	return nic.IpAddrPrefixLen
+}
+
+func (nic *SHostNicInfo) GetIpAddr6() string {
+	return nic.IpAddr6
+}
+
+func (nic *SHostNicInfo) GetIpAddr6PrefixLen() int8 {
+	return nic.IpAddr6PrefixLen
+}
+
 func (nic *SHostNicInfo) GetMtu() int32 {
 	return nic.Mtu
 }
 
 func (nic *SHostNicInfo) GetNicType() string {
 	return nic.NicType
+}
+
+func (nic *SHostNicInfo) GetDVPortGroup() string {
+	return nic.DVPortGroup
+}
+
+func (nic *SHostNicInfo) GetBridge() string {
+	return nic.DVPortGroup
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：host探测vnic的porgrou信息
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/hold