### PR TITLE
Automated cherry pick of #7961: region: fix network schedtag not cleanup when network deleted

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1599,6 +1599,7 @@ func (self *SNetwork) CustomizeDelete(ctx context.Context, userCred mcclient.Tok
 }
 
 func (self *SNetwork) RealDelete(ctx context.Context, userCred mcclient.TokenCredential) error {
+	DeleteResourceJointSchedtags(self, ctx, userCred)
 	db.OpsLog.LogEvent(self, db.ACT_DELOCATE, self.GetShortDesc(ctx), userCred)
 	self.SetStatus(userCred, api.NETWORK_STATUS_DELETED, "real delete")
 	self.ClearSchedDescCache()

--- a/pkg/compute/models/schedtags.go
+++ b/pkg/compute/models/schedtags.go
@@ -295,7 +295,7 @@ func (self *SSchedtag) GetObjectQuery() *sqlchemy.SQuery {
 	q := objs.Query()
 	q = q.Join(objschedtags, sqlchemy.AND(sqlchemy.Equals(objschedtags.Field(jointMan.GetMasterIdKey(jointMan)), objs.Field("id")),
 		sqlchemy.IsFalse(objschedtags.Field("deleted"))))
-	q = q.Filter(sqlchemy.IsTrue(objs.Field("enabled")))
+	// q = q.Filter(sqlchemy.IsTrue(objs.Field("enabled")))
 	q = q.Filter(sqlchemy.Equals(objschedtags.Field("schedtag_id"), self.Id))
 	return q
 }
@@ -305,7 +305,8 @@ func (self *SSchedtag) GetJointManager() ISchedtagJointManager {
 }
 
 func (self *SSchedtag) GetObjectCount() (int, error) {
-	return self.GetJointManager().Query().Equals("schedtag_id", self.Id).CountWithError()
+	q := self.GetObjectQuery()
+	return q.CountWithError()
 }
 
 func (self *SSchedtag) getSchedPoliciesCount() (int, error) {


### PR DESCRIPTION
Cherry pick of #7961 on release/3.1.

#7961: region: fix network schedtag not cleanup when network deleted