### PR TITLE
Automated cherry pick of #8987: fix(region): allow delete storagecachedimage with 'cache_failed' status

### DIFF
--- a/pkg/compute/models/storagecachedimages.go
+++ b/pkg/compute/models/storagecachedimages.go
@@ -273,12 +273,14 @@ func (self *SStoragecachedimage) Detach(ctx context.Context, userCred mcclient.T
 }
 
 func (self *SStoragecachedimage) ValidateDeleteCondition(ctx context.Context) error {
-	cnt, err := self.getReferenceCount()
-	if err != nil {
-		return httperrors.NewInternalServerError("getReferenceCount fail %s", err)
-	}
-	if cnt > 0 {
-		return httperrors.NewNotEmptyError("Image is in use")
+	if self.Status != api.CACHED_IMAGE_STATUS_CACHE_FAILED {
+		cnt, err := self.getReferenceCount()
+		if err != nil {
+			return httperrors.NewInternalServerError("getReferenceCount fail %s", err)
+		}
+		if cnt > 0 {
+			return httperrors.NewNotEmptyError("Image is in use")
+		}
 	}
 	return self.SJointResourceBase.ValidateDeleteCondition(ctx)
 }


### PR DESCRIPTION
Cherry pick of #8987 on release/3.4.

#8987: fix(region): allow delete storagecachedimage with 'cache_failed' status