### PR TITLE
fix: filter scopedpolicybindings with multiple categories

### DIFF
--- a/pkg/apis/yunionconf/input.go
+++ b/pkg/apis/yunionconf/input.go
@@ -83,7 +83,7 @@ type ScopedPolicyBindingListInput struct {
 	DomainId  string `json:"domain_id"`
 	ProjectId string `json:"project_id"`
 
-	Category string `json:"category"`
+	Category []string `json:"category"`
 
 	Effective *bool `json:"effective"`
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：允许通过多个cateogy来过滤scopedpolicybinding

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
None

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area yunionconf