### PR TITLE
fix(region): compute NextSyncTime for snapshotpolicydisk

### DIFF
--- a/pkg/compute/models/disks.go
+++ b/pkg/compute/models/disks.go
@@ -2525,7 +2525,7 @@ func (manager *SDiskManager) AutoSyncExtDiskSnapshot(ctx context.Context, userCr
 		}
 		db.OpsLog.LogEvent(disk, db.ACT_DISK_AUTO_SYNC_SNAPSHOT, "disk auto sync snapshot successfully", userCred)
 		_, err = db.Update(spd, func() error {
-			newNextSyncTime := spMap[spd.SnapshotpolicyId].ComputeNextSyncTime(now, spd.NextSyncTime)
+			newNextSyncTime := spMap[spd.SnapshotpolicyId].ComputeNextSyncTime(now)
 			spd.NextSyncTime = newNextSyncTime
 			return nil
 		})

--- a/pkg/compute/models/snapshotpolicy_test.go
+++ b/pkg/compute/models/snapshotpolicy_test.go
@@ -16,6 +16,7 @@ package models
 
 import (
 	"testing"
+	"time"
 
 	"yunion.io/x/log"
 	"yunion.io/x/pkg/tristate"
@@ -69,4 +70,123 @@ func TestSSnapshotPolicy_Key(t *testing.T) {
 			log.Errorf("the %d case, want %d, get %d", i, c.want, g)
 		}
 	}
+}
+
+func TestSSnapshotPolicy_ComputeNextSyncTime(t *testing.T) {
+	timeStr := "2006-01-02 15:04:05"
+	t.Run("base test", func(t *testing.T) {
+		cases := []struct {
+			in   *SSnapshotPolicy
+			base string
+			want string
+		}{
+			{
+				in: &SSnapshotPolicy{
+					RepeatWeekdays: SnapshotPolicyManager.RepeatWeekdaysParseIntArray([]int{2}),
+					TimePoints:     SnapshotPolicyManager.TimePointsParseIntArray([]int{4}),
+				},
+				base: "2020-10-31 00:00:00",
+				want: "2020-11-03 04:00:00",
+			},
+			{
+				in: &SSnapshotPolicy{
+					RepeatWeekdays: SnapshotPolicyManager.RepeatWeekdaysParseIntArray([]int{5, 7}),
+					TimePoints:     SnapshotPolicyManager.TimePointsParseIntArray([]int{2, 6}),
+				},
+				base: "2020-10-31 00:00:00",
+				want: "2020-11-01 02:00:00",
+			},
+		}
+		for _, c := range cases {
+			base, _ := time.Parse(timeStr, c.base)
+			want, _ := time.Parse(timeStr, c.want)
+			real := c.in.ComputeNextSyncTime(base)
+			if want != real {
+				t.Fatalf("want: %s, real: %s", want, real)
+			}
+		}
+	})
+	t.Run("same day", func(t *testing.T) {
+		cases := []struct {
+			in   *SSnapshotPolicy
+			base string
+			want string
+		}{
+			{
+				in: &SSnapshotPolicy{
+					RepeatWeekdays: SnapshotPolicyManager.RepeatWeekdaysParseIntArray([]int{6, 7}),
+					TimePoints:     SnapshotPolicyManager.TimePointsParseIntArray([]int{2}),
+				},
+				base: "2020-10-31 00:00:00",
+				want: "2020-10-31 02:00:00",
+			},
+			{
+				in: &SSnapshotPolicy{
+					RepeatWeekdays: SnapshotPolicyManager.RepeatWeekdaysParseIntArray([]int{6, 7}),
+					TimePoints:     SnapshotPolicyManager.TimePointsParseIntArray([]int{2}),
+				},
+				base: "2020-10-31 02:00:00",
+				want: "2020-11-01 02:00:00",
+			},
+			{
+				in: &SSnapshotPolicy{
+					RepeatWeekdays: SnapshotPolicyManager.RepeatWeekdaysParseIntArray([]int{6, 7}),
+					TimePoints:     SnapshotPolicyManager.TimePointsParseIntArray([]int{2}),
+				},
+				base: "2020-10-31 01:00:00",
+				want: "2020-10-31 02:00:00",
+			},
+		}
+		for _, c := range cases {
+			base, _ := time.Parse(timeStr, c.base)
+			want, _ := time.Parse(timeStr, c.want)
+			real := c.in.ComputeNextSyncTime(base)
+			if want != real {
+				t.Fatalf("want: %s, real: %s", want, real)
+			}
+		}
+	})
+	t.Run("retentionday", func(t *testing.T) {
+		cases := []struct {
+			in   *SSnapshotPolicy
+			base string
+			want string
+		}{
+			{
+				in: &SSnapshotPolicy{
+					RepeatWeekdays: SnapshotPolicyManager.RepeatWeekdaysParseIntArray([]int{5}),
+					TimePoints:     SnapshotPolicyManager.TimePointsParseIntArray([]int{4}),
+					RetentionDays:  2,
+				},
+				base: "2020-10-31 04:00:00",
+				want: "2020-11-01 04:00:00",
+			},
+			{
+				in: &SSnapshotPolicy{
+					RepeatWeekdays: SnapshotPolicyManager.RepeatWeekdaysParseIntArray([]int{6}),
+					TimePoints:     SnapshotPolicyManager.TimePointsParseIntArray([]int{4}),
+					RetentionDays:  8,
+				},
+				base: "2020-10-31 04:00:00",
+				want: "2020-11-01 04:00:00",
+			},
+			{
+				in: &SSnapshotPolicy{
+					RepeatWeekdays: SnapshotPolicyManager.RepeatWeekdaysParseIntArray([]int{1, 6}),
+					TimePoints:     SnapshotPolicyManager.TimePointsParseIntArray([]int{4}),
+					RetentionDays:  4,
+				},
+				base: "2020-10-31 04:00:00",
+				want: "2020-11-02 04:00:00",
+			},
+		}
+		for _, c := range cases {
+			base, _ := time.Parse(timeStr, c.base)
+			want, _ := time.Parse(timeStr, c.want)
+			real := c.in.ComputeNextSyncTime(base)
+			if want != real {
+				t.Fatalf("want: %s, real: %s", want, real)
+			}
+		}
+	})
 }

--- a/pkg/compute/models/snapshotpolicydisks.go
+++ b/pkg/compute/models/snapshotpolicydisks.go
@@ -215,7 +215,7 @@ func (sdm *SSnapshotPolicyDiskManager) InitializeData() error {
 	for i := range sds {
 		sd := &sds[i]
 		_, err := db.Update(sd, func() error {
-			sd.NextSyncTime = spMap[sd.SnapshotpolicyId].ComputeNextSyncTime(now, now)
+			sd.NextSyncTime = spMap[sd.SnapshotpolicyId].ComputeNextSyncTime(now)
 			return nil
 		})
 		if err != nil {
@@ -475,7 +475,7 @@ func (self *SSnapshotPolicyDiskManager) newSnapshotpolicyDisk(ctx context.Contex
 	spd.SnapshotpolicyId = sp.GetId()
 	spd.DiskId = disk.GetId()
 	now := time.Now()
-	spd.NextSyncTime = sp.ComputeNextSyncTime(now, now)
+	spd.NextSyncTime = sp.ComputeNextSyncTime(now)
 	spd.SetModelManager(self, &spd)
 
 	lockman.LockJointObject(ctx, disk, sp)
@@ -518,7 +518,7 @@ func (sd *SSnapshotPolicyDisk) CustomizeCreate(ctx context.Context, userCred mcc
 		return err
 	}
 	now := time.Now()
-	sd.NextSyncTime = sp.ComputeNextSyncTime(now, now)
+	sd.NextSyncTime = sp.ComputeNextSyncTime(now)
 	return nil
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. 如果计算出来的 NextSyncTime 和 base 相等，可以将 base 加1一个小时递归处理。
2. 对于 retentionday 有效的快照策略，比如某一个 snaphsotpolicy
是每周一生效，并且打的快照自动保留 3 天，那么，就应该在每周一（打快照）
和每周四（释放快照）进行快照的同步。

- [x] 功能、bugfix描述
- [x] 冒烟测试
- [x] 单元测试编写

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.5
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @swordqiu @wanyaoqi 