### PR TITLE
Notify/webhook

### DIFF
--- a/pkg/apis/notify/const.go
+++ b/pkg/apis/notify/const.go
@@ -61,4 +61,7 @@ const (
 	TEMPLATE_TYPE_TITLE   = "title"
 	TEMPLATE_TYPE_CONTENT = "content"
 	TEMPLATE_TYPE_REMOTE  = "remote"
+
+	CTYPE_ROBOT_YES  = "yes"
+	CTYPE_ROBOT_ONLY = "only"
 )

--- a/pkg/apis/notify/const.go
+++ b/pkg/apis/notify/const.go
@@ -29,6 +29,7 @@ const (
 	FEISHU_ROBOT   = "feishu-robot"
 	DINGTALK_ROBOT = "dingtalk-robot"
 	WORKWX_ROBOT   = "workwx-robot"
+	WEBHOOK        = "webhook"
 
 	ROBOT = "robot"
 

--- a/pkg/cloudcommon/notifyclient/events.go
+++ b/pkg/cloudcommon/notifyclient/events.go
@@ -14,6 +14,13 @@
 
 package notifyclient
 
+import (
+	"fmt"
+	"strings"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+)
+
 const (
 	SYSTEM_ERROR   = "SYSTEM_ERROR"
 	SYSTEM_WARNING = "SYSTEM_WARNING"
@@ -28,3 +35,42 @@ const (
 
 	IMAGE_ACTIVED = "IMAGE_ACTIVED"
 )
+
+type SAction string
+
+var (
+	Event SEvent
+
+	ActionCreate       SAction = "create"
+	ActionUpdate       SAction = "update"
+	ActionDelete       SAction = "delete"
+	ActionRebuildRoot  SAction = "rebuild_root"
+	ActionChangeConfig SAction = "change_config"
+)
+
+type SEvent struct {
+	resourceType string
+	action       SAction
+}
+
+func (se SEvent) WithResourceType(manager db.IModelManager) SEvent {
+	se.resourceType = manager.Keyword()
+	return se
+}
+
+func (se SEvent) WithAction(a SAction) SEvent {
+	se.action = a
+	return se
+}
+
+func (se SEvent) ResourceType() string {
+	return se.resourceType
+}
+
+func (se SEvent) Action() string {
+	return string(se.action)
+}
+
+func (se SEvent) String() string {
+	return strings.ToUpper(fmt.Sprintf("%s_%s", se.ResourceType(), se.Action()))
+}

--- a/pkg/compute/models/guests.go
+++ b/pkg/compute/models/guests.go
@@ -48,6 +48,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/quotas"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
+	"yunion.io/x/onecloud/pkg/cloudcommon/notifyclient"
 	"yunion.io/x/onecloud/pkg/cloudcommon/policy"
 	"yunion.io/x/onecloud/pkg/cloudcommon/userdata"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
@@ -1598,6 +1599,11 @@ func (self *SGuest) PostUpdate(ctx context.Context, userCred mcclient.TokenCrede
 		if err != nil {
 			log.Errorf("StartRemoteUpdateTask fail: %s", err)
 		}
+	}
+	// notify webhook
+	err := notifyclient.NotifyWebhook(ctx, userCred, self, notifyclient.ActionUpdate)
+	if err != nil {
+		log.Errorf("unable to NotifyWebhook: %v", err)
 	}
 }
 

--- a/pkg/compute/tasks/guest_change_config_task.go
+++ b/pkg/compute/tasks/guest_change_config_task.go
@@ -272,7 +272,11 @@ func (self *GuestChangeConfigTask) OnGuestChangeCpuMemSpecCompleteFailed(ctx con
 func (self *GuestChangeConfigTask) OnGuestChangeCpuMemSpecFinish(ctx context.Context, guest *models.SGuest) {
 	models.HostManager.ClearSchedDescCache(guest.HostId)
 	self.SetStage("OnSyncConfigComplete", nil)
-	err := guest.StartSyncTaskWithoutSyncstatus(ctx, self.UserCred, false, self.GetTaskId())
+	err := notifyclient.NotifyWebhook(ctx, self.UserCred, guest, notifyclient.ActionChangeConfig)
+	if err != nil {
+		log.Errorf("unable to NotifyWebhook: %v", err)
+	}
+	err = guest.StartSyncTaskWithoutSyncstatus(ctx, self.UserCred, false, self.GetTaskId())
 	if err != nil {
 		self.markStageFailed(ctx, guest, jsonutils.NewString(fmt.Sprintf("StartSyncstatus fail %s", err)))
 		return

--- a/pkg/compute/tasks/guest_create_task.go
+++ b/pkg/compute/tasks/guest_create_task.go
@@ -145,6 +145,10 @@ func (self *GuestCreateTask) OnDeployGuestDescComplete(ctx context.Context, obj 
 }
 
 func (self *GuestCreateTask) notifyServerCreated(ctx context.Context, guest *models.SGuest) {
+	err := notifyclient.NotifyWebhook(ctx, self.UserCred, guest, notifyclient.ActionCreate)
+	if err != nil {
+		log.Errorf("unable to NotifyWebhook: %v", err)
+	}
 	guest.NotifyServerEvent(
 		ctx, self.UserCred, notifyclient.SERVER_CREATED,
 		notify.NotifyPriorityImportant, true, nil, false,

--- a/pkg/compute/tasks/guest_delete_task.go
+++ b/pkg/compute/tasks/guest_delete_task.go
@@ -345,6 +345,10 @@ func (self *GuestDeleteTask) DeleteGuest(ctx context.Context, guest *models.SGue
 }
 
 func (self *GuestDeleteTask) NotifyServerDeleted(ctx context.Context, guest *models.SGuest) {
+	err := notifyclient.NotifyWebhook(ctx, self.UserCred, guest, notifyclient.ActionDelete)
+	if err != nil {
+		log.Errorf("unable to NotifyWebhook: %v", err)
+	}
 	guest.NotifyServerEvent(
 		ctx,
 		self.UserCred,

--- a/pkg/compute/tasks/guest_rebuild_root_task.go
+++ b/pkg/compute/tasks/guest_rebuild_root_task.go
@@ -176,6 +176,10 @@ func (self *GuestRebuildRootTask) OnRebuildAllDisksComplete(ctx context.Context,
 		}
 	}
 	db.OpsLog.LogEvent(guest, db.ACT_REBUILD_ROOT, "", self.UserCred)
+	err = notifyclient.NotifyWebhook(ctx, self.UserCred, guest, notifyclient.ActionRebuildRoot)
+	if err != nil {
+		log.Errorf("unable to NotifyWebhook: %v", err)
+	}
 	guest.NotifyServerEvent(
 		ctx,
 		self.UserCred,

--- a/pkg/mcclient/modules/notify/consts.go
+++ b/pkg/mcclient/modules/notify/consts.go
@@ -33,4 +33,5 @@ const (
 	NotifyFeishuRobot     = TNotifyChannel("feishu-robot")
 	NotifyByDingTalkRobot = TNotifyChannel("dingtalk-robot")
 	NotifyByWorkwxRobot   = TNotifyChannel("workwx-robot")
+	NotifyByWebhook       = TNotifyChannel("webhook")
 )

--- a/pkg/notify/models/config.go
+++ b/pkg/notify/models/config.go
@@ -69,7 +69,7 @@ func (cm *SConfigManager) ValidateCreateData(ctx context.Context, userCred mccli
 	if err != nil {
 		return input, err
 	}
-	if !utils.IsInStringArray(input.Type, []string{api.EMAIL, api.MOBILE, api.DINGTALK, api.FEISHU, api.WEBCONSOLE, api.WORKWX, api.FEISHU_ROBOT, api.DINGTALK_ROBOT, api.WORKWX_ROBOT}) {
+	if !utils.IsInStringArray(input.Type, []string{api.EMAIL, api.MOBILE, api.DINGTALK, api.FEISHU, api.WEBCONSOLE, api.WORKWX, api.FEISHU_ROBOT, api.DINGTALK_ROBOT, api.WORKWX_ROBOT, api.WEBHOOK}) {
 		return input, httperrors.NewInputParameterError("unkown type %q", input.Type)
 	}
 	if input.Content == nil {

--- a/pkg/notify/models/config.go
+++ b/pkg/notify/models/config.go
@@ -139,19 +139,15 @@ func (cm *SConfigManager) AllowPerformGetTypes(ctx context.Context, userCred mcc
 	return true
 }
 
-func (cm *SConfigManager) PerformGetTypes(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input api.ConfigManagerGetTypesInput) (api.ConfigManagerGetTypesOutput, error) {
-	output := api.ConfigManagerGetTypesOutput{}
-	allContactType, err := cm.allContactType()
-	if err != nil {
-		return output, err
-	}
+func (cm *SConfigManager) filterContactType(cTypes []string, robot string) []string {
 	var judge func(string) bool
-	switch input.Robot {
-	case "only":
+	ret := make([]string, 0, len(cTypes)/2)
+	switch robot {
+	case api.CTYPE_ROBOT_ONLY:
 		judge = func(ctype string) bool {
 			return strings.Contains(ctype, "robot")
 		}
-	case "yes":
+	case api.CTYPE_ROBOT_YES:
 		judge = func(ctype string) bool {
 			return true
 		}
@@ -160,12 +156,21 @@ func (cm *SConfigManager) PerformGetTypes(ctx context.Context, userCred mcclient
 			return !strings.Contains(ctype, "robot")
 		}
 	}
-	for _, ctype := range allContactType {
+	for _, ctype := range cTypes {
 		if judge(ctype) {
-			output.Types = append(output.Types, ctype)
+			ret = append(ret, ctype)
 		}
 	}
-	output.Types = sortContactType(output.Types)
+	return ret
+}
+
+func (cm *SConfigManager) PerformGetTypes(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input api.ConfigManagerGetTypesInput) (api.ConfigManagerGetTypesOutput, error) {
+	output := api.ConfigManagerGetTypesOutput{}
+	allContactType, err := cm.allContactType()
+	if err != nil {
+		return output, err
+	}
+	output.Types = sortContactType(cm.filterContactType(allContactType, input.Robot))
 	return output, nil
 }
 

--- a/pkg/notify/tasks/notifications_send_task.go
+++ b/pkg/notify/tasks/notifications_send_task.go
@@ -104,10 +104,6 @@ func (self *NotificationSendTask) OnInit(ctx context.Context, obj db.IStandalone
 		contactMap[contact] = &rns[i]
 	}
 
-	if len(contactMap) == 0 {
-		self.taskFailed(ctx, notification, strings.Join(failedRecord, "; "), true)
-	}
-
 	// set status before send
 	now := time.Now()
 	contacts := make([]string, 0, len(contactMap))
@@ -138,7 +134,7 @@ func (self *NotificationSendTask) OnInit(ctx context.Context, obj db.IStandalone
 	for _, rn := range contactMap {
 		rn.AfterSend(ctx, true, "")
 	}
-	if len(failedRecord) == len(contacts) {
+	if len(failedRecord) > 0 && len(failedRecord) == len(contacts) {
 		self.taskFailed(ctx, notification, strings.Join(failedRecord, "; "), true)
 		return
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

notify:
1. support webhook contact type
2. allow empty receivers for robot or webhook contact type

region:
1. add NotifyWebhook in notifyclient
2. call NotifyWebhook in NotifyServerEvent

- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/cc @swordqiu @zexi 