### PR TITLE
detach AlertResource on alertDisable

### DIFF
--- a/pkg/monitor/models/commonalert.go
+++ b/pkg/monitor/models/commonalert.go
@@ -17,6 +17,7 @@ import (
 	"yunion.io/x/onecloud/pkg/apis"
 	"yunion.io/x/onecloud/pkg/apis/monitor"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
 	"yunion.io/x/onecloud/pkg/hostman/hostinfo/hostconsts"
 	"yunion.io/x/onecloud/pkg/httperrors"
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -962,6 +963,47 @@ func (alert *SCommonAlert) PerformConfig(ctx context.Context, userCred mcclient.
 		return nil
 	})
 	return jsonutils.Marshal(alert), err
+}
+
+func (alert *SCommonAlert) AllowPerformDisable(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformDisableInput) bool {
+	return db.IsProjectAllowPerform(userCred, alert, "disable")
+}
+
+func (alert *SCommonAlert) PerformDisable(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, input apis.PerformDisableInput) (jsonutils.JSONObject, error) {
+	err := db.EnabledPerformEnable(alert, ctx, userCred, false)
+	if err != nil {
+		return nil, errors.Wrap(err, "EnabledPerformEnable")
+	}
+	err = alert.StartDetachTask(ctx, userCred)
+	if err != nil {
+		return nil, errors.Wrap(err, "alert StartDetachTask error")
+	}
+	return nil, nil
+}
+
+func (alert *SCommonAlert) StartDetachTask(ctx context.Context, userCred mcclient.TokenCredential) error {
+	task, err := taskman.TaskManager.NewTask(ctx, "DetachAlertResourceTask", alert, userCred, jsonutils.NewDict(), "", "", nil)
+	if err != nil {
+		return err
+	}
+	task.ScheduleRun(nil)
+	return nil
+}
+
+func (alert *SCommonAlert) DetachAlertResourceOnDisable(ctx context.Context,
+	userCred mcclient.TokenCredential) (errs []error) {
+	resources, err := GetAlertResourceManager().getResourceFromAlertId(alert.Id)
+	if err != nil {
+		errs = append(errs, errors.Wrap(err, "getResourceFromAlert error"))
+		return
+	}
+	for _, resource := range resources {
+		err := resource.DetachAlert(ctx, userCred, alert.Id)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "resource:%s DetachAlert:%s err", resource.Id, alert.Id))
+		}
+	}
+	return
 }
 
 type SCompanyInfo struct {

--- a/pkg/monitor/tasks/detach_alertresource_task.go
+++ b/pkg/monitor/tasks/detach_alertresource_task.go
@@ -1,0 +1,46 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
+	"yunion.io/x/onecloud/pkg/monitor/models"
+	"yunion.io/x/onecloud/pkg/util/logclient"
+)
+
+type DetachAlertResourceTask struct {
+	taskman.STask
+}
+
+func init() {
+	taskman.RegisterTask(&DetachAlertResourceTask{})
+}
+
+func (self *DetachAlertResourceTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
+	alert := obj.(*models.SCommonAlert)
+	errs := alert.DetachAlertResourceOnDisable(ctx, self.GetUserCred())
+	if len(errs) != 0 {
+		msg := jsonutils.NewString(fmt.Sprintf("fail to DetachAlertResourceOnAlertDisable:%s.err:%v", alert.Name, errors.NewAggregate(errs)))
+		self.taskFail(ctx, alert, msg)
+		return
+	}
+	err := models.GetAlertResourceManager().NotifyAlertResourceCount(ctx)
+	if err != nil {
+		log.Errorf("DetachAlertResourceTask NotifyAlertResourceCount error:%v", err)
+	}
+	logclient.AddActionLogWithStartable(self, alert, logclient.ACT_DETACH_ALERTRESOURCE, nil, self.UserCred, true)
+	self.SetStageComplete(ctx, nil)
+}
+
+func (self *DetachAlertResourceTask) taskFail(ctx context.Context, alert *models.SCommonAlert, msg jsonutils.JSONObject) {
+	db.OpsLog.LogEvent(alert, db.ACT_DETACH, msg, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, alert, logclient.ACT_DETACH_ALERTRESOURCE, msg, self.UserCred, false)
+	self.SetStageFailed(ctx, msg)
+	return
+}

--- a/pkg/util/logclient/consts.go
+++ b/pkg/util/logclient/consts.go
@@ -185,4 +185,6 @@ const (
 
 	ACT_SYNC_VPCS        = "sync_vpcs"
 	ACT_SYNC_RECORD_SETS = "sync_record_sets"
+
+	ACT_DETACH_ALERTRESOURCE = "detach_alertresoruce"
 )

--- a/pkg/util/logclient/consts_i18n.go
+++ b/pkg/util/logclient/consts_i18n.go
@@ -629,4 +629,8 @@ func init() {
 		EN("Freeze").
 		CN("解冻资源"),
 	)
+	t.Set(ACT_DETACH_ALERTRESOURCE, i18n.NewTableEntry().
+		EN("Detach AlertResource").
+		CN("取消关联报警资源"),
+	)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 报警规则禁用时，detach 关联的报警资源

影响范围：报警规则的禁用；logger日志服务i18n的日志展示

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.5

/cc @zexi 
/area monitor
