### PR TITLE
fix: save sso login status in cookie

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -522,7 +522,8 @@ func (h *AuthHandlers) doLogin(ctx context.Context, w http.ResponseWriter, req *
 		if err != nil {
 			return errors.Wrap(err, "isUserTotpCredInitialed")
 		}
-		authToken = clientman.NewAuthToken(token.GetTokenString(), isUserEnableTotp(userInfo), isTotpInit)
+		isIdpLogin := body.Contains("idp_driver")
+		authToken = clientman.NewAuthToken(token.GetTokenString(), isUserEnableTotp(userInfo), isTotpInit, isIdpLogin)
 	}
 
 	if !isUserAllowWebconsole(userInfo) {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：在yunionauth cookie中保存是否sso登录的状态

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
None

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area apigateway