### PR TITLE
fix: add esxicli vmrc/webmks command

### DIFF
--- a/pkg/multicloud/esxi/shell/virtualmachine.go
+++ b/pkg/multicloud/esxi/shell/virtualmachine.go
@@ -223,6 +223,32 @@ func init() {
 		return nil
 	})
 
+	shellutils.R(&VirtualMachineShowOptions{}, "vm-vmrc", "Show vm VMRC connection", func(cli *esxi.SESXiClient, args *VirtualMachineShowOptions) error {
+		vm, err := getVM(cli, args)
+		if err != nil {
+			return err
+		}
+		info, err := vm.GetVmrcInfo()
+		if err != nil {
+			return err
+		}
+		printutils.PrintJSONObject(info)
+		return nil
+	})
+
+	shellutils.R(&VirtualMachineShowOptions{}, "vm-webmks", "Show vm webmks connection", func(cli *esxi.SESXiClient, args *VirtualMachineShowOptions) error {
+		vm, err := getVM(cli, args)
+		if err != nil {
+			return err
+		}
+		info, err := vm.GetWebmksInfo()
+		if err != nil {
+			return err
+		}
+		printutils.PrintJSONObject(info)
+		return nil
+	})
+
 	shellutils.R(&VirtualMachineShowOptions{}, "vm-file-status", "Show vm files details", func(cli *esxi.SESXiClient, args *VirtualMachineShowOptions) error {
 		vm, err := getVM(cli, args)
 		if err != nil {

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -584,6 +584,14 @@ func (self *SVirtualMachine) GetVNCInfo() (jsonutils.JSONObject, error) {
 	return self.acquireVmrcUrl()
 }
 
+func (self *SVirtualMachine) GetVmrcInfo() (jsonutils.JSONObject, error) {
+	return self.acquireVmrcUrl()
+}
+
+func (self *SVirtualMachine) GetWebmksInfo() (jsonutils.JSONObject, error) {
+	return self.acquireWebmksTicket("webmks")
+}
+
 func (self *SVirtualMachine) acquireWebmksTicket(ticketType string) (jsonutils.JSONObject, error) {
 	vm := object.NewVirtualMachine(self.manager.client.Client, self.getVirtualMachine().Self)
 	ticket, err := vm.AcquireTicket(self.manager.context, ticketType)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：为esxicli增加vmrc、webmks的命令行工具

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area util