### PR TITLE
fix: project_id in resource details not correct

### DIFF
--- a/pkg/apis/output.go
+++ b/pkg/apis/output.go
@@ -157,7 +157,7 @@ type ProjectizedResourceInfo struct {
 
 	// 资源归属项目的ID(向后兼容别名）
 	// Deprecated
-	TenantId string `json:"project_id" yunion-deprecated-by:"tenant"`
+	TenantId string `json:"project_id" yunion-deprecated-by:"tenant_id"`
 
 	// 资源归属项目的名称（向后兼容别名）
 	// Deprecated


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：资源输出details的project_id字段值不正确

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area util
/cc @zexi 