### PR TITLE
fix: keystone init empty catalogy cause panic

### DIFF
--- a/pkg/mcclient/modules/mod_policies.go
+++ b/pkg/mcclient/modules/mod_policies.go
@@ -61,7 +61,7 @@ func policyReadFilter(session *mcclient.ClientSession, s jsonutils.JSONObject, q
 }
 
 func policyWriteFilter(session *mcclient.ClientSession, s jsonutils.JSONObject, query jsonutils.JSONObject) (jsonutils.JSONObject, error) {
-	ret := jsonutils.NewDict()
+	ret := s.(*jsonutils.JSONDict).CopyExcludes("policy")
 	if s.Contains("policy") {
 		blobJson, err := s.Get("policy")
 		if err != nil {
@@ -77,17 +77,6 @@ func policyWriteFilter(session *mcclient.ClientSession, s jsonutils.JSONObject, 
 		}
 		// ret.Add(jsonutils.NewString(blobJson.String()), "blob")
 		ret.Add(blobJson, "blob")
-	}
-	for _, k := range []string{
-		"name", "type", "enabled", "domain", "domain_id", "project_domain", "description", "is_public", "public_scope", "shared_domains", "scope", "is_system",
-	} {
-		if s.Contains(k) {
-			val, err := s.Get(k)
-			if err != nil {
-				return nil, err
-			}
-			ret.Add(val, k)
-		}
 	}
 	return ret, nil
 }

--- a/pkg/mcclient/session.go
+++ b/pkg/mcclient/session.go
@@ -27,6 +27,7 @@ import (
 
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/gotypes"
 	"yunion.io/x/pkg/utils"
 
 	api "yunion.io/x/onecloud/pkg/apis/identity"
@@ -147,7 +148,11 @@ func (this *ClientSession) GetServiceVersionURL(service, endpointType, apiVersio
 		endpointType = this.endpointType
 	}
 	service = this.getServiceName(service, apiVersion)
-	url, err := this.GetServiceCatalog().GetServiceURL(service, this.region, this.zone, endpointType)
+	catalog := this.GetServiceCatalog()
+	if gotypes.IsNil(catalog) {
+		return this.client.authUrl, nil
+	}
+	url, err := catalog.GetServiceURL(service, this.region, this.zone, endpointType)
 	if err != nil && service == api.SERVICE_TYPE {
 		return this.client.authUrl, nil
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：keystone初始化时无service时会导致mcclient panic

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.5

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @wanyaoqi 
/area climc
