### PR TITLE
Automated cherry pick of #8947: fix(region): change_ipaddr: retain eip_id on detach and attach

### DIFF
--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -2093,6 +2093,12 @@ func (self *SGuest) PerformChangeIpaddr(ctx context.Context, userCred mcclient.T
 			}
 			return nil, httperrors.NewBadRequestError("%v", err)
 		}
+		if _, err := db.Update(&ngn[0], func() error {
+			ngn[0].EipId = gn.EipId
+			return nil
+		}); err != nil {
+			return nil, err
+		}
 
 		return ngn, nil
 	}()


### PR DESCRIPTION
Cherry pick of #8947 on release/3.6.

#8947: fix(region): change_ipaddr: retain eip_id on detach and attach