### PR TITLE
fix: filter storages by host schedtag

### DIFF
--- a/cmd/climc/shell/compute/storages.go
+++ b/cmd/climc/shell/compute/storages.go
@@ -35,6 +35,8 @@ func init() {
 		Zone     string `help:"List storages in zone" json:"-"`
 		Region   string `help:"List storages in region"`
 		Schedtag string `help:"filter storage by schedtag"`
+
+		HostSchedtagId string `help:"filter storage by host schedtag"`
 	}
 	R(&StorageListOptions{}, "storage-list", "List storages", func(s *mcclient.ClientSession, opts *StorageListOptions) error {
 		params, err := options.ListStructToParams(opts)

--- a/pkg/apis/compute/storage_const.go
+++ b/pkg/apis/compute/storage_const.go
@@ -183,4 +183,7 @@ type StorageListInput struct {
 
 	UsableResourceListInput
 	StorageShareFilterListInput
+
+	// filter by host schedtag
+	HostSchedtagId string `json:"host_schedtag_id"`
 }

--- a/pkg/compute/models/storages.go
+++ b/pkg/compute/models/storages.go
@@ -1384,6 +1384,21 @@ func (manager *SStorageManager) ListItemFilter(
 			Filter(sqlchemy.IsTrue(q.Field("enabled")))
 	}
 
+	if len(query.HostSchedtagId) > 0 {
+		schedTagObj, err := SchedtagManager.FetchByIdOrName(userCred, query.HostSchedtagId)
+		if err != nil {
+			if errors.Cause(err) == sql.ErrNoRows {
+				return nil, errors.Wrapf(httperrors.ErrResourceNotFound, "%s %s", SchedtagManager.Keyword(), query.HostSchedtagId)
+			} else {
+				return nil, errors.Wrap(err, "SchedtagManager.FetchByIdOrName")
+			}
+		}
+		subq := HoststorageManager.Query("storage_id")
+		hostschedtags := HostschedtagManager.Query().Equals("schedtag_id", schedTagObj.GetId()).SubQuery()
+		subq = subq.Join(hostschedtags, sqlchemy.Equals(hostschedtags.Field("host_id"), subq.Field("host_id")))
+		q = q.In("id", subq.SubQuery())
+	}
+
 	return q, err
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：filter storage by schedtag

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area region
/cc @zexi 