### PR TITLE
Feat & Fix & Refactor for ESXi

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -5467,3 +5467,15 @@ func (manager *SHostManager) ListItemExportKeys(ctx context.Context,
 	}
 	return q, nil
 }
+
+func (manager *SHostManager) FetchHostByExtId(extid string) *SHost {
+	host := SHost{}
+	host.SetModelManager(manager, &host)
+	err := manager.Query().Equals("external_id", extid).First(&host)
+	if err != nil {
+		log.Errorf("fetchHostByExtId fail %s", err)
+		return nil
+	} else {
+		return &host
+	}
+}

--- a/pkg/hostman/storageman/imagecachemanager_agent.go
+++ b/pkg/hostman/storageman/imagecachemanager_agent.go
@@ -225,7 +225,7 @@ func (c *SAgentImageCacheManager) perfetchTemplateVMImageCache(ctx context.Conte
 	if err != nil {
 		return nil, errors.Wrap(err, "host.GetDatacenter")
 	}
-	_, err = dc.GetTemplateVMById(data.ImageExternalId)
+	_, err = dc.FetchTemplateVMById(data.ImageExternalId)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/multicloud/esxi/datacenter.go
+++ b/pkg/multicloud/esxi/datacenter.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/view"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 
@@ -254,6 +256,68 @@ func (dc *SDatacenter) fetchVms(vmRefs []types.ManagedObjectReference, all bool)
 		}
 	}
 	return vms, nil
+}
+
+func (dc *SDatacenter) FetchVMs() ([]*SVirtualMachine, error) {
+	return dc.fetchVMs(property.Filter{})
+}
+
+func (dc *SDatacenter) FetchNoTemplateVMs() ([]*SVirtualMachine, error) {
+	filter := property.Filter{}
+	filter["config.template"] = false
+	return dc.fetchVMs(filter)
+}
+
+func (dc *SDatacenter) fetchVMs(filter property.Filter) ([]*SVirtualMachine, error) {
+	odc := dc.getObjectDatacenter()
+	root := odc.Reference()
+	m := view.NewManager(dc.manager.client.Client)
+	v, err := m.CreateContainerView(dc.manager.context, root, []string{"VirtualMachine"}, true)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = v.Destroy(dc.manager.context)
+	}()
+	objs, err := v.Find(dc.manager.context, []string{"VirtualMachine"}, filter)
+	if err != nil {
+		return nil, err
+	}
+	vms, err := dc.fetchVms(objs, false)
+	return vms, err
+}
+
+func (dc *SDatacenter) FetchTemplateVMs() ([]*SVirtualMachine, error) {
+	filter := property.Filter{}
+	filter["config.template"] = true
+	return dc.fetchVMs(filter)
+}
+
+func (dc *SDatacenter) FetchTemplateVMById(id string) (*SVirtualMachine, error) {
+	filter := property.Filter{}
+	filter["config.template"] = true
+	filter["summary.config.uuid"] = id
+	vms, err := dc.fetchVMs(filter)
+	if err != nil {
+		return nil, err
+	}
+	if len(vms) == 0 {
+		return nil, errors.ErrNotFound
+	}
+	return vms[0], nil
+}
+
+func (dc *SDatacenter) FetchVMById(id string) (*SVirtualMachine, error) {
+	filter := property.Filter{}
+	filter["summary.config.uuid"] = id
+	vms, err := dc.fetchVMs(filter)
+	if err != nil {
+		return nil, err
+	}
+	if len(vms) == 0 {
+		return nil, errors.ErrNotFound
+	}
+	return vms[0], nil
 }
 
 func (dc *SDatacenter) fetchDatastores(datastoreRefs []types.ManagedObjectReference) ([]cloudprovider.ICloudStorage, error) {

--- a/pkg/multicloud/esxi/datacenter.go
+++ b/pkg/multicloud/esxi/datacenter.go
@@ -436,24 +436,3 @@ func (dc *SDatacenter) GetTemplateVMs() ([]*SVirtualMachine, error) {
 	}
 	return templateVms, nil
 }
-
-func (dc *SDatacenter) GetTemplateVMById(id string) (*SVirtualMachine, error) {
-	id = dc.manager.getPrivateId(id)
-	hosts, err := dc.GetIHosts()
-	if err != nil {
-		return nil, errors.Wrap(err, "SDatacenter.GetIHosts")
-	}
-	for _, ihost := range hosts {
-		host := ihost.(*SHost)
-		tvms, err := host.GetTemplateVMs()
-		if err != nil {
-			return nil, errors.Wrap(err, "host.GetTemplateVMs")
-		}
-		for i := range tvms {
-			if tvms[i].GetGlobalId() == id {
-				return tvms[i], nil
-			}
-		}
-	}
-	return nil, cloudprovider.ErrNotFound
-}

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -181,6 +181,7 @@ func (self *SHost) fetchVMs(all bool) error {
 	}
 
 	MAX_TRIES := 3
+	var vms []*SVirtualMachine
 	for tried := 0; tried < MAX_TRIES; tried += 1 {
 		hostVms := self.getHostSystem().Vm
 		if len(hostVms) == 0 {
@@ -188,15 +189,20 @@ func (self *SHost) fetchVMs(all bool) error {
 			return nil
 		}
 
-		vms, templatevms, err := dc.fetchVms(hostVms, all)
+		vms, err = dc.fetchVms(hostVms, all)
 		if err != nil {
 			log.Errorf("dc.fetchVms fail %s", err)
 			time.Sleep(time.Second)
 			self.Refresh()
 			continue
 		}
-		self.vms = vms
-		self.tempalteVMs = templatevms
+	}
+	for _, vm := range vms {
+		if vm.IsTemplate() {
+			self.tempalteVMs = append(self.tempalteVMs, vm)
+		} else {
+			self.vms = append(self.vms, vm)
+		}
 	}
 	return nil
 }

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -708,9 +708,13 @@ func (self *SHost) CreateVM2(ctx context.Context, ds *SDatastore, params SCreate
 	if err != nil {
 		return nil, errors.Wrap(err, "SEsxiClient.FindHostByIp")
 	}
-	temvm, err := imgHost.GetTemplateVMById(imageInfo.ImageExternalId)
+	dc, err := imgHost.GetDatacenter()
 	if err != nil {
-		return nil, errors.Wrap(err, "SHost.GetTemplateVMById")
+		return nil, errors.Wrap(err, "host.GetDatacenter")
+	}
+	temvm, err := dc.FetchTemplateVMById(imageInfo.ImageExternalId)
+	if err != nil {
+		return nil, errors.Wrapf(err, "datacenter.TemplateVMById for image %q and datacenter %q", imageInfo.ImageExternalId, dc.GetId())
 	}
 	return self.CloneVM(ctx, temvm, ds, params)
 }

--- a/pkg/multicloud/esxi/storage.go
+++ b/pkg/multicloud/esxi/storage.go
@@ -259,7 +259,14 @@ func (self *SDatastore) getVMs() ([]cloudprovider.ICloudVM, error) {
 	if len(vms) == 0 {
 		return nil, nil
 	}
-	ret, _, err := dc.fetchVms(vms, false)
+	svms, err := dc.fetchVms(vms, false)
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]cloudprovider.ICloudVM, len(svms))
+	for i := range svms {
+		ret[i] = svms[i]
+	}
 	return ret, err
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. refactor for fetchVms and fetchHardwareInfo
2. support fetchVM form datacenter
3. better vm operator  in esxicli
4. replace GetTemplateVMById with FetchTemplateVMById
5. fix: fetch templatevm from datacenter before clone vm
6. fix: add RequestSyncstatusOnHost for SESXiGuestDriver

details for no.6:

esxi 平台 Guest 进行 syncstatus 和其他平台有所区别，Vcenter 可能会更改
 VM 所在的 Host，所以在 Host 上寻找 VM 可能会出现 ErrNotFound。此时，应该
主动去整个 datacenter 中寻找 VM，然后更改 Host，进行同步。

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

- release/3.4
- release/3.3
- release/3.2
- release/3.1
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area esxiagent region
/cc @swordqiu @zexi 