### PR TITLE
fix:/dnsrecordset 增加CNAME检查,dnsrecord update的重复检查

### DIFF
--- a/pkg/cloudprovider/dnszone.go
+++ b/pkg/cloudprovider/dnszone.go
@@ -16,6 +16,7 @@ package cloudprovider
 
 import (
 	"fmt"
+	"strings"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/utils"
@@ -601,7 +602,7 @@ func (r DnsRecordSet) GetMxPriority() int64 {
 }
 
 func (record DnsRecordSet) Equals(r DnsRecordSet) bool {
-	if record.DnsName != r.DnsName {
+	if strings.ToLower(record.DnsName) != strings.ToLower(r.DnsName) {
 		return false
 	}
 	if record.DnsType != r.DnsType {

--- a/pkg/multicloud/aliyun/dns_domain_record.go
+++ b/pkg/multicloud/aliyun/dns_domain_record.go
@@ -212,7 +212,7 @@ func (self *SDomainRecord) GetDnsName() string {
 }
 
 func (self *SDomainRecord) GetStatus() string {
-	return api.DNS_ZONE_STATUS_AVAILABLE
+	return api.DNS_RECORDSET_STATUS_AVAILABLE
 }
 
 func (self *SDomainRecord) GetEnabled() bool {

--- a/pkg/multicloud/aliyun/private_zone_record.go
+++ b/pkg/multicloud/aliyun/private_zone_record.go
@@ -159,7 +159,7 @@ func (self *SPvtzRecord) GetDnsName() string {
 }
 
 func (self *SPvtzRecord) GetStatus() string {
-	return api.DNS_ZONE_STATUS_AVAILABLE
+	return api.DNS_RECORDSET_STATUS_AVAILABLE
 }
 
 func (self *SPvtzRecord) GetEnabled() bool {

--- a/pkg/multicloud/aws/dnshostedzone.go
+++ b/pkg/multicloud/aws/dnshostedzone.go
@@ -23,6 +23,7 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
 
+	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/multicloud"
 )
@@ -60,7 +61,7 @@ func (self *SHostedZone) GetGlobalId() string {
 }
 
 func (self *SHostedZone) GetStatus() string {
-	return ""
+	return api.DNS_ZONE_STATUS_AVAILABLE
 }
 
 func (self *SHostedZone) Refresh() error {

--- a/pkg/multicloud/aws/dnsrecordset.go
+++ b/pkg/multicloud/aws/dnsrecordset.go
@@ -26,6 +26,7 @@ import (
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/util/stringutils"
 
+	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 )
 
@@ -293,7 +294,7 @@ func (client *SAwsClient) RemoveDnsRecordSet(hostedZoneId string, opts *cloudpro
 }
 
 func (self *SdnsRecordSet) GetStatus() string {
-	return ""
+	return api.DNS_RECORDSET_STATUS_AVAILABLE
 }
 
 func (self *SdnsRecordSet) GetEnabled() bool {

--- a/pkg/multicloud/qcloud/dnspod_record.go
+++ b/pkg/multicloud/qcloud/dnspod_record.go
@@ -237,7 +237,7 @@ func (self *SDnsRecord) GetDnsName() string {
 
 func (self *SDnsRecord) GetStatus() string {
 	if self.Status != "spam" {
-		return api.DNS_ZONE_STATUS_AVAILABLE
+		return api.DNS_RECORDSET_STATUS_AVAILABLE
 	}
 	return api.DNS_ZONE_STATUS_UNKNOWN
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
dnsrecord重复检测，dnszone vpc数量统计


- [x] 功能、bugfix描述
- [x] 冒烟测试
- [ ] 单元测试编写


**是否需要 backport 到之前的 release 分支**:
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/areea region 
/cc @ioito @zexi 