### PR TITLE
fix: oidc data may be encapuslated in data field

### DIFF
--- a/cmd/climc/shell/identity/identityproviders.go
+++ b/cmd/climc/shell/identity/identityproviders.go
@@ -472,6 +472,9 @@ func init() {
 		AutoCreateProject   bool `help:"automatically create a default project when importing domain" json:"-"`
 		NoAutoCreateProject bool `help:"do not create default project when importing domain" json:"-"`
 
+		AutoCreateUser   bool `help:"automatically create a user" json:"-"`
+		NoAutoCreateUser bool `help:"do not automatically create a user" json:"-"`
+
 		TargetDomain string `help:"target domain without creating new domain" json:"-"`
 
 		api.SOIDCIdpConfigOptions
@@ -487,6 +490,11 @@ func init() {
 			params.Add(jsonutils.JSONTrue, "auto_create_project")
 		} else if args.NoAutoCreateProject {
 			params.Add(jsonutils.JSONFalse, "auto_create_project")
+		}
+		if args.AutoCreateUser {
+			params.Add(jsonutils.JSONTrue, "auto_create_user")
+		} else if args.NoAutoCreateUser {
+			params.Add(jsonutils.JSONFalse, "auto_create_user")
 		}
 
 		params.Add(jsonutils.NewString("oidc"), "driver")

--- a/pkg/keystone/driver/oidc/oidc.go
+++ b/pkg/keystone/driver/oidc/oidc.go
@@ -47,7 +47,10 @@ func NewOIDCDriver(idpId, idpName, template, targetDomainId string, conf api.TCo
 	if err != nil {
 		return nil, errors.Wrap(err, "NewBaseIdentityDriver")
 	}
-	drv := SOIDCDriver{SBaseIdentityDriver: base}
+	drv := SOIDCDriver{
+		SBaseIdentityDriver: base,
+		isDebug:             false,
+	}
 	drv.SetVirtualObject(&drv)
 	err = drv.prepareConfig()
 	if err != nil {

--- a/pkg/util/oidcutils/client/client.go
+++ b/pkg/util/oidcutils/client/client.go
@@ -126,6 +126,9 @@ func (cli *SOIDCClient) FetchToken(ctx context.Context, code string, redirUri st
 	if err != nil {
 		return nil, errors.Wrap(err, "request access token")
 	}
+	if respJson.Contains("data") && !respJson.Contains("access_token") {
+		respJson, _ = respJson.Get("data")
+	}
 	log.Debugf("AccesToken response: %s", respJson)
 	accessTokenResp := oidcutils.SOIDCAccessTokenResponse{}
 	err = respJson.Unmarshal(&accessTokenResp)
@@ -147,6 +150,9 @@ func (cli *SOIDCClient) FetchUserInfo(ctx context.Context, accessToken string) (
 	header, body, err := httputils.JSONRequest(cli.httpclient, ctx, httputils.GET, url, header, nil, cli.isDebug)
 	if err != nil {
 		return nil, errors.Wrap(err, "request userinfo")
+	}
+	if body.Contains("data") {
+		body, _ = body.Get("data")
 	}
 	info := make(map[string]string)
 	err = body.Unmarshal(&info)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：oidc的数据可能在返回json的data字段里

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.5

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @yousong 
/area keystone