### PR TITLE
Automated cherry pick of #8397: fix: monitor commonalert not detach alert resource

### DIFF
--- a/pkg/monitor/alertresourcedrivers/node.go
+++ b/pkg/monitor/alertresourcedrivers/node.go
@@ -40,6 +40,10 @@ func (drvF *nodeDriverF) IsEvalMatched(input monitor.EvalMatch) bool {
 	if !hasResType {
 		return false
 	}
+	_, hasHostType := tags[hostconsts.TELEGRAF_TAG_KEY_HOST_TYPE]
+	if !hasHostType {
+		return false
+	}
 	_, hasHost := tags[NODE_TAG_HOST_KEY]
 	if !hasHost {
 		return false

--- a/pkg/monitor/models/commonalert.go
+++ b/pkg/monitor/models/commonalert.go
@@ -782,9 +782,9 @@ func (alert *SCommonAlert) CustomizeDelete(
 	err := alert.customizeDeleteNotis(ctx, userCred, query, data)
 	if err != nil {
 		alert.SetStatus(userCred, monitor.ALERT_STATUS_DELETE_FAIL, "")
-
+		return errors.Wrap(err, "customizeDeleteNotis")
 	}
-	return err
+	return alert.SAlert.CustomizeDelete(ctx, userCred, query, data)
 }
 
 func (alert *SCommonAlert) customizeDeleteNotis(


### PR DESCRIPTION
Cherry pick of #8397 on release/3.4.

#8397: fix: monitor commonalert not detach alert resource