### PR TITLE
fix(compute): return InputParameterError while ValidateCreateData

### DIFF
--- a/pkg/compute/models/scaling_trigger.go
+++ b/pkg/compute/models/scaling_trigger.go
@@ -171,10 +171,13 @@ func (st *SScalingTimer) ValidateCreateData(input api.ScalingPolicyCreateInput) 
 	var err error
 	if input.TriggerType == api.TRIGGER_TIMING {
 		input.Timer, err = checkTimerCreateInput(input.Timer)
-		return input, err
+	} else {
+		input.CycleTimer, err = checkCycleTimerCreateInput(input.CycleTimer)
 	}
-	input.CycleTimer, err = checkCycleTimerCreateInput(input.CycleTimer)
-	return input, err
+	if err != nil {
+		return input, httperrors.NewInputParameterError(err.Error())
+	}
+	return input, nil
 }
 
 func (st *SScalingTimer) Register(ctx context.Context, userCred mcclient.TokenCredential) error {

--- a/pkg/compute/models/scheduled_tasks.go
+++ b/pkg/compute/models/scheduled_tasks.go
@@ -178,7 +178,10 @@ func (stm *SScheduledTaskManager) ValidateCreateData(ctx context.Context, userCr
 	} else {
 		input.CycleTimer, err = checkCycleTimerCreateInput(input.CycleTimer)
 	}
-	return input, err
+	if err != nil {
+		return input, httperrors.NewInputParameterError(err.Error())
+	}
+	return input, nil
 }
 
 var wdsCN = []string{"", "一", "二", "三", "四", "五", "六", "日"}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

scheduler_task 和 scaling_timer 在 ValidateCreateData 的时候返回 httperrors.InputParameterError

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

- release/3.4
- release/3.3

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @zexi 