### PR TITLE
Automated cherry pick of #8101: fix(region): set ownerId as userCred when can't FetchOwnerId

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -361,6 +361,9 @@ func (scm *SCloudaccountManager) PerformPrepareNets(ctx context.Context, userCre
 	if err != nil {
 		return output, errors.Wrap(err, "FetchOwnerId in PerformPrepareNets")
 	}
+	if ownerId == nil {
+		ownerId = userCred
+	}
 	input.CloudaccountCreateInput, err = scm.ValidateCreateData(ctx, userCred, ownerId, query, input.CloudaccountCreateInput)
 	if err != nil {
 		return output, err


### PR DESCRIPTION
Cherry pick of #8101 on release/3.4.

#8101: fix(region): set ownerId as userCred when can't FetchOwnerId