### PR TITLE
feature: allow session level yunion_auth cookie

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -406,8 +406,11 @@ func isUserAllowWebconsole(userInfo jsonutils.JSONObject) bool {
 }
 
 func saveCookie(w http.ResponseWriter, name, val, domain string, expire time.Time, base64 bool) {
-	diff := time.Until(expire)
-	maxAge := int(diff.Seconds())
+	var maxAge int
+	if !expire.IsZero() {
+		diff := time.Until(expire)
+		maxAge = int(diff.Seconds())
+	}
 	// log.Println("Set cookie", name, expire, maxAge, val)
 	var valenc string
 	if base64 {
@@ -461,7 +464,11 @@ func clearCookie(w http.ResponseWriter, name string, domain string) {
 
 func saveAuthCookie(w http.ResponseWriter, authToken *clientman.SAuthToken, token mcclient.TokenCredential) {
 	authCookie := authToken.GetAuthCookie(token)
-	saveCookie(w, constants.YUNION_AUTH_COOKIE, authCookie, options.Options.CookieDomain, token.GetExpires(), true)
+	expire := time.Time{}
+	if !options.Options.SessionLevelAuthCookie {
+		expire = token.GetExpires()
+	}
+	saveCookie(w, constants.YUNION_AUTH_COOKIE, authCookie, options.Options.CookieDomain, expire, true)
 }
 
 func clearAuthCookie(w http.ResponseWriter) {

--- a/pkg/apigateway/options/options.go
+++ b/pkg/apigateway/options/options.go
@@ -37,6 +37,8 @@ type GatewayOptions struct {
 
 	ReturnFullDomainList bool `default:"true" help:"return domain list for get_regions API"`
 
+	SessionLevelAuthCookie bool `default:"false" help:"YunionAuth cookie is valid during a browser session"`
+
 	common_options.CommonOptions `"request_worker_count->default":"32"`
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：允许设置session级别的yunionauth cookie

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area apigateway
/cc @zexi @yousong 