### PR TITLE
fix:修复dns record name校验的问题

### DIFF
--- a/pkg/compute/models/dns_recordsets.go
+++ b/pkg/compute/models/dns_recordsets.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/pkg/errors"
 	"yunion.io/x/pkg/tristate"
-	"yunion.io/x/pkg/util/regutils"
 	"yunion.io/x/pkg/utils"
 	"yunion.io/x/sqlchemy"
 
@@ -121,11 +121,11 @@ func (manager *SDnsRecordSetManager) ValidateCreateData(ctx context.Context, use
 		return input, err
 	}
 	input.Name = strings.ToLower(input.Name)
-	if input.Name != "*" && input.Name != "@" {
-		if !regutils.MatchDomainName(input.Name) {
-			return input, httperrors.NewInputParameterError("invalid domain name %s", input.Name)
-		}
+	rrRegexp := regexp.MustCompile(`^(([a-zA-Z0-9_][a-zA-Z0-9_-]{0,61}[a-zA-Z0-9_])|[a-zA-Z0-9_]|\*{1}){1}(\.(([a-zA-Z0-9_][a-zA-Z0-9_-]{0,61}[a-zA-Z0-9_])|[a-zA-Z0-9_]))*$|^@{1}$`)
+	if !rrRegexp.MatchString(input.Name) {
+		return input, httperrors.NewInputParameterError("invalid record name %s", input.Name)
 	}
+
 	if len(input.DnsZoneId) == 0 {
 		return input, httperrors.NewMissingParameterError("dns_zone_id")
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
使用域名正则校验dnsrecord name 不准确

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
-release/3.4
-release/3.5
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @ioito @zexi 