### PR TITLE
Automated cherry pick of #7902: fix(esxi): return when host.Vm is empty

### DIFF
--- a/pkg/multicloud/esxi/manager.go
+++ b/pkg/multicloud/esxi/manager.go
@@ -656,6 +656,9 @@ func (cli *SESXiClient) HostVmIPs(ctx context.Context) (map[string]string, []SSi
 }
 
 func (cli *SESXiClient) vmIPs(host *mo.HostSystem) ([]SSimpleVM, error) {
+	if len(host.Vm) == 0 {
+		return []SSimpleVM{}, nil
+	}
 	var vms []mo.VirtualMachine
 	err := cli.references2Objects(host.Vm, VM_PROPS, &vms)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #7902 on release/3.4.

#7902: fix(esxi): return when host.Vm is empty