### PR TITLE
Automated cherry pick of #9109: fix(host): make sure it won't match vpc guests by accident

### DIFF
--- a/pkg/hostman/guestman/qemu-kvm.go
+++ b/pkg/hostman/guestman/qemu-kvm.go
@@ -1001,10 +1001,13 @@ func (s *SKVMGuestInstance) ExecSuspendTask(ctx context.Context) {
 func (s *SKVMGuestInstance) GetNicDescMatch(mac, ip, port, bridge string) jsonutils.JSONObject {
 	nics, _ := s.Desc.GetArray("nics")
 	for _, nic := range nics {
+		nicBridge, _ := nic.GetString("bridge")
+		if bridge == "" && nicBridge != "" && nicBridge == options.HostOptions.OvnIntegrationBridge {
+			continue
+		}
 		nicMac, _ := nic.GetString("mac")
 		nicIp, _ := nic.GetString("ip")
 		nicPort, _ := nic.GetString("ifname")
-		nicBridge, _ := nic.GetString("bridge")
 		if (len(mac) == 0 || netutils2.MacEqual(nicMac, mac)) &&
 			(len(ip) == 0 || nicIp == ip) &&
 			(len(port) == 0 || nicPort == port) &&


### PR DESCRIPTION
Cherry pick of #9109 on release/3.5.

#9109: fix(host): make sure it won't match vpc guests by accident