### PR TITLE
fix(esxiagent): add HostDelayTaskWorkerCount

### DIFF
--- a/pkg/esxi/agent.go
+++ b/pkg/esxi/agent.go
@@ -133,7 +133,6 @@ func Start(app *appsrv.Application) error {
 }
 
 func (agent *SEsxiAgent) AddImageCacheHandler(prefix string, app *appsrv.Application) {
-	hostutils.InitWorkerManager()
 	app.AddHandler("POST",
 		fmt.Sprintf("%s/disks/image_cache", prefix),
 		auth.Authenticate(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {

--- a/pkg/esxi/options/options.go
+++ b/pkg/esxi/options/options.go
@@ -19,18 +19,19 @@ import common_options "yunion.io/x/onecloud/pkg/cloudcommon/options"
 type EsxiOptions struct {
 	common_options.CommonOptions
 
-	ListenInterface         string `help:"Master address of host server" default:"br0"`
-	ListenAddress           string `help:"Host serve IP address to select when multiple address bind to ListenInterface"`
-	EsxiAgentPath           string `default:"/opt/cloud/workspace/esxi_agent" help:"Path for esxi agent configuration files"`
-	ImageCachePath          string `help:"Path for storing image caches"`
-	ImageCacheLimit         int    `help:"Maximal storage space for image caching, in GB" default:"20"`
-	AgentTempPath           string `help:"Path for ESXI Agent"`
-	AgentTempLimit          int    `help:"Maximal storage space for ESXi agent, in GB" default:"20"`
-	LinuxDefaultRootUser    bool   `help:"Default account for Linux system is root" default:"false"`
-	WindowsDefaultAdminUser bool   `help:"Default account for Windows system is Administrator" default:"true"`
-	DefaultImageSaveFormat  string `help:"Default image save format, default is vmdk, canbe qcow2" default:"vmdk"`
-	Zone                    string `help:"Zone where the agent locates"`
-	DeployServerSocketPath  string `help:"Deploy server listen socket path" default:"/var/run/deploy.sock"`
+	ListenInterface          string `help:"Master address of host server" default:"br0"`
+	ListenAddress            string `help:"Host serve IP address to select when multiple address bind to ListenInterface"`
+	EsxiAgentPath            string `default:"/opt/cloud/workspace/esxi_agent" help:"Path for esxi agent configuration files"`
+	ImageCachePath           string `help:"Path for storing image caches"`
+	ImageCacheLimit          int    `help:"Maximal storage space for image caching, in GB" default:"20"`
+	AgentTempPath            string `help:"Path for ESXI Agent"`
+	AgentTempLimit           int    `help:"Maximal storage space for ESXi agent, in GB" default:"20"`
+	LinuxDefaultRootUser     bool   `help:"Default account for Linux system is root" default:"false"`
+	WindowsDefaultAdminUser  bool   `help:"Default account for Windows system is Administrator" default:"true"`
+	DefaultImageSaveFormat   string `help:"Default image save format, default is vmdk, canbe qcow2" default:"vmdk"`
+	Zone                     string `help:"Zone where the agent locates"`
+	DeployServerSocketPath   string `help:"Deploy server listen socket path" default:"/var/run/deploy.sock"`
+	HostDelayTaskWorkerCount int    `default:"8" help:"Host delay worker thread count, default is 8"`
 }
 
 var (

--- a/pkg/esxi/service/esxi_agent_service.go
+++ b/pkg/esxi/service/esxi_agent_service.go
@@ -30,6 +30,7 @@ import (
 	"yunion.io/x/onecloud/pkg/esxi/options"
 	"yunion.io/x/onecloud/pkg/hostman/guestfs/fsdriver"
 	"yunion.io/x/onecloud/pkg/hostman/hostdeployer/deployclient"
+	"yunion.io/x/onecloud/pkg/hostman/hostutils"
 )
 
 type SExsiAgentService struct {
@@ -70,6 +71,7 @@ func (s *SExsiAgentService) StartService() {
 	fsdriver.Init(nil)
 	deployclient.Init(options.Options.DeployServerSocketPath)
 
+	hostutils.InitWorkerManagerWithCount(options.Options.HostDelayTaskWorkerCount)
 	app := app_common.InitApp(&options.Options.BaseOptions, false)
 	handler.InitHandlers(app)
 

--- a/pkg/hostman/hostutils/hostutils.go
+++ b/pkg/hostman/hostutils/hostutils.go
@@ -189,7 +189,11 @@ func DelayTaskWithWorker(
 }
 
 func InitWorkerManager() {
-	wm = workmanager.NewWorkManger(TaskFailed, TaskComplete, options.HostOptions.DefaultRequestWorkerCount)
+	InitWorkerManagerWithCount(options.HostOptions.DefaultRequestWorkerCount)
+}
+
+func InitWorkerManagerWithCount(count int) {
+	wm = workmanager.NewWorkManger(TaskFailed, TaskComplete, count)
 }
 
 func InitK8sWorkerManager() {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

之前，HostDelayWorker 是通过 hostutils.InitWorkerManager 来初始化，
worker的数量依赖于options.HostOptions.DefaultRequestWorkerCount, 因为
这个options没有经过初始化，所以就是0，导致worker count的数量变为1。

现在增加了 HostDelayTaskWorkerCount 来管理这个count，默认值为8。

- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.3
- release/3.2
- release/3.1
- release/3.0
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area esxiagent
/cc @swordqiu @zexi @wanyaoqi 