### PR TITLE
fix: recode project-role rpc handle to support group role assignment

### DIFF
--- a/cmd/climc/shell/identity/role_assignments.go
+++ b/cmd/climc/shell/identity/role_assignments.go
@@ -23,20 +23,25 @@ import (
 
 func init() {
 	type RoleAssignmentsOptions struct {
-		Effective     bool   `help:"Include role assignment of group members"`
-		System        bool   `help:"Include system user account"`
-		Policy        bool   `help:"Show matched policies"`
-		Domain        string `help:"Role assignments for domain"`
-		User          string `help:"For user"`
-		UserDomain    string `help:"Domain for user"`
-		Group         string `help:"For group"`
-		GroupDomain   string `help:"Domain for group"`
-		Project       string `help:"Role assignments for project"`
-		ProjectDomain string `help:"Domain for project"`
-		Role          string `help:"Role assignments for role"`
-		RoleDomain    string `help:"Domain for role"`
-		Limit         int64  `help:"maximal returned number of rows"`
-		Offset        int64  `help:"offset index of returned results"`
+		Effective     bool     `help:"Include role assignment of group members"`
+		System        bool     `help:"Include system user account"`
+		Policy        bool     `help:"Show matched policies"`
+		Domain        string   `help:"Role assignments for domain"`
+		User          string   `help:"For user"`
+		UserDomain    string   `help:"Domain for user"`
+		Group         string   `help:"For group"`
+		GroupDomain   string   `help:"Domain for group"`
+		Project       string   `help:"Role assignments for project"`
+		ProjectDomain string   `help:"Domain for project"`
+		Role          string   `help:"Role assignments for role"`
+		RoleDomain    string   `help:"Domain for role"`
+		Limit         int64    `help:"maximal returned number of rows"`
+		Offset        int64    `help:"offset index of returned results"`
+		Users         []string `help:"fitler by users id or name"`
+		Groups        []string `help:"fitler by users id or name"`
+		Roles         []string `help:"fitler by users id or name"`
+		Projects      []string `help:"fitler by users id or name"`
+		Domains       []string `help:"fitler by users id or name"`
 	}
 	R(&RoleAssignmentsOptions{}, "role-assignments", "List all role assignments", func(s *mcclient.ClientSession, args *RoleAssignmentsOptions) error {
 		query := jsonutils.NewDict()
@@ -84,6 +89,21 @@ func init() {
 				return err
 			}
 			query.Add(jsonutils.NewString(rid), "role", "id")
+		}
+		if len(args.Users) > 0 {
+			query.Add(jsonutils.NewStringArray(args.Users), "users")
+		}
+		if len(args.Groups) > 0 {
+			query.Add(jsonutils.NewStringArray(args.Groups), "groups")
+		}
+		if len(args.Roles) > 0 {
+			query.Add(jsonutils.NewStringArray(args.Roles), "roles")
+		}
+		if len(args.Projects) > 0 {
+			query.Add(jsonutils.NewStringArray(args.Projects), "projects")
+		}
+		if len(args.Domains) > 0 {
+			query.Add(jsonutils.NewStringArray(args.Domains), "domains")
 		}
 		if args.Limit > 0 {
 			query.Add(jsonutils.NewInt(args.Limit), "limit")

--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ require (
 	yunion.io/x/ovsdb v0.0.0-20200526071744-27bf0940cbc7
 	yunion.io/x/pkg v0.0.0-20200814072949-4f1b541857d6
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
-	yunion.io/x/sqlchemy v0.0.0-20200820050957-1542f05b9fcd
+	yunion.io/x/sqlchemy v0.0.0-20200909073353-606d1fe76db5
 	yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1139,7 +1139,7 @@ yunion.io/x/pkg v0.0.0-20200814072949-4f1b541857d6 h1:UarEDTBGkgcgc+nc+PZ75uo9M9
 yunion.io/x/pkg v0.0.0-20200814072949-4f1b541857d6/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8J50Cise/HCylsOJngmo=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e/go.mod h1:0iFKpOs1y4lbCxeOmq3Xx/0AcQoewVPwj62eRluioEo=
-yunion.io/x/sqlchemy v0.0.0-20200820050957-1542f05b9fcd h1:G5yfI0i4Du8olStezNPWRWdmSS4cbj1wZfB11HhulQc=
-yunion.io/x/sqlchemy v0.0.0-20200820050957-1542f05b9fcd/go.mod h1:FTdwPdGhMgh4E+UFXc9klI1Ok34fMuybTT+jLhOaIjI=
+yunion.io/x/sqlchemy v0.0.0-20200909073353-606d1fe76db5 h1:Z1BoBr1LUEqQKJ5k+xTczj22OSiOvMxEN5BJrOQq7+g=
+yunion.io/x/sqlchemy v0.0.0-20200909073353-606d1fe76db5/go.mod h1:FTdwPdGhMgh4E+UFXc9klI1Ok34fMuybTT+jLhOaIjI=
 yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce h1:kU8xE7O5uZ1GSJVMZHoJ+jrNL7csUQHYGyAPW9QfNpE=
 yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce/go.mod h1:EP6NSv2C0zzqBDTKumv8hPWLb3XvgMZDHQRfyuOrQng=

--- a/pkg/apis/identity/assignments.go
+++ b/pkg/apis/identity/assignments.go
@@ -66,3 +66,41 @@ func (ra *SRoleAssignment) GetLoginIp() string {
 func (ra *SRoleAssignment) GetTokenString() string {
 	return "faketoken"
 }
+
+type RAInputObject struct {
+	Id string `json:"id"`
+}
+
+type RoleAssignmentsInput struct {
+	User  RAInputObject `json:"user"`
+	Group RAInputObject `json:"group"`
+	Role  RAInputObject `json:"role"`
+
+	Scope struct {
+		Project RAInputObject `json:"project"`
+		Domain  RAInputObject `json:"domain"`
+	} `json:"scope"`
+
+	Users    []string `json:"users"`
+	Groups   []string `json:"groups"`
+	Roles    []string `json:"roles"`
+	Projects []string `json:"projects"`
+	Domains  []string `json:"domains"`
+
+	IncludeNames    *bool `json:"include_names"`
+	Effective       *bool `json:"effective"`
+	IncludeSubtree  *bool `json:"include_subtree"`
+	IncludeSystem   *bool `json:"include_system"`
+	IncludePolicies *bool `json:"include_policies"`
+
+	Limit  *int `json:"limit"`
+	Offset *int `json:"offset"`
+}
+
+type RoleAssignmentsOutput struct {
+	RoleAssignments []SRoleAssignment `json:"role_assignments,allowempty"`
+
+	Total  int64 `json:"total"`
+	Limit  int   `json:"limit"`
+	Offset int   `json:"offset"`
+}

--- a/pkg/keystone/tokens/token.go
+++ b/pkg/keystone/tokens/token.go
@@ -291,7 +291,9 @@ func (t *SAuthToken) getTokenV3(
 			token.Token.Projects[i].Domain.Id = extProjs[i].DomainId
 			token.Token.Projects[i].Domain.Name = extProjs[i].DomainName
 		}*/
-		assigns, _, err := models.AssignmentManager.FetchAll(user.Id, "", "", "", "", true, true, true, true, true, 0, 0)
+		assigns, _, err := models.AssignmentManager.FetchAll(user.Id, "", "", "", "",
+			nil, nil, nil, nil, nil,
+			true, true, true, true, true, 0, 0)
 		if err != nil {
 			return nil, errors.Wrap(err, "models.AssignmentManager.FetchAll")
 		}

--- a/pkg/mcclient/modules/mod_credentials.go
+++ b/pkg/mcclient/modules/mod_credentials.go
@@ -275,7 +275,7 @@ func (manager *SCredentialManager) CreateAccessKeySecret(s *mcclient.ClientSessi
 	return aksk, nil
 }
 
-func (manager *SCredentialManager) DoCreateOIDCSecret(s *mcclient.ClientSession, params jsonutils.JSONObject) (jsonutils.JSONObject, error) {
+func (manager *SCredentialManager) DoCreateOidcSecret(s *mcclient.ClientSession, params jsonutils.JSONObject) (jsonutils.JSONObject, error) {
 	redirectUri, _ := params.GetString("redirect_uri")
 
 	key, err := manager.CreateOIDCSecret(s, "", "", redirectUri)

--- a/vendor/github.com/aws/aws-sdk-go/service/route53/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/route53/api.go
@@ -60,13 +60,22 @@ func (c *Route53) AssociateVPCWithHostedZoneRequest(input *AssociateVPCWithHoste
 // Associates an Amazon VPC with a private hosted zone.
 //
 // To perform the association, the VPC and the private hosted zone must already
-// exist. You can't convert a public hosted zone into a private hosted zone.
+// exist. Also, you can't convert a public hosted zone into a private hosted
+// zone.
 //
-// If you want to associate a VPC that was created by using one AWS account
-// with a private hosted zone that was created by using a different account,
-// the AWS account that created the private hosted zone must first submit a
-// CreateVPCAssociationAuthorization request. Then the account that created
-// the VPC must submit an AssociateVPCWithHostedZone request.
+// If you want to associate a VPC that was created by one AWS account with a
+// private hosted zone that was created by a different account, do one of the
+// following:
+//
+//    * Use the AWS account that created the private hosted zone to submit a
+//    CreateVPCAssociationAuthorization (https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateVPCAssociationAuthorization.html)
+//    request. Then use the account that created the VPC to submit an AssociateVPCWithHostedZone
+//    request.
+//
+//    * If a subnet in the VPC was shared with another account, you can use
+//    the account that the subnet was shared with to submit an AssociateVPCWithHostedZone
+//    request. For more information about sharing subnets, see Working with
+//    Shared VPCs (https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -95,22 +104,22 @@ func (c *Route53) AssociateVPCWithHostedZoneRequest(input *AssociateVPCWithHoste
 //   53 doesn't support associating a VPC with a public hosted zone.
 //
 //   * ErrCodeConflictingDomainExists "ConflictingDomainExists"
-//   The cause of this error depends on whether you're trying to create a public
-//   or a private hosted zone:
+//   The cause of this error depends on the operation that you're performing:
 //
-//      * Public hosted zone: Two hosted zones that have the same name or that
-//      have a parent/child relationship (example.com and test.example.com) can't
-//      have any common name servers. You tried to create a hosted zone that has
-//      the same name as an existing hosted zone or that's the parent or child
-//      of an existing hosted zone, and you specified a delegation set that shares
-//      one or more name servers with the existing hosted zone. For more information,
-//      see CreateReusableDelegationSet (https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateReusableDelegationSet.html).
+//      * Create a public hosted zone: Two hosted zones that have the same name
+//      or that have a parent/child relationship (example.com and test.example.com)
+//      can't have any common name servers. You tried to create a hosted zone
+//      that has the same name as an existing hosted zone or that's the parent
+//      or child of an existing hosted zone, and you specified a delegation set
+//      that shares one or more name servers with the existing hosted zone. For
+//      more information, see CreateReusableDelegationSet (https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateReusableDelegationSet.html).
 //
-//      * Private hosted zone: You specified an Amazon VPC that you're already
-//      using for another hosted zone, and the domain that you specified for one
-//      of the hosted zones is a subdomain of the domain that you specified for
-//      the other hosted zone. For example, you can't use the same Amazon VPC
-//      for the hosted zones for example.com and test.example.com.
+//      * Create a private hosted zone: A hosted zone with the specified name
+//      already exists and is already associated with the Amazon VPC that you
+//      specified.
+//
+//      * Associate VPCs with a private hosted zone: The VPC that you specified
+//      is already associated with another hosted zone that has the same name.
 //
 //   * ErrCodeLimitsExceeded "LimitsExceeded"
 //   This operation can't be completed either because the current account has
@@ -195,27 +204,30 @@ func (c *Route53) ChangeResourceRecordSetsRequest(input *ChangeResourceRecordSet
 // routes traffic for test.example.com to a web server that has an IP address
 // of 192.0.2.44.
 //
+// Deleting Resource Record Sets
+//
+// To delete a resource record set, you must specify all the same values that
+// you specified when you created it.
+//
 // Change Batches and Transactional Changes
 //
 // The request body must include a document with a ChangeResourceRecordSetsRequest
 // element. The request body contains a list of change items, known as a change
-// batch. Change batches are considered transactional changes. When using the
-// Amazon Route 53 API to change resource record sets, Route 53 either makes
-// all or none of the changes in a change batch request. This ensures that Route
-// 53 never partially implements the intended changes to the resource record
-// sets in a hosted zone.
+// batch. Change batches are considered transactional changes. Route 53 validates
+// the changes in the request and then either makes all or none of the changes
+// in the change batch request. This ensures that DNS routing isn't adversely
+// affected by partial changes to the resource record sets in a hosted zone.
 //
-// For example, a change batch request that deletes the CNAME record for www.example.com
-// and creates an alias resource record set for www.example.com. Route 53 deletes
-// the first resource record set and creates the second resource record set
-// in a single operation. If either the DELETE or the CREATE action fails, then
-// both changes (plus any other changes in the batch) fail, and the original
-// CNAME record continues to exist.
+// For example, suppose a change batch request contains two changes: it deletes
+// the CNAME resource record set for www.example.com and creates an alias resource
+// record set for www.example.com. If validation for both records succeeds,
+// Route 53 deletes the first resource record set and creates the second resource
+// record set in a single operation. If validation for either the DELETE or
+// the CREATE action fails, then the request is canceled, and the original CNAME
+// record continues to exist.
 //
-// Due to the nature of transactional changes, you can't delete the same resource
-// record set more than once in a single change batch. If you attempt to delete
-// the same change batch more than once, Route 53 returns an InvalidChangeBatch
-// error.
+// If you try to delete the same resource record set more than once in a single
+// change batch, Route 53 returns an InvalidChangeBatch error.
 //
 // Traffic Flow
 //
@@ -226,7 +238,7 @@ func (c *Route53) ChangeResourceRecordSetsRequest(input *ChangeResourceRecordSet
 // names (such as example.com) or subdomain names (such as www.example.com),
 // in the same hosted zone or in multiple hosted zones. You can roll back the
 // updates if the new configuration isn't performing as expected. For more information,
-// see Using Traffic Flow to Route DNS Traffic (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/traffic-flow.html)
+// see Using Traffic Flow to Route DNS Traffic (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/traffic-flow.html)
 // in the Amazon Route 53 Developer Guide.
 //
 // Create, Delete, and Upsert
@@ -495,7 +507,7 @@ func (c *Route53) CreateHealthCheckRequest(input *CreateHealthCheckInput) (req *
 //    of the Amazon EC2 StatusCheckFailed metric, add an alarm to the metric,
 //    and then create a health check that is based on the state of the alarm.
 //    For information about creating CloudWatch metrics and alarms by using
-//    the CloudWatch console, see the Amazon CloudWatch User Guide (http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/WhatIsCloudWatch.html).
+//    the CloudWatch console, see the Amazon CloudWatch User Guide (https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/WhatIsCloudWatch.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -620,10 +632,10 @@ func (c *Route53) CreateHostedZoneRequest(input *CreateHostedZoneInput) (req *re
 //    * You can't create a hosted zone for a top-level domain (TLD) such as
 //    .com.
 //
-//    * For public hosted zones, Amazon Route 53 automatically creates a default
-//    SOA record and four NS records for the zone. For more information about
-//    SOA and NS records, see NS and SOA Records that Route 53 Creates for a
-//    Hosted Zone (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html)
+//    * For public hosted zones, Route 53 automatically creates a default SOA
+//    record and four NS records for the zone. For more information about SOA
+//    and NS records, see NS and SOA Records that Route 53 Creates for a Hosted
+//    Zone (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html)
 //    in the Amazon Route 53 Developer Guide. If you want to use the same name
 //    servers for multiple public hosted zones, you can optionally associate
 //    a reusable delegation set with the hosted zone. See the DelegationSetId
@@ -632,7 +644,7 @@ func (c *Route53) CreateHostedZoneRequest(input *CreateHostedZoneInput) (req *re
 //    * If your domain is registered with a registrar other than Route 53, you
 //    must update the name servers with your registrar to make Route 53 the
 //    DNS service for the domain. For more information, see Migrating DNS Service
-//    for an Existing Domain to Amazon Route 53 (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html)
+//    for an Existing Domain to Amazon Route 53 (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html)
 //    in the Amazon Route 53 Developer Guide.
 //
 // When you submit a CreateHostedZone request, the initial status of the hosted
@@ -689,22 +701,22 @@ func (c *Route53) CreateHostedZoneRequest(input *CreateHostedZoneInput) (req *re
 //   error, contact Customer Support.
 //
 //   * ErrCodeConflictingDomainExists "ConflictingDomainExists"
-//   The cause of this error depends on whether you're trying to create a public
-//   or a private hosted zone:
+//   The cause of this error depends on the operation that you're performing:
 //
-//      * Public hosted zone: Two hosted zones that have the same name or that
-//      have a parent/child relationship (example.com and test.example.com) can't
-//      have any common name servers. You tried to create a hosted zone that has
-//      the same name as an existing hosted zone or that's the parent or child
-//      of an existing hosted zone, and you specified a delegation set that shares
-//      one or more name servers with the existing hosted zone. For more information,
-//      see CreateReusableDelegationSet (https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateReusableDelegationSet.html).
+//      * Create a public hosted zone: Two hosted zones that have the same name
+//      or that have a parent/child relationship (example.com and test.example.com)
+//      can't have any common name servers. You tried to create a hosted zone
+//      that has the same name as an existing hosted zone or that's the parent
+//      or child of an existing hosted zone, and you specified a delegation set
+//      that shares one or more name servers with the existing hosted zone. For
+//      more information, see CreateReusableDelegationSet (https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateReusableDelegationSet.html).
 //
-//      * Private hosted zone: You specified an Amazon VPC that you're already
-//      using for another hosted zone, and the domain that you specified for one
-//      of the hosted zones is a subdomain of the domain that you specified for
-//      the other hosted zone. For example, you can't use the same Amazon VPC
-//      for the hosted zones for example.com and test.example.com.
+//      * Create a private hosted zone: A hosted zone with the specified name
+//      already exists and is already associated with the Amazon VPC that you
+//      specified.
+//
+//      * Associate VPCs with a private hosted zone: The VPC that you specified
+//      is already associated with another hosted zone that has the same name.
 //
 //   * ErrCodeNoSuchDelegationSet "NoSuchDelegationSet"
 //   A reusable delegation set with the specified ID does not exist.
@@ -987,13 +999,16 @@ func (c *Route53) CreateReusableDelegationSetRequest(input *CreateReusableDelega
 // CreateReusableDelegationSet API operation for Amazon Route 53.
 //
 // Creates a delegation set (a group of four name servers) that can be reused
-// by multiple hosted zones. If a hosted zoned ID is specified, CreateReusableDelegationSet
-// marks the delegation set associated with that zone as reusable.
+// by multiple hosted zones that were created by the same AWS account.
+//
+// You can also create a reusable delegation set that uses the four name servers
+// that are associated with an existing hosted zone. Specify the hosted zone
+// ID in the CreateReusableDelegationSet request.
 //
 // You can't associate a reusable delegation set with a private hosted zone.
 //
 // For information about using a reusable delegation set to configure white
-// label name servers, see Configuring White Label Name Servers (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/white-label-name-servers.html).
+// label name servers, see Configuring White Label Name Servers (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/white-label-name-servers.html).
 //
 // The process for migrating existing hosted zones to use a reusable delegation
 // set is comparable to the process for configuring white label name servers.
@@ -1566,8 +1581,14 @@ func (c *Route53) DeleteHealthCheckRequest(input *DeleteHealthCheckInput) (req *
 // you delete a health check and you don't update the associated resource record
 // sets, the future status of the health check can't be predicted and may change.
 // This will affect the routing of DNS queries for your DNS failover configuration.
-// For more information, see Replacing and Deleting Health Checks (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/health-checks-creating-deleting.html#health-checks-deleting.html)
+// For more information, see Replacing and Deleting Health Checks (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/health-checks-creating-deleting.html#health-checks-deleting.html)
 // in the Amazon Route 53 Developer Guide.
+//
+// If you're using AWS Cloud Map and you configured Cloud Map to create a Route
+// 53 health check when you register an instance, you can't use the Route 53
+// DeleteHealthCheck command to delete the health check. The health check is
+// deleted automatically when you deregister the instance; there can be a delay
+// of several hours before the health check is deleted from Route 53.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2554,7 +2575,7 @@ func (c *Route53) GetCheckerIpRangesRequest(input *GetCheckerIpRangesInput) (req
 //
 // GetCheckerIpRanges still works, but we recommend that you download ip-ranges.json,
 // which includes IP address ranges for all AWS services. For more information,
-// see IP Address Ranges of Amazon Route 53 Servers (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/route-53-ip-addresses.html)
+// see IP Address Ranges of Amazon Route 53 Servers (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/route-53-ip-addresses.html)
 // in the Amazon Route 53 Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -2657,7 +2678,9 @@ func (c *Route53) GetGeoLocationRequest(input *GetGeoLocationInput) (req *reques
 //
 // Returned Error Codes:
 //   * ErrCodeNoSuchGeoLocation "NoSuchGeoLocation"
-//   Amazon Route 53 doesn't support the specified geographic location.
+//   Amazon Route 53 doesn't support the specified geographic location. For a
+//   list of supported geolocation codes, see the GeoLocation (https://docs.aws.amazon.com/Route53/latest/APIReference/API_GeoLocation.html)
+//   data type.
 //
 //   * ErrCodeInvalidInput "InvalidInput"
 //   The input is not valid.
@@ -3817,6 +3840,9 @@ func (c *Route53) ListGeoLocationsRequest(input *ListGeoLocationsInput) (req *re
 // the subdivisions for that country are listed in alphabetical order immediately
 // after the corresponding country.
 //
+// For a list of supported geolocation codes, see the GeoLocation (https://docs.aws.amazon.com/Route53/latest/APIReference/API_GeoLocation.html)
+// data type.
+//
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
 // the error.
@@ -3983,10 +4009,12 @@ func (c *Route53) ListHealthChecksPagesWithContext(ctx aws.Context, input *ListH
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*ListHealthChecksOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*ListHealthChecksOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -4130,10 +4158,12 @@ func (c *Route53) ListHostedZonesPagesWithContext(ctx aws.Context, input *ListHo
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*ListHostedZonesOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*ListHostedZonesOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -4202,7 +4232,7 @@ func (c *Route53) ListHostedZonesByNameRequest(input *ListHostedZonesByNameInput
 //
 // The labels are reversed and alphabetized using the escaped value. For more
 // information about valid domain name formats, including internationalized
-// domain names, see DNS Domain Name Format (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html)
+// domain names, see DNS Domain Name Format (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html)
 // in the Amazon Route 53 Developer Guide.
 //
 // Route 53 returns up to 100 items in each response. If you have a lot of hosted
@@ -4298,6 +4328,12 @@ func (c *Route53) ListQueryLoggingConfigsRequest(input *ListQueryLoggingConfigsI
 		Name:       opListQueryLoggingConfigs,
 		HTTPMethod: "GET",
 		HTTPPath:   "/2013-04-01/queryloggingconfig",
+		Paginator: &request.Paginator{
+			InputTokens:     []string{"NextToken"},
+			OutputTokens:    []string{"NextToken"},
+			LimitToken:      "MaxResults",
+			TruncationToken: "",
+		},
 	}
 
 	if input == nil {
@@ -4358,6 +4394,58 @@ func (c *Route53) ListQueryLoggingConfigsWithContext(ctx aws.Context, input *Lis
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
+}
+
+// ListQueryLoggingConfigsPages iterates over the pages of a ListQueryLoggingConfigs operation,
+// calling the "fn" function with the response data for each page. To stop
+// iterating, return false from the fn function.
+//
+// See ListQueryLoggingConfigs method for more information on how to use this operation.
+//
+// Note: This operation can generate multiple requests to a service.
+//
+//    // Example iterating over at most 3 pages of a ListQueryLoggingConfigs operation.
+//    pageNum := 0
+//    err := client.ListQueryLoggingConfigsPages(params,
+//        func(page *route53.ListQueryLoggingConfigsOutput, lastPage bool) bool {
+//            pageNum++
+//            fmt.Println(page)
+//            return pageNum <= 3
+//        })
+//
+func (c *Route53) ListQueryLoggingConfigsPages(input *ListQueryLoggingConfigsInput, fn func(*ListQueryLoggingConfigsOutput, bool) bool) error {
+	return c.ListQueryLoggingConfigsPagesWithContext(aws.BackgroundContext(), input, fn)
+}
+
+// ListQueryLoggingConfigsPagesWithContext same as ListQueryLoggingConfigsPages except
+// it takes a Context and allows setting request options on the pages.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Route53) ListQueryLoggingConfigsPagesWithContext(ctx aws.Context, input *ListQueryLoggingConfigsInput, fn func(*ListQueryLoggingConfigsOutput, bool) bool, opts ...request.Option) error {
+	p := request.Pagination{
+		NewRequest: func() (*request.Request, error) {
+			var inCpy *ListQueryLoggingConfigsInput
+			if input != nil {
+				tmp := *input
+				inCpy = &tmp
+			}
+			req, _ := c.ListQueryLoggingConfigsRequest(inCpy)
+			req.SetContext(ctx)
+			req.ApplyOptions(opts...)
+			return req, nil
+		},
+	}
+
+	for p.Next() {
+		if !fn(p.Page().(*ListQueryLoggingConfigsOutput), !p.HasNextPage()) {
+			break
+		}
+	}
+
+	return p.Err()
 }
 
 const opListResourceRecordSets = "ListResourceRecordSets"
@@ -4555,10 +4643,12 @@ func (c *Route53) ListResourceRecordSetsPagesWithContext(ctx aws.Context, input 
 		},
 	}
 
-	cont := true
-	for p.Next() && cont {
-		cont = fn(p.Page().(*ListResourceRecordSetsOutput), !p.HasNextPage())
+	for p.Next() {
+		if !fn(p.Page().(*ListResourceRecordSetsOutput), !p.HasNextPage()) {
+			break
+		}
 	}
+
 	return p.Err()
 }
 
@@ -5509,7 +5599,7 @@ func (c *Route53) UpdateHealthCheckRequest(input *UpdateHealthCheckInput) (req *
 // Updates an existing health check. Note that some values can't be updated.
 //
 // For more information about updating health checks, see Creating, Updating,
-// and Deleting Health Checks (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/health-checks-creating-deleting.html)
+// and Deleting Health Checks (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/health-checks-creating-deleting.html)
 // in the Amazon Route 53 Developer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -5902,7 +5992,7 @@ type AlarmIdentifier struct {
 	// Route 53 supports CloudWatch alarms with the following features:
 	//
 	//    * Standard-resolution metrics. High-resolution metrics aren't supported.
-	//    For more information, see High-Resolution Metrics (http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/publishingMetrics.html#high-resolution-metrics)
+	//    For more information, see High-Resolution Metrics (https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/publishingMetrics.html#high-resolution-metrics)
 	//    in the Amazon CloudWatch User Guide.
 	//
 	//    * Statistics: Average, Minimum, Maximum, Sum, and SampleCount. Extended
@@ -5915,9 +6005,8 @@ type AlarmIdentifier struct {
 	// determine whether this health check is healthy, the region that the alarm
 	// was created in.
 	//
-	// For the current list of CloudWatch regions, see Amazon CloudWatch (http://docs.aws.amazon.com/general/latest/gr/rande.html#cw_region)
-	// in the AWS Regions and Endpoints chapter of the Amazon Web Services General
-	// Reference.
+	// For the current list of CloudWatch regions, see Amazon CloudWatch (https://docs.aws.amazon.com/general/latest/gr/rande.html#cw_region)
+	// in the AWS Service Endpoints chapter of the Amazon Web Services General Reference.
 	//
 	// Region is a required field
 	Region *string `min:"1" type:"string" required:"true" enum:"CloudWatchRegion"`
@@ -5977,7 +6066,7 @@ func (s *AlarmIdentifier) SetRegion(v string) *AlarmIdentifier {
 //    record sets in a private hosted zone is unsupported.
 //
 //    * For information about creating failover resource record sets in a private
-//    hosted zone, see Configuring Failover in a Private Hosted Zone (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html).
+//    hosted zone, see Configuring Failover in a Private Hosted Zone (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html).
 type AliasTarget struct {
 	_ struct{} `type:"structure"`
 
@@ -6012,7 +6101,7 @@ type AliasTarget struct {
 	// the name of the resource record set. For example, if the name of the resource
 	// record set is acme.example.com, your CloudFront distribution must include
 	// acme.example.com as one of the alternate domain names. For more information,
-	// see Using Alternate Domain Names (CNAMEs) (http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html)
+	// see Using Alternate Domain Names (CNAMEs) (https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html)
 	// in the Amazon CloudFront Developer Guide.
 	//
 	// You can't create a resource record set in a private hosted zone to route
@@ -6045,17 +6134,17 @@ type AliasTarget struct {
 	//
 	//    * AWS Management Console: For information about how to get the value by
 	//    using the console, see Using Custom Domains with AWS Elastic Beanstalk
-	//    (http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customdomains.html)
+	//    (https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customdomains.html)
 	//    in the AWS Elastic Beanstalk Developer Guide.
 	//
 	//    * Elastic Beanstalk API: Use the DescribeEnvironments action to get the
 	//    value of the CNAME attribute. For more information, see DescribeEnvironments
-	//    (http://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_DescribeEnvironments.html)
+	//    (https://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_DescribeEnvironments.html)
 	//    in the AWS Elastic Beanstalk API Reference.
 	//
 	//    * AWS CLI: Use the describe-environments command to get the value of the
-	//    CNAME attribute. For more information, see describe-environments (http://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/describe-environments.html)
-	//    in the AWS Command Line Interface Reference.
+	//    CNAME attribute. For more information, see describe-environments (https://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/describe-environments.html)
+	//    in the AWS CLI Command Reference.
 	//
 	// ELB load balancer
 	//
@@ -6071,22 +6160,31 @@ type AliasTarget struct {
 	//
 	//    * Elastic Load Balancing API: Use DescribeLoadBalancers to get the value
 	//    of DNSName. For more information, see the applicable guide: Classic Load
-	//    Balancers: DescribeLoadBalancers (http://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeLoadBalancers.html)
-	//    Application and Network Load Balancers: DescribeLoadBalancers (http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html)
+	//    Balancers: DescribeLoadBalancers (https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeLoadBalancers.html)
+	//    Application and Network Load Balancers: DescribeLoadBalancers (https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html)
 	//
 	//    * AWS CLI: Use describe-load-balancers to get the value of DNSName. For
 	//    more information, see the applicable guide: Classic Load Balancers: describe-load-balancers
 	//    (http://docs.aws.amazon.com/cli/latest/reference/elb/describe-load-balancers.html)
 	//    Application and Network Load Balancers: describe-load-balancers (http://docs.aws.amazon.com/cli/latest/reference/elbv2/describe-load-balancers.html)
 	//
+	// AWS Global Accelerator accelerator
+	//
+	// Specify the DNS name for your accelerator:
+	//
+	//    * Global Accelerator API: To get the DNS name, use DescribeAccelerator
+	//    (https://docs.aws.amazon.com/global-accelerator/latest/api/API_DescribeAccelerator.html).
+	//
+	//    * AWS CLI: To get the DNS name, use describe-accelerator (https://docs.aws.amazon.com/cli/latest/reference/globalaccelerator/describe-accelerator.html).
+	//
 	// Amazon S3 bucket that is configured as a static website
 	//
 	// Specify the domain name of the Amazon S3 website endpoint that you created
 	// the bucket in, for example, s3-website.us-east-2.amazonaws.com. For more
-	// information about valid values, see the table Amazon Simple Storage Service
-	// (S3) Website Endpoints (http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
+	// information about valid values, see the table Amazon S3 Website Endpoints
+	// (https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints)
 	// in the Amazon Web Services General Reference. For more information about
-	// using S3 buckets for websites, see Getting Started with Amazon Route 53 (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/getting-started.html)
+	// using S3 buckets for websites, see Getting Started with Amazon Route 53 (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/getting-started.html)
 	// in the Amazon Route 53 Developer Guide.
 	//
 	// Another Route 53 resource record set
@@ -6167,11 +6265,11 @@ type AliasTarget struct {
 	// records (for example, a group of weighted records) but is not another alias
 	// record, we recommend that you associate a health check with all of the records
 	// in the alias target. For more information, see What Happens When You Omit
-	// Health Checks? (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-complex-configs.html#dns-failover-complex-configs-hc-omitting)
+	// Health Checks? (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-complex-configs.html#dns-failover-complex-configs-hc-omitting)
 	// in the Amazon Route 53 Developer Guide.
 	//
 	// For more information and examples, see Amazon Route 53 Health Checks and
-	// DNS Failover (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html)
+	// DNS Failover (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html)
 	// in the Amazon Route 53 Developer Guide.
 	//
 	// EvaluateTargetHealth is a required field
@@ -6204,8 +6302,8 @@ type AliasTarget struct {
 	//
 	// Specify the hosted zone ID for the region that you created the environment
 	// in. The environment must have a regionalized subdomain. For a list of regions
-	// and the corresponding hosted zone IDs, see AWS Elastic Beanstalk (http://docs.aws.amazon.com/general/latest/gr/rande.html#elasticbeanstalk_region)
-	// in the "AWS Regions and Endpoints" chapter of the Amazon Web Services General
+	// and the corresponding hosted zone IDs, see AWS Elastic Beanstalk (https://docs.aws.amazon.com/general/latest/gr/rande.html#elasticbeanstalk_region)
+	// in the "AWS Service Endpoints" chapter of the Amazon Web Services General
 	// Reference.
 	//
 	// ELB load balancer
@@ -6213,11 +6311,12 @@ type AliasTarget struct {
 	// Specify the value of the hosted zone ID for the load balancer. Use the following
 	// methods to get the hosted zone ID:
 	//
-	//    * Elastic Load Balancing (https://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region)
-	//    table in the "AWS Regions and Endpoints" chapter of the Amazon Web Services
-	//    General Reference: Use the value that corresponds with the region that
-	//    you created your load balancer in. Note that there are separate columns
-	//    for Application and Classic Load Balancers and for Network Load Balancers.
+	//    * Service Endpoints (https://docs.aws.amazon.com/general/latest/gr/elb.html)
+	//    table in the "Elastic Load Balancing Endpoints and Quotas" topic in the
+	//    Amazon Web Services General Reference: Use the value that corresponds
+	//    with the region that you created your load balancer in. Note that there
+	//    are separate columns for Application and Classic Load Balancers and for
+	//    Network Load Balancers.
 	//
 	//    * AWS Management Console: Go to the Amazon EC2 page, choose Load Balancers
 	//    in the navigation pane, select the load balancer, and get the value of
@@ -6225,9 +6324,9 @@ type AliasTarget struct {
 	//
 	//    * Elastic Load Balancing API: Use DescribeLoadBalancers to get the applicable
 	//    value. For more information, see the applicable guide: Classic Load Balancers:
-	//    Use DescribeLoadBalancers (http://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeLoadBalancers.html)
+	//    Use DescribeLoadBalancers (https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeLoadBalancers.html)
 	//    to get the value of CanonicalHostedZoneNameId. Application and Network
-	//    Load Balancers: Use DescribeLoadBalancers (http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html)
+	//    Load Balancers: Use DescribeLoadBalancers (https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html)
 	//    to get the value of CanonicalHostedZoneId.
 	//
 	//    * AWS CLI: Use describe-load-balancers to get the applicable value. For
@@ -6237,13 +6336,16 @@ type AliasTarget struct {
 	//    Load Balancers: Use describe-load-balancers (http://docs.aws.amazon.com/cli/latest/reference/elbv2/describe-load-balancers.html)
 	//    to get the value of CanonicalHostedZoneId.
 	//
+	// AWS Global Accelerator accelerator
+	//
+	// Specify Z2BJ6XQ5FK7U4H.
+	//
 	// An Amazon S3 bucket configured as a static website
 	//
 	// Specify the hosted zone ID for the region that you created the bucket in.
-	// For more information about valid values, see the Amazon Simple Storage Service
-	// Website Endpoints (http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
-	// table in the "AWS Regions and Endpoints" chapter of the Amazon Web Services
-	// General Reference.
+	// For more information about valid values, see the table Amazon S3 Website
+	// Endpoints (https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints)
+	// in the Amazon Web Services General Reference.
 	//
 	// Another Route 53 resource record set in your hosted zone
 	//
@@ -6816,7 +6918,7 @@ type CloudWatchAlarmConfiguration struct {
 
 	// For the metric that the CloudWatch alarm is associated with, a complex type
 	// that contains information about the dimensions for the metric. For information,
-	// see Amazon CloudWatch Namespaces, Dimensions, and Metrics Reference (http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html)
+	// see Amazon CloudWatch Namespaces, Dimensions, and Metrics Reference (https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html)
 	// in the Amazon CloudWatch User Guide.
 	Dimensions []*Dimension `locationNameList:"Dimension" type:"list"`
 
@@ -6832,7 +6934,7 @@ type CloudWatchAlarmConfiguration struct {
 	MetricName *string `min:"1" type:"string" required:"true"`
 
 	// The namespace of the metric that the alarm is associated with. For more information,
-	// see Amazon CloudWatch Namespaces, Dimensions, and Metrics Reference (http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html)
+	// see Amazon CloudWatch Namespaces, Dimensions, and Metrics Reference (https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html)
 	// in the Amazon CloudWatch User Guide.
 	//
 	// Namespace is a required field
@@ -7916,7 +8018,7 @@ func (s *DelegationSet) SetNameServers(v []*string) *DelegationSet {
 
 // This action deletes a health check.
 type DeleteHealthCheckInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteHealthCheckRequest" type:"structure"`
 
 	// The ID of the health check that you want to delete.
 	//
@@ -7973,7 +8075,7 @@ func (s DeleteHealthCheckOutput) GoString() string {
 
 // A request to delete a hosted zone.
 type DeleteHostedZoneInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteHostedZoneRequest" type:"structure"`
 
 	// The ID of the hosted zone you want to delete.
 	//
@@ -8041,7 +8143,7 @@ func (s *DeleteHostedZoneOutput) SetChangeInfo(v *ChangeInfo) *DeleteHostedZoneO
 }
 
 type DeleteQueryLoggingConfigInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteQueryLoggingConfigRequest" type:"structure"`
 
 	// The ID of the configuration that you want to delete.
 	//
@@ -8097,7 +8199,7 @@ func (s DeleteQueryLoggingConfigOutput) GoString() string {
 
 // A request to delete a reusable delegation set.
 type DeleteReusableDelegationSetInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteReusableDelegationSetRequest" type:"structure"`
 
 	// The ID of the reusable delegation set that you want to delete.
 	//
@@ -8154,7 +8256,7 @@ func (s DeleteReusableDelegationSetOutput) GoString() string {
 
 // A request to delete a specified traffic policy version.
 type DeleteTrafficPolicyInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteTrafficPolicyRequest" type:"structure"`
 
 	// The ID of the traffic policy that you want to delete.
 	//
@@ -8213,7 +8315,7 @@ func (s *DeleteTrafficPolicyInput) SetVersion(v int64) *DeleteTrafficPolicyInput
 
 // A request to delete a specified traffic policy instance.
 type DeleteTrafficPolicyInstanceInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"DeleteTrafficPolicyInstanceRequest" type:"structure"`
 
 	// The ID of the traffic policy instance that you want to delete.
 	//
@@ -8515,17 +8617,39 @@ type GeoLocation struct {
 
 	// The two-letter code for the continent.
 	//
-	// Valid values: AF | AN | AS | EU | OC | NA | SA
+	// Amazon Route 53 supports the following continent codes:
+	//
+	//    * AF: Africa
+	//
+	//    * AN: Antarctica
+	//
+	//    * AS: Asia
+	//
+	//    * EU: Europe
+	//
+	//    * OC: Oceania
+	//
+	//    * NA: North America
+	//
+	//    * SA: South America
 	//
 	// Constraint: Specifying ContinentCode with either CountryCode or SubdivisionCode
 	// returns an InvalidInput error.
 	ContinentCode *string `min:"2" type:"string"`
 
-	// The two-letter code for the country.
+	// For geolocation resource record sets, the two-letter code for a country.
+	//
+	// Amazon Route 53 uses the two-letter country codes that are specified in ISO
+	// standard 3166-1 alpha-2 (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
 	CountryCode *string `min:"1" type:"string"`
 
-	// The code for the subdivision. Route 53 currently supports only states in
-	// the United States.
+	// For geolocation resource record sets, the two-letter code for a state of
+	// the United States. Route 53 doesn't support any other values for SubdivisionCode.
+	// For a list of state abbreviations, see Appendix B: Two–Letter State and
+	// Possession Abbreviations (https://pe.usps.com/text/pub28/28apb.htm) on the
+	// United States Postal Service website.
+	//
+	// If you specify subdivisioncode, you must also specify US for CountryCode.
 	SubdivisionCode *string `min:"1" type:"string"`
 }
 
@@ -8651,7 +8775,7 @@ func (s *GeoLocationDetails) SetSubdivisionName(v string) *GeoLocationDetails {
 // A complex type that contains information about the request to create a hosted
 // zone.
 type GetAccountLimitInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetAccountLimitRequest" type:"structure"`
 
 	// The limit that you want to get. Valid values include the following:
 	//
@@ -8753,7 +8877,7 @@ func (s *GetAccountLimitOutput) SetLimit(v *AccountLimit) *GetAccountLimitOutput
 
 // The input for a GetChange request.
 type GetChangeInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetChangeRequest" type:"structure"`
 
 	// The ID of the change batch request. The value that you specify here is the
 	// value that ChangeResourceRecordSets returned in the Id element when you submitted
@@ -8823,7 +8947,7 @@ func (s *GetChangeOutput) SetChangeInfo(v *ChangeInfo) *GetChangeOutput {
 
 // Empty request.
 type GetCheckerIpRangesInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetCheckerIpRangesRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -8866,9 +8990,10 @@ func (s *GetCheckerIpRangesOutput) SetCheckerIpRanges(v []*string) *GetCheckerIp
 // A request for information about whether a specified geographic location is
 // supported for Amazon Route 53 geolocation resource record sets.
 type GetGeoLocationInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetGeoLocationRequest" type:"structure"`
 
-	// Amazon Route 53 supports the following continent codes:
+	// For geolocation resource record sets, a two-letter abbreviation that identifies
+	// a continent. Amazon Route 53 supports the following continent codes:
 	//
 	//    * AF: Africa
 	//
@@ -8889,10 +9014,12 @@ type GetGeoLocationInput struct {
 	// standard 3166-1 alpha-2 (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
 	CountryCode *string `location:"querystring" locationName:"countrycode" min:"1" type:"string"`
 
-	// Amazon Route 53 uses the one- to three-letter subdivision codes that are
-	// specified in ISO standard 3166-1 alpha-2 (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
-	// Route 53 doesn't support subdivision codes for all countries. If you specify
-	// subdivisioncode, you must also specify countrycode.
+	// For SubdivisionCode, Amazon Route 53 supports only states of the United States.
+	// For a list of state abbreviations, see Appendix B: Two–Letter State and
+	// Possession Abbreviations (https://pe.usps.com/text/pub28/28apb.htm) on the
+	// United States Postal Service website.
+	//
+	// If you specify subdivisioncode, you must also specify US for CountryCode.
 	SubdivisionCode *string `location:"querystring" locationName:"subdivisioncode" min:"1" type:"string"`
 }
 
@@ -8974,7 +9101,7 @@ func (s *GetGeoLocationOutput) SetGeoLocationDetails(v *GeoLocationDetails) *Get
 // A request for the number of health checks that are associated with the current
 // AWS account.
 type GetHealthCheckCountInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetHealthCheckCountRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -9015,7 +9142,7 @@ func (s *GetHealthCheckCountOutput) SetHealthCheckCount(v int64) *GetHealthCheck
 
 // A request to get information about a specified health check.
 type GetHealthCheckInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetHealthCheckRequest" type:"structure"`
 
 	// The identifier that Amazon Route 53 assigned to the health check when you
 	// created it. When you add or update a resource record set, you use this value
@@ -9060,7 +9187,7 @@ func (s *GetHealthCheckInput) SetHealthCheckId(v string) *GetHealthCheckInput {
 
 // A request for the reason that a health check failed most recently.
 type GetHealthCheckLastFailureReasonInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetHealthCheckLastFailureReasonRequest" type:"structure"`
 
 	// The ID for the health check for which you want the last failure reason. When
 	// you created the health check, CreateHealthCheck returned the ID in the response,
@@ -9163,7 +9290,7 @@ func (s *GetHealthCheckOutput) SetHealthCheck(v *HealthCheck) *GetHealthCheckOut
 
 // A request to get the status for a health check.
 type GetHealthCheckStatusInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetHealthCheckStatusRequest" type:"structure"`
 
 	// The ID for the health check that you want the current status for. When you
 	// created the health check, CreateHealthCheck returned the ID in the response,
@@ -9239,7 +9366,7 @@ func (s *GetHealthCheckStatusOutput) SetHealthCheckObservations(v []*HealthCheck
 // A request to retrieve a count of all the hosted zones that are associated
 // with the current AWS account.
 type GetHostedZoneCountInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetHostedZoneCountRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -9281,7 +9408,7 @@ func (s *GetHostedZoneCountOutput) SetHostedZoneCount(v int64) *GetHostedZoneCou
 
 // A request to get information about a specified hosted zone.
 type GetHostedZoneInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetHostedZoneRequest" type:"structure"`
 
 	// The ID of the hosted zone that you want to get information about.
 	//
@@ -9324,7 +9451,7 @@ func (s *GetHostedZoneInput) SetId(v string) *GetHostedZoneInput {
 // A complex type that contains information about the request to create a hosted
 // zone.
 type GetHostedZoneLimitInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetHostedZoneLimitRequest" type:"structure"`
 
 	// The ID of the hosted zone that you want to get a limit for.
 	//
@@ -9478,7 +9605,7 @@ func (s *GetHostedZoneOutput) SetVPCs(v []*VPC) *GetHostedZoneOutput {
 }
 
 type GetQueryLoggingConfigInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetQueryLoggingConfigRequest" type:"structure"`
 
 	// The ID of the configuration for DNS query logging that you want to get information
 	// about.
@@ -9548,7 +9675,7 @@ func (s *GetQueryLoggingConfigOutput) SetQueryLoggingConfig(v *QueryLoggingConfi
 
 // A request to get information about a specified reusable delegation set.
 type GetReusableDelegationSetInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetReusableDelegationSetRequest" type:"structure"`
 
 	// The ID of the reusable delegation set that you want to get a list of name
 	// servers for.
@@ -9592,7 +9719,7 @@ func (s *GetReusableDelegationSetInput) SetId(v string) *GetReusableDelegationSe
 // A complex type that contains information about the request to create a hosted
 // zone.
 type GetReusableDelegationSetLimitInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetReusableDelegationSetLimitRequest" type:"structure"`
 
 	// The ID of the delegation set that you want to get the limit for.
 	//
@@ -9719,7 +9846,7 @@ func (s *GetReusableDelegationSetOutput) SetDelegationSet(v *DelegationSet) *Get
 
 // Gets information about a specific traffic policy version.
 type GetTrafficPolicyInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetTrafficPolicyRequest" type:"structure"`
 
 	// The ID of the traffic policy that you want to get information about.
 	//
@@ -9780,7 +9907,7 @@ func (s *GetTrafficPolicyInput) SetVersion(v int64) *GetTrafficPolicyInput {
 // Request to get the number of traffic policy instances that are associated
 // with the current AWS account.
 type GetTrafficPolicyInstanceCountInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetTrafficPolicyInstanceCountRequest" type:"structure"`
 }
 
 // String returns the string representation
@@ -9823,7 +9950,7 @@ func (s *GetTrafficPolicyInstanceCountOutput) SetTrafficPolicyInstanceCount(v in
 
 // Gets information about a specified traffic policy instance.
 type GetTrafficPolicyInstanceInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"GetTrafficPolicyInstanceRequest" type:"structure"`
 
 	// The ID of the traffic policy instance that you want to get information about.
 	//
@@ -10062,7 +10189,7 @@ type HealthCheckConfig struct {
 	// The number of consecutive health checks that an endpoint must pass or fail
 	// for Amazon Route 53 to change the current status of the endpoint from unhealthy
 	// to healthy or vice versa. For more information, see How Amazon Route 53 Determines
-	// Whether an Endpoint Is Healthy (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html)
+	// Whether an Endpoint Is Healthy (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html)
 	// in the Amazon Route 53 Developer Guide.
 	//
 	// If you don't specify a value for FailureThreshold, the default value is three
@@ -10206,8 +10333,11 @@ type HealthCheckConfig struct {
 	// You can't change the value of MeasureLatency after you create a health check.
 	MeasureLatency *bool `type:"boolean"`
 
-	// The port on the endpoint on which you want Amazon Route 53 to perform health
-	// checks. Specify a value for Port only when you specify a value for IPAddress.
+	// The port on the endpoint that you want Amazon Route 53 to perform health
+	// checks on.
+	//
+	// Don't specify a value for Port when you specify a value for Type of CLOUDWATCH_METRIC
+	// or CALCULATED.
 	Port *int64 `min:"1" type:"integer"`
 
 	// A complex type that contains one Region element for each region from which
@@ -10239,7 +10369,7 @@ type HealthCheckConfig struct {
 	// parameters, for example, /welcome.html?language=jp&login=y.
 	ResourcePath *string `type:"string"`
 
-	// If the value of Type is HTTP_STR_MATCH or HTTP_STR_MATCH, the string that
+	// If the value of Type is HTTP_STR_MATCH or HTTPS_STR_MATCH, the string that
 	// you want Amazon Route 53 to search for in the response body from the specified
 	// resource. If the string appears in the response body, Route 53 considers
 	// the resource healthy.
@@ -10690,7 +10820,7 @@ func (s *LinkedService) SetServicePrincipal(v string) *LinkedService {
 // A request to get a list of geographic locations that Amazon Route 53 supports
 // for geolocation resource record sets.
 type ListGeoLocationsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListGeoLocationsRequest" type:"structure"`
 
 	// (Optional) The maximum number of geolocations to be included in the response
 	// body for this request. If more than maxitems geolocations remain to be listed,
@@ -10713,18 +10843,15 @@ type ListGeoLocationsInput struct {
 	// a page or more of results, if IsTruncated is true, and if NextCountryCode
 	// from the previous response has a value, enter that value in startcountrycode
 	// to return the next page of results.
-	//
-	// Route 53 uses the two-letter country codes that are specified in ISO standard
-	// 3166-1 alpha-2 (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
 	StartCountryCode *string `location:"querystring" locationName:"startcountrycode" min:"1" type:"string"`
 
-	// The code for the subdivision (for example, state or province) with which
-	// you want to start listing locations that Amazon Route 53 supports for geolocation.
-	// If Route 53 has already returned a page or more of results, if IsTruncated
-	// is true, and if NextSubdivisionCode from the previous response has a value,
-	// enter that value in startsubdivisioncode to return the next page of results.
+	// The code for the state of the United States with which you want to start
+	// listing locations that Amazon Route 53 supports for geolocation. If Route
+	// 53 has already returned a page or more of results, if IsTruncated is true,
+	// and if NextSubdivisionCode from the previous response has a value, enter
+	// that value in startsubdivisioncode to return the next page of results.
 	//
-	// To list subdivisions of a country, you must include both startcountrycode
+	// To list subdivisions (U.S. states), you must include both startcountrycode
 	// and startsubdivisioncode.
 	StartSubdivisionCode *string `location:"querystring" locationName:"startsubdivisioncode" min:"1" type:"string"`
 }
@@ -10871,7 +10998,7 @@ func (s *ListGeoLocationsOutput) SetNextSubdivisionCode(v string) *ListGeoLocati
 // A request to retrieve a list of the health checks that are associated with
 // the current AWS account.
 type ListHealthChecksInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListHealthChecksRequest" type:"structure"`
 
 	// If the value of IsTruncated in the previous response was true, you have more
 	// health checks. To get another group, submit another ListHealthChecks request.
@@ -10992,7 +11119,7 @@ func (s *ListHealthChecksOutput) SetNextMarker(v string) *ListHealthChecksOutput
 // Retrieves a list of the public and private hosted zones that are associated
 // with the current AWS account in ASCII order by domain name.
 type ListHostedZonesByNameInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListHostedZonesByNameRequest" type:"structure"`
 
 	// (Optional) For your first request to ListHostedZonesByName, include the dnsname
 	// parameter only if you want to specify the name of the first hosted zone in
@@ -11154,7 +11281,7 @@ func (s *ListHostedZonesByNameOutput) SetNextHostedZoneId(v string) *ListHostedZ
 // A request to retrieve a list of the public and private hosted zones that
 // are associated with the current AWS account.
 type ListHostedZonesInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListHostedZonesRequest" type:"structure"`
 
 	// If you're using reusable delegation sets and you want to list all of the
 	// hosted zones that are associated with a reusable delegation set, specify
@@ -11286,7 +11413,7 @@ func (s *ListHostedZonesOutput) SetNextMarker(v string) *ListHostedZonesOutput {
 }
 
 type ListQueryLoggingConfigsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListQueryLoggingConfigsRequest" type:"structure"`
 
 	// (Optional) If you want to list the query logging configuration that is associated
 	// with a hosted zone, specify the ID in HostedZoneId.
@@ -11388,7 +11515,7 @@ func (s *ListQueryLoggingConfigsOutput) SetQueryLoggingConfigs(v []*QueryLogging
 // A request for the resource record sets that are associated with a specified
 // hosted zone.
 type ListResourceRecordSetsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListResourceRecordSetsRequest" type:"structure"`
 
 	// The ID of the hosted zone that contains the resource record sets that you
 	// want to list.
@@ -11404,14 +11531,16 @@ type ListResourceRecordSetsInput struct {
 	// of maxitems resource record sets.
 	MaxItems *string `location:"querystring" locationName:"maxitems" type:"string"`
 
-	// Weighted resource record sets only: If results were truncated for a given
-	// DNS name and type, specify the value of NextRecordIdentifier from the previous
-	// response to get the next resource record set that has the current DNS name
-	// and type.
+	// Resource record sets that have a routing policy other than simple: If results
+	// were truncated for a given DNS name and type, specify the value of NextRecordIdentifier
+	// from the previous response to get the next resource record set that has the
+	// current DNS name and type.
 	StartRecordIdentifier *string `location:"querystring" locationName:"identifier" min:"1" type:"string"`
 
 	// The first name in the lexicographic ordering of resource record sets that
-	// you want to list.
+	// you want to list. If the specified record name doesn't exist, the results
+	// begin with the first resource record set that has a name greater than the
+	// value of name.
 	StartRecordName *string `location:"querystring" locationName:"name" type:"string"`
 
 	// The type of resource record set to begin the record listing from.
@@ -11432,9 +11561,9 @@ type ListResourceRecordSetsInput struct {
 	//
 	//    * Elastic Load Balancing load balancer: A | AAAA
 	//
-	//    * Amazon S3 bucket: A
+	//    * S3 bucket: A
 	//
-	//    * Amazon VPC interface VPC endpoint: A
+	//    * VPC interface VPC endpoint: A
 	//
 	//    * Another resource record set in this hosted zone: The type of the resource
 	//    record set that the alias references.
@@ -11592,7 +11721,7 @@ func (s *ListResourceRecordSetsOutput) SetResourceRecordSets(v []*ResourceRecord
 // A request to get a list of the reusable delegation sets that are associated
 // with the current AWS account.
 type ListReusableDelegationSetsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListReusableDelegationSetsRequest" type:"structure"`
 
 	// If the value of IsTruncated in the previous response was true, you have more
 	// reusable delegation sets. To get another group, submit another ListReusableDelegationSets
@@ -11713,7 +11842,7 @@ func (s *ListReusableDelegationSetsOutput) SetNextMarker(v string) *ListReusable
 // A complex type containing information about a request for a list of the tags
 // that are associated with an individual resource.
 type ListTagsForResourceInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListTagsForResourceRequest" type:"structure"`
 
 	// The ID of the resource for which you want to retrieve tags.
 	//
@@ -11895,7 +12024,7 @@ func (s *ListTagsForResourcesOutput) SetResourceTagSets(v []*ResourceTagSet) *Li
 // A complex type that contains the information about the request to list the
 // traffic policies that are associated with the current AWS account.
 type ListTrafficPoliciesInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListTrafficPoliciesRequest" type:"structure"`
 
 	// (Optional) The maximum number of traffic policies that you want Amazon Route
 	// 53 to return in response to this request. If you have more than MaxItems
@@ -12018,7 +12147,7 @@ func (s *ListTrafficPoliciesOutput) SetTrafficPolicySummaries(v []*TrafficPolicy
 // A request for the traffic policy instances that you created in a specified
 // hosted zone.
 type ListTrafficPolicyInstancesByHostedZoneInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListTrafficPolicyInstancesByHostedZoneRequest" type:"structure"`
 
 	// The ID of the hosted zone that you want to list traffic policy instances
 	// for.
@@ -12182,7 +12311,7 @@ func (s *ListTrafficPolicyInstancesByHostedZoneOutput) SetTrafficPolicyInstances
 // A complex type that contains the information about the request to list your
 // traffic policy instances.
 type ListTrafficPolicyInstancesByPolicyInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListTrafficPolicyInstancesByPolicyRequest" type:"structure"`
 
 	// If the value of IsTruncated in the previous response was true, you have more
 	// traffic policy instances. To get more traffic policy instances, submit another
@@ -12399,7 +12528,7 @@ func (s *ListTrafficPolicyInstancesByPolicyOutput) SetTrafficPolicyInstances(v [
 // A request to get information about the traffic policy instances that you
 // created by using the current AWS account.
 type ListTrafficPolicyInstancesInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListTrafficPolicyInstancesRequest" type:"structure"`
 
 	// If the value of IsTruncated in the previous response was true, you have more
 	// traffic policy instances. To get more traffic policy instances, submit another
@@ -12568,7 +12697,7 @@ func (s *ListTrafficPolicyInstancesOutput) SetTrafficPolicyInstances(v []*Traffi
 // A complex type that contains the information about the request to list your
 // traffic policies.
 type ListTrafficPolicyVersionsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListTrafficPolicyVersionsRequest" type:"structure"`
 
 	// Specify the value of Id of the traffic policy for which you want to list
 	// all versions.
@@ -12710,7 +12839,7 @@ func (s *ListTrafficPolicyVersionsOutput) SetTrafficPolicyVersionMarker(v string
 // A complex type that contains information about that can be associated with
 // your hosted zone.
 type ListVPCAssociationAuthorizationsInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"ListVPCAssociationAuthorizationsRequest" type:"structure"`
 
 	// The ID of the hosted zone for which you want a list of VPCs that can be associated
 	// with the hosted zone.
@@ -12944,7 +13073,7 @@ type ResourceRecordSet struct {
 	//    record sets in a private hosted zone is unsupported.
 	//
 	//    * For information about creating failover resource record sets in a private
-	//    hosted zone, see Configuring Failover in a Private Hosted Zone (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html)
+	//    hosted zone, see Configuring Failover in a Private Hosted Zone (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html)
 	//    in the Amazon Route 53 Developer Guide.
 	AliasTarget *AliasTarget `type:"structure"`
 
@@ -12984,9 +13113,9 @@ type ResourceRecordSet struct {
 	// For more information about configuring failover for Route 53, see the following
 	// topics in the Amazon Route 53 Developer Guide:
 	//
-	//    * Route 53 Health Checks and DNS Failover (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html)
+	//    * Route 53 Health Checks and DNS Failover (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html)
 	//
-	//    * Configuring Failover in a Private Hosted Zone (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html)
+	//    * Configuring Failover in a Private Hosted Zone (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html)
 	Failover *string `type:"string" enum:"ResourceRecordSetFailover"`
 
 	// Geolocation resource record sets only: A complex type that lets you control
@@ -12995,8 +13124,8 @@ type ResourceRecordSet struct {
 	// to a web server with an IP address of 192.0.2.111, create a resource record
 	// set with a Type of A and a ContinentCode of AF.
 	//
-	// Creating geolocation and geolocation alias resource record sets in private
-	// hosted zones is not supported.
+	// Although creating geolocation and geolocation alias resource record sets
+	// in a private hosted zone is allowed, it's not supported.
 	//
 	// If you create separate resource record sets for overlapping geographic regions
 	// (for example, one resource record set for a continent and one for a country
@@ -13015,11 +13144,12 @@ type ResourceRecordSet struct {
 	// addresses aren't mapped to geographic locations, so even if you create geolocation
 	// resource record sets that cover all seven continents, Route 53 will receive
 	// some DNS queries from locations that it can't identify. We recommend that
-	// you create a resource record set for which the value of CountryCode is *,
-	// which handles both queries that come from locations for which you haven't
-	// created geolocation resource record sets and queries from IP addresses that
-	// aren't mapped to a location. If you don't create a * resource record set,
-	// Route 53 returns a "no answer" response for queries from those locations.
+	// you create a resource record set for which the value of CountryCode is *.
+	// Two groups of queries are routed to the resource that you specify in this
+	// record: queries that come from locations for which you haven't created geolocation
+	// resource record sets and queries from IP addresses that aren't mapped to
+	// a location. If you don't create a * resource record set, Route 53 returns
+	// a "no answer" response for queries from those locations.
 	//
 	// You can't create non-geolocation resource record sets that have the same
 	// values for the Name and Type elements as geolocation resource record sets.
@@ -13052,9 +13182,9 @@ type ResourceRecordSet struct {
 	//
 	//    * How Amazon Route 53 Determines Whether an Endpoint Is Healthy (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html)
 	//
-	//    * Route 53 Health Checks and DNS Failover (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html)
+	//    * Route 53 Health Checks and DNS Failover (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html)
 	//
-	//    * Configuring Failover in a Private Hosted Zone (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html)
+	//    * Configuring Failover in a Private Hosted Zone (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-private-hosted-zones.html)
 	//
 	// When to Specify HealthCheckId
 	//
@@ -13167,7 +13297,7 @@ type ResourceRecordSet struct {
 	//
 	// For information about how to specify characters other than a-z, 0-9, and
 	// - (hyphen) and how to specify internationalized domain names, see DNS Domain
-	// Name Format (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html)
+	// Name Format (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html)
 	// in the Amazon Route 53 Developer Guide.
 	//
 	// You can use the asterisk (*) wildcard to replace the leftmost label in a
@@ -13197,8 +13327,8 @@ type ResourceRecordSet struct {
 	// and is referred to by an IP address or a DNS domain name, depending on the
 	// record type.
 	//
-	// Creating latency and latency alias resource record sets in private hosted
-	// zones is not supported.
+	// Although creating latency and latency alias resource record sets in a private
+	// hosted zone is allowed, it's not supported.
 	//
 	// When Amazon Route 53 receives a DNS query for a domain name and type for
 	// which you have created latency resource record sets, Route 53 selects the
@@ -13272,7 +13402,7 @@ type ResourceRecordSet struct {
 	TrafficPolicyInstanceId *string `min:"1" type:"string"`
 
 	// The DNS record type. For information about different record types and how
-	// data is encoded for them, see Supported DNS Resource Record Types (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html)
+	// data is encoded for them, see Supported DNS Resource Record Types (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html)
 	// in the Amazon Route 53 Developer Guide.
 	//
 	// Valid values for basic resource record sets: A | AAAA | CAA | CNAME | MX
@@ -13303,8 +13433,7 @@ type ResourceRecordSet struct {
 	//    create two resource record sets to route traffic to your distribution,
 	//    one with a value of A and one with a value of AAAA.
 	//
-	//    * AWS Elastic Beanstalk environment that has a regionalized subdomain:
-	//    A
+	//    * Amazon API Gateway environment that has a regionalized subdomain: A
 	//
 	//    * ELB load balancers: A | AAAA
 	//
@@ -13352,7 +13481,7 @@ type ResourceRecordSet struct {
 	//    of DNS name and type, traffic is routed to all resources with equal probability.
 	//    The effect of setting Weight to 0 is different when you associate health
 	//    checks with weighted resource record sets. For more information, see Options
-	//    for Configuring Route 53 Active-Active and Active-Passive Failover (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-configuring-options.html)
+	//    for Configuring Route 53 Active-Active and Active-Passive Failover (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-configuring-options.html)
 	//    in the Amazon Route 53 Developer Guide.
 	Weight *int64 `type:"long"`
 }
@@ -13672,7 +13801,7 @@ func (s *Tag) SetValue(v string) *Tag {
 // for a specified record name and type. You can optionally specify the IP address
 // of a DNS resolver, an EDNS0 client subnet IP address, and a subnet mask.
 type TestDNSAnswerInput struct {
-	_ struct{} `type:"structure"`
+	_ struct{} `locationName:"TestDNSAnswerRequest" type:"structure"`
 
 	// If the resolver that you specified for resolverip supports EDNS0, specify
 	// the IPv4 or IPv6 address of a client in the applicable location, for example,
@@ -14225,7 +14354,7 @@ type UpdateHealthCheckInput struct {
 	// The number of consecutive health checks that an endpoint must pass or fail
 	// for Amazon Route 53 to change the current status of the endpoint from unhealthy
 	// to healthy or vice versa. For more information, see How Amazon Route 53 Determines
-	// Whether an Endpoint Is Healthy (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html)
+	// Whether an Endpoint Is Healthy (https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-determining-health-of-endpoints.html)
 	// in the Amazon Route 53 Developer Guide.
 	//
 	// If you don't specify a value for FailureThreshold, the default value is three
@@ -14396,8 +14525,11 @@ type UpdateHealthCheckInput struct {
 	// would be considered healthy.
 	Inverted *bool `type:"boolean"`
 
-	// The port on the endpoint on which you want Amazon Route 53 to perform health
-	// checks.
+	// The port on the endpoint that you want Amazon Route 53 to perform health
+	// checks on.
+	//
+	// Don't specify a value for Port when you specify a value for Type of CLOUDWATCH_METRIC
+	// or CALCULATED.
 	Port *int64 `min:"1" type:"integer"`
 
 	// A complex type that contains one Region element for each region that you
@@ -14430,7 +14562,7 @@ type UpdateHealthCheckInput struct {
 	// Specify this value only if you want to change it.
 	ResourcePath *string `type:"string"`
 
-	// If the value of Type is HTTP_STR_MATCH or HTTP_STR_MATCH, the string that
+	// If the value of Type is HTTP_STR_MATCH or HTTPS_STR_MATCH, the string that
 	// you want Amazon Route 53 to search for in the response body from the specified
 	// resource. If the string appears in the response body, Route 53 considers
 	// the resource healthy. (You can't change the value of Type when you update
@@ -15026,6 +15158,9 @@ const (
 	// CloudWatchRegionApEast1 is a CloudWatchRegion enum value
 	CloudWatchRegionApEast1 = "ap-east-1"
 
+	// CloudWatchRegionMeSouth1 is a CloudWatchRegion enum value
+	CloudWatchRegionMeSouth1 = "me-south-1"
+
 	// CloudWatchRegionApSouth1 is a CloudWatchRegion enum value
 	CloudWatchRegionApSouth1 = "ap-south-1"
 
@@ -15055,6 +15190,24 @@ const (
 
 	// CloudWatchRegionCnNorth1 is a CloudWatchRegion enum value
 	CloudWatchRegionCnNorth1 = "cn-north-1"
+
+	// CloudWatchRegionAfSouth1 is a CloudWatchRegion enum value
+	CloudWatchRegionAfSouth1 = "af-south-1"
+
+	// CloudWatchRegionEuSouth1 is a CloudWatchRegion enum value
+	CloudWatchRegionEuSouth1 = "eu-south-1"
+
+	// CloudWatchRegionUsGovWest1 is a CloudWatchRegion enum value
+	CloudWatchRegionUsGovWest1 = "us-gov-west-1"
+
+	// CloudWatchRegionUsGovEast1 is a CloudWatchRegion enum value
+	CloudWatchRegionUsGovEast1 = "us-gov-east-1"
+
+	// CloudWatchRegionUsIsoEast1 is a CloudWatchRegion enum value
+	CloudWatchRegionUsIsoEast1 = "us-iso-east-1"
+
+	// CloudWatchRegionUsIsobEast1 is a CloudWatchRegion enum value
+	CloudWatchRegionUsIsobEast1 = "us-isob-east-1"
 )
 
 const (
@@ -15257,8 +15410,17 @@ const (
 	// ResourceRecordSetRegionApEast1 is a ResourceRecordSetRegion enum value
 	ResourceRecordSetRegionApEast1 = "ap-east-1"
 
+	// ResourceRecordSetRegionMeSouth1 is a ResourceRecordSetRegion enum value
+	ResourceRecordSetRegionMeSouth1 = "me-south-1"
+
 	// ResourceRecordSetRegionApSouth1 is a ResourceRecordSetRegion enum value
 	ResourceRecordSetRegionApSouth1 = "ap-south-1"
+
+	// ResourceRecordSetRegionAfSouth1 is a ResourceRecordSetRegion enum value
+	ResourceRecordSetRegionAfSouth1 = "af-south-1"
+
+	// ResourceRecordSetRegionEuSouth1 is a ResourceRecordSetRegion enum value
+	ResourceRecordSetRegionEuSouth1 = "eu-south-1"
 )
 
 const (
@@ -15319,6 +15481,21 @@ const (
 	// VPCRegionApEast1 is a VPCRegion enum value
 	VPCRegionApEast1 = "ap-east-1"
 
+	// VPCRegionMeSouth1 is a VPCRegion enum value
+	VPCRegionMeSouth1 = "me-south-1"
+
+	// VPCRegionUsGovWest1 is a VPCRegion enum value
+	VPCRegionUsGovWest1 = "us-gov-west-1"
+
+	// VPCRegionUsGovEast1 is a VPCRegion enum value
+	VPCRegionUsGovEast1 = "us-gov-east-1"
+
+	// VPCRegionUsIsoEast1 is a VPCRegion enum value
+	VPCRegionUsIsoEast1 = "us-iso-east-1"
+
+	// VPCRegionUsIsobEast1 is a VPCRegion enum value
+	VPCRegionUsIsobEast1 = "us-isob-east-1"
+
 	// VPCRegionApSoutheast1 is a VPCRegion enum value
 	VPCRegionApSoutheast1 = "ap-southeast-1"
 
@@ -15348,4 +15525,10 @@ const (
 
 	// VPCRegionCnNorth1 is a VPCRegion enum value
 	VPCRegionCnNorth1 = "cn-north-1"
+
+	// VPCRegionAfSouth1 is a VPCRegion enum value
+	VPCRegionAfSouth1 = "af-south-1"
+
+	// VPCRegionEuSouth1 is a VPCRegion enum value
+	VPCRegionEuSouth1 = "eu-south-1"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/route53/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/route53/errors.go
@@ -14,22 +14,22 @@ const (
 	// ErrCodeConflictingDomainExists for service response error code
 	// "ConflictingDomainExists".
 	//
-	// The cause of this error depends on whether you're trying to create a public
-	// or a private hosted zone:
+	// The cause of this error depends on the operation that you're performing:
 	//
-	//    * Public hosted zone: Two hosted zones that have the same name or that
-	//    have a parent/child relationship (example.com and test.example.com) can't
-	//    have any common name servers. You tried to create a hosted zone that has
-	//    the same name as an existing hosted zone or that's the parent or child
-	//    of an existing hosted zone, and you specified a delegation set that shares
-	//    one or more name servers with the existing hosted zone. For more information,
-	//    see CreateReusableDelegationSet (https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateReusableDelegationSet.html).
+	//    * Create a public hosted zone: Two hosted zones that have the same name
+	//    or that have a parent/child relationship (example.com and test.example.com)
+	//    can't have any common name servers. You tried to create a hosted zone
+	//    that has the same name as an existing hosted zone or that's the parent
+	//    or child of an existing hosted zone, and you specified a delegation set
+	//    that shares one or more name servers with the existing hosted zone. For
+	//    more information, see CreateReusableDelegationSet (https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateReusableDelegationSet.html).
 	//
-	//    * Private hosted zone: You specified an Amazon VPC that you're already
-	//    using for another hosted zone, and the domain that you specified for one
-	//    of the hosted zones is a subdomain of the domain that you specified for
-	//    the other hosted zone. For example, you can't use the same Amazon VPC
-	//    for the hosted zones for example.com and test.example.com.
+	//    * Create a private hosted zone: A hosted zone with the specified name
+	//    already exists and is already associated with the Amazon VPC that you
+	//    specified.
+	//
+	//    * Associate VPCs with a private hosted zone: The VPC that you specified
+	//    is already associated with another hosted zone that has the same name.
 	ErrCodeConflictingDomainExists = "ConflictingDomainExists"
 
 	// ErrCodeConflictingTypes for service response error code
@@ -240,7 +240,9 @@ const (
 	// ErrCodeNoSuchGeoLocation for service response error code
 	// "NoSuchGeoLocation".
 	//
-	// Amazon Route 53 doesn't support the specified geographic location.
+	// Amazon Route 53 doesn't support the specified geographic location. For a
+	// list of supported geolocation codes, see the GeoLocation (https://docs.aws.amazon.com/Route53/latest/APIReference/API_GeoLocation.html)
+	// data type.
 	ErrCodeNoSuchGeoLocation = "NoSuchGeoLocation"
 
 	// ErrCodeNoSuchHealthCheck for service response error code

--- a/vendor/github.com/aws/aws-sdk-go/service/route53/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/route53/service.go
@@ -31,7 +31,7 @@ var initRequest func(*request.Request)
 const (
 	ServiceName = "route53"   // Name of service.
 	EndpointsID = ServiceName // ID to lookup a service endpoint with.
-	ServiceID   = "Route 53"  // ServiceID is a unique identifer of a specific service.
+	ServiceID   = "Route 53"  // ServiceID is a unique identifier of a specific service.
 )
 
 // New creates a new instance of the Route53 client with a session.
@@ -39,6 +39,8 @@ const (
 // aws.Config parameter to add your extra config.
 //
 // Example:
+//     mySession := session.Must(session.NewSession())
+//
 //     // Create a Route53 client from just a session.
 //     svc := route53.New(mySession)
 //
@@ -46,11 +48,11 @@ const (
 //     svc := route53.New(mySession, aws.NewConfig().WithRegion("us-west-2"))
 func New(p client.ConfigProvider, cfgs ...*aws.Config) *Route53 {
 	c := p.ClientConfig(EndpointsID, cfgs...)
-	return newClient(*c.Config, c.Handlers, c.Endpoint, c.SigningRegion, c.SigningName)
+	return newClient(*c.Config, c.Handlers, c.PartitionID, c.Endpoint, c.SigningRegion, c.SigningName)
 }
 
 // newClient creates, initializes and returns a new service client instance.
-func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegion, signingName string) *Route53 {
+func newClient(cfg aws.Config, handlers request.Handlers, partitionID, endpoint, signingRegion, signingName string) *Route53 {
 	svc := &Route53{
 		Client: client.New(
 			cfg,
@@ -59,6 +61,7 @@ func newClient(cfg aws.Config, handlers request.Handlers, endpoint, signingRegio
 				ServiceID:     ServiceID,
 				SigningName:   signingName,
 				SigningRegion: signingRegion,
+				PartitionID:   partitionID,
 				Endpoint:      endpoint,
 				APIVersion:    "2013-04-01",
 			},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1109,7 +1109,7 @@ yunion.io/x/pkg/util/workqueue
 yunion.io/x/pkg/utils
 # yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 yunion.io/x/s3cli
-# yunion.io/x/sqlchemy v0.0.0-20200820050957-1542f05b9fcd
+# yunion.io/x/sqlchemy v0.0.0-20200909073353-606d1fe76db5
 yunion.io/x/sqlchemy
 # yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce
 yunion.io/x/structarg

--- a/vendor/yunion.io/x/sqlchemy/conditions.go
+++ b/vendor/yunion.io/x/sqlchemy/conditions.go
@@ -378,6 +378,14 @@ func Like(f IQueryField, v string) ICondition {
 	return &c
 }
 
+func ContainsAny(f IQueryField, v []string) ICondition {
+	conds := make([]ICondition, len(v))
+	for i := range v {
+		conds[i] = Contains(f, v[i])
+	}
+	return OR(conds...)
+}
+
 func Contains(f IQueryField, v string) ICondition {
 	v = likeEscape(v)
 	nv := fmt.Sprintf("%%%s%%", v)


### PR DESCRIPTION
results by user or project

**这个 PR 实现什么功能/修复什么问题**:
修正：允许对roleassignment的结果进行按id或名字过滤，改进project-role rpc的实现，同时支持以user和project来group返回的结果

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area apigateway keystone
/hold