### PR TITLE
scheduler: ignore non running guests only exclude ready status

### DIFF
--- a/pkg/scheduler/cache/candidate/hosts.go
+++ b/pkg/scheduler/cache/candidate/hosts.go
@@ -193,7 +193,7 @@ func NewGuestReservedResourceUsedByBuilder(b *HostBuilder, host *computemodels.S
 	for _, g := range gst {
 		dSize := guestDiskSize(&g, true)
 		disk += int64(dSize)
-		if o.GetOptions().IgnoreNonrunningGuests && !utils.IsInStringArray(g.Status, computeapi.VM_RUNNING_STATUS) {
+		if o.GetOptions().IgnoreNonrunningGuests && (g.Status == computeapi.VM_READY) {
 			continue
 		}
 		cpu += int64(g.VcpuCount)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

调度期 ignore_nonrunning_guestss 选项只会户忽略 ready 状态的虚拟机，其它状态的虚拟机统统计算进使用的资源。

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
- 3.3
/area scheduler
/cc @swordqiu @wanyaoqi 