### PR TITLE
Automated cherry pick of #8464: check disk is in reset before delete snapshot

### DIFF
--- a/pkg/compute/models/snapshots.go
+++ b/pkg/compute/models/snapshots.go
@@ -621,6 +621,11 @@ func (self *SSnapshot) ValidateDeleteCondition(ctx context.Context) error {
 	if count > 0 {
 		return httperrors.NewBadRequestError("snapshot referenced by instance snapshot")
 	}
+	if disk, err := self.GetDisk(); err == nil {
+		if disk.Status == api.DISK_RESET {
+			return httperrors.NewBadRequestError("Cannot delete snapshot on disk reset")
+		}
+	}
 	driver := self.GetRegionDriver()
 	if driver != nil {
 		return driver.ValidateSnapshotDelete(ctx, self)


### PR DESCRIPTION
Cherry pick of #8464 on release/3.5.

#8464: check disk is in reset before delete snapshot