### PR TITLE
fix: network address list respect privilige of user

### DIFF
--- a/cmd/climc/shell/compute/networks.go
+++ b/cmd/climc/shell/compute/networks.go
@@ -20,6 +20,7 @@ import (
 	"yunion.io/x/jsonutils"
 
 	"yunion.io/x/onecloud/cmd/climc/shell"
+	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
@@ -203,15 +204,18 @@ func init() {
 
 	type NetworkAddressOptions struct {
 		NETWORK string `help:"id or name of network to query"`
+
+		api.GetNetworkAddressesInput
 	}
 	R(&NetworkAddressOptions{}, "network-addresses", "Query used addresses of network", func(s *mcclient.ClientSession, args *NetworkAddressOptions) error {
-		result, err := modules.Networks.GetSpecific(s, args.NETWORK, "addresses", nil)
+		result, err := modules.Networks.GetSpecific(s, args.NETWORK, "addresses", jsonutils.Marshal(args.GetNetworkAddressesInput))
 		if err != nil {
 			return err
 		}
-		addrList, err := result.GetArray("addresses")
-		if err != nil {
-			return err
+		addrList, _ := result.GetArray("addresses")
+		if addrList == nil {
+			fmt.Println("no result")
+			return nil
 		}
 		listResult := modulebase.ListResult{Data: addrList}
 		printList(&listResult, nil)

--- a/pkg/apis/compute/network.go
+++ b/pkg/apis/compute/network.go
@@ -310,3 +310,13 @@ type NetworkUpdateInput struct {
 	// 是否加入自动分配地址池
 	IsAutoAlloc *bool `json:"is_auto_alloc"`
 }
+
+type GetNetworkAddressesInput struct {
+	// 获取资源的范围，例如 project|domain|system
+	Scope string `json:"scope"`
+}
+
+type GetNetworkAddressesOutput struct {
+	// IP子网地址记录
+	Addresses []SNetworkAddress `json:"addresses"`
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：network的地址占用列表需要按照用户的权限来返回关联资源的名称和ID

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @ioito 
/area region