### PR TITLE
fix: filter cloudprovider/network by host-schedtag-id

### DIFF
--- a/cmd/climc/shell/compute/cloudproviders.go
+++ b/cmd/climc/shell/compute/cloudproviders.go
@@ -35,6 +35,8 @@ func init() {
 		NoObjectStorage  bool     `help:"filter cloudproviders that has no object storage"`
 		Capability       []string `help:"capability filter" choices:"project|compute|network|loadbalancer|objectstore|rds|cache|event"`
 		Cloudregion      string   `help:"filter cloudproviders by cloudregion"`
+
+		HostSchedtagId string `help:"filter by host schedtag"`
 	}
 	R(&CloudproviderListOptions{}, "cloud-provider-list", "List cloud providers", func(s *mcclient.ClientSession, args *CloudproviderListOptions) error {
 		var params *jsonutils.JSONDict
@@ -61,6 +63,10 @@ func init() {
 
 			if len(args.Cloudregion) > 0 {
 				params.Add(jsonutils.NewString(args.Cloudregion), "cloudregion")
+			}
+
+			if len(args.HostSchedtagId) > 0 {
+				params.Add(jsonutils.NewString(args.HostSchedtagId), "host_schedtag_id")
 			}
 		}
 		result, err := modules.Cloudproviders.List(s, params)

--- a/pkg/apis/compute/cloudprovider.go
+++ b/pkg/apis/compute/cloudprovider.go
@@ -232,6 +232,9 @@ type CloudproviderListInput struct {
 
 	// 账号健康状态
 	HealthStatus []string `json:"health_status"`
+
+	// filter by host schedtag
+	HostSchedtagId string `json:"host_schedtag_id"`
 }
 
 func (input *CapabilityListInput) AfterUnmarshal() {

--- a/pkg/apis/compute/network.go
+++ b/pkg/apis/compute/network.go
@@ -114,6 +114,9 @@ type NetworkListInput struct {
 	IsAutoAlloc *bool `json:"is_auto_alloc"`
 	// 是否为基础网络（underlay）
 	IsClassic *bool `json:"is_classic"`
+
+	// filter by Host schedtag
+	HostSchedtagId string `json:"host_schedtag_id"`
 }
 
 type NetworkResourceInfoBase struct {

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -1201,6 +1201,22 @@ func (manager *SCloudproviderManager) ListItemFilter(
 		q = q.In("cloudaccount_id", subq)
 	}
 
+	if len(query.HostSchedtagId) > 0 {
+		schedTagObj, err := SchedtagManager.FetchByIdOrName(userCred, query.HostSchedtagId)
+		if err != nil {
+			if errors.Cause(err) == sql.ErrNoRows {
+				return nil, errors.Wrapf(httperrors.ErrResourceNotFound, "%s %s", SchedtagManager.Keyword(), query.HostSchedtagId)
+			} else {
+				return nil, errors.Wrap(err, "SchedtagManager.FetchByIdOrName")
+			}
+		}
+		subq := HostManager.Query("manager_id")
+		hostschedtags := HostschedtagManager.Query().Equals("schedtag_id", schedTagObj.GetId()).SubQuery()
+		subq = subq.Join(hostschedtags, sqlchemy.Equals(hostschedtags.Field("host_id"), subq.Field("id")))
+		log.Debugf("%s", subq.String())
+		q = q.In("id", subq.SubQuery())
+	}
+
 	return q, nil
 }
 

--- a/pkg/mcclient/options/network.go
+++ b/pkg/mcclient/options/network.go
@@ -34,6 +34,8 @@ type NetworkListOptions struct {
 	ServerType string   `help:"search networks belongs to a ServerType" choices:"baremetal|container|eip|guest|ipmi|pxe"`
 	Schedtag   string   `help:"filter networks by schedtag"`
 
+	HostSchedtagId string `help:"filter by host schedtag"`
+
 	IsAutoAlloc *bool `help:"search network with is_auto_alloc"`
 	IsClassic   *bool `help:"search classic on-premise network"`
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：允许对cloudprovider和network使用schedtag进行过滤

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area region
