### PR TITLE
feat(esxi): copy disk from image when creating vm

### DIFF
--- a/pkg/multicloud/esxi/devtools.go
+++ b/pkg/multicloud/esxi/devtools.go
@@ -26,22 +26,14 @@ import (
 
 func NewDiskDev(sizeMb int64, templatePath string, uuid string, index int32, keyBase int32, controlKey int32, key int32) *types.VirtualDisk {
 	device := types.VirtualDisk{}
-
-	var backFile *types.VirtualDiskFlatVer2BackingInfo
-	if len(templatePath) > 0 {
-		backFile = &types.VirtualDiskFlatVer2BackingInfo{}
-		backFile.FileName = templatePath
-	}
-
 	diskFile := types.VirtualDiskFlatVer2BackingInfo{}
 	diskFile.DiskMode = "persistent"
 	thinProvisioned := true
 	diskFile.ThinProvisioned = &thinProvisioned
 	diskFile.Uuid = uuid
-	if backFile != nil {
-		diskFile.Parent = backFile
+	if len(templatePath) > 0 {
+		diskFile.FileName = templatePath
 	}
-
 	device.Backing = &diskFile
 
 	if sizeMb > 0 {

--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -818,49 +818,6 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 		index   = 0
 		ctrlKey = 0
 	)
-	for _, disk := range disks {
-		imagePath := disk.ImagePath
-		var size = disk.Size
-		if len(imagePath) == 0 {
-			if size == 0 {
-				size = 30 * 1024
-			}
-		} else {
-			imagePath, err = self.FileUrlPathToDsPath(imagePath)
-			if err != nil {
-				return nil, errors.Wrapf(err, "SHost.FileUrlPathToDsPath")
-			}
-		}
-		uuid, driver := disk.DiskId, "scsi"
-		if len(disk.Driver) > 0 {
-			driver = disk.Driver
-		}
-		if driver == "scsi" || driver == "pvscsi" {
-			if self.isVersion50() {
-				driver = "scsi"
-			}
-			ctrlKey = 1000
-			index = scsiIdx
-			scsiIdx += 1
-			if scsiIdx == 7 {
-				scsiIdx++
-			}
-		} else {
-			ideno := ideIdx % 2
-			if ideno == 0 {
-				index = ideIdx/2 + ide1un
-			} else {
-				index = ideIdx/2 + ide2un
-			}
-			ctrlKey = 200 + ideno
-			ideIdx += 1
-		}
-		log.Debugf("size: %d, image path: %s, uuid: %s, index: %d, ctrlKey: %d, driver: %s.", size, imagePath, uuid,
-			index, ctrlKey, disk.Driver)
-		spec := addDevSpec(NewDiskDev(size, imagePath, uuid, int32(index), 2000, int32(ctrlKey), 0))
-		spec.FileOperation = "create"
-		deviceChange = append(deviceChange, spec)
-	}
 
 	// add usb to support mouse
 	usbController := addDevSpec(NewUSBController(nil))
@@ -914,8 +871,77 @@ func (self *SHost) DoCreateVM(ctx context.Context, ds *SDatastore, params SCreat
 		return nil, errors.Wrap(err, "Task.WaitForResult")
 	}
 
+	deviceChange = make([]types.BaseVirtualDeviceConfigSpec, 0, 1)
+	// add disks
+	for _, disk := range disks {
+		imagePath := disk.ImagePath
+		var size = disk.Size
+		if len(imagePath) == 0 {
+			if size == 0 {
+				size = 30 * 1024
+			}
+		} else {
+			imagePath, err = self.FileUrlPathToDsPath(imagePath)
+			if err != nil {
+				return nil, errors.Wrapf(err, "SHost.FileUrlPathToDsPath")
+			}
+			newImagePath := fmt.Sprintf("[%s] %s/%s.vmdk", ds.GetRelName(), params.Uuid, params.Uuid)
+			fm := ds.getDatastoreObj().NewFileManager(dc.getObjectDatacenter(), true)
+			err := fm.Copy(ctx, imagePath, newImagePath)
+			if err != nil {
+				return nil, errors.Wrap(err, "unable to copy system disk")
+			}
+			imagePath = newImagePath
+		}
+		uuid, driver := disk.DiskId, "scsi"
+		if len(disk.Driver) > 0 {
+			driver = disk.Driver
+		}
+		if driver == "scsi" || driver == "pvscsi" {
+			if self.isVersion50() {
+				driver = "scsi"
+			}
+			ctrlKey = 1000
+			index = scsiIdx
+			scsiIdx += 1
+			if scsiIdx == 7 {
+				scsiIdx++
+			}
+		} else {
+			ideno := ideIdx % 2
+			if ideno == 0 {
+				index = ideIdx/2 + ide1un
+			} else {
+				index = ideIdx/2 + ide2un
+			}
+			ctrlKey = 200 + ideno
+			ideIdx += 1
+		}
+		log.Debugf("size: %d, image path: %s, uuid: %s, index: %d, ctrlKey: %d, driver: %s.", size, imagePath, uuid,
+			index, ctrlKey, disk.Driver)
+		spec := addDevSpec(NewDiskDev(size, imagePath, uuid, int32(index), 2000, int32(ctrlKey), 0))
+		if len(imagePath) == 0 {
+			spec.FileOperation = "create"
+		}
+		deviceChange = append(deviceChange, spec)
+	}
+
+	configSpec := types.VirtualMachineConfigSpec{}
+	configSpec.DeviceChange = deviceChange
+
+	vmRef := info.Result.(types.ManagedObjectReference)
+	objectVM := object.NewVirtualMachine(self.manager.client.Client, vmRef)
+	task, err = objectVM.Reconfigure(ctx, configSpec)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to reconfigure")
+	}
+	err = task.Wait(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "task.Wait")
+	}
+
 	var moVM mo.VirtualMachine
-	err = self.manager.reference2Object(info.Result.(types.ManagedObjectReference), VIRTUAL_MACHINE_PROPS, &moVM)
+	err = self.manager.reference2Object(vmRef, VIRTUAL_MACHINE_PROPS, &moVM)
 	if err != nil {
 		return nil, errors.Wrap(err, "fail to fetch virtual machine just created")
 	}


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:

Before, we use delta disk based on vmdk in image_cache when creating vm.
In theory, creating a machine like this is faster and occupies less storage.
However, it may also affect performance and definitely cannot change the
size of the system disk.

Now, we copy disk from vmdk in image_cache to solve above questions.

- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.5
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area esxiagent region
/cc @swordqiu @zexi 