### PR TITLE
sync and use of ESXi template 

### DIFF
--- a/pkg/apis/compute/network.go
+++ b/pkg/apis/compute/network.go
@@ -187,6 +187,12 @@ type NetworkCreateInput struct {
 
 	// 是否加入自动分配地址池
 	IsAutoAlloc *bool `json:"is_auto_alloc"`
+
+	// VlanId
+	VlanId *int `json:"vlan_id"`
+
+	// deprecated
+	Vlan *int `json:"vlan" yunion-deprecated-by:"vlan_id"`
 }
 
 type NetworkDetails struct {

--- a/pkg/cloudcommon/db/namevalidator.go
+++ b/pkg/cloudcommon/db/namevalidator.go
@@ -87,6 +87,10 @@ func alterNameValidator(model IModel, name string) error {
 	return nil
 }
 
+func GenerateAlertName(model IModel, hint string) (string, error) {
+	return GenerateName2(model.GetModelManager(), nil, hint, model, 1)
+}
+
 func GenerateName(manager IModelManager, ownerId mcclient.IIdentityProvider, hint string) (string, error) {
 	return GenerateName2(manager, ownerId, hint, nil, 1)
 }

--- a/pkg/compute/guestdrivers/esxi.go
+++ b/pkg/compute/guestdrivers/esxi.go
@@ -192,8 +192,13 @@ func (self *SESXiGuestDriver) GetJsonDescAtHost(ctx context.Context, userCred mc
 	var hostIp string
 	storageCacheHost, err := storageCaches[0].GetHost()
 	if err != nil {
-		log.Errorf("fail to GetHost of storageCache %s", storageCaches[0].Id)
+		log.Errorf("unable to GetHost of storageCache %s: %v", storageCaches[0].Id, err)
 		hostIp = storageCaches[0].ExternalId
+	} else if storageCacheHost == nil {
+		log.Errorf("unable to GetHost of storageCache %s: result is nil", storageCaches[0].Id)
+		hostIp = storageCaches[0].ExternalId
+	} else {
+		hostIp = storageCacheHost.AccessIp
 	}
 	hostIp = storageCacheHost.AccessIp
 	imageInfo := SEsxiImageInfo{

--- a/pkg/compute/models/cachedimages.go
+++ b/pkg/compute/models/cachedimages.go
@@ -472,7 +472,11 @@ func (self *SCachedimage) canDeleteLastCache() bool {
 
 func (self *SCachedimage) syncWithCloudImage(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, image cloudprovider.ICloudImage, managerId string) error {
 	diff, err := db.UpdateWithLock(ctx, self, func() error {
-		self.Name = image.GetName()
+		newName, err := db.GenerateAlertName(self, image.GetName())
+		if err != nil {
+			return errors.Wrap(err, "GenerateAlertName")
+		}
+		self.Name = newName
 		self.Size = image.GetSizeByte()
 		self.ExternalId = image.GetGlobalId()
 		self.ImageType = image.GetImageType()

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1334,6 +1334,20 @@ func (manager *SNetworkManager) ValidateCreateData(ctx context.Context, userCred
 	}
 
 	{
+		defaultVlanId := 1
+
+		if input.VlanId == nil {
+			input.VlanId = &defaultVlanId
+		} else if *input.VlanId < 1 {
+			input.VlanId = &defaultVlanId
+		}
+
+		if *input.VlanId > 4095 {
+			return input, httperrors.NewInputParameterError("valid vlan id")
+		}
+	}
+
+	{
 		if len(input.IfnameHint) == 0 {
 			input.IfnameHint = input.Name
 		}

--- a/pkg/hostman/storageman/storage_agent.go
+++ b/pkg/hostman/storageman/storage_agent.go
@@ -310,10 +310,9 @@ func (as *SAgentStorage) AgentDeployGuest(ctx context.Context, data interface{})
 	}
 
 	array := jsonutils.NewArray()
-	diskArray, _ := desc.GetArray("disks")
-	for idx, d := range disks {
+	for _, d := range disks {
 		disk := d.(*esxi.SVirtualDisk)
-		diskId, _ := diskArray[idx].GetString("disk_id")
+		diskId := disk.GetId()
 		diskDict := jsonutils.NewDict()
 		diskDict.Add(jsonutils.NewString(diskId), "disk_id")
 		diskDict.Add(jsonutils.NewString(disk.GetGlobalId()), "uuid")

--- a/pkg/multicloud/esxi/datacenter.go
+++ b/pkg/multicloud/esxi/datacenter.go
@@ -287,7 +287,7 @@ func (dc *SDatacenter) fetchFakeTemplateVMs(movms []mo.VirtualMachine, regex str
 	objs := make([]types.ManagedObjectReference, 0)
 	for i := range movms {
 		name := movms[i].Name
-		if tNameRegex.MatchString(name) {
+		if tNameRegex != nil && tNameRegex.MatchString(name) {
 			objs = append(objs, movms[i].Reference())
 		}
 	}

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -1008,15 +1008,15 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, ds *SData
 			log.Infof("resize system disk: %dGB => %dGB", from.vdisks[0].GetDiskSizeMB()/1024, vdisk.CapacityInKB/1024/1024)
 		}
 		// remove extra disk
-		for i := 1; i < len(from.vdisks); i++ {
-			dev := from.vdisks[i].dev
-			spec := &types.VirtualDeviceConfigSpec{}
-			spec.Operation = types.VirtualDeviceConfigSpecOperationRemove
-			spec.Device = dev
-			spec.FileOperation = types.VirtualDeviceConfigSpecFileOperationDestroy
-			deviceChange = append(deviceChange, spec)
-			log.Debugf("remove disk, index: %d", i)
-		}
+		// for i := 1; i < len(from.vdisks); i++ {
+		// 	 dev := from.vdisks[i].dev
+		// 	 spec := &types.VirtualDeviceConfigSpec{}
+		// 	 spec.Operation = types.VirtualDeviceConfigSpecOperationRemove
+		// 	 spec.Device = dev
+		//	 spec.FileOperation = types.VirtualDeviceConfigSpecFileOperationDestroy
+		//	 deviceChange = append(deviceChange, spec)
+		//	 log.Debugf("remove disk, index: %d", i)
+		// }
 	}
 
 	dc, err := host.GetDatacenter()

--- a/pkg/multicloud/esxi/manager.go
+++ b/pkg/multicloud/esxi/manager.go
@@ -351,7 +351,8 @@ func (cli *SESXiClient) scanAllMObjects(props []string, dst interface{}) error {
 
 func (cli *SESXiClient) SearchTemplateVM(id string) (*SVirtualMachine, error) {
 	filter := property.Filter{}
-	filter["summary.config.uuid"] = id
+	uuid := toTemplateUuid(id)
+	filter["summary.config.uuid"] = uuid
 	var movms []mo.VirtualMachine
 	err := cli.scanMObjectsWithFilter(cli.client.ServiceContent.RootFolder, VIRTUAL_MACHINE_PROPS, &movms, filter)
 	if err != nil {

--- a/pkg/multicloud/esxi/manager.go
+++ b/pkg/multicloud/esxi/manager.go
@@ -351,7 +351,6 @@ func (cli *SESXiClient) scanAllMObjects(props []string, dst interface{}) error {
 
 func (cli *SESXiClient) SearchTemplateVM(id string) (*SVirtualMachine, error) {
 	filter := property.Filter{}
-	filter["config.template"] = true
 	filter["summary.config.uuid"] = id
 	var movms []mo.VirtualMachine
 	err := cli.scanMObjectsWithFilter(cli.client.ServiceContent.RootFolder, VIRTUAL_MACHINE_PROPS, &movms, filter)
@@ -362,6 +361,9 @@ func (cli *SESXiClient) SearchTemplateVM(id string) (*SVirtualMachine, error) {
 		return nil, errors.ErrNotFound
 	}
 	vm := NewVirtualMachine(cli, &movms[0], nil)
+	if !vm.IsTemplate() {
+		return nil, errors.ErrNotFound
+	}
 	dc, err := vm.fetchDatacenter()
 	if err != nil {
 		return nil, errors.Wrap(err, "fetchDatacenter")

--- a/pkg/multicloud/esxi/storagecache.go
+++ b/pkg/multicloud/esxi/storagecache.go
@@ -100,6 +100,9 @@ func (self *SDatastoreImageCache) getTempalteVMs() ([]*SVirtualMachine, error) {
 }
 
 func (self *SDatastoreImageCache) getFakeTempateVMs() ([]*SVirtualMachine, error) {
+	if tempalteNameRegex == nil {
+		return nil, nil
+	}
 	return self.datastore.FetchFakeTempateVMs("")
 }
 

--- a/pkg/multicloud/esxi/template.go
+++ b/pkg/multicloud/esxi/template.go
@@ -16,6 +16,8 @@ package esxi
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	"yunion.io/x/jsonutils"
@@ -42,8 +44,23 @@ func NewVMTemplate(vm *SVirtualMachine, cache *SDatastoreImageCache) *SVMTemplat
 	}
 }
 
+const splitStr = "/"
+
+func toTemplateUuid(templateId string) string {
+	ids := strings.Split(templateId, splitStr)
+	if len(ids) == 1 {
+		return ids[0]
+	}
+	return ids[1]
+}
+
+func toTemplateId(providerId string, templateUuid string) string {
+	return fmt.Sprintf("%s%s%s", providerId, splitStr, templateUuid)
+}
+
 func (t *SVMTemplate) GetId() string {
-	return t.uuid
+	providerId := t.vm.manager.cpcfg.Id
+	return toTemplateId(providerId, t.uuid)
 }
 
 func (t *SVMTemplate) UEFI() bool {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. clone vm的时候不再主动删除vm自带的数据盘
2. 修复regexp nil检查
3. search template vm 支持 fake template
4. template vm的id变为<provider_id>/<uuid>，同步的时候名字使用generate来防止重复
5. network的创建支持vlan_id

- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/cc @swordqiu @zexi 