### PR TITLE
Automated cherry pick of #8361: fix: do not lock guest after lock eip, to prevent possible dead lock

### DIFF
--- a/pkg/compute/tasks/eip_dissociate_task.go
+++ b/pkg/compute/tasks/eip_dissociate_task.go
@@ -23,7 +23,6 @@ import (
 
 	api "yunion.io/x/onecloud/pkg/apis/compute"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
-	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/compute/models"
@@ -85,8 +84,8 @@ func (self *EipDissociateTask) OnInit(ctx context.Context, obj db.IStandaloneMod
 			self.TaskFail(ctx, eip, jsonutils.NewString("unsupported associate type"), nil)
 			return
 		}
-		lockman.LockObject(ctx, model)
-		defer lockman.ReleaseObject(ctx, model)
+		// lockman.LockObject(ctx, model)
+		// defer lockman.ReleaseObject(ctx, model)
 
 		if eip.IsManaged() {
 			extEip, err := eip.GetIEip()


### PR DESCRIPTION
Cherry pick of #8361 on release/3.4.

#8361: fix: do not lock guest after lock eip, to prevent possible dead lock