### PR TITLE
fix: scopedpolicybinding filter by category sql error

### DIFF
--- a/pkg/yunionconf/models/scopedpolicybindings.go
+++ b/pkg/yunionconf/models/scopedpolicybindings.go
@@ -239,13 +239,12 @@ func (manager *SScopedPolicyBindingManager) ListItemFilter(
 		maxq = filterByOwnerId(maxq, query.DomainId, query.ProjectId, *query.Effective, query.Category, query.PolicyId)
 		maxq = maxq.GroupBy(bindingQ.Field("category"))
 		subq := maxq.SubQuery()
-		q = q.Join(subq, sqlchemy.AND(
-			sqlchemy.Equals(q.Field("category"), subq.Field("category")),
-			sqlchemy.Equals(q.Field("priority"), subq.Field("max_priority")),
-		))
+		q = q.Join(subq, sqlchemy.Equals(q.Field("category"), subq.Field("category")))
+		q = q.Filter(sqlchemy.Equals(q.Field("priority"), subq.Field("max_priority")))
+	} else {
+		effective := (query.Effective != nil && *query.Effective)
+		q = filterByOwnerId(q, query.DomainId, query.ProjectId, effective, query.Category, query.PolicyId)
 	}
-	effective := (query.Effective != nil && *query.Effective)
-	q = filterByOwnerId(q, query.DomainId, query.ProjectId, effective, query.Category, query.PolicyId)
 
 	return q, nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：scopedpolicybinding的category过滤器失效

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.5

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area yunionconf
/cc @zexi 