### PR TITLE
fix: disable webkms for esxi older than 6.5

### DIFF
--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -43,6 +43,7 @@ import (
 	"yunion.io/x/onecloud/pkg/multicloud"
 	"yunion.io/x/onecloud/pkg/util/billing"
 	"yunion.io/x/onecloud/pkg/util/netutils2"
+	"yunion.io/x/onecloud/pkg/util/version"
 )
 
 var VIRTUAL_MACHINE_PROPS = []string{"name", "parent", "runtime", "summary", "config", "guest", "resourcePool", "layoutEx"}
@@ -573,11 +574,14 @@ func (self *SVirtualMachine) doDetachDisk(ctx context.Context, vdisk *SVirtualDi
 }
 
 func (self *SVirtualMachine) GetVNCInfo() (jsonutils.JSONObject, error) {
-	info, err := self.acquireWebmksTicket("webmks")
-	if err != nil {
-		info, err = self.acquireVmrcUrl()
+	hostVer := self.GetIHost().GetVersion()
+	if version.GE(hostVer, "6.5") {
+		info, err := self.acquireWebmksTicket("webmks")
+		if err == nil {
+			return info, nil
+		}
 	}
-	return info, err
+	return self.acquireVmrcUrl()
 }
 
 func (self *SVirtualMachine) acquireWebmksTicket(ticketType string) (jsonutils.JSONObject, error) {
@@ -599,14 +603,6 @@ func (self *SVirtualMachine) acquireWebmksTicket(ticketType string) (jsonutils.J
 	if port == 0 {
 		port = 443
 	}
-	/*
-		ret.Add(jsonutils.NewString(ticketType), "type")
-		ret.Add(jsonutils.NewString(ticket.Host), "host")
-		ret.Add(jsonutils.NewInt(int64(ticket.Port)), "port")
-		ret.Add(jsonutils.NewString(ticket.Ticket), "ticket")
-		ret.Add(jsonutils.NewString(ticket.SslThumbprint), "slThumbprint")
-		ret.Add(jsonutils.NewString(ticket.CfgFile), "cfgFile")
-	*/
 	url := fmt.Sprintf("wss://%s:%d/ticket/%s", host, port, ticket.Ticket)
 	ret.Add(jsonutils.NewString("wmks"), "protocol")
 	ret.Add(jsonutils.NewString(url), "url")
@@ -1266,7 +1262,7 @@ func (self *SVirtualMachine) GetIHostId() string {
 		log.Errorf("hostsystem reference2Object %s", err)
 		return ""
 	}
-	shost := NewHost(nil, &moHost, nil)
+	shost := NewHost(self.manager, &moHost, nil)
 	return shost.GetGlobalId()
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：ESXi版本低于6.5的宿主机上的主机，默认用VMRC打开控制台

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area region
/cc @zexi @rainzm 