### PR TITLE
fix: role assignment filter by users not working for effective users in groups

### DIFF
--- a/pkg/keystone/models/assignments.go
+++ b/pkg/keystone/models/assignments.go
@@ -648,6 +648,14 @@ func (manager *SAssignmentManager) FetchAll(
 		if len(userId) > 0 {
 			q2 = q2.Filter(sqlchemy.Equals(memberships.Field("user_id"), userId))
 		}
+		if len(userStrs) > 0 {
+			subq := UserManager.Query("id")
+			subq = subq.Filter(sqlchemy.OR(
+				sqlchemy.In(subq.Field("id"), userStrs),
+				sqlchemy.ContainsAny(subq.Field("name"), userStrs),
+			))
+			q2 = q2.Filter(sqlchemy.In(memberships.Field("user_id"), subq.SubQuery()))
+		}
 
 		q = sqlchemy.Union(usrq, q2).Query().Distinct()
 	} else {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：role-assignment列表user过滤器对组内用户不生效

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area keystone
/cc @zexi 