### PR TITLE
Fix of Syncing Schedtag

### DIFF
--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -133,8 +133,10 @@ func (self *SHost) GetSchedtags() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	cpName := self.datacenter.manager.cpcfg.Name
 	reference := self.GetoHostSystem().Reference()
 	tags := make([]string, 0, 1)
+	oDatacenter := self.datacenter.getDatacenter()
 Loop:
 	for i := range clusters {
 		oc := clusters[i].getoCluster()
@@ -143,7 +145,7 @@ Loop:
 		}
 		for _, h := range oc.Host {
 			if h == reference {
-				tags = append(tags, fmt.Sprintf("cluster:%s", oc.Name))
+				tags = append(tags, fmt.Sprintf("cluster:/%s/%s/%s", cpName, oDatacenter.Name, oc.Name))
 				continue Loop
 			}
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. Guarantee the uniqueness of the schedtag for esxi host
2. 把extTagName存到metadata里面，这样就算修改tag的name，也能在metadata里面拿到。
3. 已经创建的schedtag就不要重复创建了。

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region esxiagent
/cc @zexi @swordqiu 