### PR TITLE
Automated cherry pick of #8104: region: fix schedtag joint resource master/slave field wrong order

### DIFF
--- a/pkg/compute/models/hostschedtags.go
+++ b/pkg/compute/models/hostschedtags.go
@@ -44,7 +44,6 @@ func init() {
 				"schedtaghost",
 				"schedtaghosts",
 				HostManager,
-				SchedtagManager,
 			),
 		}
 		HostschedtagManager.SetVirtualObject(HostschedtagManager)
@@ -57,7 +56,7 @@ type SHostschedtag struct {
 	HostId string `width:"36" charset:"ascii" nullable:"false" list:"admin" create:"admin_required"` // Column(VARCHAR(36, charset='ascii'), nullable=False)
 }
 
-func (manager *SHostschedtagManager) GetSlaveFieldName() string {
+func (manager *SHostschedtagManager) GetMasterFieldName() string {
 	return "host_id"
 }
 

--- a/pkg/compute/models/networkschedtags.go
+++ b/pkg/compute/models/networkschedtags.go
@@ -44,7 +44,6 @@ func init() {
 				"schedtagnetwork",
 				"schedtagnetworks",
 				NetworkManager,
-				SchedtagManager,
 			),
 		}
 		NetworkschedtagManager.SetVirtualObject(NetworkschedtagManager)
@@ -57,7 +56,7 @@ type SNetworkschedtag struct {
 	NetworkId string `width:"36" charset:"ascii" nullable:"false" list:"admin" create:"admin_required"` // Column(VARCHAR(36, charset='ascii'), nullable=False)
 }
 
-func (manager *SNetworkschedtagManager) GetSlaveFieldName() string {
+func (manager *SNetworkschedtagManager) GetMasterFieldName() string {
 	return "network_id"
 }
 

--- a/pkg/compute/models/schedtagjoint.go
+++ b/pkg/compute/models/schedtagjoint.go
@@ -44,7 +44,6 @@ func NewSchedtagJointsManager(
 	keyword string,
 	keywordPlural string,
 	master db.IStandaloneModelManager,
-	slave db.IStandaloneModelManager,
 ) *SSchedtagJointsManager {
 	return &SSchedtagJointsManager{
 		SJointResourceBaseManager: db.NewJointResourceBaseManager(
@@ -53,7 +52,7 @@ func NewSchedtagJointsManager(
 			keyword,
 			keywordPlural,
 			master,
-			slave,
+			SchedtagManager,
 		),
 	}
 }
@@ -64,7 +63,7 @@ type SSchedtagJointsBase struct {
 	SchedtagId string `width:"36" charset:"ascii" nullable:"false" list:"admin" create:"admin_required"` // =Column(VARCHAR(36, charset='ascii'), nullable=False)
 }
 
-func (manager *SSchedtagJointsManager) GetMasterFieldName() string {
+func (manager *SSchedtagJointsManager) GetSlaveFieldName() string {
 	return "schedtag_id"
 }
 
@@ -118,7 +117,7 @@ func (man *SSchedtagJointsManager) AllowListDescendent(ctx context.Context, user
 	return db.IsAdminAllowList(userCred, man)
 }
 
-func (man *SSchedtagJointsManager) GetMasterIdKey(m db.IJointModelManager) string {
+func (man *SSchedtagJointsManager) GetResourceIdKey(m db.IJointModelManager) string {
 	return fmt.Sprintf("%s_id", m.GetMasterManager().Keyword())
 }
 

--- a/pkg/compute/models/schedtags.go
+++ b/pkg/compute/models/schedtags.go
@@ -51,7 +51,7 @@ var STRATEGY_LIST = api.STRATEGY_LIST
 
 type ISchedtagJointManager interface {
 	db.IJointModelManager
-	GetMasterIdKey(db.IJointModelManager) string
+	GetResourceIdKey(db.IJointModelManager) string
 }
 
 type ISchedtagJointModel interface {
@@ -367,7 +367,7 @@ func (self *SSchedtag) GetObjectQuery() *sqlchemy.SQuery {
 	objs := masterMan.Query().SubQuery()
 	objschedtags := jointMan.Query().SubQuery()
 	q := objs.Query()
-	q = q.Join(objschedtags, sqlchemy.AND(sqlchemy.Equals(objschedtags.Field(jointMan.GetMasterIdKey(jointMan)), objs.Field("id")),
+	q = q.Join(objschedtags, sqlchemy.AND(sqlchemy.Equals(objschedtags.Field(jointMan.GetResourceIdKey(jointMan)), objs.Field("id")),
 		sqlchemy.IsFalse(objschedtags.Field("deleted"))))
 	// q = q.Filter(sqlchemy.IsTrue(objs.Field("enabled")))
 	q = q.Filter(sqlchemy.Equals(objschedtags.Field("schedtag_id"), self.Id))
@@ -469,7 +469,7 @@ func (self *SSchedtag) GetShortDescV2(ctx context.Context) api.SchedtagShortDesc
 
 func GetResourceJointSchedtags(obj IModelWithSchedtag) ([]ISchedtagJointModel, error) {
 	jointMan := obj.GetSchedtagJointManager()
-	q := jointMan.Query().Equals(jointMan.GetMasterIdKey(jointMan), obj.GetId())
+	q := jointMan.Query().Equals(jointMan.GetResourceIdKey(jointMan), obj.GetId())
 	jointTags := make([]ISchedtagJointModel, 0)
 	rows, err := q.Rows()
 	if err != nil {
@@ -501,7 +501,7 @@ func GetSchedtags(jointMan ISchedtagJointManager, masterId string) []SSchedtag {
 	q := schedtags.Query()
 	q = q.Join(objschedtags, sqlchemy.AND(sqlchemy.Equals(objschedtags.Field("schedtag_id"), schedtags.Field("id")),
 		sqlchemy.IsFalse(objschedtags.Field("deleted"))))
-	q = q.Filter(sqlchemy.Equals(objschedtags.Field(jointMan.GetMasterIdKey(jointMan)), masterId))
+	q = q.Filter(sqlchemy.Equals(objschedtags.Field(jointMan.GetResourceIdKey(jointMan)), masterId))
 	err := db.FetchModelObjects(SchedtagManager, q, &tags)
 	if err != nil {
 		log.Errorf("GetSchedtags error: %s", err)
@@ -553,7 +553,7 @@ func PerformSetResourceSchedtag(obj IModelWithSchedtag, ctx context.Context, use
 			if newTagObj, err := db.NewModelObject(jointMan); err != nil {
 				return nil, httperrors.NewGeneralError(err)
 			} else {
-				objectKey := jointMan.GetMasterIdKey(jointMan)
+				objectKey := jointMan.GetResourceIdKey(jointMan)
 				createData := jsonutils.NewDict()
 				createData.Add(jsonutils.NewString(setTagId), "schedtag_id")
 				createData.Add(jsonutils.NewString(obj.GetId()), objectKey)

--- a/pkg/compute/models/storageschedtags.go
+++ b/pkg/compute/models/storageschedtags.go
@@ -44,7 +44,6 @@ func init() {
 				"schedtagstorage",
 				"schedtagstorages",
 				StorageManager,
-				SchedtagManager,
 			),
 		}
 		StorageschedtagManager.SetVirtualObject(StorageschedtagManager)
@@ -57,7 +56,7 @@ type SStorageschedtag struct {
 	StorageId string `width:"36" charset:"ascii" nullable:"false" list:"admin" create:"admin_required"` // Column(VARCHAR(36, charset='ascii'), nullable=False)
 }
 
-func (manager *SStorageschedtagManager) GetSlaveFieldName() string {
+func (manager *SStorageschedtagManager) GetMasterFieldName() string {
 	return "storage_id"
 }
 


### PR DESCRIPTION
Cherry pick of #8104 on release/3.3.

#8104: region: fix schedtag joint resource master/slave field wrong order