### PR TITLE
fix(region,scheduler): fix netwrok predicate

### DIFF
--- a/pkg/apis/scheduler/api.go
+++ b/pkg/apis/scheduler/api.go
@@ -82,6 +82,10 @@ type ScheduleInput struct {
 	CpuMode      string `json:"cpu_mode"`
 	OsArch       string `json:"os_arch"`
 
+	// In the migrate and create backup cases
+	// we don't need reallocate network
+	ReuseNetwork bool `json:"reuse_network"`
+
 	PendingUsages []jsonutils.JSONObject
 }
 

--- a/pkg/compute/models/guestnetworks.go
+++ b/pkg/compute/models/guestnetworks.go
@@ -873,6 +873,7 @@ func (self *SGuestnetwork) ToNetworkConfig() *api.NetworkConfig {
 		Domain:  net.DomainId,
 		Ifname:  self.Ifname,
 		NetType: net.ServerType,
+		Exit:    net.IsExitNetwork(),
 	}
 	return ret
 }

--- a/pkg/compute/tasks/guest_backup_tasks.go
+++ b/pkg/compute/tasks/guest_backup_tasks.go
@@ -294,6 +294,7 @@ func (self *GuestCreateBackupTask) GetSchedParams() (*schedapi.ScheduleInput, er
 		preferHostId, _ := self.Params.GetString("prefer_host_id")
 		schedDesc.ServerConfig.PreferHost = preferHostId
 	}
+	schedDesc.ReuseNetwork = true
 	return schedDesc, nil
 }
 

--- a/pkg/compute/tasks/guest_live_migrate_task.go
+++ b/pkg/compute/tasks/guest_live_migrate_task.go
@@ -77,6 +77,7 @@ func (self *GuestMigrateTask) GetSchedParams() (*schedapi.ScheduleInput, error) 
 			schedDesc.CpuMode = api.CPU_MODE_QEMU
 		}
 	}
+	schedDesc.ReuseNetwork = true
 	return schedDesc, nil
 }
 


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:
1. Guest config to schedule input should include network exit propertites.
2. Guest migrate and create backup server should not check network count,
because of migrate and create backup server will not allocate new network to guest.

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

cherrypick: release/3.5
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/cc @zexi @rainzm 