### PR TITLE
Automated cherry pick of #8143: mcclient modules: fix k8s fed rolebinding joint wrong resource manager

### DIFF
--- a/pkg/mcclient/modules/k8s/fed_rolebinding_cluster.go
+++ b/pkg/mcclient/modules/k8s/fed_rolebinding_cluster.go
@@ -29,7 +29,7 @@ func init() {
 		"federatedrolebindingclusters",
 		NewFedJointClusterCols(),
 		NewColumns(),
-		FederatedRoles,
+		FederatedRoleBindings,
 		KubeClusters,
 	)
 	modules.Register(&FederatedRoleBindingClusters)


### PR DESCRIPTION
Cherry pick of #8143 on release/3.4.

#8143: mcclient modules: fix k8s fed rolebinding joint wrong resource manager