### PR TITLE
Automated cherry pick of #8347: fix: remote update metadata may cause metadata update loop

### DIFF
--- a/cmd/climc/shell/helper.go
+++ b/cmd/climc/shell/helper.go
@@ -284,10 +284,7 @@ type IPerformOpt interface {
 func (cmd ResourceCmd) Perform(action string, args IPerformOpt) {
 	man := cmd.manager
 	callback := func(s *mcclient.ClientSession, args IPerformOpt) error {
-		params, err := args.Params()
-		if err != nil {
-			return err
-		}
+		params := jsonutils.Marshal(args) // .Params()
 		ret, err := man.(modulebase.Manager).PerformAction(s, args.GetId(), action, params)
 		if err != nil {
 			return err

--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -412,5 +412,5 @@ type GuestAddSecgroupInput struct {
 
 type ServerRemoteUpdateInput struct {
 	// 是否覆盖替换所有标签
-	ReplaceTags *bool `json:"replace_tags"`
+	ReplaceTags *bool `json:"replace_tags" help:"replace all remote tags"`
 }

--- a/pkg/cloudcommon/db/metadata.go
+++ b/pkg/cloudcommon/db/metadata.go
@@ -492,6 +492,7 @@ func (manager *SMetadataManager) SetValues(ctx context.Context, obj IModel, stor
 		}
 
 		newRecord := SMetadata{}
+		newRecord.SetModelManager(manager, &newRecord)
 
 		newRecord.ObjId = obj.GetId()
 		newRecord.ObjType = obj.GetModelManager().Keyword()

--- a/pkg/cloudcommon/db/standalone.go
+++ b/pkg/cloudcommon/db/standalone.go
@@ -266,12 +266,27 @@ func (model *SStandaloneResourceBase) GetMetadataJson(key string, userCred mccli
 	return Metadata.GetJsonValue(model, key, userCred)
 }
 
+func isUserMetadata(key string) bool {
+	return strings.HasPrefix(key, USER_TAG_PREFIX)
+}
+
+func containsUserMetadata(dict map[string]interface{}) bool {
+	for k := range dict {
+		if isUserMetadata(k) {
+			return true
+		}
+	}
+	return false
+}
+
 func (model *SStandaloneResourceBase) SetMetadata(ctx context.Context, key string, value interface{}, userCred mcclient.TokenCredential) error {
 	err := Metadata.SetValue(ctx, model, key, value, userCred)
 	if err != nil {
 		return errors.Wrap(err, "SetValue")
 	}
-	model.GetIStandaloneModel().OnMetadataUpdated(ctx, userCred)
+	if isUserMetadata(key) {
+		model.GetIStandaloneModel().OnMetadataUpdated(ctx, userCred)
+	}
 	return nil
 }
 
@@ -280,7 +295,9 @@ func (model *SStandaloneResourceBase) SetAllMetadata(ctx context.Context, dictst
 	if err != nil {
 		return errors.Wrap(err, "SetValuesWithLog")
 	}
-	model.GetIStandaloneModel().OnMetadataUpdated(ctx, userCred)
+	if containsUserMetadata(dictstore) {
+		model.GetIStandaloneModel().OnMetadataUpdated(ctx, userCred)
+	}
 	return nil
 }
 
@@ -307,7 +324,6 @@ func (model *SStandaloneResourceBase) SetCloudMetadataAll(ctx context.Context, d
 	if err != nil {
 		return errors.Wrap(err, "SetAll")
 	}
-	model.GetIStandaloneModel().OnMetadataUpdated(ctx, userCred)
 	return nil
 }
 
@@ -316,7 +332,6 @@ func (model *SStandaloneResourceBase) RemoveMetadata(ctx context.Context, key st
 	if err != nil {
 		return errors.Wrap(err, "SetValue")
 	}
-	model.GetIStandaloneModel().OnMetadataUpdated(ctx, userCred)
 	return nil
 }
 
@@ -325,7 +340,6 @@ func (model *SStandaloneResourceBase) RemoveAllMetadata(ctx context.Context, use
 	if err != nil {
 		return errors.Wrap(err, "RemoveAll")
 	}
-	model.GetIStandaloneModel().OnMetadataUpdated(ctx, userCred)
 	return nil
 }
 

--- a/pkg/compute/guestdrivers/managedvirtual.go
+++ b/pkg/compute/guestdrivers/managedvirtual.go
@@ -1230,6 +1230,11 @@ func (self *SManagedVirtualizedGuestDriver) RequestRemoteUpdate(ctx context.Cont
 		if err != nil {
 			return errors.Wrap(err, "iVM.SetMetadata")
 		}
+		// sync back cloud metadata
+		err = models.SyncVirtualResourceMetadata(ctx, userCred, guest, iVM)
+		if err != nil {
+			return errors.Wrap(err, "syncVirtualResourceMetadata")
+		}
 	}
 	err = iVM.UpdateVM(ctx, guest.Name)
 	if err != nil {

--- a/pkg/compute/tasks/guest_remote_update_task.go
+++ b/pkg/compute/tasks/guest_remote_update_task.go
@@ -52,16 +52,5 @@ func (self *GuestRemoteUpdateTask) OnInit(ctx context.Context, obj db.IStandalon
 }
 
 func (self *GuestRemoteUpdateTask) OnRemoteUpdateComplete(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
-	guest := obj.(*models.SGuest)
-	if !self.IsSubtask() {
-		self.SetStage("OnSyncStatusComplete", nil)
-		guest.StartSyncstatus(ctx, self.UserCred, self.GetTaskId())
-	} else {
-		self.OnSyncStatusComplete(ctx, obj, data)
-	}
-}
-
-func (self *GuestRemoteUpdateTask) OnSyncStatusComplete(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
-	// guest := obj.(*models.SGuest)
 	self.SetStageComplete(ctx, nil)
 }

--- a/pkg/multicloud/qcloud/tags.go
+++ b/pkg/multicloud/qcloud/tags.go
@@ -210,6 +210,9 @@ type SDescribeTagsSeqResponse struct {
 }
 
 func (region *SRegion) fetchTags(keys []string, limit int, offset int) (int, []SDescribeTag, error) {
+	if len(keys) == 0 {
+		return 0, nil, nil
+	}
 	params := make(map[string]string)
 	for i, k := range keys {
 		params[fmt.Sprintf("TagKeys.%d", i)] = k


### PR DESCRIPTION
Cherry pick of #8347 on release/3.4.

#8347: fix: remote update metadata may cause metadata update loop