### PR TITLE
fix: add climc support vpc/schedtag user metadata

### DIFF
--- a/cmd/climc/shell/compute/schedtags.go
+++ b/cmd/climc/shell/compute/schedtags.go
@@ -153,4 +153,17 @@ func init() {
 		printBatchResults(ret, modules.Schedtags.GetColumns(s))
 		return nil
 	})
+
+	R(&options.ResourceMetadataOptions{}, "schedtag-set-user-metadata", "Set metadata of a server", func(s *mcclient.ClientSession, opts *options.ResourceMetadataOptions) error {
+		params, err := opts.Params()
+		if err != nil {
+			return err
+		}
+		result, err := modules.Schedtags.PerformAction(s, opts.ID, "user-metadata", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
 }

--- a/cmd/climc/shell/compute/vpcs.go
+++ b/cmd/climc/shell/compute/vpcs.go
@@ -16,6 +16,7 @@ package compute
 
 import (
 	"yunion.io/x/onecloud/cmd/climc/shell"
+	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/mcclient/options"
 )
@@ -35,4 +36,17 @@ func init() {
 	cmd.Perform("public", &options.BasePublicOptions{})
 	cmd.Perform("change-owner", &options.VpcChangeOwnerOptions{})
 	cmd.Get("vpc-change-owner-candidate-domains", &options.VpcIdOptions{})
+
+	R(&options.ResourceMetadataOptions{}, "vpc-set-user-metadata", "Set metadata of a vpc", func(s *mcclient.ClientSession, opts *options.ResourceMetadataOptions) error {
+		params, err := opts.Params()
+		if err != nil {
+			return err
+		}
+		result, err := modules.Vpcs.PerformAction(s, opts.ID, "user-metadata", params)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
 }

--- a/pkg/mcclient/modules/mod_schedtags.go
+++ b/pkg/mcclient/modules/mod_schedtags.go
@@ -70,7 +70,7 @@ func (this *SchedtagManager) DoBatchSchedtagHostAddRemove(s *mcclient.ClientSess
 
 func init() {
 	Schedtags = SchedtagManager{NewComputeManager("schedtag", "schedtags",
-		[]string{"ID", "Name", "Default_strategy", "Resource_type", "Domain_id", "Project_id"},
+		[]string{"ID", "Name", "Default_strategy", "Resource_type", "Domain_id", "Project_id", "Metadata"},
 		[]string{})}
 
 	registerCompute(&Schedtags)

--- a/pkg/mcclient/modules/mod_vpcs.go
+++ b/pkg/mcclient/modules/mod_vpcs.go
@@ -22,7 +22,7 @@ var (
 
 func init() {
 	Vpcs = NewComputeManager("vpc", "vpcs",
-		[]string{"ID", "Name", "Enabled", "Status", "Cloudregion_Id", "Is_default", "Cidr_Block", "Region", "Public_Scope", "Domain_Id", "Domain"},
+		[]string{"ID", "Name", "Enabled", "Status", "Cloudregion_Id", "Is_default", "Cidr_Block", "Region", "Public_Scope", "Domain_Id", "Domain", "Metadata"},
 		[]string{})
 
 	registerCompute(&Vpcs)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：增加climc设置vpc和schedtag的user-metadata的接口

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area climc