### PR TITLE
Automated cherry pick of #8672: scheduler: ignore non running guests only exclude ready status

### DIFF
--- a/pkg/scheduler/cache/candidate/hosts.go
+++ b/pkg/scheduler/cache/candidate/hosts.go
@@ -194,7 +194,7 @@ func NewGuestReservedResourceUsedByBuilder(b *HostBuilder, host *computemodels.S
 	for _, g := range gst {
 		dSize := guestDiskSize(&g, true)
 		disk += int64(dSize)
-		if o.GetOptions().IgnoreNonrunningGuests && !utils.IsInStringArray(g.Status, computeapi.VM_RUNNING_STATUS) {
+		if o.GetOptions().IgnoreNonrunningGuests && (g.Status == computeapi.VM_READY) {
 			continue
 		}
 		cpu += int64(g.VcpuCount)


### PR DESCRIPTION
Cherry pick of #8672 on release/3.3.

#8672: scheduler: ignore non running guests only exclude ready status