### PR TITLE
fix(keystone): not allow to disable sql driver

### DIFF
--- a/pkg/keystone/models/identity_provider.go
+++ b/pkg/keystone/models/identity_provider.go
@@ -1481,6 +1481,9 @@ func (idp *SIdentityProvider) PerformDisable(
 	query jsonutils.JSONObject,
 	input apis.PerformDisableInput,
 ) (jsonutils.JSONObject, error) {
+	if idp.Driver == api.IdentityDriverSQL {
+		return nil, errors.Wrap(httperrors.ErrForbidden, "not allow to disable sql idp")
+	}
 	if idp.Driver == api.IdentityDriverLDAP || idp.AutoCreateUser.IsTrue() {
 		domains, _ := idp.getLinkedDomains()
 		for i := range domains {


### PR DESCRIPTION
not allow to disable default SQL identity_provider driver

**这个 PR 实现什么功能/修复什么问题**:
修正：禁止禁用缺省的SQL认证源

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.5
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area keystone
/cc @zexi @yousong 
