### PR TITLE
Automated cherry pick of #8558: informer: ignore outside context cancel when worker run

### DIFF
--- a/pkg/cloudcommon/informer/etcd.go
+++ b/pkg/cloudcommon/informer/etcd.go
@@ -156,6 +156,10 @@ func (b *EtcdBackend) put(ctx context.Context, key, val string) error {
 	return b.PutWithLease(ctx, key, val, b.leaseTTL)
 }
 
+func (b *EtcdBackend) PutSession(ctx context.Context, key, val string) error {
+	return b.client.PutSession(ctx, key, val)
+}
+
 func (b *EtcdBackend) PutWithLease(ctx context.Context, key, val string, ttlSeconds int64) error {
 	return b.client.PutWithLease(ctx, key, val, ttlSeconds)
 }

--- a/pkg/cloudcommon/informer/etcd_client.go
+++ b/pkg/cloudcommon/informer/etcd_client.go
@@ -99,7 +99,7 @@ func (b *EtcdBackendForClient) registerClientResource(ctx context.Context, key s
 	if err != nil {
 		return err
 	}
-	if err := b.PutWithLease(ctx, clientKey, "ok", 60); err != nil {
+	if err := b.PutSession(ctx, clientKey, "ok"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cloudcommon/informer/informer.go
+++ b/pkg/cloudcommon/informer/informer.go
@@ -92,7 +92,7 @@ func Create(ctx context.Context, obj *ModelObject) error {
 	if !isResourceWatched(obj.KeywordPlural) {
 		return nil
 	}
-	return run(func(be IInformerBackend) error {
+	return run(ctx, func(ctx context.Context, be IInformerBackend) error {
 		return be.Create(ctx, obj)
 	})
 }
@@ -101,7 +101,7 @@ func Update(ctx context.Context, obj *ModelObject, oldObj *jsonutils.JSONDict) e
 	if !isResourceWatched(obj.KeywordPlural) {
 		return nil
 	}
-	return run(func(be IInformerBackend) error {
+	return run(ctx, func(ctx context.Context, be IInformerBackend) error {
 		return be.Update(ctx, obj, oldObj)
 	})
 }
@@ -110,7 +110,7 @@ func Delete(ctx context.Context, obj *ModelObject) error {
 	if !isResourceWatched(obj.KeywordPlural) {
 		return nil
 	}
-	return run(func(be IInformerBackend) error {
+	return run(ctx, func(ctx context.Context, be IInformerBackend) error {
 		return be.Delete(ctx, obj)
 	})
 }


### PR DESCRIPTION
Cherry pick of #8558 on release/3.4.

#8558: informer: ignore outside context cancel when worker run