### PR TITLE
fix(monitor): delete suggestConfig auto Initialized data

### DIFF
--- a/pkg/monitor/alerting/conditions/nodataquery.go
+++ b/pkg/monitor/alerting/conditions/nodataquery.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"yunion.io/x/jsonutils"
-	"yunion.io/x/log"
 	"yunion.io/x/pkg/errors"
 
 	"yunion.io/x/onecloud/pkg/apis/monitor"
@@ -58,7 +57,6 @@ serLoop:
 				if err != nil {
 					return nil, errors.Wrap(err, "NoDataQueryCondition NewEvalMatch error")
 				}
-				log.Errorf("nodata match:%#v", match)
 				normalHostIds[val] = match
 				continue serLoop
 			}

--- a/pkg/monitor/models/commonalert.go
+++ b/pkg/monitor/models/commonalert.go
@@ -761,7 +761,6 @@ func (alert *SCommonAlert) ValidateUpdateData(
 			return data, errors.Wrap(err, "metric_query Unmarshal error")
 		}
 		scope, _ := data.GetString("scope")
-		log.Errorf("update query from:%s", metricQuery.From)
 		err = CommonAlertManager.ValidateMetricQuery(metricQuery, scope, userCred)
 		if err != nil {
 			return data, errors.Wrap(err, "metric query error")

--- a/pkg/monitor/models/suggestsysalert.go
+++ b/pkg/monitor/models/suggestsysalert.go
@@ -379,6 +379,8 @@ func (self *SSuggestSysAlert) GetSuggestConfig(scope rbacutils.TRbacScope, domai
 	q := SuggestSysRuleConfigManager.Query().Equals("type", drvType).Equals("resource_type", resType)
 	if !batchIgnore {
 		q = q.Equals("resource_id", resId)
+	} else {
+		q = q.IsNull("resource_id")
 	}
 	q = SuggestSysRuleConfigManager.FilterByScope(q, scope, scopeId)
 	configs := make([]SSuggestSysRuleConfig, 0)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1.删除忽略列表之前逻辑初始化生成的配置config
2.忽略列表默认查询ignore=true的数据
3.修复建议列表 忽略一类建议不生效的问题

**是否需要 backport 到之前的 release 分支**:
- release/3.6

/cc @zexi 
/area monitor
