### PR TITLE
feat: add valid filter for cachedimage list

### DIFF
--- a/cmd/climc/shell/compute/cachedimages.go
+++ b/cmd/climc/shell/compute/cachedimages.go
@@ -29,6 +29,7 @@ func init() {
 		Zone   string `help:"show images cached at zone"`
 
 		HostSchedtagId string `help:"filter cached image with host schedtag"`
+		Valid          *bool  `help:"valid cachedimage"`
 	}
 	R(&CachedImageListOptions{}, "cached-image-list", "List cached images", func(s *mcclient.ClientSession, args *CachedImageListOptions) error {
 		params, err := options.ListStructToParams(args)

--- a/pkg/apis/compute/input.go
+++ b/pkg/apis/compute/input.go
@@ -61,6 +61,9 @@ type CachedimageListInput struct {
 
 	// filter by host schedtag
 	HostSchedtagId string `json:"host_schedtag_id"`
+
+	// valid cachedimage
+	Valid *bool `json:"valid"`
 }
 
 type ExternalProjectListInput struct {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

Use the 'valid' switch to control whether to filter out
the cachedimage corresponding to invalid storage

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @swordqiu @zexi 