### PR TITLE
Automated cherry pick of #8214: remove aws lbbg cache metedata

### DIFF
--- a/pkg/compute/models/initdb.go
+++ b/pkg/compute/models/initdb.go
@@ -52,6 +52,7 @@ func InitDB() error {
 		LoadbalancerListenerRuleManager,
 		LoadbalancerBackendGroupManager,
 		LoadbalancerBackendManager,
+		AwsCachedLbbgManager,
 		LoadbalancerClusterManager,
 		SchedtagManager,
 		DynamicschedtagManager,

--- a/pkg/compute/models/loadbalancerawscachedlbb.go
+++ b/pkg/compute/models/loadbalancerawscachedlbb.go
@@ -159,16 +159,14 @@ func (man *SAwsCachedLbManager) SyncLoadbalancerBackends(ctx context.Context, us
 		if err != nil {
 			syncResult.UpdateError(err)
 		} else {
-			syncMetadata(ctx, userCred, &commondb[i], commonext[i])
 			syncResult.Update()
 		}
 	}
 	for i := 0; i < len(added); i++ {
-		local, err := man.newFromCloudLoadbalancerBackend(ctx, userCred, loadbalancerBackendgroup, added[i], syncOwnerId)
+		_, err := man.newFromCloudLoadbalancerBackend(ctx, userCred, loadbalancerBackendgroup, added[i], syncOwnerId)
 		if err != nil {
 			syncResult.AddError(err)
 		} else {
-			syncMetadata(ctx, userCred, local, added[i])
 			syncResult.Add()
 		}
 	}

--- a/pkg/compute/models/loadbalancerhuaweicachedlbb.go
+++ b/pkg/compute/models/loadbalancerhuaweicachedlbb.go
@@ -162,16 +162,14 @@ func (man *SHuaweiCachedLbManager) SyncLoadbalancerBackends(ctx context.Context,
 		if err != nil {
 			syncResult.UpdateError(err)
 		} else {
-			syncMetadata(ctx, userCred, &commondb[i], commonext[i])
 			syncResult.Update()
 		}
 	}
 	for i := 0; i < len(added); i++ {
-		local, err := man.newFromCloudLoadbalancerBackend(ctx, userCred, loadbalancerBackendgroup, added[i], syncOwnerId)
+		_, err := man.newFromCloudLoadbalancerBackend(ctx, userCred, loadbalancerBackendgroup, added[i], syncOwnerId)
 		if err != nil {
 			syncResult.AddError(err)
 		} else {
-			syncMetadata(ctx, userCred, local, added[i])
 			syncResult.Add()
 		}
 	}

--- a/pkg/compute/models/loadbalancerhuaweicachedlbbg.go
+++ b/pkg/compute/models/loadbalancerhuaweicachedlbbg.go
@@ -222,7 +222,6 @@ func (man *SHuaweiCachedLbbgManager) SyncLoadbalancerBackendgroups(ctx context.C
 		if err != nil {
 			syncResult.UpdateError(err)
 		} else {
-			syncMetadata(ctx, userCred, &commondb[i], commonext[i])
 			localLbgs = append(localLbgs, commondb[i])
 			remoteLbbgs = append(remoteLbbgs, commonext[i])
 			syncResult.Update()
@@ -233,7 +232,6 @@ func (man *SHuaweiCachedLbbgManager) SyncLoadbalancerBackendgroups(ctx context.C
 		if err != nil {
 			syncResult.AddError(err)
 		} else {
-			syncMetadata(ctx, userCred, new, added[i])
 			localLbgs = append(localLbgs, *new)
 			remoteLbbgs = append(remoteLbbgs, added[i])
 			syncResult.Add()

--- a/pkg/compute/models/loadbalancerqcloudcachedlbb.go
+++ b/pkg/compute/models/loadbalancerqcloudcachedlbb.go
@@ -234,16 +234,14 @@ func (man *SQcloudCachedLbManager) SyncLoadbalancerBackends(ctx context.Context,
 		if err != nil {
 			syncResult.UpdateError(err)
 		} else {
-			syncMetadata(ctx, userCred, &commondb[i], commonext[i])
 			syncResult.Update()
 		}
 	}
 	for i := 0; i < len(added); i++ {
-		local, err := man.newFromCloudLoadbalancerBackend(ctx, userCred, loadbalancerBackendgroup, added[i], syncOwnerId)
+		_, err := man.newFromCloudLoadbalancerBackend(ctx, userCred, loadbalancerBackendgroup, added[i], syncOwnerId)
 		if err != nil {
 			syncResult.AddError(err)
 		} else {
-			syncMetadata(ctx, userCred, local, added[i])
 			syncResult.Add()
 		}
 	}

--- a/pkg/compute/models/loadbalancerqcloudcachedlbbg.go
+++ b/pkg/compute/models/loadbalancerqcloudcachedlbbg.go
@@ -294,7 +294,6 @@ func (man *SQcloudCachedLbbgManager) SyncLoadbalancerBackendgroups(ctx context.C
 		if err != nil {
 			syncResult.UpdateError(err)
 		} else {
-			syncMetadata(ctx, userCred, &commondb[i], commonext[i])
 			localLbgs = append(localLbgs, commondb[i])
 			remoteLbbgs = append(remoteLbbgs, commonext[i])
 			syncResult.Update()
@@ -305,7 +304,6 @@ func (man *SQcloudCachedLbbgManager) SyncLoadbalancerBackendgroups(ctx context.C
 		if err != nil {
 			syncResult.AddError(err)
 		} else {
-			syncMetadata(ctx, userCred, newlbbg, added[i])
 			localLbgs = append(localLbgs, *newlbbg)
 			remoteLbbgs = append(remoteLbbgs, added[i])
 			syncResult.Add()


### PR DESCRIPTION
Cherry pick of #8214 on release/3.2.

#8214: remove aws lbbg cache metedata