### PR TITLE
Automated cherry pick of #8181: hotfix: 1. allow merge networks without continuous addresses 2. filter guest_ip_start and guest_ip_end with contains operator

### DIFF
--- a/pkg/mcclient/options/network.go
+++ b/pkg/mcclient/options/network.go
@@ -40,6 +40,9 @@ type NetworkListOptions struct {
 	IsClassic   *bool `help:"search classic on-premise network"`
 
 	Status string `help:"filter by network status"`
+
+	GuestIpStart []string `help:"search by guest_ip_start"`
+	GuestIpEnd   []string `help:"search by guest_ip_end"`
 }
 
 func (opts *NetworkListOptions) GetContextId() string {


### PR DESCRIPTION
Cherry pick of #8181 on release/3.4.

#8181: hotfix: 1. allow merge networks without continuous addresses 2. filter guest_ip_start and guest_ip_end with contains operator