### PR TITLE
Faster docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+ _output/alpine-build/_cache
+pkg
+vendor
+cmd
+locales
+docs
+scripts

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -34,6 +34,9 @@ popd > /dev/null
 
 DOCKER_DIR="$SRC_DIR/build/docker"
 
+# https://docs.docker.com/develop/develop-images/build_enhancements/
+DOCKER_BUILDKIT=1
+
 REGISTRY=${REGISTRY:-docker.io/yunion}
 TAG=${TAG:-latest}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. add .dockerignore
2. add DOCKER_BUILDKIT in docker_push.sh 

目前在使用`docker build`，send context to Docker daemon 需要花费很多时间，因为使用了两种方法来优化。其中`DOCKER_BUILDKIT`是效果最好的方法。

但是DOCKER_BUILDKIT 需要 docker 18.09+，详情参考https://docs.docker.com/develop/develop-images/build_enhancements/

低版本的添加此变量不会生效，也不会有其他副作用。

低版本的`docker`会使用 .dockerignore 文件，但是因为 `_output/bin`以及`_output/alpine-build/bin`目录下可能有大量其他服务的遗留二进制文件，所以可以手动来删除目录下的文件来提高 build 的速度。

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.5

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/cc @wanyaoqi @zexi @swordqiu