### PR TITLE
feat(scripts): add prompt of `hub` version

### DIFF
--- a/scripts/cherry_pick_pull.sh
+++ b/scripts/cherry_pick_pull.sh
@@ -59,6 +59,15 @@ if ! which hub > /dev/null; then
   exit 1
 fi
 
+function version_lt() { 
+    test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != "$1" 
+}
+
+if version_lt "$(hub version | awk '/hub/ {print $3}')" "2.13.0"; then
+  echo "Please install 'hub' with version 2.13.0+ from https://github.com/github/hub/releases"
+  exit 1
+fi
+
 if [[ "$#" -lt 2 ]]; then
   echo "${0} <remote branch> <pr-number>...: cherry pick one or more <pr> onto <remote branch> and leave instructions for proposing pull request"
   echo


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

The flag `hub pr show -f ...` as used in cherry_pick_pull.sh was
permited since version 2.13.0.

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
NONE
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/cc @yousong @zexi
