### PR TITLE
fix: save service config changes may send invalid action log

### DIFF
--- a/pkg/apis/identity/consts.go
+++ b/pkg/apis/identity/consts.go
@@ -203,3 +203,19 @@ var (
 		},
 	}
 )
+
+func mergeConfigOptionsFrom(opt1, opt2 map[string][]string) map[string][]string {
+	for opt, values := range opt2 {
+		ovalues, _ := opt1[opt]
+		opt1[opt] = append(ovalues, values...)
+	}
+	return opt1
+}
+
+func MergeServiceConfigOptions(opts ...map[string][]string) map[string][]string {
+	ret := make(map[string][]string)
+	for i := range opts {
+		ret = mergeConfigOptionsFrom(ret, opts[i])
+	}
+	return ret
+}

--- a/pkg/cloudcommon/options/manager.go
+++ b/pkg/cloudcommon/options/manager.go
@@ -116,7 +116,7 @@ func optionsEquals(newOpts interface{}, oldOpts interface{}) bool {
 func (manager *SOptionManager) DoSync(first bool) (time.Duration, error) {
 	newOpts := manager.newOptions()
 	copyOptions(newOpts, manager.options)
-	merged := manager.session.Merge(newOpts, manager.serviceType, manager.serviceVersion, first)
+	merged := manager.session.Merge(newOpts, manager.serviceType, manager.serviceVersion)
 
 	if merged && !optionsEquals(newOpts, manager.options) {
 		if manager.onOptionsChange != nil && manager.onOptionsChange(manager.options, newOpts) && !first {
@@ -124,7 +124,10 @@ func (manager *SOptionManager) DoSync(first bool) (time.Duration, error) {
 			appsrv.SetExitFlag()
 		}
 		copyOptions(manager.options, newOpts)
-		manager.session.Upload(first)
+		if first {
+			// upload config for the first time ONLY
+			manager.session.Upload()
+		}
 	}
 	return manager.refreshInterval, nil
 }

--- a/pkg/cloudcommon/options/mergeconf.go
+++ b/pkg/cloudcommon/options/mergeconf.go
@@ -57,8 +57,8 @@ func getServiceConfig(s *mcclient.ClientSession, serviceId string) (jsonutils.JS
 }
 
 type IServiceConfigSession interface {
-	Merge(opts interface{}, serviceType string, serviceVersion string, isFirst bool) bool
-	Upload(isFirst bool)
+	Merge(opts interface{}, serviceType string, serviceVersion string) bool
+	Upload()
 	IsRemote() bool
 }
 
@@ -72,7 +72,7 @@ func newServiceConfigSession() IServiceConfigSession {
 	return &mcclientServiceConfigSession{}
 }
 
-func (s *mcclientServiceConfigSession) Merge(opts interface{}, serviceType string, serviceVersion string, isFirst bool) bool {
+func (s *mcclientServiceConfigSession) Merge(opts interface{}, serviceType string, serviceVersion string) bool {
 	merged := false
 	s.config = jsonutils.Marshal(opts).(*jsonutils.JSONDict)
 	region, _ := s.config.GetString("region")
@@ -88,7 +88,7 @@ func (s *mcclientServiceConfigSession) Merge(opts interface{}, serviceType strin
 			merged = true
 		} else {
 			// not initialized
-			s.Upload(isFirst)
+			s.Upload()
 		}
 	}
 	commonServiceId, _ := getServiceIdByType(s.session, consts.COMMON_SERVICE, "")
@@ -113,7 +113,7 @@ func (s *mcclientServiceConfigSession) Merge(opts interface{}, serviceType strin
 	return false
 }
 
-func (s *mcclientServiceConfigSession) Upload(isFirst bool) {
+func (s *mcclientServiceConfigSession) Upload() {
 	// upload service config
 	if len(s.serviceId) > 0 {
 		nconf := jsonutils.NewDict()

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -188,5 +188,12 @@ func OnOptionsChange(oldO, newO interface{}) bool {
 	if common_options.OnCommonOptionsChange(&oldOpts.CommonOptions, &newOpts.CommonOptions) {
 		changed = true
 	}
+
+	if oldOpts.PendingDeleteCheckSeconds != newOpts.PendingDeleteCheckSeconds {
+		if !oldOpts.IsSlaveNode {
+			changed = true
+		}
+	}
+
 	return changed
 }

--- a/pkg/image/options/options.go
+++ b/pkg/image/options/options.go
@@ -56,5 +56,11 @@ func OnOptionsChange(oldO, newO interface{}) bool {
 		changed = true
 	}
 
+	if oldOpts.PendingDeleteCheckSeconds != newOpts.PendingDeleteCheckSeconds {
+		if !oldOpts.IsSlaveNode {
+			changed = true
+		}
+	}
+
 	return changed
 }

--- a/pkg/keystone/models/identity_provider.go
+++ b/pkg/keystone/models/identity_provider.go
@@ -340,7 +340,7 @@ func (ident *SIdentityProvider) PerformConfig(ctx context.Context, userCred mccl
 
 	opts := input.Config
 	action := input.Action
-	err = saveConfigs(userCred, action, ident, opts, nil, nil, api.SensitiveDomainConfigMap, false)
+	err = saveConfigs(userCred, action, ident, opts, nil, nil, api.SensitiveDomainConfigMap)
 	if err != nil {
 		return nil, httperrors.NewInternalServerError("saveConfig fail %s", err)
 	}
@@ -492,7 +492,7 @@ func (ident *SIdentityProvider) PostCreate(ctx context.Context, userCred mcclien
 		log.Errorf("parse config error %s", err)
 		return
 	}
-	err = saveConfigs(userCred, "", ident, opts, nil, nil, api.SensitiveDomainConfigMap, false)
+	err = saveConfigs(userCred, "", ident, opts, nil, nil, api.SensitiveDomainConfigMap)
 	if err != nil {
 		log.Errorf("saveConfig fail %s", err)
 		return

--- a/pkg/keystone/models/passwords.go
+++ b/pkg/keystone/models/passwords.go
@@ -27,6 +27,7 @@ import (
 	"yunion.io/x/onecloud/pkg/httperrors"
 	o "yunion.io/x/onecloud/pkg/keystone/options"
 	"yunion.io/x/onecloud/pkg/util/seclib2"
+	"yunion.io/x/onecloud/pkg/util/stringutils2"
 )
 
 // +onecloud:swagger-gen-ignore
@@ -110,6 +111,15 @@ func (manager *SPasswordManager) fetchByLocaluserId(localUserId int) ([]SPasswor
 func validatePasswordComplexity(password string) error {
 	if o.Options.PasswordMinimalLength > 0 && len(password) < o.Options.PasswordMinimalLength {
 		return errors.Wrap(httperrors.ErrWeakPassword, "too simple password")
+	}
+	if o.Options.PasswordCharComplexity > 0 {
+		complexity := o.Options.PasswordCharComplexity
+		if complexity > 4 {
+			complexity = 4
+		}
+		if stringutils2.GetCharTypeCount(password) < complexity {
+			return errors.Wrap(httperrors.ErrWeakPassword, "too simple password")
+		}
 	}
 	return nil
 }

--- a/pkg/keystone/models/services.go
+++ b/pkg/keystone/models/services.go
@@ -201,9 +201,9 @@ func (service *SService) PerformConfig(ctx context.Context, userCred mcclient.To
 	action := input.Action
 	opts := input.Config
 	if service.isCommonService() {
-		err = saveConfigs(userCred, action, service, opts, api.CommonWhitelistOptionMap, nil, nil, false)
+		err = saveConfigs(userCred, action, service, opts, api.CommonWhitelistOptionMap, nil, nil)
 	} else {
-		err = saveConfigs(userCred, action, service, opts, nil, api.ServiceBlacklistOptionMap, nil, false)
+		err = saveConfigs(userCred, action, service, opts, nil, api.MergeServiceConfigOptions(api.CommonWhitelistOptionMap, api.ServiceBlacklistOptionMap), nil)
 	}
 	if err != nil {
 		return nil, httperrors.NewInternalServerError("saveConfig fail %s", err)

--- a/pkg/keystone/options/options.go
+++ b/pkg/keystone/options/options.go
@@ -41,6 +41,7 @@ type SKeystoneOptions struct {
 	PasswordExpirationSeconds  int `help:"password expires after the duration in seconds"`
 	PasswordMinimalLength      int `help:"password minimal length" default:"6"`
 	PasswordUniqueHistoryCheck int `help:"password must be unique in last N passwords"`
+	PasswordCharComplexity     int `help:"password complexity policy" default:"0"`
 
 	PasswordErrorLockCount int `help:"lock user account if given number of failed auth"`
 

--- a/pkg/util/stringutils2/stringutils.go
+++ b/pkg/util/stringutils2/stringutils.go
@@ -185,3 +185,29 @@ func GenerateHostName(name string, osType string) string {
 	}
 	return forOther(name)
 }
+
+func GetCharTypeCount(str string) int {
+	digitIdx := 0
+	lowerIdx := 1
+	upperIdx := 2
+	otherIdx := 3
+	complexity := make([]int, 4)
+	for _, b := range []byte(str) {
+		if b >= '0' && b <= '9' {
+			complexity[digitIdx] += 1
+		} else if b >= 'a' && b <= 'z' {
+			complexity[lowerIdx] += 1
+		} else if b >= 'A' && b <= 'Z' {
+			complexity[upperIdx] += 1
+		} else {
+			complexity[otherIdx] += 1
+		}
+	}
+	ret := 0
+	for i := range complexity {
+		if complexity[i] > 0 {
+			ret += 1
+		}
+	}
+	return ret
+}

--- a/pkg/util/stringutils2/stringutils_test.go
+++ b/pkg/util/stringutils2/stringutils_test.go
@@ -166,3 +166,45 @@ func TestGenerateHostName(t *testing.T) {
 		}
 	}
 }
+
+func TestGetCharTypeCount(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{
+			in:   "",
+			want: 0,
+		},
+		{
+			in:   "123",
+			want: 1,
+		},
+		{
+			in:   "abc",
+			want: 1,
+		},
+		{
+			in:   "abcAbc",
+			want: 2,
+		},
+		{
+			in:   "123dbA",
+			want: 3,
+		},
+		{
+			in:   "123@Acv",
+			want: 4,
+		},
+		{
+			in:   "中文",
+			want: 1,
+		},
+	}
+	for _, c := range cases {
+		got := GetCharTypeCount(c.in)
+		if got != c.want {
+			t.Errorf("GetCharTypeCount %s want %d got %d", c.in, c.want, got)
+		}
+	}
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：
1. 保存服务配置时候会提交无效的操作日志
2. 保存服务配置时候，避免同时保存common的配置 
新增：1.  增加密码复杂度的keystone选项 

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.5

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area keystone
/cc @zexi @yousong 