### PR TITLE
bugfix: wait put host offline success

### DIFF
--- a/pkg/hostman/hostinfo/hostinfo.go
+++ b/pkg/hostman/hostinfo/hostinfo.go
@@ -1608,12 +1608,17 @@ func (h *SHostInfo) stop() {
 }
 
 func (h *SHostInfo) unregister() {
-	h.stopped = true
-	_, err := modules.Hosts.PerformAction(
-		h.GetSession(), h.HostId, "offline", nil)
-	if err != nil {
-		log.Errorln(err)
+	for {
+		_, err := modules.Hosts.PerformAction(
+			h.GetSession(), h.HostId, "offline", nil)
+		if err != nil {
+			log.Errorf("put host offline failed: %s", err)
+			time.Sleep(time.Second * 1)
+		} else {
+			break
+		}
 	}
+	h.stopped = true
 }
 
 func (h *SHostInfo) OnCatalogChanged(catalog mcclient.KeystoneServiceCatalogV3) {


### PR DESCRIPTION


**这个 PR 实现什么功能/修复什么问题**:
Unregister host wait for host offline success,
in case region is in upgrading.

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
cherrypick: release/3.4

/area host
/cc @zexi @swordqiu 
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
