### PR TITLE
fix(glance): allow public and private operations of guestimage

### DIFF
--- a/pkg/image/models/image_guest.go
+++ b/pkg/image/models/image_guest.go
@@ -541,7 +541,7 @@ func (self *SGuestImage) PerformPublic(
 		return nil, errors.Wrap(err, "fail to fetch subimages of guest image")
 	}
 	for i := range images {
-		_, err := images[i].PerformPublic(ctx, userCred, query, input)
+		_, err := images[i].performPublic(ctx, userCred, query, input)
 		if err != nil {
 			return nil, errors.Wrapf(err, "fail to public subimage %s", images[i].GetId())
 		}
@@ -560,7 +560,7 @@ func (self *SGuestImage) PerformPrivate(
 		return nil, errors.Wrap(err, "fail to fetch subimages of guest image")
 	}
 	for i := range images {
-		_, err := images[i].PerformPrivate(ctx, userCred, query, input)
+		_, err := images[i].performPrivate(ctx, userCred, query, input)
 		if err != nil {
 			return nil, errors.Wrapf(err, "fail to private subimage %s", images[i].GetId())
 		}

--- a/pkg/image/models/images.go
+++ b/pkg/image/models/images.go
@@ -1476,21 +1476,29 @@ func (img *SImage) PerformUpdateStatus(ctx context.Context, userCred mcclient.To
 }
 
 func (img *SImage) PerformPublic(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPublicProjectInput) (jsonutils.JSONObject, error) {
-	if img.IsStandard.IsTrue() {
-		return nil, errors.Wrap(httperrors.ErrForbidden, "cannot perform public for standard image")
-	}
 	if img.IsGuestImage.IsTrue() {
 		return nil, errors.Wrap(httperrors.ErrForbidden, "cannot perform public for guest image")
+	}
+	return img.performPublic(ctx, userCred, query, input)
+}
+
+func (img *SImage) performPublic(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPublicProjectInput) (jsonutils.JSONObject, error) {
+	if img.IsStandard.IsTrue() {
+		return nil, errors.Wrap(httperrors.ErrForbidden, "cannot perform public for standard image")
 	}
 	return img.SSharableVirtualResourceBase.PerformPublic(ctx, userCred, query, input)
 }
 
-func (img *SImage) PerformPrivate(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPrivateInput) (jsonutils.JSONObject, error) {
+func (img *SImage) performPrivate(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPrivateInput) (jsonutils.JSONObject, error) {
 	if img.IsStandard.IsTrue() {
 		return nil, errors.Wrap(httperrors.ErrForbidden, "cannot perform private for standard image")
 	}
+	return img.SSharableVirtualResourceBase.PerformPrivate(ctx, userCred, query, input)
+}
+
+func (img *SImage) PerformPrivate(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformPrivateInput) (jsonutils.JSONObject, error) {
 	if img.IsGuestImage.IsTrue() {
 		return nil, errors.Wrap(httperrors.ErrForbidden, "cannot perform private for guest image")
 	}
-	return img.SSharableVirtualResourceBase.PerformPrivate(ctx, userCred, query, input)
+	return img.performPrivate(ctx, userCred, query, input)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

The public and private operations of the guest image depends on these operations of the subimage.
fix problems introduced from #5757

- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.5
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area glance
/cc @wanyaoqi @swordqiu 