### PR TITLE
vpcagent: respect guest src check settings

### DIFF
--- a/pkg/vpcagent/ovn/keeper.go
+++ b/pkg/vpcagent/ovn/keeper.go
@@ -439,9 +439,25 @@ func (keeper *OVNNorthboundKeeper) ClaimGuestnetwork(ctx context.Context, guestn
 	gnp := &ovn_nb.LogicalSwitchPort{
 		Name:          lportName,
 		Addresses:     []string{fmt.Sprintf("%s %s", guestnetwork.MacAddr, guestnetwork.IpAddr)},
-		PortSecurity:  []string{fmt.Sprintf("%s %s/%d", guestnetwork.MacAddr, guestnetwork.IpAddr, guestnetwork.Network.GuestIpMask)},
 		Dhcpv4Options: &dhcpOpt,
 		Options:       map[string]string{},
+	}
+	if guest.SrcMacCheck.IsFalse() {
+		gnp.Addresses = append(gnp.Addresses, "unknown")
+		// empty, not nil, as match condition
+		gnp.PortSecurity = []string{}
+	} else if guest.SrcIpCheck.IsFalse() {
+		gnp.PortSecurity = []string{
+			fmt.Sprintf("%s", guestnetwork.MacAddr),
+		}
+	} else {
+		gnp.PortSecurity = []string{
+			fmt.Sprintf("%s %s/%d",
+				guestnetwork.MacAddr,
+				guestnetwork.IpAddr,
+				guestnetwork.Network.GuestIpMask,
+			),
+		}
 	}
 
 	var qosVif []*ovn_nb.QoS


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:

```
  mac   ip    dhcp    ping    xipping    xmacping
  on    on    y       y       n          n
  on    off   y       y       y          n
  off   off   y       y       y          y

external access depends on source routing, changing ip address will
fail that

note dst mac address of reply packet when changing only mac address
with vpc ip remains the same
```

**是否需要 backport 到之前的 release 分支**:


- release/3.3

/area vpcagent
/cc @swordqiu @zexi @wanyaoqi 