### PR TITLE
Fix for Esxi and GetIImage

### DIFF
--- a/pkg/compute/models/cachedimages.go
+++ b/pkg/compute/models/cachedimages.go
@@ -288,7 +288,8 @@ func (manager *SCachedimageManager) GetImageById(ctx context.Context, userCred m
 	imgObj, _ := manager.FetchById(imageId)
 	if imgObj != nil {
 		cachedImage := imgObj.(*SCachedimage)
-		if !refresh && cachedImage.GetStatus() == cloudprovider.IMAGE_STATUS_ACTIVE && len(cachedImage.GetOSType()) > 0 && !cachedImage.isRefreshSessionExpire() {
+		oSTypeOk := options.Options.NoCheckOsTypeForCachedImage || len(cachedImage.GetOSType()) > 0
+		if !refresh && cachedImage.GetStatus() == cloudprovider.IMAGE_STATUS_ACTIVE && oSTypeOk && !cachedImage.isRefreshSessionExpire() {
 			return cachedImage.GetImage()
 		} else if len(cachedImage.ExternalId) > 0 { // external image, request refresh
 			return cachedImage.requestRefreshExternalImage(ctx, userCred)

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -159,6 +159,8 @@ type ComputeOptions struct {
 
 	DefaultNetworkGatewayAddressEsxi uint32 `help:"Default address for network gateway" default:"1"`
 
+	NoCheckOsTypeForCachedImage bool `help:"Don't check os type for cached image"`
+
 	esxi.EsxiOptions
 }
 

--- a/pkg/compute/options/options.go
+++ b/pkg/compute/options/options.go
@@ -145,7 +145,7 @@ type ComputeOptions struct {
 
 	EnableAutoRenameProject bool `help:"when it set true, auto create project will rename when cloud project name changed" default:"false"`
 
-	SyncStorageCapacityUsedIntervalMinutes int  `help:"interval sync storage capacity used" default:"10"`
+	SyncStorageCapacityUsedIntervalMinutes int  `help:"interval sync storage capacity used" default:"20"`
 	LockStorageFromCachedimage             bool `help:"must use storage in where selected cachedimage when creating vm"`
 
 	SyncExtDiskSnapshotIntervalMinutes int `help:"sync snapshot for external disk" default:"20"`

--- a/pkg/compute/service/service.go
+++ b/pkg/compute/service/service.go
@@ -141,7 +141,7 @@ func StartService() {
 		cron.AddJobAtIntervalsWithStartRun("AutoSyncCloudaccountTask", time.Duration(opts.CloudAutoSyncIntervalSeconds)*time.Second, models.CloudaccountManager.AutoSyncCloudaccountTask, true)
 		cron.AddJobAtIntervalsWithStartRun("ReconcileBackupGuests", time.Duration(opts.ReconcileGuestBackupIntervalSeconds)*time.Second, models.GuestManager.ReconcileBackupGuests, true)
 
-		cron.AddJobAtIntervalsWithStartRun("SyncCapacityUsedForStorage", time.Duration(opts.SyncStorageCapacityUsedIntervalMinutes)*time.Minute, models.StorageManager.SyncCapacityUsedForStorage, true)
+		cron.AddJobAtIntervalsWithStartRun("SyncCapacityUsedForEsxiStorage", time.Duration(opts.SyncStorageCapacityUsedIntervalMinutes)*time.Minute, models.StorageManager.SyncCapacityUsedForEsxiStorage, true)
 
 		cron.AddJobAtIntervalsWithStartRun("AutoSyncExtDiskSnapshot", time.Duration(opts.SyncExtDiskSnapshotIntervalMinutes)*time.Minute, models.DiskManager.AutoSyncExtDiskSnapshot, true)
 

--- a/pkg/compute/tasks/guest_create_task.go
+++ b/pkg/compute/tasks/guest_create_task.go
@@ -110,10 +110,10 @@ func (self *GuestCreateTask) StartDeployGuest(ctx context.Context, guest *models
 func (self *GuestCreateTask) OnDeployGuestDescComplete(ctx context.Context, obj db.IStandaloneModel, data jsonutils.JSONObject) {
 	guest := obj.(*models.SGuest)
 	// sync capacityUsed for storage
-	err := guest.SyncCapacityUsedForStorage(ctx, nil)
-	if err != nil {
-		log.Errorf("unable to SyncCapacityUsedForStorage: %v", err)
-	}
+	// err := guest.SyncCapacityUsedForStorage(ctx, nil)
+	// if err != nil {
+	// 	log.Errorf("unable to SyncCapacityUsedForStorage: %v", err)
+	// }
 
 	// bind eip
 	{

--- a/pkg/compute/tasks/guest_delete_task.go
+++ b/pkg/compute/tasks/guest_delete_task.go
@@ -317,17 +317,17 @@ func (self *GuestDeleteTask) OnGuestDeleteComplete(ctx context.Context, obj db.I
 	guest.DeleteEip(ctx, self.UserCred)
 	guest.GetDriver().OnDeleteGuestFinalCleanup(ctx, guest, self.UserCred)
 	// sync capacity used for storage
-	ja, err := self.Params.GetArray(STORAGEIDS)
-	if err == nil {
-		storageIds := make([]string, len(ja))
-		for i := range ja {
-			storageIds[i], _ = ja[i].GetString()
-		}
-		err = guest.SyncCapacityUsedForStorage(ctx, storageIds)
-		if err != nil {
-			log.Errorf("unable to SyncCapacityUsedForStoarage: %v", err)
-		}
-	}
+	// ja, err := self.Params.GetArray(STORAGEIDS)
+	// if err == nil {
+	// 	storageIds := make([]string, len(ja))
+	// 	for i := range ja {
+	// 		storageIds[i], _ = ja[i].GetString()
+	// 	}
+	// 	err = guest.SyncCapacityUsedForStorage(ctx, storageIds)
+	// 	if err != nil {
+	// 		log.Errorf("unable to SyncCapacityUsedForStoarage: %v", err)
+	// 	}
+	// }
 	self.DeleteGuest(ctx, guest)
 }
 

--- a/pkg/multicloud/esxi/virtualmachine.go
+++ b/pkg/multicloud/esxi/virtualmachine.go
@@ -1168,7 +1168,7 @@ func (self *SVirtualMachine) DoCustomize(ctx context.Context, params jsonutils.J
 	spec.NicSettingMap = maps
 
 	var (
-		osName = "Linux"
+		osName string
 		name   = "yunionhost"
 	)
 	if params.Contains("os_name") {
@@ -1184,7 +1184,7 @@ func (self *SVirtualMachine) DoCustomize(ctx context.Context, params jsonutils.J
 			TimeZone: "Asia/Shanghai",
 		}
 		spec.Identity = &linuxPrep
-	} else {
+	} else if osName == "Windows" {
 		sysPrep := types.CustomizationSysprep{
 			GuiUnattended: types.CustomizationGuiUnattended{
 				TimeZone:  210,


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. add option NoCheckOsTypeForCachedImage in region
2. faster sync CapacityUsed for Storage
   1. replace cronjob SyncCapacityUsedForStorage with SyncCapacityUsedForEsxiStorage
   2. do not sync capacityUsed for storage when deleting and creating vm for now because of performance issues
3. faster GetIImageById of esxi
4. add device after cloning vm
5. don't specify spec.Identity when osName is empty when Customizing vm

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.5
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area reigon esxiagent
/cc @swordqiu @zexi 