### PR TITLE
Fix of snapshotpolicy

### DIFF
--- a/pkg/cloudcommon/db/caller.go
+++ b/pkg/cloudcommon/db/caller.go
@@ -301,8 +301,9 @@ func FetchCustomizeColumns(
 	retVal := make([]*jsonutils.JSONDict, ret[0].Len())
 	for i := 0; i < ret[0].Len(); i += 1 {
 		jsonDict := ValueToJSONDict(ret[0].Index(i))
-		jsonDict.Update(jsonutils.Marshal(objs[i]).(*jsonutils.JSONDict))
-		retVal[i] = jsonDict
+		objDict := jsonutils.Marshal(objs[i]).(*jsonutils.JSONDict)
+		objDict.Update(jsonDict)
+		retVal[i] = objDict
 	}
 	return retVal, nil
 }

--- a/pkg/compute/models/snapshotpolicy.go
+++ b/pkg/compute/models/snapshotpolicy.go
@@ -350,7 +350,6 @@ func (manager *SSnapshotPolicyManager) FetchCustomizeColumns(
 			VirtualResourceDetails: virtRows[i],
 		}
 		rows[i] = objs[i].(*SSnapshotPolicy).getMoreDetails(rows[i])
-		log.Infof("details: %v", rows[i])
 	}
 
 	return rows

--- a/pkg/compute/models/snapshotpolicy.go
+++ b/pkg/compute/models/snapshotpolicy.go
@@ -310,11 +310,11 @@ func (sp *SSnapshotPolicy) DetachAfterDelete(ctx context.Context, userCred mccli
 
 func (sp *SSnapshotPolicy) CustomizeDelete(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) error {
 	// check if sp bind to some disks
-	sds, err := SnapshotPolicyDiskManager.FetchAllBySnapshotpolicyID(ctx, userCred, sp.GetId())
+	count, err := SnapshotPolicyDiskManager.FetchDiskCountBySPID(sp.Id)
 	if err != nil {
-		return errors.Wrap(err, "fetch bind info failed")
+		return errors.Wrap(err, "unable to FetchDiskCountBySPID")
 	}
-	if len(sds) != 0 {
+	if count != 0 {
 		return httperrors.NewBadRequestError("Couldn't delete snapshot policy binding to disks")
 	}
 	sp.SetStatus(userCred, api.SNAPSHOT_POLICY_DELETING, "")
@@ -350,6 +350,7 @@ func (manager *SSnapshotPolicyManager) FetchCustomizeColumns(
 			VirtualResourceDetails: virtRows[i],
 		}
 		rows[i] = objs[i].(*SSnapshotPolicy).getMoreDetails(rows[i])
+		log.Infof("details: %v", rows[i])
 	}
 
 	return rows


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. snapshotpolicy的详情没有正常展示，因为snapshotpolicy的字段名和details里面的展示名重复了，在FetchCustomizeColumns中使用字段来覆盖details，这里应该倒置过来，用于展示的话，details肯定是优于字段名的
2. snapshotpolicy 删除的时候，检查是否有绑定的磁盘，没有检测磁盘是否有效。

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.3
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @zexi 