### PR TITLE
SnapshotPolicy Display and Sync

### DIFF
--- a/pkg/apis/compute/snapshotpolicy.go
+++ b/pkg/apis/compute/snapshotpolicy.go
@@ -21,10 +21,10 @@ type SnapshotPolicyDetails struct {
 
 	SSnapshotPolicy
 
-	RetentionDays  int   `json:"retention_days"`
-	RepeatWeekdays []int `json:"repeat_weekdays"`
-	TimePoints     []int `json:"time_points"`
-	IsActivated    *bool `json:"is_activated,omitempty"`
+	RetentionDays         int   `json:"retention_days"`
+	RepeatWeekdaysDisplay []int `json:"repeat_weekdays_display"`
+	TimePointsDisplay     []int `json:"time_points_display"`
+	IsActivated           *bool `json:"is_activated,omitempty"`
 
 	BindingDiskCount int `json:"binding_disk_count"`
 }

--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -2458,6 +2458,12 @@ func (self *SDisk) UpdataSnapshotsBackingDisk(backingDiskId string) error {
 func (manager *SDiskManager) AutoSyncExtDiskSnapshot(ctx context.Context, userCred mcclient.TokenCredential, isStart bool) {
 
 	now := time.Now()
+	week := now.Weekday()
+	if week == 0 {
+		week += 7
+	}
+	timePoint := now.Hour()
+
 	q := SnapshotPolicyDiskManager.Query().LE("next_sync_time", now)
 	spds := make([]SSnapshotPolicyDisk, 0)
 	err := db.FetchModelObjects(SnapshotPolicyDiskManager, q, &spds)
@@ -2487,7 +2493,11 @@ func (manager *SDiskManager) AutoSyncExtDiskSnapshot(ctx context.Context, userCr
 			db.OpsLog.LogEvent(disk, db.ACT_DISK_AUTO_SYNC_SNAPSHOT_FAIL, syncResult.Result(), userCred)
 			continue
 		}
-		if syncResult.AddCnt == 0 {
+		sp := spMap[spd.GetId()]
+		repeatWeekdays := SnapshotPolicyManager.RepeatWeekdaysToIntArray(sp.RepeatWeekdays)
+		timePoints := SnapshotPolicyManager.TimePointsToIntArray(sp.TimePoints)
+		if isInInts(int(week), repeatWeekdays) && isInInts(timePoint, timePoints) && syncResult.AddCnt == 0 {
+			// should add one
 			continue
 		}
 		db.OpsLog.LogEvent(disk, db.ACT_DISK_AUTO_SYNC_SNAPSHOT, "disk auto sync snapshot successfully", userCred)
@@ -2499,6 +2509,15 @@ func (manager *SDiskManager) AutoSyncExtDiskSnapshot(ctx context.Context, userCr
 			log.Errorf("unable to update NextSyncTime for snapshotpolicydisk %q %q", spd.SnapshotpolicyId, spd.DiskId)
 		}
 	}
+}
+
+func isInInts(a int, array []int) bool {
+	for _, i := range array {
+		if i == a {
+			return true
+		}
+	}
+	return false
 }
 
 func (self *SDisk) syncSnapshots(ctx context.Context, userCred mcclient.TokenCredential) compare.SyncResult {

--- a/pkg/compute/models/snapshotpolicy.go
+++ b/pkg/compute/models/snapshotpolicy.go
@@ -370,8 +370,8 @@ func (sp *SSnapshotPolicy) GetExtraDetails(
 }
 
 func (sp *SSnapshotPolicy) getMoreDetails(out api.SnapshotPolicyDetails) api.SnapshotPolicyDetails {
-	out.RepeatWeekdays = SnapshotPolicyManager.RepeatWeekdaysToIntArray(sp.RepeatWeekdays)
-	out.TimePoints = SnapshotPolicyManager.TimePointsToIntArray(sp.TimePoints)
+	out.RepeatWeekdaysDisplay = SnapshotPolicyManager.RepeatWeekdaysToIntArray(sp.RepeatWeekdays)
+	out.TimePointsDisplay = SnapshotPolicyManager.TimePointsToIntArray(sp.TimePoints)
 	out.BindingDiskCount, _ = SnapshotPolicyDiskManager.FetchDiskCountBySPID(sp.Id)
 	return out
 }

--- a/pkg/compute/models/snapshotpolicydisks.go
+++ b/pkg/compute/models/snapshotpolicydisks.go
@@ -494,6 +494,16 @@ func (self *SSnapshotPolicyDiskManager) ValidateCreateData(ctx context.Context, 
 	return data, nil
 }
 
+func (sd *SSnapshotPolicyDisk) CustomizeCreate(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data jsonutils.JSONObject) error {
+	sp, err := SnapshotPolicyManager.FetchSnapshotPolicyById(sd.SnapshotpolicyId)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	sd.NextSyncTime = sp.ComputeNextSyncTime(now, now)
+	return nil
+}
+
 func (sd *SSnapshotPolicyDisk) PostCreate(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.
 	IIdentityProvider, query jsonutils.JSONObject, data jsonutils.JSONObject) {
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. add suffix 'display' for time_points and repeat_weekdays 
TimePoints and RepeatWeekdays in SnapshotPolicyDetails is duplicated
with thess in SnapshotPolicy, which result in the fault of reponse for
request GET.
2. init NextSyncTimeiwhen create snapshotpolicydisks
3. don't update NextSyncTime when snapshots that should be added has not

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.5
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/cc @wanyaoqi @zexi 