### PR TITLE
modify  alertResource ws info

### DIFF
--- a/pkg/monitor/models/alertresource.go
+++ b/pkg/monitor/models/alertresource.go
@@ -495,7 +495,7 @@ func (manager *SAlertResourceManager) GetAdminRoleUsers(ctx context.Context, use
 			userId, err := roleAssign.GetString("user", "id")
 			if err != nil {
 				log.Errorf("roleAssign:%v", roleAssign)
-				return
+				continue
 			}
 			//_, err = mc_modules.NotifyReceiver.GetById(session, userId, jsonutils.NewDict())
 			//if err != nil {
@@ -519,6 +519,7 @@ func (manager *SAlertResourceManager) sendWebsocketInfo(uids []string, alertReso
 	params.Set("obj_name", jsonutils.NewString(""))
 	params.Set("success", jsonutils.JSONTrue)
 	params.Set("action", jsonutils.NewString("alertResourceCount"))
+	params.Set("ignore_alert", jsonutils.JSONTrue)
 	params.Set("notes", jsonutils.NewString(fmt.Sprintf("priority=%s; content=%s", string(npk.NotifyPriorityCritical),
 		jsonutils.Marshal(&alertResourceCount).String())))
 	for _, uid := range uids {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
ignore_alert:ture 前端不再进行弹窗提示

影响范围：alertResource 通知前端报警资源数量

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.5

/area monitor
/cc @yousong 