### PR TITLE
feature: allow join project across domain

### DIFF
--- a/pkg/keystone/models/assignments.go
+++ b/pkg/keystone/models/assignments.go
@@ -29,6 +29,7 @@ import (
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/httperrors"
+	"yunion.io/x/onecloud/pkg/keystone/options"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
@@ -248,7 +249,7 @@ func (manager *SAssignmentManager) ProjectAddUser(ctx context.Context, userCred 
 		return err
 	}
 	if project.DomainId != user.DomainId {
-		if project.DomainId != api.DEFAULT_DOMAIN_ID {
+		if project.DomainId != api.DEFAULT_DOMAIN_ID && !options.Options.AllowJoinProjectsAcrossDomains {
 			return httperrors.NewInputParameterError("join user into project of default domain or identical domain")
 		} else if !db.IsAllowPerform(rbacutils.ScopeSystem, userCred, user, "join-project") {
 			return httperrors.NewForbiddenError("not enough privilege")
@@ -348,7 +349,7 @@ func (manager *SAssignmentManager) projectAddGroup(ctx context.Context, userCred
 		return err
 	}
 	if project.DomainId != group.DomainId {
-		if project.DomainId != api.DEFAULT_DOMAIN_ID {
+		if project.DomainId != api.DEFAULT_DOMAIN_ID && !options.Options.AllowJoinProjectsAcrossDomains {
 			return httperrors.NewInputParameterError("join group into project of default domain or identical domain")
 		} else if !db.IsAllowPerform(rbacutils.ScopeSystem, userCred, group, "join-project") {
 			return httperrors.NewForbiddenError("not enough privilege")

--- a/pkg/keystone/models/roles.go
+++ b/pkg/keystone/models/roles.go
@@ -351,8 +351,14 @@ func (role *SRole) UpdateInContext(ctx context.Context, userCred mcclient.TokenC
 	if !ok {
 		return nil, httperrors.NewInputParameterError("not supported update context %s", ctxObjs[0].Keyword())
 	}
-	if project.DomainId != role.DomainId && !role.GetIsPublic() {
-		return nil, httperrors.NewInputParameterError("inconsistent domain for project and roles")
+	if project.DomainId != role.DomainId {
+		projectOwner := &db.SOwnerId{
+			ProjectId: project.Id,
+			DomainId:  project.DomainId,
+		}
+		if !role.IsSharable(projectOwner) {
+			return nil, httperrors.NewInputParameterError("inconsistent domain for project and roles")
+		}
 	}
 	err := validateJoinProject(userCred, project, []string{role.Id})
 	if err != nil {

--- a/pkg/keystone/options/options.go
+++ b/pkg/keystone/options/options.go
@@ -52,6 +52,8 @@ type SKeystoneOptions struct {
 	DefaultPolicyQuota  int `default:"500" help:"default quota for policy per domain, default is 500"`
 
 	SessionEndpointType string `help:"Client session end point type"`
+
+	AllowJoinProjectsAcrossDomains bool `help:"allow users/groups to join projects across domains" default:"false"`
 }
 
 var (


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
改进：keystone增加选项allow_join_projects_across_domains, 为true时允许任意域的用户加入任意域的项目，默认为false。

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.5

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @yousong 
/area keystone