### PR TITLE
fix: ignore 409 error when doing redfish power on

### DIFF
--- a/pkg/baremetal/manager.go
+++ b/pkg/baremetal/manager.go
@@ -61,6 +61,7 @@ import (
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/util/dhcp"
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
+	"yunion.io/x/onecloud/pkg/util/httputils"
 	"yunion.io/x/onecloud/pkg/util/influxdb"
 	"yunion.io/x/onecloud/pkg/util/procutils"
 	"yunion.io/x/onecloud/pkg/util/redfish"
@@ -1402,7 +1403,15 @@ func (b *SBaremetalInstance) DoRedfishPowerOn() error {
 	b.ClearSSHConfig()
 	redfishApi := b.GetRedfishCli(ctx)
 	if redfishApi != nil {
-		return redfishApi.Reset(ctx, "On")
+		err := redfishApi.Reset(ctx, "On")
+		if err != nil {
+			if httputils.ErrorCode(err) == 409 {
+				log.Warningf("redfishApi.Reset On fail %s", err)
+			} else {
+				return errors.Wrap(err, "redfishApi.Reset On")
+			}
+		}
+		return nil
 	}
 	return fmt.Errorf("Baremetal %s redfishApi is nil", b.GetId())
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：当通过redfish API启动主机时，忽略409错误

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3
- release/3.4


<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/arear baremetal-agent
/cc @zexi 