### PR TITLE
fix: climc vpc-create missing cloudregion_id

### DIFF
--- a/pkg/mcclient/options/vpc.go
+++ b/pkg/mcclient/options/vpc.go
@@ -39,18 +39,19 @@ func (opts *VpcListOptions) Params() (jsonutils.JSONObject, error) {
 }
 
 type VpcCreateOptions struct {
-	REGION             string `help:"ID or name of the region where the VPC is created"`
+	REGION             string `help:"ID or name of the region where the VPC is created" json:"cloudregion_id"`
 	Id                 string `help:"ID of the new VPC"`
-	NAME               string `help:"Name of the VPC"`
+	NAME               string `help:"Name of the VPC" json:"name"`
 	CIDR               string `help:"CIDR block"`
 	Default            bool   `help:"default VPC for the region" default:"false"`
 	Desc               string `help:"Description of the VPC"`
-	Manager            string `help:"ID or Name of Cloud provider"`
-	ExternalAccessMode string `help:"Filter by external access mode" choices:"distgw|eip|eip-distgw" default:"eip-distgw"`
+	Manager            string `help:"ID or Name of Cloud provider" json:"manager_id"`
+	ExternalAccessMode string `help:"Filter by external access mode" choices:"distgw|eip|eip-distgw" default:""`
 }
 
 func (opts *VpcCreateOptions) Params() (jsonutils.JSONObject, error) {
 	params := jsonutils.NewDict()
+	params.Add(jsonutils.NewString(opts.REGION), "cloudregion_id")
 	params.Add(jsonutils.NewString(opts.NAME), "name")
 	params.Add(jsonutils.NewString(opts.CIDR), "cidr_block")
 	if len(opts.Id) > 0 {
@@ -66,7 +67,7 @@ func (opts *VpcCreateOptions) Params() (jsonutils.JSONObject, error) {
 		params.Add(jsonutils.JSONTrue, "is_default")
 	}
 	if len(opts.Manager) > 0 {
-		params.Add(jsonutils.NewString(opts.Manager), "manager")
+		params.Add(jsonutils.NewString(opts.Manager), "manager_id")
 	}
 	return params, nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：vpc-create命令未传输cloudregion_id

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
None
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area climc