### PR TITLE
server generate name should be historically unique

### DIFF
--- a/pkg/cloudcommon/consts/consts.go
+++ b/pkg/cloudcommon/consts/consts.go
@@ -35,6 +35,8 @@ var (
 	maxPagingLimit     int64 = 2048
 
 	domainizedNamespace = true
+
+	historicalUniqueName = false
 )
 
 func SetRegion(region string) {
@@ -84,4 +86,16 @@ func SetDomainizedNamespace(domainNS bool) {
 
 func IsDomainizedNamespace() bool {
 	return nonDefaultDomainProjects && domainizedNamespace
+}
+
+func EnableHistoricalUniqueName() {
+	historicalUniqueName = true
+}
+
+func DisableHistoricalUniqueName() {
+	historicalUniqueName = false
+}
+
+func IsHistoricalUniqueName() bool {
+	return historicalUniqueName
 }

--- a/pkg/cloudcommon/database.go
+++ b/pkg/cloudcommon/database.go
@@ -44,6 +44,12 @@ func InitDB(options *common_options.DBOptions) {
 
 	consts.QueryOffsetOptimization = options.QueryOffsetOptimization
 
+	if options.HistoricalUniqueName {
+		consts.EnableHistoricalUniqueName()
+	} else {
+		consts.DisableHistoricalUniqueName()
+	}
+
 	dialect, sqlStr, err := options.GetDBConnection()
 	if err != nil {
 		log.Fatalf("Invalid SqlConnection string: %s error: %v", options.SqlConnection, err)

--- a/pkg/cloudcommon/db/taskman/tasks.go
+++ b/pkg/cloudcommon/db/taskman/tasks.go
@@ -329,6 +329,7 @@ func (manager *STaskManager) NewParallelTask(
 	}
 	for _, obj := range objs {
 		to := STaskObject{TaskId: task.Id, ObjId: obj.GetId()}
+		to.SetModelManager(TaskObjectManager, &to)
 		err := TaskObjectManager.TableSpec().Insert(ctx, &to)
 		if err != nil {
 			log.Errorf("Taskobject insert error %s", err)

--- a/pkg/cloudcommon/db/virtualresource.go
+++ b/pkg/cloudcommon/db/virtualresource.go
@@ -82,11 +82,10 @@ func (manager *SVirtualResourceBaseManager) GetIVirtualModelManager() IVirtualMo
 }
 */
 
-func (manager *SVirtualResourceBaseManager) FilterByName(q *sqlchemy.SQuery, name string) *sqlchemy.SQuery {
+/*func (manager *SVirtualResourceBaseManager) FilterByName(q *sqlchemy.SQuery, name string) *sqlchemy.SQuery {
 	q = manager.SStatusStandaloneResourceBaseManager.FilterByName(q, name)
-	q = q.Filter(sqlchemy.OR(sqlchemy.IsNull(q.Field("pending_deleted")), sqlchemy.IsFalse(q.Field("pending_deleted"))))
 	return q
-}
+}*/
 
 func (manager *SVirtualResourceBaseManager) FilterByHiddenSystemAttributes(q *sqlchemy.SQuery, userCred mcclient.TokenCredential, query jsonutils.JSONObject, scope rbacutils.TRbacScope) *sqlchemy.SQuery {
 	q = manager.SStatusStandaloneResourceBaseManager.FilterByHiddenSystemAttributes(q, userCred, query, scope)

--- a/pkg/cloudcommon/options/changes.go
+++ b/pkg/cloudcommon/options/changes.go
@@ -81,3 +81,20 @@ func OnCommonOptionsChange(oOpts, nOpts interface{}) bool {
 
 	return changed
 }
+
+func OnDBOptionsChange(oOpts, nOpts interface{}) bool {
+	oldOpts := oOpts.(*DBOptions)
+	newOpts := nOpts.(*DBOptions)
+
+	changed := false
+
+	if oldOpts.HistoricalUniqueName != newOpts.HistoricalUniqueName {
+		if newOpts.HistoricalUniqueName {
+			consts.EnableHistoricalUniqueName()
+		} else {
+			consts.DisableHistoricalUniqueName()
+		}
+	}
+
+	return changed
+}

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -127,6 +127,8 @@ type DBOptions struct {
 
 	QueryOffsetOptimization bool `help:"apply query offset optimization"`
 
+	HistoricalUniqueName bool `help:"use historically unique name" default:"false"`
+
 	LockmanMethod string `help:"method for lock synchronization" choices:"inmemory|etcd" default:"inmemory"`
 
 	EtcdOptions

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -189,6 +189,9 @@ func OnOptionsChange(oldO, newO interface{}) bool {
 	if common_options.OnCommonOptionsChange(&oldOpts.CommonOptions, &newOpts.CommonOptions) {
 		changed = true
 	}
+	if common_options.OnDBOptionsChange(&oldOpts.DBOptions, &newOpts.DBOptions) {
+		changed = true
+	}
 
 	if oldOpts.PendingDeleteCheckSeconds != newOpts.PendingDeleteCheckSeconds {
 		if !oldOpts.IsSlaveNode {

--- a/pkg/compute/tasks/schedule.go
+++ b/pkg/compute/tasks/schedule.go
@@ -17,6 +17,7 @@ package tasks
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"yunion.io/x/jsonutils"
 
@@ -173,12 +174,19 @@ func onObjScheduleFail(
 	task.OnScheduleFailCallback(ctx, obj, reason)
 }
 
+type sortedIScheduleModelList []IScheduleModel
+
+func (a sortedIScheduleModelList) Len() int           { return len(a) }
+func (a sortedIScheduleModelList) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a sortedIScheduleModelList) Less(i, j int) bool { return a[i].GetName() < a[j].GetName() }
+
 func onSchedulerResults(
 	ctx context.Context,
 	task IScheduleTask,
 	objs []IScheduleModel,
 	results []*schedapi.CandidateResource,
 ) {
+	sort.Sort(sortedIScheduleModelList(objs))
 	succCount := 0
 	for idx := 0; idx < len(objs); idx += 1 {
 		obj := objs[idx]

--- a/pkg/image/options/options.go
+++ b/pkg/image/options/options.go
@@ -56,6 +56,10 @@ func OnOptionsChange(oldO, newO interface{}) bool {
 		changed = true
 	}
 
+	if common_options.OnDBOptionsChange(&oldOpts.DBOptions, &newOpts.DBOptions) {
+		changed = true
+	}
+
 	if oldOpts.PendingDeleteCheckSeconds != newOpts.PendingDeleteCheckSeconds {
 		if !oldOpts.IsSlaveNode {
 			changed = true

--- a/pkg/keystone/options/options.go
+++ b/pkg/keystone/options/options.go
@@ -67,5 +67,9 @@ func OnOptionsChange(oldOptions, newOptions interface{}) bool {
 		changed = true
 	}
 
+	if options.OnDBOptionsChange(&oldOpts.DBOptions, &newOpts.DBOptions) {
+		changed = true
+	}
+
 	return changed
 }


### PR DESCRIPTION
1. server generate name should be historically unique
2. ipaddr of a batch of server is in the same order as generated name

**这个 PR 实现什么功能/修复什么问题**:
1. 自动生成的主机名应该在历史上不重复，增加了historical_unique_name的开关，默认关闭
2. 主机的ip地址最好跟主机名的顺序一致

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.5

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi  @yousong 
/area region