### PR TITLE
Automated cherry pick of #8474: monitor: set default influxdb datasource by endpoint type

### DIFF
--- a/pkg/monitor/service/handlers.go
+++ b/pkg/monitor/service/handlers.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	_ "net/http/pprof"
 	"strconv"
 
 	"github.com/gorilla/mux"
@@ -120,4 +121,13 @@ func addMiscHandlers(root *mux.Router) {
 		}
 	}
 	root.HandleFunc("/subscriptions/write", adapterF(performHandler))
+
+	// ref: pkg/appsrv/appsrv:addDefaultHandlers
+	root.HandleFunc("/version", adapterF(appsrv.VersionHandler))
+	root.HandleFunc("/stats", adapterF(appsrv.StatisticHandler))
+	root.HandleFunc("/ping", adapterF(appsrv.PingHandler))
+	root.HandleFunc("/worker_stats", adapterF(appsrv.WorkerStatsHandler))
+
+	// pprof handler
+	root.PathPrefix("/debug/pprof/").Handler(http.DefaultServeMux)
 }

--- a/pkg/webconsole/service/service.go
+++ b/pkg/webconsole/service/service.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"net/http/pprof"
+	_ "net/http/pprof"
 	"net/url"
 	"os"
 	"strconv"
@@ -133,9 +133,5 @@ func addMiscHandlers(root *mux.Router) {
 	root.HandleFunc("/worker_stats", adapterF(appsrv.WorkerStatsHandler))
 
 	// pprof handler
-	root.HandleFunc("/debug/pprof/", pprof.Index)
-	root.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	root.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	root.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	root.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	root.PathPrefix("/debug/pprof/").Handler(http.DefaultServeMux)
 }


### PR DESCRIPTION
Cherry pick of #8474 on release/3.5.

#8474: monitor: set default influxdb datasource by endpoint type