### PR TITLE
fix(scheduler): cleanup exipre cache before schedule

### DIFF
--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1734,7 +1734,9 @@ func (self *SNetwork) PostCreate(ctx context.Context, userCred mcclient.TokenCre
 		}
 	} else {
 		self.SetStatus(userCred, api.NETWORK_STATUS_AVAILABLE, "")
-		self.ClearSchedDescCache()
+		if err := self.ClearSchedDescCache(); err != nil {
+			log.Errorf("network post create clear schedcache error: %v", err)
+		}
 	}
 }
 
@@ -1825,12 +1827,7 @@ func (self *SNetwork) isManaged() bool {
 }
 
 func (self *SNetwork) isOneCloudVpcNetwork() bool {
-	vpc := self.GetVpc()
-	region := self.GetRegion()
-	if region.Provider == api.CLOUD_PROVIDER_ONECLOUD && vpc.Id != api.DEFAULT_VPC_ID {
-		return true
-	}
-	return false
+	return IsOneCloudVpcResource(self)
 }
 
 func parseIpToIntArray(ip string) ([]int, error) {

--- a/pkg/compute/models/networks.go
+++ b/pkg/compute/models/networks.go
@@ -1765,7 +1765,6 @@ func (self *SNetwork) RealDelete(ctx context.Context, userCred mcclient.TokenCre
 	DeleteResourceJointSchedtags(self, ctx, userCred)
 	db.OpsLog.LogEvent(self, db.ACT_DELOCATE, self.GetShortDesc(ctx), userCred)
 	self.SetStatus(userCred, api.NETWORK_STATUS_DELETED, "real delete")
-	self.ClearSchedDescCache()
 	networkinterfaces, err := self.GetNetworkInterfaces()
 	if err != nil {
 		return errors.Wrap(err, "GetNetworkInterfaces")
@@ -1786,7 +1785,11 @@ func (self *SNetwork) RealDelete(ctx context.Context, userCred mcclient.TokenCre
 			return errors.Wrapf(err, "reservedIps.Release %s(%d)", reservedIps[i].IpAddr, reservedIps[i].Id)
 		}
 	}
-	return self.SSharableVirtualResourceBase.Delete(ctx, userCred)
+	if err := self.SSharableVirtualResourceBase.Delete(ctx, userCred); err != nil {
+		return err
+	}
+	self.ClearSchedDescCache()
+	return nil
 }
 
 func (self *SNetwork) StartDeleteNetworkTask(ctx context.Context, userCred mcclient.TokenCredential) error {

--- a/pkg/compute/models/vpcresource.go
+++ b/pkg/compute/models/vpcresource.go
@@ -32,6 +32,11 @@ import (
 	"yunion.io/x/onecloud/pkg/util/stringutils2"
 )
 
+type IVpcResource interface {
+	GetVpc() *SVpc
+	GetRegion() *SCloudregion
+}
+
 type SVpcResourceBase struct {
 	VpcId string `width:"36" charset:"ascii" nullable:"true" list:"user" create:"optional" json:"vpc_id"`
 }
@@ -306,4 +311,19 @@ func (self *SVpcResourceBase) GetChangeOwnerCandidateDomainIds() []string {
 		return vpc.GetChangeOwnerCandidateDomainIds()
 	}
 	return nil
+}
+
+func IsOneCloudVpcResource(res IVpcResource) bool {
+	vpc := res.GetVpc()
+	if vpc == nil {
+		return false
+	}
+	region := res.GetRegion()
+	if region == nil {
+		return false
+	}
+	if region.Provider == api.CLOUD_PROVIDER_ONECLOUD && vpc.Id != api.DEFAULT_VPC_ID {
+		return true
+	}
+	return false
 }

--- a/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
@@ -168,6 +168,7 @@ func (p *DiskSchedtagPredicate) DoSelect(
 	res []ISchedtagCandidateResource,
 ) []ISchedtagCandidateResource {
 	return p.GetUsedStorages(res, input.(*diskW).Backend)
+
 }
 
 func (p *DiskSchedtagPredicate) GetCandidateResourceSortScore(selectRes ISchedtagCandidateResource) int64 {
@@ -207,8 +208,8 @@ func (p *DiskSchedtagPredicate) GetUsedStorages(res []ISchedtagCandidateResource
 	} else {
 		backendStorages = storages
 	}
-	if len(backendStorages) == 0 {
+	/*if len(backendStorages) == 0 {
 		backendStorages = storages
-	}
+	}*/
 	return backendStorages
 }

--- a/pkg/scheduler/manager/manager.go
+++ b/pkg/scheduler/manager/manager.go
@@ -97,6 +97,9 @@ func (sm *SchedulerManager) start() {
 }
 
 func (sm *SchedulerManager) schedule(info *api.SchedInfo) (*core.ScheduleResult, error) {
+	// force sync clean expire cache before do schedule
+	sm.ExpireManager.Trigger()
+
 	log.V(10).Infof("SchedulerManager do schedule, input: %#v", info)
 	task, err := sm.TaskManager.AddTask(sm, info)
 	if err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. 每次调度都先把 expire 的 cache 清理下（调度时间会增加）
2. network 应该被删除后再 clear schedule cache

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/cc @yousong 
- 3.4