### PR TITLE
fix: filter cached images with host schedtag

### DIFF
--- a/cmd/climc/shell/compute/cachedimages.go
+++ b/cmd/climc/shell/compute/cachedimages.go
@@ -27,6 +27,8 @@ func init() {
 
 		Region string `help:"show images cached at cloud region"`
 		Zone   string `help:"show images cached at zone"`
+
+		HostSchedtagId string `help:"filter cached image with host schedtag"`
 	}
 	R(&CachedImageListOptions{}, "cached-image-list", "List cached images", func(s *mcclient.ClientSession, args *CachedImageListOptions) error {
 		params, err := options.ListStructToParams(args)

--- a/pkg/apis/compute/input.go
+++ b/pkg/apis/compute/input.go
@@ -58,6 +58,9 @@ type CachedimageListInput struct {
 	// 镜像类型，可能值为: system(公有云公共镜像), customized(自定义镜像)
 	// example: system
 	ImageType []string `json:"image_type"`
+
+	// filter by host schedtag
+	HostSchedtagId string `json:"host_schedtag_id"`
 }
 
 type ExternalProjectListInput struct {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：通过host_schedtag过滤缓存镜像

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @yousong @ioito @tb365 
/area region