### PR TITLE
Automated cherry pick of #9054: fix(monitor): modify monitor nodata alert matching onecloud host func

### DIFF
--- a/pkg/monitor/alerting/conditions/nodataquery.go
+++ b/pkg/monitor/alerting/conditions/nodataquery.go
@@ -94,6 +94,7 @@ serLoop:
 func (c *NoDataQueryCondition) getOnecloudHosts() ([]jsonutils.JSONObject, error) {
 	query := jsonutils.NewDict()
 	query.Set("brand", jsonutils.NewString(hostconsts.TELEGRAF_TAG_ONECLOUD_BRAND))
+	query.Set("host-type", jsonutils.NewString(hostconsts.TELEGRAF_TAG_KEY_HYPERVISOR))
 	allHosts, err := ListAllResources(&mc_mds.Hosts, query)
 	if err != nil {
 		return nil, errors.Wrap(err, "NoDataQueryCondition Host list error")


### PR DESCRIPTION
Cherry pick of #9054 on release/3.6.

#9054: fix(monitor): modify monitor nodata alert matching onecloud host func