### PR TITLE
Automated cherry pick of #8063: fix(region): fetch correct ownerId in PerformPrepareNets

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -356,7 +356,11 @@ func (scm *SCloudaccountManager) PerformPrepareNets(ctx context.Context, userCre
 		return output, httperrors.NewNotSupportedError("not support for cloudaccount with provider '%s'", input.Provider)
 	}
 	// validate first
-	input.CloudaccountCreateInput, err = scm.ValidateCreateData(ctx, userCred, userCred, query, input.CloudaccountCreateInput)
+	ownerId, err := scm.FetchOwnerId(ctx, jsonutils.Marshal(input))
+	if err != nil {
+		return output, errors.Wrap(err, "FetchOwnerId in PerformPrepareNets")
+	}
+	input.CloudaccountCreateInput, err = scm.ValidateCreateData(ctx, userCred, ownerId, query, input.CloudaccountCreateInput)
 	if err != nil {
 		return output, err
 	}


### PR DESCRIPTION
Cherry pick of #8063 on release/3.3.

#8063: fix(region): fetch correct ownerId in PerformPrepareNets