### PR TITLE
Automated cherry pick of #8114: fix: filter cloudprovider/network by host-schedtag-id

### DIFF
--- a/cmd/climc/shell/compute/cloudproviders.go
+++ b/cmd/climc/shell/compute/cloudproviders.go
@@ -35,6 +35,8 @@ func init() {
 		NoObjectStorage  bool     `help:"filter cloudproviders that has no object storage"`
 		Capability       []string `help:"capability filter" choices:"project|compute|network|loadbalancer|objectstore|rds|cache|event"`
 		Cloudregion      string   `help:"filter cloudproviders by cloudregion"`
+
+		HostSchedtagId string `help:"filter by host schedtag"`
 	}
 	R(&CloudproviderListOptions{}, "cloud-provider-list", "List cloud providers", func(s *mcclient.ClientSession, args *CloudproviderListOptions) error {
 		var params *jsonutils.JSONDict
@@ -61,6 +63,10 @@ func init() {
 
 			if len(args.Cloudregion) > 0 {
 				params.Add(jsonutils.NewString(args.Cloudregion), "cloudregion")
+			}
+
+			if len(args.HostSchedtagId) > 0 {
+				params.Add(jsonutils.NewString(args.HostSchedtagId), "host_schedtag_id")
 			}
 		}
 		result, err := modules.Cloudproviders.List(s, params)

--- a/pkg/apis/compute/cloudprovider.go
+++ b/pkg/apis/compute/cloudprovider.go
@@ -232,6 +232,9 @@ type CloudproviderListInput struct {
 
 	// 账号健康状态
 	HealthStatus []string `json:"health_status"`
+
+	// filter by host schedtag
+	HostSchedtagId string `json:"host_schedtag_id"`
 }
 
 func (input *CapabilityListInput) AfterUnmarshal() {

--- a/pkg/apis/compute/network.go
+++ b/pkg/apis/compute/network.go
@@ -114,6 +114,9 @@ type NetworkListInput struct {
 	IsAutoAlloc *bool `json:"is_auto_alloc"`
 	// 是否为基础网络（underlay）
 	IsClassic *bool `json:"is_classic"`
+
+	// filter by Host schedtag
+	HostSchedtagId string `json:"host_schedtag_id"`
 }
 
 type NetworkResourceInfoBase struct {

--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -1201,6 +1201,22 @@ func (manager *SCloudproviderManager) ListItemFilter(
 		q = q.In("cloudaccount_id", subq)
 	}
 
+	if len(query.HostSchedtagId) > 0 {
+		schedTagObj, err := SchedtagManager.FetchByIdOrName(userCred, query.HostSchedtagId)
+		if err != nil {
+			if errors.Cause(err) == sql.ErrNoRows {
+				return nil, errors.Wrapf(httperrors.ErrResourceNotFound, "%s %s", SchedtagManager.Keyword(), query.HostSchedtagId)
+			} else {
+				return nil, errors.Wrap(err, "SchedtagManager.FetchByIdOrName")
+			}
+		}
+		subq := HostManager.Query("manager_id")
+		hostschedtags := HostschedtagManager.Query().Equals("schedtag_id", schedTagObj.GetId()).SubQuery()
+		subq = subq.Join(hostschedtags, sqlchemy.Equals(hostschedtags.Field("host_id"), subq.Field("id")))
+		log.Debugf("%s", subq.String())
+		q = q.In("id", subq.SubQuery())
+	}
+
 	return q, nil
 }
 

--- a/pkg/mcclient/options/network.go
+++ b/pkg/mcclient/options/network.go
@@ -34,6 +34,8 @@ type NetworkListOptions struct {
 	ServerType string   `help:"search networks belongs to a ServerType" choices:"baremetal|container|eip|guest|ipmi|pxe"`
 	Schedtag   string   `help:"filter networks by schedtag"`
 
+	HostSchedtagId string `help:"filter by host schedtag"`
+
 	IsAutoAlloc *bool `help:"search network with is_auto_alloc"`
 	IsClassic   *bool `help:"search classic on-premise network"`
 


### PR DESCRIPTION
Cherry pick of #8114 on release/3.4.

#8114: fix: filter cloudprovider/network by host-schedtag-id