### PR TITLE
fix:openstack lb 后端ip无法映射到主机的异常处理

### DIFF
--- a/pkg/compute/models/loadbalancerhuaweicachedlbb.go
+++ b/pkg/compute/models/loadbalancerhuaweicachedlbb.go
@@ -301,7 +301,9 @@ func newLocalBackendFromCloudLoadbalancerBackend(ctx context.Context, userCred m
 		sq := HostManager.Query().SubQuery()
 		return q.Join(sq, sqlchemy.Equals(sq.Field("id"), q.Field("host_id"))).Filter(sqlchemy.Equals(sq.Field("manager_id"), lbbgProvider.Id))
 	})
-
+	if err != nil {
+		return nil, err
+	}
 	guest := instance.(*SGuest)
 	//address, err := LoadbalancerBackendManager.GetGuestAddress(guest)
 	//if err != nil {

--- a/pkg/compute/models/loadbalanceropenstackcachedlbb.go
+++ b/pkg/compute/models/loadbalanceropenstackcachedlbb.go
@@ -246,7 +246,10 @@ func (man *SOpenstackCachedLbManager) newFromCloudLoadbalancerBackend(ctx contex
 	if err != nil {
 		return nil, err
 	}
-
+	// openstack lb后端是ip:port 不一定有server映射
+	if len(extLoadbalancerBackend.GetBackendId()) == 0 {
+		return nil, errors.Wrap(cloudprovider.ErrNotFound, "extLoadbalancerBackend.GetBackendId()")
+	}
 	locallbb, err := newLocalBackendFromCloudLoadbalancerBackend(ctx, userCred, localBackendGroup, extLoadbalancerBackend, syncOwnerId)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix:openstack lb 后端ip无法映射到主机的异常处理
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
-release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @ioito @zexi 
