### PR TITLE
fix(region): allow delete storagecachedimage with 'cache_failed' status

### DIFF
--- a/pkg/compute/models/storagecachedimages.go
+++ b/pkg/compute/models/storagecachedimages.go
@@ -273,12 +273,14 @@ func (self *SStoragecachedimage) Detach(ctx context.Context, userCred mcclient.T
 }
 
 func (self *SStoragecachedimage) ValidateDeleteCondition(ctx context.Context) error {
-	cnt, err := self.getReferenceCount()
-	if err != nil {
-		return httperrors.NewInternalServerError("getReferenceCount fail %s", err)
-	}
-	if cnt > 0 {
-		return httperrors.NewNotEmptyError("Image is in use")
+	if self.Status != api.CACHED_IMAGE_STATUS_CACHE_FAILED {
+		cnt, err := self.getReferenceCount()
+		if err != nil {
+			return httperrors.NewInternalServerError("getReferenceCount fail %s", err)
+		}
+		if cnt > 0 {
+			return httperrors.NewNotEmptyError("Image is in use")
+		}
 	}
 	return self.SJointResourceBase.ValidateDeleteCondition(ctx)
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

Having status 'cache_failed' means this storagecachedimage does not actually exist.

bug出现的场景：之前没有禁用vmware平台挂在iso，虽然最后会失败，但是iso对应的cachedimage于vmware的storagecache会有一个storagecachedimage，其状态为cache_failed。这样在删除云账号的时候，会先删除所有的虚拟机，然后删除storagecachedimage，如果上面提到的iso被其他平台的虚拟机用到了，那么上面提到 storagecachedimage会因为有机器在用，而删除失败。

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6
- release/3.5
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/cc @swordqiu 
/area region