### PR TITLE
feat: add a retry mechanism to AutoSyncExtDiskSnapshot

### DIFF
--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -144,9 +144,10 @@ type ComputeOptions struct {
 
 	EnableAutoRenameProject bool `help:"when it set true, auto create project will rename when cloud project name changed" default:"false"`
 
-	SyncStorageCapacityUsedIntervalMinutes int `help:"interval sync storage capacity used" default:"10"`
+	SyncStorageCapacityUsedIntervalMinutes int  `help:"interval sync storage capacity used" default:"10"`
+	LockStorageFromCachedimage             bool `help:"must use storage in where selected cachedimage when creating vm"`
 
-	LockStorageFromCachedimage bool `help:"must use storage in where selected cachedimage when creating vm"`
+	SyncExtDiskSnapshotIntervalMinutes int `help:"sync snapshot for external disk" default:"20"`
 
 	SCapabilityOptions
 	SASControllerOptions

--- a/pkg/compute/service/service.go
+++ b/pkg/compute/service/service.go
@@ -143,9 +143,10 @@ func StartService() {
 
 		cron.AddJobAtIntervalsWithStartRun("SyncCapacityUsedForStorage", time.Duration(opts.SyncStorageCapacityUsedIntervalMinutes)*time.Minute, models.StorageManager.SyncCapacityUsedForStorage, true)
 
+		cron.AddJobAtIntervalsWithStartRun("AutoSyncExtDiskSnapshot", time.Duration(opts.SyncExtDiskSnapshotIntervalMinutes)*time.Minute, models.DiskManager.AutoSyncExtDiskSnapshot, true)
+
 		cron.AddJobEveryFewHour("AutoDiskSnapshot", 1, 5, 0, models.DiskManager.AutoDiskSnapshot, false)
 		cron.AddJobEveryFewHour("SnapshotsCleanup", 1, 35, 0, models.SnapshotManager.CleanupSnapshots, false)
-		cron.AddJobEveryFewHour("AutoSyncExtDiskSnapshot", 1, 10, 0, models.DiskManager.AutoSyncExtDiskSnapshot, false)
 		cron.AddJobEveryFewDays("SyncSkus", opts.SyncSkusDay, opts.SyncSkusHour, 0, 0, models.SyncServerSkus, true)
 		cron.AddJobEveryFewDays("SyncDBInstanceSkus", opts.SyncSkusDay, opts.SyncSkusHour, 0, 0, models.SyncDBInstanceSkus, true)
 		cron.AddJobEveryFewDays("SyncElasticCacheSkus", opts.SyncSkusDay, opts.SyncSkusHour, 0, 0, models.SyncElasticCacheSkus, true)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

问题：
给磁盘绑定快照策略（最小时间粒度是小时）之后，我们会在快照策略生效的那个小时的10分去云上拉去快照，但是有的快照可能在此之后才会生成出来。而且如果在快照策略应该生效的时间，region未启动，就会错过同步的时间。
现在，增加了一个字段 NextSyncTime 来记录下一次同步的时间。如果 NextSyncTime 早于或者等于当前时间，就会去同步，如果同步成功就会更新NextSyncTime。

- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @wanyaoqi @zexi 