### PR TITLE
fix(esxiagent): return image extid not id

### DIFF
--- a/pkg/hostman/storageman/imagecachemanager_agent.go
+++ b/pkg/hostman/storageman/imagecachemanager_agent.go
@@ -230,7 +230,7 @@ func (c *SAgentImageCacheManager) perfetchTemplateVMImageCache(ctx context.Conte
 		return nil, err
 	}
 	res := jsonutils.NewDict()
-	res.Add(jsonutils.NewString(data.ImageId), "image_id")
+	res.Add(jsonutils.NewString(data.ImageExternalId), "image_id")
 	return res, nil
 }
 


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:

修复的问题：
使用vmware template创建机器之后，对应的 storagecachedimage externalid 会变。

原因：
调用 disk/image_cache 接口的Task StorageCacheImageTask 会根据回调
回来数据中的 image_id，来设置 storagecachedimage 中的 externalid，
所以这里的 image_id 应该是 externalid。

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

- release/3.4
- release/3.3
- release/3.2
- release/3.1
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area esxiagent
/cc @swordqiu @zexi 