### PR TITLE
feat(esxi): correctly judge whether inet is nil

### DIFF
--- a/pkg/multicloud/esxi/devtools.go
+++ b/pkg/multicloud/esxi/devtools.go
@@ -156,7 +156,7 @@ func NewVNICDev(host *SHost, mac, driver string, bridge string, vlanId int32, ke
 			log.Errorf("fail to find dvportgroup by name %s: %s", bridge, err)
 		}
 	}
-	if inet == nil {
+	if inet == nil || reflect.ValueOf(inet).IsNil() {
 		inet, err = host.FindNetworkByVlanID(vlanId)
 		if err != nil {
 			log.Errorf("fail to find network by vlanid %d: %s", vlanId, err)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

由于返回inet的函数返回了 实现了IVMNetwork 接口的类型 *T。
所以对inet是否为nil的判断应该修改为现在的样子。

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.3
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area esxi
/cc @swordqiu @zexi 