### PR TITLE
fix: role-set-policies support update only operation

### DIFF
--- a/cmd/climc/shell/identity/rolepolicies.go
+++ b/cmd/climc/shell/identity/rolepolicies.go
@@ -73,4 +73,16 @@ func init() {
 		printObject(result)
 		return nil
 	})
+
+	type RolePolicyDeleteOptions struct {
+		ID string `json:"-" help:"id or role policy binding"`
+	}
+	R(&RolePolicyDeleteOptions{}, "role-policy-delete", "Delete role policy binding", func(s *mcclient.ClientSession, args *RolePolicyDeleteOptions) error {
+		result, err := modules.RolePolicies.Delete(s, args.ID, nil)
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
 }

--- a/cmd/climc/shell/identity/rolepolicies.go
+++ b/cmd/climc/shell/identity/rolepolicies.go
@@ -60,4 +60,17 @@ func init() {
 		printObject(result)
 		return nil
 	})
+
+	type RoleSetPolicyOptions struct {
+		ID string `json:"-" help:"role id or name to set policies"`
+		api.RolePerformSetPoliciesInput
+	}
+	R(&RoleSetPolicyOptions{}, "role-set-policies", "Set policies for a role", func(s *mcclient.ClientSession, args *RoleSetPolicyOptions) error {
+		result, err := modules.RolesV3.PerformAction(s, args.ID, "set-policies", jsonutils.Marshal(args))
+		if err != nil {
+			return err
+		}
+		printObject(result)
+		return nil
+	})
 }

--- a/pkg/apis/identity/rolepolicy.go
+++ b/pkg/apis/identity/rolepolicy.go
@@ -47,9 +47,20 @@ type RolePolicyDetails struct {
 	Scope rbacutils.TRbacScope `json:"scope"`
 
 	Description string `json:"description"`
+
+	SRolePolicy
 }
 
+const (
+	ROLE_SET_POLICY_ACTION_REPLACE = "replace"
+	ROLE_SET_POLICY_ACTION_UPDATE  = "update"
+	ROLE_SET_POLICY_ACTION_DEFAULT = ROLE_SET_POLICY_ACTION_REPLACE
+)
+
 type RolePerformSetPoliciesInput struct {
+	// 操作：replace|update, 默认为replace
+	Action string `json:"action"`
+	// 权限列表
 	Policies []RolePerformAddPolicyInput `json:"policies"`
 }
 

--- a/pkg/keystone/models/rolepolicies.go
+++ b/pkg/keystone/models/rolepolicies.go
@@ -449,3 +449,29 @@ func (manager *SRolePolicyManager) fetchByRoleId(roleId string) ([]SRolePolicy, 
 	}
 	return rps, nil
 }
+
+func (manager *SRolePolicyManager) FilterById(q *sqlchemy.SQuery, idStr string) *sqlchemy.SQuery {
+	parts := strings.Split(idStr, ":")
+	if len(parts) == 3 {
+		return q.Equals("role_id", parts[0]).Equals("project_id", parts[1]).Equals("policy_id", parts[2])
+	} else {
+		return q.Equals("ips", idStr)
+	}
+}
+
+func (manager *SRolePolicyManager) FilterByNotId(q *sqlchemy.SQuery, idStr string) *sqlchemy.SQuery {
+	parts := strings.Split(idStr, ":")
+	if len(parts) == 3 {
+		return q.Filter(sqlchemy.OR(
+			sqlchemy.NotEquals(q.Field("role_id"), parts[0]),
+			sqlchemy.NotEquals(q.Field("project_id"), parts[1]),
+			sqlchemy.NotEquals(q.Field("policy_id"), parts[2]),
+		))
+	} else {
+		return q
+	}
+}
+
+func (manager *SRolePolicyManager) FilterByName(q *sqlchemy.SQuery, name string) *sqlchemy.SQuery {
+	return manager.FilterById(q, name)
+}

--- a/pkg/mcclient/modules/mod_rolepolicies.go
+++ b/pkg/mcclient/modules/mod_rolepolicies.go
@@ -59,7 +59,7 @@ func init() {
 	RolePolicies = SRolePolicyManager{NewIdentityV3Manager(
 		"rolepolicy",
 		"rolepolicies",
-		[]string{"role", "role_id", "project", "project_id", "policy", "policy_id", "ips", "scope"},
+		[]string{"id", "name", "role", "role_id", "project", "project_id", "policy", "policy_id", "ips", "scope"},
 		[]string{},
 	)}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：role-set-policies增加action字段，可以自增加关联policies

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
None

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area keystone