### PR TITLE
refactor(region): faster list for cachedimage

### DIFF
--- a/pkg/compute/models/cachedimages.go
+++ b/pkg/compute/models/cachedimages.go
@@ -684,20 +684,6 @@ func (manager *SCachedimageManager) ListItemFilter(
 		return nil, errors.Wrapf(err, "SSharableBaseResourceManager.ListItemFilter")
 	}
 
-	q, err = managedResourceFilterByAccount(q, query.ManagedResourceListInput, "id", func() *sqlchemy.SQuery {
-		cachedImages := CachedimageManager.Query().SubQuery()
-		storagecachedImages := StoragecachedimageManager.Query().SubQuery()
-		storageCaches := StoragecacheManager.Query().SubQuery()
-
-		subq := cachedImages.Query(cachedImages.Field("id"))
-		subq = subq.Join(storagecachedImages, sqlchemy.Equals(cachedImages.Field("id"), storagecachedImages.Field("cachedimage_id")))
-		subq = subq.Join(storageCaches, sqlchemy.Equals(storagecachedImages.Field("storagecache_id"), storageCaches.Field("id")))
-		return subq
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "managedResourceFilterByAccount")
-	}
-
 	q, err = manager.SSharableVirtualResourceBaseManager.ListItemFilter(ctx, q, userCred, query.SharableVirtualResourceListInput)
 	if err != nil {
 		return nil, errors.Wrap(err, "SSharableVirtualResourceBaseManager.ListItemFilter")
@@ -708,74 +694,61 @@ func (manager *SCachedimageManager) ListItemFilter(
 		return nil, errors.Wrap(err, "SExternalizedResourceBaseManager.ListItemFilter")
 	}
 
-	q, err = managedResourceFilterByRegion(q, query.RegionalFilterListInput, "id", func() *sqlchemy.SQuery {
+	{
 		storagecachedImages := StoragecachedimageManager.Query().SubQuery()
 		storageCaches := StoragecacheManager.Query().SubQuery()
-		storages := StorageManager.Query().SubQuery()
+		var storages *sqlchemy.SSubQuery
+
+		if query.Valid == nil {
+			storages = StorageManager.Query().SubQuery()
+		} else if *query.Valid {
+			storages = StorageManager.Query().In("status", []string{api.STORAGE_ENABLED, api.STORAGE_ONLINE}).IsTrue("enabled").SubQuery()
+		} else {
+			stroage := StorageManager.Query()
+			storages = stroage.Filter(sqlchemy.OR(sqlchemy.NotIn(stroage.Field("status"), []string{}), sqlchemy.IsFalse(stroage.Field("enabled")))).SubQuery()
+		}
 		zones := ZoneManager.Query().SubQuery()
 
 		subq := storagecachedImages.Query(storagecachedImages.Field("cachedimage_id"))
 		subq = subq.Join(storageCaches, sqlchemy.Equals(storagecachedImages.Field("storagecache_id"), storageCaches.Field("id")))
 		subq = subq.Join(storages, sqlchemy.Equals(storageCaches.Field("id"), storages.Field("storagecache_id")))
 		subq = subq.Join(zones, sqlchemy.Equals(storages.Field("zone_id"), zones.Field("id")))
-		subq = subq.Filter(sqlchemy.Equals(storagecachedImages.Field("status"), api.CACHED_IMAGE_STATUS_ACTIVE))
-		return subq
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "managedResourceFilterByRegion")
-	}
 
-	q, err = managedResourceFilterByZone(q, query.ZonalFilterListInput, "id", func() *sqlchemy.SQuery {
-		storagecachedImages := StoragecachedimageManager.Query().SubQuery()
-		storageCaches := StoragecacheManager.Query().SubQuery()
-		storages := StorageManager.Query().SubQuery()
-
-		subq := storagecachedImages.Query(storagecachedImages.Field("cachedimage_id"))
-		subq = subq.Join(storageCaches, sqlchemy.Equals(storagecachedImages.Field("storagecache_id"), storageCaches.Field("id")))
-		subq = subq.Join(storages, sqlchemy.Equals(storageCaches.Field("id"), storages.Field("storagecache_id")))
+		if len(query.HostSchedtagId) > 0 {
+			schedTagObj, err := SchedtagManager.FetchByIdOrName(userCred, query.HostSchedtagId)
+			if err != nil {
+				if errors.Cause(err) == sql.ErrNoRows {
+					return nil, errors.Wrapf(httperrors.ErrResourceNotFound, "%s %s", SchedtagManager.Keyword(), query.HostSchedtagId)
+				} else {
+					return nil, errors.Wrap(err, "SchedtagManager.FetchByIdOrName")
+				}
+			}
+			hoststorages := HoststorageManager.Query("host_id", "storage_id").SubQuery()
+			hostschedtags := HostschedtagManager.Query().Equals("schedtag_id", schedTagObj.GetId()).SubQuery()
+			subq = subq.Join(hoststorages, sqlchemy.Equals(hoststorages.Field("storage_id"), storages.Field("id")))
+			subq = subq.Join(hostschedtags, sqlchemy.Equals(hostschedtags.Field("host_id"), hoststorages.Field("host_id")))
+		}
 		subq = subq.Filter(sqlchemy.Equals(storagecachedImages.Field("status"), api.CACHED_IMAGE_STATUS_ACTIVE))
-		return subq
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "managedResourceFilterByZone")
+		subq, err = managedResourceFilterByAccount(subq, query.ManagedResourceListInput, "", nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "managedResourceFilterByAccount")
+		}
+
+		subq, err = _managedResourceFilterByRegion(subq, query.RegionalFilterListInput)
+		if err != nil {
+			return nil, errors.Wrap(err, "_managedResourceFilterByRegion")
+		}
+
+		subq, err = _managedResourceFilterByZone(subq, query.ZonalFilterListInput)
+		if err != nil {
+			return nil, errors.Wrap(err, "_managedResourceFilterByZone")
+		}
+
+		q = q.In("id", subq)
 	}
 
 	if len(query.ImageType) > 0 {
-		q = q.In("image_type", query.ImageType)
-	}
-
-	if len(query.HostSchedtagId) > 0 {
-		schedTagObj, err := SchedtagManager.FetchByIdOrName(userCred, query.HostSchedtagId)
-		if err != nil {
-			if errors.Cause(err) == sql.ErrNoRows {
-				return nil, errors.Wrapf(httperrors.ErrResourceNotFound, "%s %s", SchedtagManager.Keyword(), query.HostSchedtagId)
-			} else {
-				return nil, errors.Wrap(err, "SchedtagManager.FetchByIdOrName")
-			}
-		}
-		subq := StoragecachedimageManager.Query("cachedimage_id")
-		storages := StorageManager.Query("id", "storagecache_id").SubQuery()
-		hoststorages := HoststorageManager.Query("host_id", "storage_id").SubQuery()
-		hostschedtags := HostschedtagManager.Query().Equals("schedtag_id", schedTagObj.GetId()).SubQuery()
-		subq = subq.Join(storages, sqlchemy.Equals(storages.Field("storagecache_id"), subq.Field("storagecache_id")))
-		subq = subq.Join(hoststorages, sqlchemy.Equals(hoststorages.Field("storage_id"), storages.Field("id")))
-		subq = subq.Join(hostschedtags, sqlchemy.Equals(hostschedtags.Field("host_id"), hoststorages.Field("host_id")))
-		q = q.In("id", subq.SubQuery())
-	}
-
-	if query.Valid != nil {
-		storagecachedImages := StoragecachedimageManager.Query().SubQuery()
-		storageCaches := StoragecacheManager.Query().SubQuery()
-		storages := StorageManager.Query().In("status", []string{api.STORAGE_ENABLED, api.STORAGE_ONLINE}).IsTrue("enabled").SubQuery()
-
-		subq := storagecachedImages.Query(storagecachedImages.Field("cachedimage_id"))
-		subq = subq.Join(storageCaches, sqlchemy.Equals(storagecachedImages.Field("storagecache_id"), storageCaches.Field("id")))
-		subq = subq.Join(storages, sqlchemy.Equals(storageCaches.Field("id"), storages.Field("storagecache_id")))
-		if *query.Valid {
-			q = q.In("id", subq.SubQuery())
-		} else {
-			q = q.NotIn("id", subq.SubQuery())
-		}
+		q = q.Equals("image_type", query.ImageType)
 	}
 
 	return q, nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修改之前：
诸如provider, zone, host_schedtag_id, valid
等过滤条件，是通过过滤出符合条件的 storagecachedimage 然后使用 cachedimage_id 来过滤 cachedimge,
问题是，每一个过滤条件都会独立的去执行上面的过程，这样同样的查询可能要经过很多次，并且如果遇到
弱的过滤条件，比如 valid ，过滤出来的 storagecachedimage
非常之多，然后在使用 cachedimage_id 去过滤 cachedimage，会非常慢。

修改之后：
过滤条件的相似的逻辑合并起来，只需要向 subQuery 中添加 filter，使用 subQuery 一次把 storagecachedimage
过滤出来，然后使用 cachedimage_id 过滤 cachedimage。

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.5
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @swordqiu @zexi 