### PR TITLE
bugfix: fix set host image cache properties

### DIFF
--- a/pkg/hostman/storageman/imagecache_local.go
+++ b/pkg/hostman/storageman/imagecache_local.go
@@ -191,8 +191,8 @@ func (l *SLocalImageCache) prepare(ctx context.Context, zone, srcUrl, format str
 }
 
 func (l *SLocalImageCache) fetch(ctx context.Context, zone, srcUrl, format string) bool {
-	if (fileutils2.Exists(l.GetPath()) &&
-		l.remoteFile.VerifyIntegrity()) || l.remoteFile.Fetch() {
+	if (fileutils2.Exists(l.GetPath()) && l.remoteFile.VerifyIntegrity()) ||
+		l.remoteFile.Fetch() {
 		if len(l.Manager.GetId()) > 0 {
 			_, err := hostutils.RemoteStoragecacheCacheImage(ctx,
 				l.Manager.GetId(), l.imageId, "ready", l.GetPath())

--- a/pkg/hostman/storageman/remotefile/remotefile.go
+++ b/pkg/hostman/storageman/remotefile/remotefile.go
@@ -259,7 +259,13 @@ func (r *SRemoteFile) downloadInternal(getData bool, preChksum string) bool {
 }
 
 func (r *SRemoteFile) setProperties(header http.Header) {
-	r.chksum = header.Get("X-Image-Meta-Checksum")
-	r.format = header.Get("X-Image-Meta-Disk_format")
-	r.name = header.Get("X-Image-Meta-Name")
+	if chksum := header.Get("X-Image-Meta-Checksum"); len(chksum) > 0 {
+		r.chksum = chksum
+	}
+	if format := header.Get("X-Image-Meta-Disk_format"); len(format) > 0 {
+		r.format = format
+	}
+	if name := header.Get("X-Image-Meta-Name"); len(name) > 0 {
+		r.name = name
+	}
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
```
bugfix: fix set host image cache properties on fetch image from glance
```

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
release/3.2
/cc @zexi @swordqiu 
/area host
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
