### PR TITLE
fix: disable qcloud verifyAppId temporarily

### DIFF
--- a/pkg/multicloud/qcloud/qcloud.go
+++ b/pkg/multicloud/qcloud/qcloud.go
@@ -103,10 +103,10 @@ func NewQcloudClient(cfg *QcloudClientConfig) (*SQcloudClient, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "fetchRegions")
 	}
-	err = client.verifyAppId()
-	if err != nil {
-		return nil, errors.Wrap(err, "verifyAppId")
-	}
+	// err = client.verifyAppId()
+	// if err != nil {
+	//	return nil, errors.Wrap(err, "verifyAppId")
+	// }
 	err = client.fetchBuckets()
 	if err != nil {
 		return nil, errors.Wrap(err, "fetchBuckets")
@@ -663,7 +663,8 @@ func (client *SQcloudClient) fetchBuckets() error {
 		createAt, _ := timeutils.ParseTimeStr(bInfo.CreationDate)
 		name := bInfo.Name
 		// name = name[:len(name)-len(result.Owner.ID)-1]
-		name = name[:strings.LastIndexByte(name, '-')]
+		slashPos := strings.LastIndexByte(name, '-')
+		name = name[:slashPos]
 		region, err := client.getIRegionByRegionId(bInfo.Region)
 		if err != nil {
 			log.Errorf("fail to find region %s", bInfo.Region)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：暂时禁用qcloud的appId校验，不太准确，存在误判

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area region