### PR TITLE
fix: find correct esxi host access ip

### DIFF
--- a/pkg/multicloud/esxi/manager.go
+++ b/pkg/multicloud/esxi/manager.go
@@ -466,6 +466,20 @@ func (cli *SESXiClient) checkHostManagedByVCenter() error {
 	return nil
 }
 
+func (cli *SESXiClient) IsHostIpExists(hostIp string) (bool, error) {
+	searchIndex := object.NewSearchIndex(cli.client.Client)
+
+	hostRef, err := searchIndex.FindByIp(cli.context, nil, cli.getPrivateId(hostIp), false)
+	if err != nil {
+		log.Errorf("searchIndex.FindByIp fail %s", err)
+		return false, err
+	}
+	if hostRef == nil {
+		return false, nil
+	}
+	return true, nil
+}
+
 func (cli *SESXiClient) FindHostByIp(hostIp string) (*SHost, error) {
 	searchIndex := object.NewSearchIndex(cli.client.Client)
 

--- a/pkg/multicloud/esxi/network.go
+++ b/pkg/multicloud/esxi/network.go
@@ -30,6 +30,7 @@ type IVMNetwork interface {
 	GetActivePorts() []string
 	GetType() string
 	ContainHost(host *SHost) bool
+	SetHostPortGroup(pg types.HostPortGroup)
 }
 
 const (
@@ -52,6 +53,7 @@ type SNetwork struct {
 
 type SDistributedVirtualPortgroup struct {
 	SManagedObject
+	HostPortGroup types.HostPortGroup
 }
 
 func NewNetwork(manager *SESXiClient, net *mo.Network, dc *SDatacenter) *SNetwork {
@@ -99,6 +101,10 @@ func (net *SNetwork) ContainHost(host *SHost) bool {
 		}
 	}
 	return false
+}
+
+func (net *SNetwork) SetHostPortGroup(pg types.HostPortGroup) {
+	net.HostPortGroup = pg
 }
 
 func (net *SDistributedVirtualPortgroup) getMODVPortgroup() *mo.DistributedVirtualPortgroup {
@@ -168,6 +174,10 @@ func (net *SDistributedVirtualPortgroup) ContainHost(host *SHost) bool {
 		}
 	}
 	return false
+}
+
+func (net *SDistributedVirtualPortgroup) SetHostPortGroup(pg types.HostPortGroup) {
+	net.HostPortGroup = pg
 }
 
 func (net *SDistributedVirtualPortgroup) Uplink() bool {

--- a/pkg/multicloud/esxi/shell/host.go
+++ b/pkg/multicloud/esxi/shell/host.go
@@ -82,7 +82,7 @@ func init() {
 		if err != nil {
 			return err
 		}
-		networks, err := host.GetNetwork()
+		networks, err := host.GetNetworks()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：判断esxi host management ip的过程不太准确，采用esxi findhostbyip来判断一个ip是否为manegement ip

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @rainzm @zexi 
/area esxi-agent

/hold