### PR TITLE
baremetal: fix pxe filter network by guest_dhcp

### DIFF
--- a/pkg/baremetal/pxe/dhcp.go
+++ b/pkg/baremetal/pxe/dhcp.go
@@ -269,6 +269,9 @@ func (req *dhcpRequest) findNetworkConf(session *mcclient.ClientSession, filterU
 		params.Add(jsonutils.NewString(
 			fmt.Sprintf("guest_dhcp.endswith(',%s')", req.RelayAddr)),
 			"filter.3")
+		params.Add(jsonutils.NewString(
+			fmt.Sprintf("guest_dhcp.equals(%s)", req.RelayAddr)),
+			"filter.4")
 		params.Add(jsonutils.JSONTrue, "filter_any")
 	}
 	params.Add(jsonutils.JSONTrue, "is_classic")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: 当 network 的 guest_dhcp 存储为 ‘ip’ 格式而不是 'ip1,ip2' 这种格式，会过滤失败

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
- 3.2
/area baremetal
/cc @swordqiu 