### PR TITLE
fix: scheduler token not support policy

### DIFF
--- a/pkg/scheduler/api/sched.go
+++ b/pkg/scheduler/api/sched.go
@@ -26,6 +26,7 @@ import (
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/cloudcommon/cmdline"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/cloudcommon/policy"
 	"yunion.io/x/onecloud/pkg/compute/models"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -83,7 +84,7 @@ func FetchSchedInfo(req *http.Request) (*SchedInfo, error) {
 	input = models.ApplySchedPolicies(input)
 
 	data := NewSchedInfo(input)
-	data.UserCred = token
+	data.UserCred = policy.FilterPolicyCredential(token)
 
 	domainId := data.Domain
 	for _, net := range data.Networks {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：scheduler的policy检查不生效。修正https://github.com/yunionio/onecloud/pull/7760
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @rainzm 
/area scheduler