### PR TITLE
Automated cherry pick of #8392: fix(region): compute binded disk count when deleting snapshotpolicy

### DIFF
--- a/pkg/cloudcommon/db/caller.go
+++ b/pkg/cloudcommon/db/caller.go
@@ -302,8 +302,9 @@ func FetchCustomizeColumns(
 	retVal := make([]*jsonutils.JSONDict, ret[0].Len())
 	for i := 0; i < ret[0].Len(); i += 1 {
 		jsonDict := ValueToJSONDict(ret[0].Index(i))
-		jsonDict.Update(jsonutils.Marshal(objs[i]).(*jsonutils.JSONDict))
-		retVal[i] = jsonDict
+		objDict := jsonutils.Marshal(objs[i]).(*jsonutils.JSONDict)
+		objDict.Update(jsonDict)
+		retVal[i] = objDict
 	}
 	return retVal, nil
 }

--- a/pkg/compute/models/snapshotpolicy.go
+++ b/pkg/compute/models/snapshotpolicy.go
@@ -350,7 +350,6 @@ func (manager *SSnapshotPolicyManager) FetchCustomizeColumns(
 			VirtualResourceDetails: virtRows[i],
 		}
 		rows[i] = objs[i].(*SSnapshotPolicy).getMoreDetails(rows[i])
-		log.Infof("details: %v", rows[i])
 	}
 
 	return rows

--- a/pkg/compute/models/snapshotpolicy.go
+++ b/pkg/compute/models/snapshotpolicy.go
@@ -310,11 +310,11 @@ func (sp *SSnapshotPolicy) DetachAfterDelete(ctx context.Context, userCred mccli
 
 func (sp *SSnapshotPolicy) CustomizeDelete(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) error {
 	// check if sp bind to some disks
-	sds, err := SnapshotPolicyDiskManager.FetchAllBySnapshotpolicyID(ctx, userCred, sp.GetId())
+	count, err := SnapshotPolicyDiskManager.FetchDiskCountBySPID(sp.Id)
 	if err != nil {
-		return errors.Wrap(err, "fetch bind info failed")
+		return errors.Wrap(err, "unable to FetchDiskCountBySPID")
 	}
-	if len(sds) != 0 {
+	if count != 0 {
 		return httperrors.NewBadRequestError("Couldn't delete snapshot policy binding to disks")
 	}
 	sp.SetStatus(userCred, api.SNAPSHOT_POLICY_DELETING, "")
@@ -350,6 +350,7 @@ func (manager *SSnapshotPolicyManager) FetchCustomizeColumns(
 			VirtualResourceDetails: virtRows[i],
 		}
 		rows[i] = objs[i].(*SSnapshotPolicy).getMoreDetails(rows[i])
+		log.Infof("details: %v", rows[i])
 	}
 
 	return rows


### PR DESCRIPTION
Cherry pick of #8392 on release/3.3.

#8392: fix(region): compute binded disk count when deleting snapshotpolicy