### PR TITLE
Automated cherry pick of #8135: specs: fix specKey url not escape

### DIFF
--- a/pkg/mcclient/modules/mod_specs.go
+++ b/pkg/mcclient/modules/mod_specs.go
@@ -79,6 +79,7 @@ func (this *SpecsManager) GetObjects(s *mcclient.ClientSession, params jsonutils
 		return nil, httperrors.NewInputParameterError("Not found key in query: %v", err)
 	}
 	dict.Remove("key")
+	specKey = url.QueryEscape(specKey)
 	url := newSpecActionURL(model, specKey, "resource", dict)
 	return modulebase.Get(this.ResourceManager, s, url, this.Keyword)
 }


### PR DESCRIPTION
Cherry pick of #8135 on release/3.4.

#8135: specs: fix specKey url not escape