### PR TITLE
Automated cherry pick of #8099: fix(esxi): Guarantee the uniqueness of the schedtag for esxi host

### DIFF
--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -133,8 +133,10 @@ func (self *SHost) GetSchedtags() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	cpName := self.datacenter.manager.cpcfg.Name
 	reference := self.GetoHostSystem().Reference()
 	tags := make([]string, 0, 1)
+	oDatacenter := self.datacenter.getDatacenter()
 Loop:
 	for i := range clusters {
 		oc := clusters[i].getoCluster()
@@ -143,7 +145,7 @@ Loop:
 		}
 		for _, h := range oc.Host {
 			if h == reference {
-				tags = append(tags, fmt.Sprintf("cluster:%s", oc.Name))
+				tags = append(tags, fmt.Sprintf("cluster:/%s/%s/%s", cpName, oDatacenter.Name, oc.Name))
 				continue Loop
 			}
 		}


### PR DESCRIPTION
Cherry pick of #8099 on release/3.4.

#8099: fix(esxi): Guarantee the uniqueness of the schedtag for esxi host