### PR TITLE
fix: cleanup logic for nics of pending_deleted guests

### DIFF
--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -636,6 +636,8 @@ func totalGuestNicCount(
 	q = q.Join(guests, sqlchemy.Equals(guests.Field("id"), guestnics.Field("guest_id")))
 	q = q.Join(hosts, sqlchemy.Equals(guests.Field("host_id"), hosts.Field("id")))
 
+	q = q.Filter(sqlchemy.IsFalse(guests.Field("pending_deleted")))
+
 	q = CloudProviderFilter(q, hosts.Field("manager_id"), providers, brands, cloudEnv)
 	q = RangeObjectsFilter(q, rangeObjs, nil, hosts.Field("zone_id"), hosts.Field("manager_id"), hosts.Field("id"), nil)
 

--- a/pkg/compute/models/loadbalancernetworks.go
+++ b/pkg/compute/models/loadbalancernetworks.go
@@ -275,6 +275,8 @@ func totalLBNicCount(
 	lbnics := LoadbalancernetworkManager.Query().SubQuery()
 	q := lbnics.Query()
 	q = q.Join(lbs, sqlchemy.Equals(lbs.Field("id"), lbnics.Field("loadbalancer_id")))
+	q = q.Filter(sqlchemy.IsFalse(lbs.Field("pending_deleted")))
+
 	switch scope {
 	case rbacutils.ScopeSystem:
 		// do nothing


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：1. 使用量包含回收站中主机的IP数量统计 2. 配额使用量中不计算回收站中主机占用的IP 3. 补充eip，db，netif等三种资源的IP占用统计

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @yousong 
/area region