### PR TITLE
fix(region): delete guest without 'purge' in GuestDetachScalingGroupTask

### DIFF
--- a/pkg/compute/tasks/guest_detach_scalinggroup.go
+++ b/pkg/compute/tasks/guest_detach_scalinggroup.go
@@ -98,7 +98,7 @@ func (self *GuestDetachScalingGroupTask) OnDetachLoadbalancerComplete(ctx contex
 	}
 	self.Params.Set("guest_name", jsonutils.NewString(guest.GetName()))
 	self.SetStage("OnDeleteGuestComplete", nil)
-	if err := guest.StartDeleteGuestTask(ctx, self.UserCred, self.Id, true, true, true); err != nil {
+	if err := guest.StartDeleteGuestTask(ctx, self.UserCred, self.Id, false, true, true); err != nil {
 		self.taskFailed(ctx, sg, nil, jsonutils.NewString(err.Error()))
 	}
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

purge的最初含义是只删除本地数据库的虚拟机，但是在实际的使用中，如果虚拟机的宿主机是启用状态的话，还是会undeploy虚拟机。

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6
- release/3.5
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region