### PR TITLE
Automated cherry pick of #9104: fix(notify): return the result of the second attempt to execute the rpc call

### DIFF
--- a/pkg/notify/rpc/send.go
+++ b/pkg/notify/rpc/send.go
@@ -238,7 +238,7 @@ func (self *SRpcService) execute(ctx context.Context, f func(client *apis.SendNo
 			return nil, errors.Wrapf(err, "restart service %s failed", serviceName)
 		}
 
-		_, err := f(sendService)
+		ret, err = f(sendService)
 		if err != nil {
 			st := status.Convert(err)
 			if st.Code() == codes.Unavailable {


### PR DESCRIPTION
Cherry pick of #9104 on release/3.4.

#9104: fix(notify): return the result of the second attempt to execute the rpc call