### PR TITLE
fix(cloudcommon): adjust policy refresh to default 30 seconds

### DIFF
--- a/cmd/climc/shell/identity/policies.go
+++ b/cmd/climc/shell/identity/policies.go
@@ -63,6 +63,8 @@ func init() {
 		Enabled  bool   `help:"create policy enabled"`
 		Disabled bool   `help:"create policy disabled"`
 		Desc     string `help:"policy description"`
+		Scope    string `help:"scope of policy"`
+		IsSystem *bool  `help:"create system policy" negative:"no-system"`
 	}
 	R(&PolicyCreateOptions{}, "policy-create", "Create a new policy", func(s *mcclient.ClientSession, args *PolicyCreateOptions) error {
 		policyBytes, err := ioutil.ReadFile(args.FILE)
@@ -83,6 +85,16 @@ func init() {
 		}
 		if len(args.Desc) > 0 {
 			params.Add(jsonutils.NewString(args.Desc), "description")
+		}
+		if len(args.Scope) > 0 {
+			params.Add(jsonutils.NewString(args.Scope), "scope")
+		}
+		if args.IsSystem != nil {
+			if *args.IsSystem {
+				params.Add(jsonutils.JSONTrue, "is_system")
+			} else {
+				params.Add(jsonutils.JSONFalse, "is_system")
+			}
 		}
 
 		result, err := modules.Policies.Create(s, params)

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -70,7 +70,7 @@ type BaseOptions struct {
 
 	EnableRbac                  bool `help:"Switch on Role-based Access Control" default:"true"`
 	RbacDebug                   bool `help:"turn on rbac debug log" default:"false"`
-	RbacPolicySyncPeriodSeconds int  `help:"policy sync interval in seconds, default 30 minutes" default:"1800"`
+	RbacPolicySyncPeriodSeconds int  `help:"policy sync interval in seconds, default half a minute" default:"30"`
 	// RbacPolicySyncFailedRetrySeconds int  `help:"seconds to wait after a failed sync, default 30 seconds" default:"30"`
 
 	ConfigSyncPeriodSeconds int `help:"service config sync interval in seconds, default 30 minutes" default:"1800"`


### PR DESCRIPTION
Cache policy check result for 30 seconds by default

**这个 PR 实现什么功能/修复什么问题**:
修正：调整policy检查结果的缓存时间为30秒（以前为30分钟），导致operator初始化时sysadmin权限需等待30分钟后才生效

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @zhasm 
/area util