### PR TITLE
Respect multiple disks in VMware Template

### DIFF
--- a/pkg/cloudprovider/images.go
+++ b/pkg/cloudprovider/images.go
@@ -50,6 +50,17 @@ type SImage struct {
 	// UpdatedAt       time.Time
 	PublicScope string
 	ExternalId  string
+
+	// SubImages record the subImages of the guest image.
+	// For normal image, it's nil.
+	SubImages []SSubImage
+}
+
+type SSubImage struct {
+	Index     int
+	MinDiskMB int
+	MinRamMb  int
+	SizeBytes int64
 }
 
 func CloudImage2Image(image ICloudImage) SImage {
@@ -71,6 +82,7 @@ func CloudImage2Image(image ICloudImage) SImage {
 		Protected: true,
 		SizeBytes: image.GetSizeByte(),
 		Status:    image.GetImageStatus(),
+		SubImages: image.GetSubImages(),
 	}
 }
 

--- a/pkg/cloudprovider/resources.go
+++ b/pkg/cloudprovider/resources.go
@@ -174,6 +174,7 @@ type ICloudImage interface {
 	GetCreatedAt() time.Time
 	UEFI() bool
 	GetPublicScope() rbacutils.TRbacScope
+	GetSubImages() []SSubImage
 }
 
 type ICloudStoragecache interface {

--- a/pkg/compute/models/cachedimages.go
+++ b/pkg/compute/models/cachedimages.go
@@ -329,6 +329,10 @@ func (manager *SCachedimageManager) getImageByName(ctx context.Context, userCred
 	return cachedImage.GetImage()
 }
 
+func (manager *SCachedimageManager) GetImageInfo(ctx context.Context, userCred mcclient.TokenCredential, imageId string, refresh bool) (*cloudprovider.SImage, error) {
+	return manager.getImageInfo(ctx, userCred, imageId, refresh)
+}
+
 func (manager *SCachedimageManager) getImageInfo(ctx context.Context, userCred mcclient.TokenCredential, imageId string, refresh bool) (*cloudprovider.SImage, error) {
 	img, err := manager.GetImageById(ctx, userCred, imageId, refresh)
 	if err == nil {

--- a/pkg/multicloud/esxi/template.go
+++ b/pkg/multicloud/esxi/template.go
@@ -183,3 +183,18 @@ func (t *SVMTemplate) GetCreatedAt() time.Time {
 	}
 	return t.vm.vdisks[0].GetCreatedAt()
 }
+
+func (t *SVMTemplate) GetSubImages() []cloudprovider.SSubImage {
+	subImages := make([]cloudprovider.SSubImage, 0, len(t.vm.vdisks))
+	for i := range t.vm.vdisks {
+		vdisk := t.vm.vdisks[i]
+		sizeMb := vdisk.GetDiskSizeMB()
+		subImages = append(subImages, cloudprovider.SSubImage{
+			Index:     i,
+			SizeBytes: int64(sizeMb) * (1 << 20),
+			MinDiskMB: sizeMb,
+			MinRamMb:  0,
+		})
+	}
+	return subImages
+}

--- a/pkg/multicloud/image_base.go
+++ b/pkg/multicloud/image_base.go
@@ -14,7 +14,10 @@
 
 package multicloud
 
-import "yunion.io/x/onecloud/pkg/util/rbacutils"
+import (
+	"yunion.io/x/onecloud/pkg/cloudprovider"
+	"yunion.io/x/onecloud/pkg/util/rbacutils"
+)
 
 type SImageBase struct {
 	SVirtualResourceBase
@@ -22,4 +25,8 @@ type SImageBase struct {
 
 func (self *SImageBase) GetPublicScope() rbacutils.TRbacScope {
 	return rbacutils.ScopeSystem
+}
+
+func (self *SImageBase) GetSubImages() []cloudprovider.SSubImage {
+	return nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

在Image中增加SubImage: 
CachedImage 对应着公有云，VMware等外部的镜像，以及Glance中自定义的镜像。
对于VMware来说，CachedImage对应这它们的Template，Template实际上是一个完整的虚拟机，所以有可能是有数据盘的，
这个数据盘应该在创建机器的时候展示出来。
有一种方案是写一种新的类型，CachedGuestImage  来描述这种特殊的镜像，目前觉得只为了数据盘的展示做一个只有VMware使用的类型有些过于麻烦。
一种快捷、暂时的方案是，扩展一下CachedImage的Info，把SubImages的信息（主要是磁盘大小）放进去，然后创建机器的时候指定了带有SubImages的镜像是，自动扩展为多个磁盘。但是这种方式没有办法在创建机器的时候自定义已有磁盘的大小，只能在创建完成后去做。

克隆机器时，遵循params中描述的磁盘信息：
上面的改动可以在创建机器时将Template中的多磁盘信息展示出来，那么在最终创建机器时，就应该按照params中描述的磁盘信息对虚拟机的磁盘进行配置。多余的磁盘应该删除，不够的磁盘需要创建。磁盘的大小可以按照params更改。

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.5
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/cc @swordqiu @zexi 