### PR TITLE
fix(notify): break down permissions of notifyconfigs

### DIFF
--- a/pkg/notify/models/config.go
+++ b/pkg/notify/models/config.go
@@ -33,6 +33,7 @@ import (
 	notifyv2 "yunion.io/x/onecloud/pkg/notify"
 	"yunion.io/x/onecloud/pkg/notify/oldmodels"
 	"yunion.io/x/onecloud/pkg/notify/options"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
 	"yunion.io/x/onecloud/pkg/util/stringutils2"
 )
 
@@ -356,6 +357,26 @@ func (self *SConfigManager) InitializeData() error {
 	})
 	err = self.TableSpec().InsertOrUpdate(context.TODO(), config)
 	return nil
+}
+
+func (cm *SConfigManager) ResourceScope() rbacutils.TRbacScope {
+	return rbacutils.ScopeUser
+}
+
+func (cm *SConfigManager) AllowCreateItem(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) bool {
+	return db.IsAdminAllowCreate(userCred, cm)
+}
+
+func (c *SConfig) AllowUpdateItem(ctx context.Context, userCred mcclient.TokenCredential) bool {
+	return db.IsAdminAllowUpdate(userCred, c)
+}
+
+func (cm *SConfigManager) AllowListItems(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject) bool {
+	return db.IsAdminAllowList(userCred, cm)
+}
+
+func (c *SConfig) AllowDeleteItem(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) bool {
+	return db.IsAdminAllowDelete(userCred, c)
 }
 
 // Fetch all SConfig struct which type is contactType.


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. Only allow admin to create, list, update or delete.
2. Allow user to get types.

- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area notify
/cc @zexi 