### PR TITLE
bugfix :esxi 多机器环境下拉取监控超时

### DIFF
--- a/pkg/multicloud/aws/region.go
+++ b/pkg/multicloud/aws/region.go
@@ -297,7 +297,7 @@ func (self *SRegion) cloudWatchRequest(apiName string, params *cloudwatch.GetMet
 	client.Handlers.Unmarshal.PushBackNamed(query.UnmarshalHandler)
 	client.Handlers.UnmarshalMeta.PushBackNamed(query.UnmarshalMetaHandler)
 	client.Handlers.UnmarshalError.PushBackNamed(query.UnmarshalErrorHandler)
-	return cloudWatchRequest(client, apiName, params, retval, true)
+	return cloudWatchRequest(client, apiName, params, retval, false)
 }
 
 func (self *SRegion) GetElbV2Client() (*elbv2.ELBV2, error) {

--- a/pkg/multicloud/huawei/client/modules/mod_ces.go
+++ b/pkg/multicloud/huawei/client/modules/mod_ces.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/httperrors"
@@ -143,7 +142,7 @@ func (ces *SCloudEyeManager) GetMetricsData(metrics []SMetricMeta, since time.Ti
 	if err != nil {
 		return nil, errors.Wrap(err, "ces.jsonRequest")
 	}
-	log.Debugf("%s", resp)
+	//log.Debugf("%s", resp)
 	result := make([]SMetricData, 0)
 	err = resp.Unmarshal(&result, "metrics")
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1.简化mo.virtualMachine 实体中的属性
2.批量获取cloudprovider下所有的虚拟机的监控信息

- [x] 冒烟测试

**是否需要 backport 到之前的 release 分支**:
- release/3.4

/cc @zexi 
/cc @rainzm 

/area region
