### PR TITLE
fix: user idps attributes includes template name

### DIFF
--- a/pkg/apis/identity/identityprovider.go
+++ b/pkg/apis/identity/identityprovider.go
@@ -59,6 +59,9 @@ type IdpResourceInfo struct {
 
 	// 认证源类型, 例如sql, cas, ldap等
 	IdpDriver string `json:"idp_driver"`
+
+	// 认证源模板
+	Template string `json:"template"`
 }
 
 type IdentityProviderCreateInput struct {

--- a/pkg/keystone/models/expandidps.go
+++ b/pkg/keystone/models/expandidps.go
@@ -44,6 +44,9 @@ func expandIdpAttributes(entType string, idList []string, fields stringutils2.SS
 					if len(fields) == 0 || fields.Contains("idp_driver") {
 						rows[i].IdpDriver = idp[0].IdpDriver
 					}
+					if len(fields) == 0 || fields.Contains("template") {
+						rows[i].Template = idp[0].Template
+					}
 				}
 			}
 		} else if err != nil {
@@ -66,6 +69,7 @@ func fetchIdmappings(idList []string, resType string) (map[string][]sIdpInfo, er
 		idmappings.Field("local_id", "idp_entity_id"),
 		idps.Field("name", "idp"),
 		idps.Field("driver", "idp_driver"),
+		idps.Field("template", "template"),
 		idmappings.Field("public_id"),
 	)
 	q = q.Join(idps, sqlchemy.Equals(idps.Field("id"), idmappings.Field("domain_id")))


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：在user的idps列表中包含idp template信息

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area keystone
