### PR TITLE
treewide: DeleteFailReason as an object with translated details

### DIFF
--- a/pkg/apis/output.go
+++ b/pkg/apis/output.go
@@ -16,6 +16,8 @@ package apis
 
 import (
 	"time"
+
+	"yunion.io/x/onecloud/pkg/httperrors"
 )
 
 type ModelBaseDetails struct {
@@ -26,7 +28,7 @@ type ModelBaseDetails struct {
 	CanDelete bool `json:"can_delete"`
 
 	// 资源不能删除的原因
-	DeleteFailReason string `json:"delete_fail_reason"`
+	DeleteFailReason httperrors.Error `json:"delete_fail_reason"`
 
 	// 资源是否可以更新, 若为false,update_fail_reason会返回资源不能删除的原因
 	// example: true

--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -778,7 +778,7 @@ func getModelExtraDetails(item IModel, ctx context.Context, showReason bool) api
 	if err != nil {
 		out.CanDelete = false
 		if showReason {
-			out.DeleteFailReason = err.Error()
+			out.DeleteFailReason = httperrors.NewErrorFromGeneralError(ctx, err)
 		}
 	}
 	err = item.ValidateUpdateCondition(ctx)

--- a/pkg/httperrors/httperrors.go
+++ b/pkg/httperrors/httperrors.go
@@ -118,37 +118,21 @@ func formatDetails(ctx context.Context, errData httputils.Error, msg string) str
 	return details
 }
 
-func HTTPError(ctx context.Context, w http.ResponseWriter, msg string, statusCode int, class string, err httputils.Error) {
+func HTTPError(ctx context.Context, w http.ResponseWriter, msg string, statusCode int, class string, errData httputils.Error) {
+	details := formatDetails(ctx, errData, msg)
 	if statusCode >= 300 && statusCode <= 400 {
-		SetHTTPRedirectLocationHeader(w, msg)
+		SetHTTPRedirectLocationHeader(w, details)
 	}
 
 	// 需要在调用w.WriteHeader方法之前，设置header才能生效
 	SendHTTPErrorHeader(w, statusCode)
 
-	var details string
-	if err.Id == "" {
-		details = msg
-	} else {
-		var (
-			langv = ctx.Value(ctxLangKey)
-			lang  language.Tag
-		)
-		if langv != nil {
-			lang = langv.(language.Tag)
-		} else {
-			lang = language.English
-		}
-		a := make([]interface{}, len(err.Fields))
-		for i := range err.Fields {
-			a[i] = err.Fields[i]
-		}
-		details = P(lang, err.Id, a...)
+	err := Error{
+		Code:    statusCode,
+		Class:   class,
+		Details: details,
 	}
-	body := jsonutils.NewDict()
-	body.Add(jsonutils.NewInt(int64(statusCode)), "code")
-	body.Add(jsonutils.NewString(class), "class")
-	body.Add(jsonutils.NewString(details), "details")
+	body := jsonutils.Marshal(err)
 	w.Write([]byte(body.String()))
 	log.Errorf("Send error %s", details)
 	if statusCode >= 500 {

--- a/pkg/httperrors/httperrors.go
+++ b/pkg/httperrors/httperrors.go
@@ -75,6 +75,49 @@ func SetHTTPRedirectLocationHeader(w http.ResponseWriter, location string) {
 	w.Header().Set("Location", location)
 }
 
+type Error struct {
+	Code    int    `json:"code"`
+	Class   string `json:"class"`
+	Details string `json:"details"`
+}
+
+func NewErrorFromJCError(ctx context.Context, je *httputils.JSONClientError) Error {
+	err := Error{
+		Code:    je.Code,
+		Class:   je.Class,
+		Details: formatDetails(ctx, je.Data, je.Details),
+	}
+	return err
+}
+
+func NewErrorFromGeneralError(ctx context.Context, e error) Error {
+	je := NewGeneralError(e)
+	return NewErrorFromJCError(ctx, je)
+}
+
+func formatDetails(ctx context.Context, errData httputils.Error, msg string) string {
+	var details string
+	if errData.Id == "" {
+		details = msg
+	} else {
+		var (
+			langv = ctx.Value(ctxLangKey)
+			lang  language.Tag
+		)
+		if langv != nil {
+			lang = langv.(language.Tag)
+		} else {
+			lang = language.English
+		}
+		a := make([]interface{}, len(errData.Fields))
+		for i := range errData.Fields {
+			a[i] = errData.Fields[i]
+		}
+		details = P(lang, errData.Id, a...)
+	}
+	return details
+}
+
 func HTTPError(ctx context.Context, w http.ResponseWriter, msg string, statusCode int, class string, err httputils.Error) {
 	if statusCode >= 300 && statusCode <= 400 {
 		SetHTTPRedirectLocationHeader(w, msg)

--- a/pkg/monitor/subscriptionmodel/subcription.go
+++ b/pkg/monitor/subscriptionmodel/subcription.go
@@ -117,7 +117,7 @@ func (self *SSubscriptionManager) PerformWrite(ctx context.Context, userCred mcc
 	sysAlerts := self.GetSystemAlerts()
 	for _, sysalert := range sysAlerts {
 		details := monitor.CommonAlertDetails{}
-		details, err := sysalert.GetMoreDetails(details)
+		details, err := sysalert.GetMoreDetails(ctx, details)
 		if err != nil {
 			log.Errorln("sysalert getMoreDetails err", err)
 			continue


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

```
httperrors: add Error type
httperrors: HTTPError: use Error type
treewide: DeleteFailReason as an object with translated details
```

API变更，delete_fail_reason的值从之前的字符串，变为现在的json object.

**是否需要 backport 到之前的 release 分支**:

- release/3.4