### PR TITLE
modify monitor querycondition:

### DIFF
--- a/pkg/apis/monitor/commalert.go
+++ b/pkg/apis/monitor/commalert.go
@@ -41,9 +41,10 @@ type CommonAlertCreateInput struct {
 	AlertType string `json:"alert_type"`
 
 	//scope Resource
-	Scope     string `json:"scope"`
-	DomainId  string `json:"domain_id"`
-	ProjectId string `json:"project_id"`
+	Scope       string `json:"scope"`
+	DomainId    string `json:"domain_id"`
+	ProjectId   string `json:"project_id"`
+	GetPointStr bool   `json:"get_point_str"`
 }
 
 type CommonMetricInputQuery struct {
@@ -88,6 +89,7 @@ type CommonAlertUpdateInput struct {
 	Recipients []string `json:"recipients"`
 	// systemalert policy may need update through operator
 	ForceUpdate bool `json:"force_update"`
+	GetPointStr bool `json:"get_point_str"`
 }
 
 type CommonAlertDetails struct {
@@ -117,4 +119,5 @@ type CommonAlertMetricDetails struct {
 	Filters                []MetricQueryTag `json:"filters"`
 	FieldDescription       MetricFieldDetail
 	FieldOpt               string `json:"field_opt"`
+	GetPointStr            bool   `json:"get_point_str"`
 }

--- a/pkg/hostman/hostmetrics/hostmetrics.go
+++ b/pkg/hostman/hostmetrics/hostmetrics.go
@@ -33,6 +33,7 @@ import (
 	"yunion.io/x/pkg/util/netutils"
 
 	"yunion.io/x/onecloud/pkg/hostman/guestman"
+	"yunion.io/x/onecloud/pkg/hostman/hostinfo/hostconsts"
 	"yunion.io/x/onecloud/pkg/hostman/options"
 	"yunion.io/x/onecloud/pkg/util/httputils"
 )
@@ -244,7 +245,8 @@ func (s *SGuestMonitorCollector) toTelegrafReportData(data *jsonutils.JSONDict) 
 		for metrics, stat := range rs {
 			tags := map[string]string{
 				"vm_id": guestId, "vm_name": vmName, "vm_ip": vmIp,
-				"is_vm": "true", "brand": "OneCloud", "res_type": "guest",
+				"is_vm": "true", hostconsts.TELEGRAF_TAG_KEY_BRAND: hostconsts.TELEGRAF_TAG_ONECLOUD_BRAND,
+				hostconsts.TELEGRAF_TAG_KEY_RES_TYPE: "guest",
 			}
 			if len(scalingGroupId) > 0 {
 				tags["vm_scaling_group_id"] = scalingGroupId

--- a/pkg/monitor/alerting/conditions/reducer.go
+++ b/pkg/monitor/alerting/conditions/reducer.go
@@ -27,7 +27,7 @@ import (
 )
 
 type Reducer interface {
-	Reduce(series *tsdb.TimeSeries) *float64
+	Reduce(series *tsdb.TimeSeries) (*float64, []string)
 	GetType() string
 }
 
@@ -42,14 +42,14 @@ func (s *queryReducer) GetType() string {
 	return s.Type
 }
 
-func (s *queryReducer) Reduce(series *tsdb.TimeSeries) *float64 {
+func (s *queryReducer) Reduce(series *tsdb.TimeSeries) (*float64, []string) {
 	if len(series.Points) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	value := float64(0)
 	allNull := true
-
+	valArr := make([]string, 0)
 	switch s.Type {
 	case "avg":
 		validPointsCount := 0
@@ -98,6 +98,7 @@ func (s *queryReducer) Reduce(series *tsdb.TimeSeries) *float64 {
 		for i := len(points) - 1; i >= 0; i-- {
 			if points[i].IsValid() {
 				value = points[i].Value()
+				valArr = points[i].PointValueStr()
 				allNull = false
 				break
 			}
@@ -136,10 +137,10 @@ func (s *queryReducer) Reduce(series *tsdb.TimeSeries) *float64 {
 	}
 
 	if allNull {
-		return nil
+		return nil, nil
 	}
 
-	return &value
+	return &value, valArr
 }
 
 func newSimpleReducer(t string) *queryReducer {

--- a/pkg/monitor/alerting/conditions/reducer_test.go
+++ b/pkg/monitor/alerting/conditions/reducer_test.go
@@ -78,7 +78,7 @@ func TestSimpleReducer(t *testing.T) {
 			series.Points = append(series.Points, tsdb.NewTimePointByVal(2, 5))
 			series.Points = append(series.Points, tsdb.NewTimePointByVal(3, 6))
 
-			result := reducer.Reduce(series)
+			result, _ := reducer.Reduce(series)
 			So(result, ShouldNotBeNil)
 			So(*result, ShouldEqual, 2)
 		})
@@ -99,9 +99,9 @@ func TestSimpleReducer(t *testing.T) {
 				series.Points = append(series.Points, tsdb.NewTimePoint(nil, 2))
 				series.Points = append(series.Points, tsdb.NewTimePointByVal(3, 3))
 				series.Points = append(series.Points, tsdb.NewTimePointByVal(4, 4))
-
-				So(reducer.Reduce(series), ShouldNotBeNil)
-				So(*reducer.Reduce(series), ShouldEqual, 2)
+				reduce, _ := reducer.Reduce(series)
+				So(reduce, ShouldNotBeNil)
+				So(*reduce, ShouldEqual, 2)
 			})
 
 			Convey("with null values", func() {
@@ -112,8 +112,8 @@ func TestSimpleReducer(t *testing.T) {
 
 				series.Points = append(series.Points, tsdb.NewTimePoint(nil, 1))
 				series.Points = append(series.Points, tsdb.NewTimePoint(nil, 2))
-
-				So(reducer.Reduce(series), ShouldBeNil)
+				reduce, _ := reducer.Reduce(series)
+				So(reduce, ShouldBeNil)
 			})
 		})
 
@@ -127,8 +127,8 @@ func TestSimpleReducer(t *testing.T) {
 			series.Points = append(series.Points, tsdb.NewTimePoint(nil, 2))
 			series.Points = append(series.Points, tsdb.NewTimePoint(nil, 3))
 			series.Points = append(series.Points, tsdb.NewTimePointByVal(3, 4))
-
-			So(*reduer.Reduce(series), ShouldEqual, 3)
+			reduce, _ := reduer.Reduce(series)
+			So(*reduce, ShouldEqual, 3)
 		})
 
 		Convey("diff one point", func() {
@@ -154,8 +154,8 @@ func TestSimpleReducer(t *testing.T) {
 
 			series.Points = append(series.Points, tsdb.NewTimePoint(nil, 1))
 			series.Points = append(series.Points, tsdb.NewTimePoint(nil, 2))
-
-			So(reducer.Reduce(series), ShouldBeNil)
+			reduce, _ := reducer.Reduce(series)
+			So(reduce, ShouldBeNil)
 		})
 
 		Convey("percent_diff one point", func() {
@@ -181,8 +181,8 @@ func TestSimpleReducer(t *testing.T) {
 
 			series.Points = append(series.Points, tsdb.NewTimePoint(nil, 1))
 			series.Points = append(series.Points, tsdb.NewTimePoint(nil, 2))
-
-			So(reducer.Reduce(series), ShouldBeNil)
+			reduce, _ := reducer.Reduce(series)
+			So(reduce, ShouldBeNil)
 		})
 	})
 }
@@ -197,6 +197,6 @@ func testReducer(reducerType string, datapoints ...float64) float64 {
 		val := datapoints[idx]
 		serires.Points = append(serires.Points, tsdb.NewTimePoint(&val, 1234134))
 	}
-
-	return *reducer.Reduce(serires)
+	reduce, _ := reducer.Reduce(serires)
+	return *reduce
 }

--- a/pkg/monitor/alerting/conditions/suggestrulereducer.go
+++ b/pkg/monitor/alerting/conditions/suggestrulereducer.go
@@ -32,9 +32,9 @@ func NewSuggestRuleReducer(t string, duration time.Duration) Reducer {
 	}
 }
 
-func (s *suggestRuleReducer) Reduce(series *tsdb.TimeSeries) *float64 {
+func (s *suggestRuleReducer) Reduce(series *tsdb.TimeSeries) (*float64, []string) {
 	if int(s.duration.Seconds()) > len(series.Points) {
-		return nil
+		return nil, nil
 	}
 	return s.queryReducer.Reduce(series)
 }

--- a/pkg/monitor/alertresourcedrivers/node.go
+++ b/pkg/monitor/alertresourcedrivers/node.go
@@ -36,12 +36,19 @@ func (drvF *nodeDriverF) GetType() monitor.AlertResourceType {
 
 func (drvF *nodeDriverF) IsEvalMatched(input monitor.EvalMatch) bool {
 	tags := input.Tags
-	_, hasResType := tags[hostconsts.TELEGRAF_TAG_KEY_RES_TYPE]
+	resType, hasResType := tags[hostconsts.TELEGRAF_TAG_KEY_RES_TYPE]
 	if !hasResType {
 		return false
 	}
-	_, hasHostType := tags[hostconsts.TELEGRAF_TAG_KEY_HOST_TYPE]
+	if resType != hostconsts.TELEGRAF_TAG_ONECLOUD_RES_TYPE {
+		return false
+	}
+	hostType, hasHostType := tags[hostconsts.TELEGRAF_TAG_KEY_HOST_TYPE]
 	if !hasHostType {
+		return false
+	}
+	if hostType != hostconsts.TELEGRAF_TAG_ONECLOUD_HOST_TYPE_HOST ||
+		hostType != hostconsts.TELEGRAF_TAG_ONECLOUD_HOST_TYPE_CONTROLLER {
 		return false
 	}
 	_, hasHost := tags[NODE_TAG_HOST_KEY]

--- a/pkg/monitor/models/commonalert.go
+++ b/pkg/monitor/models/commonalert.go
@@ -17,6 +17,7 @@ import (
 	"yunion.io/x/onecloud/pkg/apis"
 	"yunion.io/x/onecloud/pkg/apis/monitor"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/hostman/hostinfo/hostconsts"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	merrors "yunion.io/x/onecloud/pkg/monitor/errors"
@@ -28,6 +29,7 @@ import (
 const (
 	CommonAlertMetadataAlertType = "alert_type"
 	CommonAlertMetadataFieldOpt  = "field_opt"
+	CommonAlertMetadataPointStr  = "point_str"
 )
 
 var (
@@ -187,6 +189,14 @@ func (alert *SCommonAlert) getFieldOpt() string {
 	return alert.GetMetadata(CommonAlertMetadataFieldOpt, nil)
 }
 
+func (alert *SCommonAlert) setPointStr(ctx context.Context, userCred mcclient.TokenCredential, fieldOpt string) error {
+	return alert.SetMetadata(ctx, CommonAlertMetadataPointStr, fieldOpt, userCred)
+}
+
+func (alert *SCommonAlert) getPointStr() string {
+	return alert.GetMetadata(CommonAlertMetadataPointStr, nil)
+}
+
 func (alert *SCommonAlert) CustomizeCreate(
 	ctx context.Context, userCred mcclient.TokenCredential,
 	ownerId mcclient.IIdentityProvider,
@@ -278,6 +288,9 @@ func (alert *SCommonAlert) PostCreate(ctx context.Context,
 	}
 	if fieldOpt != "" {
 		alert.setFieldOpt(ctx, userCred, fieldOpt)
+	}
+	if input.GetPointStr {
+		alert.setPointStr(ctx, userCred, strconv.FormatBool(input.GetPointStr))
 	}
 	_, err := alert.PerformSetScope(ctx, userCred, query, data)
 	if err != nil {
@@ -487,6 +500,11 @@ func (alert *SCommonAlert) GetCommonAlertMetricDetailsFromAlertCondition(index i
 	if fieldOpt != "" {
 		metricDetails.FieldOpt = strings.Split(fieldOpt, "+")[index]
 	}
+	poinStr := alert.getPointStr()
+	if len(poinStr) != 0 {
+		bl, _ := strconv.ParseBool(poinStr)
+		metricDetails.GetPointStr = bl
+	}
 	getCommonAlertMetricDetailsFromCondition(cond, metricDetails)
 	return metricDetails
 }
@@ -530,17 +548,8 @@ func getCommonAlertMetricDetailsFromCondition(cond *monitor.AlertCondition,
 			break
 		}
 	}
-	newQueryTags := make([]monitor.MetricQueryTag, 0)
-	for i, tagFilter := range q.Model.Tags {
-		if tagFilter.Key == "tenant_id" {
-			continue
-		}
-		if tagFilter.Key == "domain_id" {
-			continue
-		}
-		newQueryTags = append(newQueryTags, q.Model.Tags[i])
-	}
-	cond.Query.Model.Tags = newQueryTags
+
+	cond.Query.Model.Tags = filterDefaultTags(q.Model.Tags)
 	metricDetails.Measurement = measurement
 	metricDetails.Field = field
 	metricDetails.DB = db
@@ -549,6 +558,23 @@ func getCommonAlertMetricDetailsFromCondition(cond *monitor.AlertCondition,
 
 	//fill measurement\field desciption info
 	getMetricDescriptionDetails(metricDetails)
+}
+
+func filterDefaultTags(queryTag []monitor.MetricQueryTag) []monitor.MetricQueryTag {
+	newQueryTags := make([]monitor.MetricQueryTag, 0)
+	for i, tagFilter := range queryTag {
+		if tagFilter.Key == "tenant_id" {
+			continue
+		}
+		if tagFilter.Key == "domain_id" {
+			continue
+		}
+		if tagFilter.Key == hostconsts.TELEGRAF_TAG_KEY_RES_TYPE {
+			continue
+		}
+		newQueryTags = append(newQueryTags, queryTag[i])
+	}
+	return newQueryTags
 }
 
 func getMetricDescriptionDetails(metricDetails *monitor.CommonAlertMetricDetails) {
@@ -750,6 +776,9 @@ func (alert *SCommonAlert) PostUpdate(
 		if err != nil {
 			log.Errorln(errors.Wrap(err, "Alert PerformSetScope"))
 		}
+	}
+	if updateInput.GetPointStr {
+		alert.setPointStr(ctx, userCred, strconv.FormatBool(updateInput.GetPointStr))
 	}
 	CommonAlertManager.SetSubscriptionAlert(alert)
 }

--- a/pkg/monitor/models/unifiedmonitor.go
+++ b/pkg/monitor/models/unifiedmonitor.go
@@ -300,8 +300,8 @@ func setDefaultValue(query *monitor.AlertQuery, inputQuery *monitor.MetricInputQ
 			})
 	}
 
+	metricMeasurement, _ := MetricMeasurementManager.GetCache().Get(query.Model.Measurement)
 	if query.Model.Database == "" {
-		metricMeasurement, _ := MetricMeasurementManager.GetCache().Get(query.Model.Measurement)
 		database := ""
 		if metricMeasurement == nil {
 			log.Warningf("Not found measurement %s from metrics measurement cache", query.Model.Measurement)
@@ -361,6 +361,14 @@ func setDefaultValue(query *monitor.AlertQuery, inputQuery *monitor.MetricInputQ
 				Condition: "and",
 			})
 		}
+	}
+	if metricMeasurement.ResType == hostconsts.TELEGRAF_TAG_ONECLOUD_RES_TYPE {
+		query.Model.Tags = append(query.Model.Tags, monitor.MetricQueryTag{
+			Key:       hostconsts.TELEGRAF_TAG_KEY_RES_TYPE,
+			Operator:  "=",
+			Value:     hostconsts.TELEGRAF_TAG_ONECLOUD_RES_TYPE,
+			Condition: "and",
+		})
 	}
 }
 

--- a/pkg/monitor/subscriptionmodel/subcription.go
+++ b/pkg/monitor/subscriptionmodel/subcription.go
@@ -204,7 +204,7 @@ func (self *SSubscriptionManager) Eval(details monitor.CommonAlertMetricDetails,
 	if err != nil {
 		return false, nil, err
 	}
-	reduceValue := reducer.Reduce(serie)
+	reduceValue, _ := reducer.Reduce(serie)
 
 	evalCond := monitor.Condition{
 		Type:   getQueryEvalType(details.Comparator),


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1.对于策略可以返回多个field value。供策略进行使用
2. 对于1种情况需要在commonalert种设置metadata属性
3. 修改alertresource get driver的判断逻辑
4. 针对host 相关的measurement 默认增加res_type 过滤filter
5. sql结构化，增加columns返回

**是否需要 backport 到之前的 release 分支**:
- release/3.5

/cc @zexi 
/area monitor
