### PR TITLE
eip & vpc manager match fix

### DIFF
--- a/pkg/compute/regiondrivers/huawei.go
+++ b/pkg/compute/regiondrivers/huawei.go
@@ -127,6 +127,10 @@ func (self *SHuaWeiRegionDriver) ValidateCreateLoadbalancerData(ctx context.Cont
 			return nil, fmt.Errorf("eip external id is empty")
 		}
 
+		if eip.ManagerId != vpc.ManagerId {
+			return nil, httperrors.NewInputParameterError("eip's manager (%s(%s)) does not match vpc's(%s(%s)) (%s)", eip.GetName(), eip.GetId(), vpc.GetName(), vpc.GetId(), vpc.ManagerId)
+		}
+
 		data.Set("eip_id", jsonutils.NewString(eip.ExternalId))
 	}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
* 检查华为云vpc 和 eip处于同一个订阅

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.3

/area region 
/cc @yousong @zexi 
