### PR TITLE
Fix for cloudaccount PrepareNets

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -590,6 +590,9 @@ func (scm *SCloudaccountManager) PerformPrepareNets(ctx context.Context, userCre
 	lastEndIp := netutils.IPV4Addr(0)
 Loop:
 	for neti = 0; neti < len(excludeNets); {
+		if vmi >= len(vms) {
+			break
+		}
 		startIp, _ := netutils.NewIPV4Addr(excludeNets[neti].GuestIpStart)
 		endIp, _ := netutils.NewIPV4Addr(excludeNets[neti].GuestIpEnd)
 		switch {

--- a/pkg/multicloud/esxi/ip.go
+++ b/pkg/multicloud/esxi/ip.go
@@ -50,7 +50,10 @@ func (cli *SESXiClient) VMIP(host mo.HostSystem) (map[string][]string, error) {
 	ret := make(map[string][]string, len(vms))
 	for i := range vms {
 		vm := vms[i]
-		if vm.Config.Template {
+		if vm.Config == nil || vm.Config.Template {
+			continue
+		}
+		if vm.Guest == nil {
 			continue
 		}
 		guestIps := make([]string, 0)
@@ -75,7 +78,10 @@ func (cli *SESXiClient) VMIP2() (map[string][]string, error) {
 	ret := make(map[string][]string, len(vms))
 	for i := range vms {
 		vm := vms[i]
-		if vm.Config.Template {
+		if vm.Config == nil || vm.Config.Template {
+			continue
+		}
+		if vm.Guest == nil {
 			continue
 		}
 		guestIps := make([]string, 0)

--- a/pkg/multicloud/esxi/manager.go
+++ b/pkg/multicloud/esxi/manager.go
@@ -667,7 +667,10 @@ func (cli *SESXiClient) vmIPs(host *mo.HostSystem) ([]SSimpleVM, error) {
 	ret := make([]SSimpleVM, 0, len(vms))
 	for i := range vms {
 		vm := vms[i]
-		if vm.Config.Template {
+		if vm.Config == nil || vm.Config.Template {
+			continue
+		}
+		if vm.Guest == nil {
 			continue
 		}
 		guestIps := make([]string, 0)

--- a/pkg/multicloud/esxi/manager.go
+++ b/pkg/multicloud/esxi/manager.go
@@ -36,6 +36,7 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/netutils"
 	"yunion.io/x/pkg/util/regutils"
 	"yunion.io/x/pkg/utils"
 
@@ -677,6 +678,10 @@ func (cli *SESXiClient) vmIPs(host *mo.HostSystem) ([]SSimpleVM, error) {
 		for _, net := range vm.Guest.Net {
 			for _, ip := range net.IpAddress {
 				if regutils.MatchIP4Addr(ip) {
+					ipaddr, _ := netutils.NewIPV4Addr(ip)
+					if netutils.IsLinkLocal(ipaddr) {
+						continue
+					}
 					guestIps = append(guestIps, ip)
 				}
 			}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. 获取vmip的时候要检查config是否为nil。
2. 过滤 linkLocalAddress
3. vms长度为0，避免数组越界

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.3
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area compute
/cc @swordqiu @zexi 