### PR TITLE
Automated cherry pick of #8123: fix: suffix template cache key

### DIFF
--- a/pkg/cloudcommon/notifyclient/notify.go
+++ b/pkg/cloudcommon/notifyclient/notify.go
@@ -78,7 +78,7 @@ func getTemplateString(ctx context.Context, topic string, contType string, chann
 }
 
 func getTemplate(ctx context.Context, topic string, contType string, channel npk.TNotifyChannel) (*template.Template, error) {
-	key := fmt.Sprintf("%s.%s.%s", topic, contType, channel)
+	key := fmt.Sprintf("%s.%s.%s@%s", topic, contType, channel, getLangSuffix(ctx))
 	templatesTableLock.Lock()
 	defer templatesTableLock.Unlock()
 


### PR DESCRIPTION
Cherry pick of #8123 on release/3.4.

#8123: fix: suffix template cache key