### PR TITLE
fix: skup syncing lb, rds, redis instances in tasks

### DIFF
--- a/pkg/compute/models/dbinstances.go
+++ b/pkg/compute/models/dbinstances.go
@@ -1299,6 +1299,13 @@ func (manager *SDBInstanceManager) SyncDBInstances(ctx context.Context, userCred
 		return nil, nil, syncResult
 	}
 
+	for i := range dbInstances {
+		if taskman.TaskManager.IsInTask(&dbInstances[i]) {
+			syncResult.Error(fmt.Errorf("dbInstance %s(%s)in task", dbInstances[i].Name, dbInstances[i].Id))
+			return nil, nil, syncResult
+		}
+	}
+
 	removed := make([]SDBInstance, 0)
 	commondb := make([]SDBInstance, 0)
 	commonext := make([]cloudprovider.ICloudDBInstance, 0)

--- a/pkg/compute/models/elasticcache_instances.go
+++ b/pkg/compute/models/elasticcache_instances.go
@@ -452,6 +452,13 @@ func (manager *SElasticcacheManager) SyncElasticcaches(ctx context.Context, user
 		return nil, nil, syncResult
 	}
 
+	for i := range dbInstances {
+		if taskman.TaskManager.IsInTask(&dbInstances[i]) {
+			syncResult.Error(fmt.Errorf("ElasticCacheInstance %s(%s)in task", dbInstances[i].Name, dbInstances[i].Id))
+			return nil, nil, syncResult
+		}
+	}
+
 	removed := make([]SElasticcache, 0)
 	commondb := make([]SElasticcache, 0)
 	commonext := make([]cloudprovider.ICloudElasticcache, 0)

--- a/pkg/compute/models/loadbalancers.go
+++ b/pkg/compute/models/loadbalancers.go
@@ -732,6 +732,13 @@ func (man *SLoadbalancerManager) SyncLoadbalancers(ctx context.Context, userCred
 		return nil, nil, syncResult
 	}
 
+	for i := range dbLbs {
+		if taskman.TaskManager.IsInTask(&dbLbs[i]) {
+			syncResult.Error(fmt.Errorf("loadbalancer %s(%s)in task", dbLbs[i].Name, dbLbs[i].Id))
+			return nil, nil, syncResult
+		}
+	}
+
 	removed := []SLoadbalancer{}
 	commondb := []SLoadbalancer{}
 	commonext := []cloudprovider.ICloudLoadbalancer{}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：不对在task中的lb, rds, redis实例进行同步

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.3
- release/3.2

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area region
/cc @zexi  @ioito 