### PR TITLE
fix: add host.memoty.total and host.cpu.total usage stats

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -2554,9 +2554,11 @@ type HostsCountStat struct {
 	StorageSize             int64
 	Count                   int64
 	Memory                  int64
+	MemoryTotal             int64
 	MemoryVirtual           float64
 	MemoryReserved          int64
 	CPU                     int64
+	CPUTotal                int64
 	CPUVirtual              float64
 	IsolatedReservedMemory  int64
 	IsolatedReservedCpu     int64
@@ -2584,6 +2586,9 @@ func (manager *SHostManager) calculateCount(q *sqlchemy.SQuery) HostsCountStat {
 		irMem   int64   = 0
 		irCpu   int64   = 0
 		irStore int64   = 0
+
+		totalMem int64 = 0
+		totalCPU int64 = 0
 	)
 	stats := make([]HostStat, 0)
 	err := q.All(&stats)
@@ -2601,7 +2606,9 @@ func (manager *SHostManager) calculateCount(q *sqlchemy.SQuery) HostsCountStat {
 		aMem := usableSize(stat.MemSize, stat.MemReserved)
 		aCpu := usableSize(int(stat.CpuCount), int(stat.CpuReserved))
 		tMem += int64(aMem)
+		totalMem += int64(stat.MemSize)
 		tCPU += int64(aCpu)
+		totalCPU += int64(stat.CpuCount)
 		if stat.MemCmtbound <= 0.0 {
 			stat.MemCmtbound = options.Options.DefaultMemoryOvercommitBound
 		}
@@ -2619,9 +2626,11 @@ func (manager *SHostManager) calculateCount(q *sqlchemy.SQuery) HostsCountStat {
 		StorageSize:             tStore,
 		Count:                   tCnt,
 		Memory:                  tMem,
+		MemoryTotal:             totalMem,
 		MemoryVirtual:           tVmem,
 		MemoryReserved:          rMem,
 		CPU:                     tCPU,
+		CPUTotal:                totalCPU,
 		CPUVirtual:              tVCPU,
 		IsolatedReservedCpu:     irCpu,
 		IsolatedReservedMemory:  irMem,

--- a/pkg/compute/usages/handler.go
+++ b/pkg/compute/usages/handler.go
@@ -708,7 +708,9 @@ func hostUsage(
 	result := models.HostManager.TotalCount(userCred, scope, rangeObjs, "", "", hostTypes, resourceTypes, providers, brands, cloudEnv, enabled, isBaremetal)
 	count[prefix] = result.Count
 	count[fmt.Sprintf("%s.memory", prefix)] = result.Memory
+	count[fmt.Sprintf("%s.memory.total", prefix)] = result.MemoryTotal
 	count[fmt.Sprintf("%s.cpu", prefix)] = result.CPU
+	count[fmt.Sprintf("%s.cpu.total", prefix)] = result.CPUTotal
 	count[fmt.Sprintf("%s.memory.virtual", prefix)] = result.MemoryVirtual
 	count[fmt.Sprintf("%s.cpu.virtual", prefix)] = result.CPUVirtual
 	count[fmt.Sprintf("%s.memory.reserved", prefix)] = result.MemoryReserved


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：增加host.memory.total和host.cpu.total指标标识包含预留cpu和内存的总量

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.5

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @wanyaoqi 
/area region