### PR TITLE
fix(monitor): modify notify alertInfo and alertOk detach resource

### DIFF
--- a/build/monitor/root/opt/yunion/share/notify_templates/alerter/content@cn/DEFAULT
+++ b/build/monitor/root/opt/yunion/share/notify_templates/alerter/content@cn/DEFAULT
@@ -2,7 +2,7 @@
 策略名称: {{.name}}
 触发时间: {{.start_time}}
 报警级别: {{.level}}
-触发条件: {{.description}}
+触发条件: {{.description | unescaped}}
 资源数量：{{len .matches}}
 资源名称：{{.resource_name}}
 

--- a/build/monitor/root/opt/yunion/share/notify_templates/alerter/content@en/DEFAULT
+++ b/build/monitor/root/opt/yunion/share/notify_templates/alerter/content@en/DEFAULT
@@ -2,7 +2,7 @@
 AlertName: {{.name}}
 Time: {{.start_time}}
 Level: {{.level}}
-TriggerCondition: {{html .description}}
+TriggerCondition: {{.description | unescaped}}
 ResourceCount: {{len .matches}}
 ResourceName: {{.resource_name}}
 

--- a/pkg/apis/monitor/alertrecord.go
+++ b/pkg/apis/monitor/alertrecord.go
@@ -34,7 +34,9 @@ type AlertRecordCreateInput struct {
 
 type AlertRecordRule struct {
 	Metric          string `json:"metric"`
+	Measurement     string `json:"measurement"`
 	MeasurementDesc string `json:"measurement_desc"`
+	Field           string `json:"field"`
 	FieldDesc       string `json:"field_desc"`
 	// 比较运算符, 比如: >, <, >=, <=
 	Comparator string `json:"comparator"`

--- a/pkg/cloudcommon/notifyclient/notify.go
+++ b/pkg/cloudcommon/notifyclient/notify.go
@@ -91,13 +91,19 @@ func getTemplate(ctx context.Context, topic string, contType string, channel npk
 		if err != nil {
 			return nil, err
 		}
-		tmp, err := template.New(key).Parse(string(cont))
+		tmp := template.New(key)
+		tmp.Funcs(template.FuncMap{"unescaped": unescaped})
+		tmp, err = tmp.Parse(string(cont))
 		if err != nil {
 			return nil, err
 		}
 		templatesTable[key] = tmp
 	}
 	return templatesTable[key], nil
+}
+
+func unescaped(str string) template.HTML {
+	return template.HTML(str)
 }
 
 func getContent(ctx context.Context, topic string, contType string, channel npk.TNotifyChannel, data jsonutils.JSONObject) (string, error) {

--- a/pkg/monitor/alerting/conditions/query.go
+++ b/pkg/monitor/alerting/conditions/query.go
@@ -223,9 +223,23 @@ func (c *QueryCondition) NewEvalMatch(context *alerting.EvalContext, series tsdb
 	if alertDetails.GetPointStr {
 		evalMatch.ValueStr = c.jointPointStr(series, evalMatch.ValueStr, valStrArr)
 	}
-	evalMatch.MeasurementDesc = alertDetails.MeasurementDisplayName
-	evalMatch.FieldDesc = alertDetails.FieldDescription.DisplayName
+	c.newRuleDescription(context, alertDetails)
 	return evalMatch, nil
+}
+
+func (c *QueryCondition) newRuleDescription(context *alerting.EvalContext, alertDetails *monitor.CommonAlertMetricDetails) {
+	ruleDes := alerting.RuleDescription{
+		AlertRecordRule: monitor.AlertRecordRule{
+			Metric:          fmt.Sprintf("%s.%s", alertDetails.Measurement, alertDetails.Field),
+			Measurement:     alertDetails.Measurement,
+			MeasurementDesc: alertDetails.MeasurementDisplayName,
+			Field:           alertDetails.Field,
+			FieldDesc:       alertDetails.FieldDescription.DisplayName,
+			Comparator:      alertDetails.Comparator,
+			Threshold:       c.RationalizeValueFromUnit(alertDetails.Threshold, alertDetails.FieldDescription.Unit, ""),
+		},
+	}
+	context.RuleDescription = &ruleDes
 }
 
 func (c *QueryCondition) jointPointStr(series tsdb.TimeSeries, value string, valStrArr []string) string {

--- a/pkg/monitor/alerting/eval_context.go
+++ b/pkg/monitor/alerting/eval_context.go
@@ -42,12 +42,17 @@ type EvalContext struct {
 	StartTime          time.Time
 	EndTime            time.Time
 	Rule               *Rule
+	RuleDescription    *RuleDescription
 
 	NoDataFound    bool
 	PrevAlertState monitor.AlertStateType
 
 	Ctx      context.Context
 	UserCred mcclient.TokenCredential
+}
+
+type RuleDescription struct {
+	monitor.AlertRecordRule
 }
 
 // NewEvalContext is the EvalContext constructor.

--- a/pkg/monitor/models/commonalert.go
+++ b/pkg/monitor/models/commonalert.go
@@ -992,15 +992,20 @@ func (alert *SCommonAlert) StartDetachTask(ctx context.Context, userCred mcclien
 
 func (alert *SCommonAlert) DetachAlertResourceOnDisable(ctx context.Context,
 	userCred mcclient.TokenCredential) (errs []error) {
-	resources, err := GetAlertResourceManager().getResourceFromAlertId(alert.Id)
+	return CommonAlertManager.DetachAlertResourceByAlertId(ctx, userCred, alert.Id)
+}
+
+func (manager *SCommonAlertManager) DetachAlertResourceByAlertId(ctx context.Context,
+	userCred mcclient.TokenCredential, alertId string) (errs []error) {
+	resources, err := GetAlertResourceManager().getResourceFromAlertId(alertId)
 	if err != nil {
 		errs = append(errs, errors.Wrap(err, "getResourceFromAlert error"))
 		return
 	}
 	for _, resource := range resources {
-		err := resource.DetachAlert(ctx, userCred, alert.Id)
+		err := resource.DetachAlert(ctx, userCred, alertId)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "resource:%s DetachAlert:%s err", resource.Id, alert.Id))
+			errs = append(errs, errors.Wrapf(err, "resource:%s DetachAlert:%s err", resource.Id, alertId))
 		}
 	}
 	return


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1.修复报警信息中>等被转义的问题
2.针对：host_raid.adapter和smart_device.exit_status
  只能出现alerting和nodata
两种报警状态。在queryCondition的查询逻辑下，nodata情况也进行detach操作
3.修复报警记录中报警策略翻译异常的问题

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.5

/cc @zexi 
/area monitor
