### PR TITLE
fix: baremetal usage should exclude converted hypervisor

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -2507,11 +2507,17 @@ func (manager *SHostManager) totalCountQ(
 		q = q.Filter(cond(hosts.Field("enabled")))
 	}
 	if !isBaremetal.IsNone() {
-		cond := sqlchemy.IsFalse
 		if isBaremetal.Bool() {
-			cond = sqlchemy.IsTrue
+			q = q.Filter(sqlchemy.AND(
+				sqlchemy.IsTrue(hosts.Field("is_baremetal")),
+				sqlchemy.Equals(hosts.Field("host_type"), api.HOST_TYPE_BAREMETAL),
+			))
+		} else {
+			q = q.Filter(sqlchemy.OR(
+				sqlchemy.IsFalse(hosts.Field("is_baremetal")),
+				sqlchemy.NotEquals(hosts.Field("host_type"), api.HOST_TYPE_BAREMETAL),
+			))
 		}
-		q = q.Filter(cond(hosts.Field("is_baremetal")))
 	}
 	isolatedDevices := IsolatedDeviceManager.Query().SubQuery()
 	iq := isolatedDevices.Query(


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：裸金属的使用量不应该包含转换为宿主机的裸金属

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.5

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area region
/cc @zexi @wanyaoqi 