### PR TITLE
Automated cherry pick of #7821: fix(esxiagent): return image extid not id

### DIFF
--- a/pkg/hostman/storageman/imagecachemanager_agent.go
+++ b/pkg/hostman/storageman/imagecachemanager_agent.go
@@ -230,7 +230,7 @@ func (c *SAgentImageCacheManager) perfetchTemplateVMImageCache(ctx context.Conte
 		return nil, err
 	}
 	res := jsonutils.NewDict()
-	res.Add(jsonutils.NewString(data.ImageId), "image_id")
+	res.Add(jsonutils.NewString(data.ImageExternalId), "image_id")
 	return res, nil
 }
 


### PR DESCRIPTION
Cherry pick of #7821 on release/3.3.

#7821: fix(esxiagent): return image extid not id