### PR TITLE
hotfix: 1. allow merge networks without continuous addresses 2. filter guest_ip_start and guest_ip_end with contains operator

### DIFF
--- a/pkg/mcclient/options/network.go
+++ b/pkg/mcclient/options/network.go
@@ -40,6 +40,9 @@ type NetworkListOptions struct {
 	IsClassic   *bool `help:"search classic on-premise network"`
 
 	Status string `help:"filter by network status"`
+
+	GuestIpStart []string `help:"search by guest_ip_start"`
+	GuestIpEnd   []string `help:"search by guest_ip_end"`
 }
 
 func (opts *NetworkListOptions) GetContextId() string {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：
1、允许合并地址不连续的两个IP子网，只要两个子网的地址空间之间没有其他IP子网
2、允许对guest_ip_start和guest_ip_end两个字段做模糊匹配过滤 


<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @wanyaoqi @ioito @yousong 
/area region