### PR TITLE
Automated cherry pick of #8593: fix(region): prevent dirty data when syncing snapshot

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -1837,6 +1837,10 @@ func (self *SDisk) Delete(ctx context.Context, userCred mcclient.TokenCredential
 }
 
 func (self *SDisk) RealDelete(ctx context.Context, userCred mcclient.TokenCredential) error {
+	err := self.DetachAllSnapshotpolicies(ctx, userCred)
+	if err != nil {
+		log.Errorf("unable to DetachAllSnapshotpolicies: %v", err)
+	}
 	return self.SVirtualResourceBase.Delete(ctx, userCred)
 }
 

--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -2487,8 +2487,15 @@ func (manager *SDiskManager) AutoSyncExtDiskSnapshot(ctx context.Context, userCr
 
 	for i := 0; i < len(spds); i++ {
 		spd := &spds[i]
-		disk := manager.FetchDiskById(spd.DiskId)
-
+		obj, err := manager.FetchById(spd.DiskId)
+		if errors.Cause(err) == sql.ErrNoRows || errors.Cause(err) == errors.ErrNotFound {
+			err := spd.RealDetach(ctx, userCred)
+			if err != nil {
+				log.Errorf("unable to detach s %q, d %q: %v", spd.SnapshotpolicyId, spd.DiskId, err)
+			}
+			continue
+		}
+		disk := obj.(*SDisk)
 		syncResult := disk.syncSnapshots(ctx, userCred)
 		if syncResult.IsError() {
 			db.OpsLog.LogEvent(disk, db.ACT_DISK_AUTO_SYNC_SNAPSHOT_FAIL, syncResult.Result(), userCred)
@@ -2502,7 +2509,7 @@ func (manager *SDiskManager) AutoSyncExtDiskSnapshot(ctx context.Context, userCr
 			continue
 		}
 		db.OpsLog.LogEvent(disk, db.ACT_DISK_AUTO_SYNC_SNAPSHOT, "disk auto sync snapshot successfully", userCred)
-		_, err := db.Update(spd, func() error {
+		_, err = db.Update(spd, func() error {
 			newNextSyncTime := spMap[spd.SnapshotpolicyId].ComputeNextSyncTime(now, spd.NextSyncTime)
 			spd.NextSyncTime = newNextSyncTime
 			return nil

--- a/pkg/compute/models/initdb.go
+++ b/pkg/compute/models/initdb.go
@@ -67,6 +67,8 @@ func InitDB() error {
 		DBInstanceNetworkManager,
 		DBInstanceAccountManager,
 		DBInstanceDatabaseManager,
+
+		SnapshotPolicyDiskManager,
 	} {
 		err := manager.InitializeData()
 		if err != nil {

--- a/pkg/compute/models/purge.go
+++ b/pkg/compute/models/purge.go
@@ -150,12 +150,7 @@ func (disk *SDisk) purge(ctx context.Context, userCred mcclient.TokenCredential)
 	lockman.LockObject(ctx, disk)
 	defer lockman.ReleaseObject(ctx, disk)
 
-	err := disk.DetachAllSnapshotpolicies(ctx, userCred)
-	if err != nil {
-		return errors.Wrap(err, "disk.DetachAllSnapshotpolicies")
-	}
-
-	err = disk.ValidatePurgeCondition(ctx)
+	err := disk.ValidatePurgeCondition(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/compute/tasks/disk_delete_task.go
+++ b/pkg/compute/tasks/disk_delete_task.go
@@ -179,7 +179,6 @@ func (self *DiskDeleteTask) OnGuestDiskDeleteComplete(ctx context.Context, obj d
 	if len(disk.SnapshotId) > 0 && disk.GetMetadata("merge_snapshot", nil) == "true" {
 		models.SnapshotManager.AddRefCount(disk.SnapshotId, -1)
 	}
-	disk.DetachAllSnapshotpolicies(ctx, self.UserCred)
 	disk.RealDelete(ctx, self.UserCred)
 	self.SetStageComplete(ctx, nil)
 }

--- a/pkg/compute/tasks/guest_detach_disk_task.go
+++ b/pkg/compute/tasks/guest_detach_disk_task.go
@@ -80,14 +80,6 @@ func (self *GuestDetachDiskTask) OnDetachDiskComplete(ctx context.Context, guest
 		return
 	}
 	disk := objDisk.(*models.SDisk)
-	// detach disk and snapshotpolicy if hypervisor is kvm
-	if guest.Hypervisor == api.HYPERVISOR_KVM {
-		err := disk.DetachAllSnapshotpolicies(ctx, self.UserCred)
-		if err != nil {
-			self.OnTaskFail(ctx, guest, nil, jsonutils.NewString(fmt.Sprintf("detach all snapshotpolicies failed: %s", err.Error())))
-			return
-		}
-	}
 	disk.SetStatus(self.UserCred, api.DISK_READY, "on detach disk complete")
 	keepDisk := jsonutils.QueryBoolean(self.Params, "keep_disk", true)
 	host := guest.GetHost()


### PR DESCRIPTION
Cherry pick of #8593 on release/3.4.

#8593: fix(region): prevent dirty data when syncing snapshot