### PR TITLE
fix: search by name and order by scopedpolicy for scopedpolicybindings

### DIFF
--- a/pkg/apis/yunionconf/input.go
+++ b/pkg/apis/yunionconf/input.go
@@ -79,6 +79,8 @@ type ScopedPolicyDetails struct {
 type ScopedPolicyBindingListInput struct {
 	apis.ResourceBaseListInput
 
+	Name []string `json:"name"`
+
 	PolicyId  string `json:"policy_id"`
 	DomainId  string `json:"domain_id"`
 	ProjectId string `json:"project_id"`
@@ -88,6 +90,8 @@ type ScopedPolicyBindingListInput struct {
 	Effective *bool `json:"effective"`
 
 	Scope rbacutils.TRbacScope `json:"scope"`
+
+	OrderByScopedpolicy string `json:"order_by_scopedpolicy"`
 }
 
 type ScopedPolicyBindingDetails struct {

--- a/pkg/yunionconf/models/scopedpolicybindings.go
+++ b/pkg/yunionconf/models/scopedpolicybindings.go
@@ -165,6 +165,13 @@ func (manager *SScopedPolicyBindingManager) ListItemFilter(
 		return nil, errors.Wrap(err, "SResourceBaseManager.ListItemFilter")
 	}
 
+	var policySubq *sqlchemy.SSubQuery
+	if len(query.Name) > 0 {
+		subq := ScopedPolicyManager.Query("id")
+		subq = subq.Filter(sqlchemy.ContainsAny(subq.Field("name"), query.Name))
+		policySubq = subq.SubQuery()
+	}
+
 	if len(query.PolicyId) > 0 {
 		policyObj, err := ScopedPolicyManager.FetchByIdOrName(userCred, query.PolicyId)
 		if err != nil {
@@ -175,7 +182,6 @@ func (manager *SScopedPolicyBindingManager) ListItemFilter(
 			}
 		}
 		query.PolicyId = policyObj.GetId()
-
 	}
 
 	if len(query.ProjectId) > 0 {
@@ -234,11 +240,11 @@ func (manager *SScopedPolicyBindingManager) ListItemFilter(
 	}
 
 	effective := (query.Effective != nil && *query.Effective)
-	q = filterByOwnerId(q, query.DomainId, query.ProjectId, effective, query.Category, query.PolicyId)
+	q = filterByOwnerId(q, query.DomainId, query.ProjectId, effective, query.Category, query.PolicyId, policySubq)
 	if query.Effective != nil && *query.Effective && (len(query.ProjectId) > 0 || len(query.DomainId) > 0) {
 		bindingQ := manager.Query().SubQuery()
 		maxq := bindingQ.Query(bindingQ.Field("category"), sqlchemy.MAX("max_priority", bindingQ.Field("priority")))
-		maxq = filterByOwnerId(maxq, query.DomainId, query.ProjectId, *query.Effective, query.Category, query.PolicyId)
+		maxq = filterByOwnerId(maxq, query.DomainId, query.ProjectId, *query.Effective, query.Category, query.PolicyId, policySubq)
 		maxq = maxq.GroupBy(bindingQ.Field("category"))
 		subq := maxq.SubQuery()
 		q = q.Join(subq, sqlchemy.Equals(q.Field("category"), subq.Field("category")))
@@ -248,7 +254,7 @@ func (manager *SScopedPolicyBindingManager) ListItemFilter(
 	return q, nil
 }
 
-func filterByOwnerId(q *sqlchemy.SQuery, domainId, projectId string, effective bool, category []string, policyId string) *sqlchemy.SQuery {
+func filterByOwnerId(q *sqlchemy.SQuery, domainId, projectId string, effective bool, category []string, policyId string, policySubq *sqlchemy.SSubQuery) *sqlchemy.SQuery {
 	if len(projectId) > 0 {
 		q = q.Filter(sqlchemy.OR(
 			sqlchemy.AND(sqlchemy.IsNullOrEmpty(q.Field("domain_id")), sqlchemy.IsNullOrEmpty(q.Field("project_id"))),
@@ -276,6 +282,9 @@ func filterByOwnerId(q *sqlchemy.SQuery, domainId, projectId string, effective b
 	if len(policyId) > 0 {
 		q = q.Equals("policy_id", policyId)
 	}
+	if policySubq != nil {
+		q = q.In("policy_id", policySubq)
+	}
 	return q
 }
 
@@ -283,13 +292,21 @@ func (manager *SScopedPolicyBindingManager) OrderByExtraFields(
 	ctx context.Context,
 	q *sqlchemy.SQuery,
 	userCred mcclient.TokenCredential,
-	query api.ScopedPolicyListInput,
+	query api.ScopedPolicyBindingListInput,
 ) (*sqlchemy.SQuery, error) {
 	var err error
 
 	q, err = manager.SResourceBaseManager.OrderByExtraFields(ctx, q, userCred, query.ResourceBaseListInput)
 	if err != nil {
 		return nil, errors.Wrap(err, "SResourceBaseManager.OrderByExtraFields")
+	}
+
+	if db.NeedOrderQuery([]string{query.OrderByScopedpolicy}) {
+		subq := ScopedPolicyManager.Query("id", "name").SubQuery()
+		q = q.Join(subq, sqlchemy.Equals(subq.Field("id"), q.Field("policy_id")))
+		q = db.OrderByFields(q,
+			[]string{query.OrderByScopedpolicy},
+			[]sqlchemy.IQueryField{subq.Field("name")})
 	}
 
 	return q, nil


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：scopedpolicybinding列表支持按scoped policy name查询和排序

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.5

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area yunionconf
