### PR TITLE
fix: mcclient panic when keystone init empty service catalog

### DIFF
--- a/cmd/climc/shell/identity/policies.go
+++ b/cmd/climc/shell/identity/policies.go
@@ -24,6 +24,7 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 
+	api "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/cloudcommon/policy"
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -236,6 +237,21 @@ func init() {
 			return err
 		}
 
+		printObject(result)
+		return nil
+	})
+
+	type PolicyBindRoleOptions struct {
+		POLICY string `json:"-" help:"policy Id or name"`
+		api.PolicyBindRoleInput
+	}
+	R(&PolicyBindRoleOptions{}, "policy-bind-role", "Policy bind role", func(s *mcclient.ClientSession, args *PolicyBindRoleOptions) error {
+		params := jsonutils.Marshal(args)
+		log.Debugf("params: %s", params)
+		result, err := modules.Policies.PerformAction(s, args.POLICY, "bind-role", params)
+		if err != nil {
+			return err
+		}
 		printObject(result)
 		return nil
 	})

--- a/pkg/apis/identity/policy.go
+++ b/pkg/apis/identity/policy.go
@@ -22,3 +22,12 @@ type PolicyDetails struct {
 
 	SPolicy
 }
+
+type PolicyBindRoleInput struct {
+	// 角色ID
+	RoleId string `json:"role_id"`
+	// 项目ID
+	ProjectId string `json:"project_id"`
+	//	IP白名单
+	Ips []string `json:"ips"`
+}

--- a/pkg/keystone/models/roles.go
+++ b/pkg/keystone/models/roles.go
@@ -149,6 +149,8 @@ func (manager *SRoleManager) initSysRole(ctx context.Context) error {
 	// insert
 	role := SRole{}
 	role.Name = api.SystemAdminRole
+	role.IsPublic = true
+	role.PublicScope = string(rbacutils.ScopeSystem)
 	role.DomainId = api.DEFAULT_DOMAIN_ID
 	role.Description = "Boostrap system default admin role"
 	role.SetModelManager(manager, &role)

--- a/pkg/keystone/policy/defaults.go
+++ b/pkg/keystone/policy/defaults.go
@@ -154,6 +154,36 @@ var (
 					Action:   PolicyActionPerform,
 					Result:   rbacutils.Allow,
 				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "roles",
+					Action:   PolicyActionCreate,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "roles",
+					Action:   PolicyActionUpdate,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "roles",
+					Action:   PolicyActionGet,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "roles",
+					Action:   PolicyActionList,
+					Result:   rbacutils.Allow,
+				},
+				{
+					Service:  api.SERVICE_TYPE,
+					Resource: "roles",
+					Action:   PolicyActionPerform,
+					Result:   rbacutils.Allow,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：keystone初始化时sevice列表为初始化导致mcclient panic

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi  @wanyaoqi 
/area climc