### PR TITLE
feature(cloudcommon): split opslog table

### DIFF
--- a/cmd/climc/shell/events/splitable.go
+++ b/cmd/climc/shell/events/splitable.go
@@ -1,0 +1,70 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"yunion.io/x/jsonutils"
+
+	"yunion.io/x/onecloud/pkg/mcclient"
+	"yunion.io/x/onecloud/pkg/mcclient/modulebase"
+	"yunion.io/x/onecloud/pkg/mcclient/modules"
+)
+
+func init() {
+	type EventSplitableOptions struct {
+		Service string `help:"service" choices:"compute|identity|image" default:"compute"`
+	}
+	R(&EventSplitableOptions{}, "logs-splitable", "Show splitable info of event table", func(s *mcclient.ClientSession, args *EventSplitableOptions) error {
+		var results jsonutils.JSONObject
+		var err error
+		switch args.Service {
+		case "identity":
+			results, err = modules.IdentityLogs.Get(s, "splitable", nil)
+		case "image":
+			results, err = modules.ImageLogs.Get(s, "splitable", nil)
+		default:
+			results, err = modules.Logs.Get(s, "splitable", nil)
+		}
+		if err != nil {
+			return err
+		}
+		tables, err := results.GetArray()
+		if err != nil {
+			return err
+		}
+		listResult := &modulebase.ListResult{
+			Data: tables,
+		}
+		printList(listResult, nil)
+		return nil
+	})
+	R(&EventSplitableOptions{}, "logs-purge", "Purge obsolete splitable of event table", func(s *mcclient.ClientSession, args *EventSplitableOptions) error {
+		var results jsonutils.JSONObject
+		var err error
+		switch args.Service {
+		case "identity":
+			results, err = modules.IdentityLogs.PerformClassAction(s, "purge-splitable", nil)
+		case "image":
+			results, err = modules.ImageLogs.PerformClassAction(s, "purge-splitable", nil)
+		default:
+			results, err = modules.Logs.PerformClassAction(s, "purge-splitable", nil)
+		}
+		if err != nil {
+			return err
+		}
+		printObject(results)
+		return nil
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ require (
 	yunion.io/x/ovsdb v0.0.0-20200526071744-27bf0940cbc7
 	yunion.io/x/pkg v0.0.0-20201123083159-ca3aea986ff2
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
-	yunion.io/x/sqlchemy v0.0.0-20201116041103-013e56cab959
+	yunion.io/x/sqlchemy v0.0.0-20201208011733-4adc2e143fde
 	yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce
 )
 

--- a/go.sum
+++ b/go.sum
@@ -931,7 +931,7 @@ yunion.io/x/pkg v0.0.0-20201123083159-ca3aea986ff2 h1:NeCr2J8HjcIuJvEhP0rwWA1UKP
 yunion.io/x/pkg v0.0.0-20201123083159-ca3aea986ff2/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8J50Cise/HCylsOJngmo=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e/go.mod h1:0iFKpOs1y4lbCxeOmq3Xx/0AcQoewVPwj62eRluioEo=
-yunion.io/x/sqlchemy v0.0.0-20201116041103-013e56cab959 h1:42hMtiEXrGgSf2aS+LE5FNK9i3FzKwyaPgYoX0rD6NQ=
-yunion.io/x/sqlchemy v0.0.0-20201116041103-013e56cab959/go.mod h1:FTdwPdGhMgh4E+UFXc9klI1Ok34fMuybTT+jLhOaIjI=
+yunion.io/x/sqlchemy v0.0.0-20201208011733-4adc2e143fde h1:qE2NGwZdiALSGsVbnzugFBSZ5N1cmGMJsWOGnoexuDg=
+yunion.io/x/sqlchemy v0.0.0-20201208011733-4adc2e143fde/go.mod h1:FTdwPdGhMgh4E+UFXc9klI1Ok34fMuybTT+jLhOaIjI=
 yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce h1:kU8xE7O5uZ1GSJVMZHoJ+jrNL7csUQHYGyAPW9QfNpE=
 yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce/go.mod h1:EP6NSv2C0zzqBDTKumv8hPWLb3XvgMZDHQRfyuOrQng=

--- a/pkg/apis/identity/consts.go
+++ b/pkg/apis/identity/consts.go
@@ -163,6 +163,8 @@ var (
 			"etcd_cacert",
 			"etcd_cert",
 			"etcd_key",
+			"splitable_max_duration_hours",
+			"splitable_max_keep_segments",
 
 			// ############################
 			// keystone blacklist options

--- a/pkg/cloudcommon/consts/opslog.go
+++ b/pkg/cloudcommon/consts/opslog.go
@@ -14,8 +14,12 @@
 
 package consts
 
+import "time"
+
 var (
-	globalOpsLogEnabled = true
+	globalOpsLogEnabled       = true
+	splitableMaxDurationHours = 24 * 30 // 30 days
+	splitableMaxKeepSegments  = 6       // 6 * 30 days, half year
 )
 
 func DisableOpsLog() {
@@ -24,4 +28,20 @@ func DisableOpsLog() {
 
 func OpsLogEnabled() bool {
 	return globalOpsLogEnabled
+}
+
+func SetSplitableMaxKeepSegments(cnt int) {
+	splitableMaxKeepSegments = cnt
+}
+
+func SetSplitableMaxDurationHours(h int) {
+	splitableMaxDurationHours = h
+}
+
+func SplitableMaxKeepSegments() int {
+	return splitableMaxKeepSegments
+}
+
+func SplitableMaxDuration() time.Duration {
+	return time.Hour * time.Duration(splitableMaxDurationHours)
 }

--- a/pkg/cloudcommon/db/interface.go
+++ b/pkg/cloudcommon/db/interface.go
@@ -27,6 +27,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/object"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
+	"yunion.io/x/onecloud/pkg/util/splitable"
 	"yunion.io/x/onecloud/pkg/util/stringutils2"
 )
 
@@ -130,6 +131,8 @@ type IModelManager interface {
 	GetPagingConfig() *SPagingConfig
 
 	GetI18N(ctx context.Context, idstr string, resObj jsonutils.JSONObject) *jsonutils.JSONDict
+
+	GetSplitTable() *splitable.SSplitTableSpec
 }
 
 type IModel interface {

--- a/pkg/cloudcommon/db/opslog.go
+++ b/pkg/cloudcommon/db/opslog.go
@@ -78,7 +78,16 @@ var _ IModel = (*SOpsLog)(nil)
 var opslogQueryWorkerMan *appsrv.SWorkerManager
 
 func init() {
-	OpsLog = &SOpsLogManager{NewModelBaseManager(SOpsLog{}, "opslog_tbl", "event", "events")}
+	OpsLog = &SOpsLogManager{NewModelBaseManagerWithSplitable(
+		SOpsLog{},
+		"opslog_tbl",
+		"event",
+		"events",
+		"id",
+		"ops_time",
+		consts.SplitableMaxDuration(),
+		consts.SplitableMaxKeepSegments(),
+	)}
 	OpsLog.SetVirtualObject(OpsLog)
 
 	opslogQueryWorkerMan = appsrv.NewWorkerManager("opslog_query_worker", 2, 1024, true)

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -138,6 +138,9 @@ type DBOptions struct {
 
 	LockmanMethod string `help:"method for lock synchronization" choices:"inmemory|etcd" default:"inmemory"`
 
+	// SplitableMaxKeepSegments  int `help:"maximal segements of splitable to keep, default 6 segments" default:"6"`
+	// SplitableMaxDurationHours int `help:"maximal number of hours that a splitable segement lasts, default 30 days" default:"720"`
+
 	EtcdOptions
 
 	EtcdLockPrefix string `help:"prefix of etcd lock records" default:"/onecloud/lockman"`

--- a/pkg/cloudevent/models/cloudevents.go
+++ b/pkg/cloudevent/models/cloudevents.go
@@ -24,6 +24,7 @@ import (
 	"yunion.io/x/sqlchemy"
 
 	api "yunion.io/x/onecloud/pkg/apis/cloudevent"
+	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudprovider"
 	"yunion.io/x/onecloud/pkg/mcclient"
@@ -40,11 +41,15 @@ var CloudeventManager *SCloudeventManager
 
 func init() {
 	CloudeventManager = &SCloudeventManager{
-		SModelBaseManager: db.NewModelBaseManager(
+		SModelBaseManager: db.NewModelBaseManagerWithSplitable(
 			SCloudevent{},
 			"cloudevents_tbl",
 			"cloudevent",
 			"cloudevents",
+			"event_id",
+			"created_at",
+			consts.SplitableMaxDuration(),
+			consts.SplitableMaxKeepSegments(),
 		),
 	}
 	CloudeventManager.SetVirtualObject(CloudeventManager)

--- a/pkg/logger/models/actionlog.go
+++ b/pkg/logger/models/actionlog.go
@@ -21,6 +21,7 @@ import (
 	"yunion.io/x/jsonutils"
 	"yunion.io/x/log"
 
+	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
@@ -59,7 +60,16 @@ func init() {
 	InitActionWhiteList()
 	ActionLog = &SActionlogManager{
 		SOpsLogManager: db.SOpsLogManager{
-			SModelBaseManager: db.NewModelBaseManager(SActionlog{}, "action_tbl", "action", "actions"),
+			SModelBaseManager: db.NewModelBaseManagerWithSplitable(
+				SActionlog{},
+				"action_tbl",
+				"action",
+				"actions",
+				"id",
+				"start_time",
+				consts.SplitableMaxDuration(),
+				consts.SplitableMaxKeepSegments(),
+			),
 		},
 	}
 	ActionLog.SetVirtualObject(ActionLog)

--- a/pkg/logger/models/baremetalevents.go
+++ b/pkg/logger/models/baremetalevents.go
@@ -23,6 +23,7 @@ import (
 	"yunion.io/x/sqlchemy"
 
 	api "yunion.io/x/onecloud/pkg/apis/logger"
+	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
@@ -51,11 +52,15 @@ var BaremetalEventManager *SBaremetalEventManager
 
 func init() {
 	BaremetalEventManager = &SBaremetalEventManager{
-		SModelBaseManager: db.NewModelBaseManager(
+		SModelBaseManager: db.NewModelBaseManagerWithSplitable(
 			SBaremetalEvent{},
 			"baremetal_event_tbl",
 			"baremetalevent",
 			"baremetalevents",
+			"id",
+			"created",
+			consts.SplitableMaxDuration(),
+			consts.SplitableMaxKeepSegments(),
 		),
 	}
 	BaremetalEventManager.SetVirtualObject(BaremetalEventManager)

--- a/pkg/util/splitable/doc.go
+++ b/pkg/util/splitable/doc.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splitable // import "yunion.io/x/onecloud/pkg/util/splitable"

--- a/pkg/util/splitable/insert.go
+++ b/pkg/util/splitable/insert.go
@@ -1,0 +1,92 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splitable
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/reflectutils"
+	"yunion.io/x/sqlchemy"
+)
+
+func (t *SSplitTableSpec) Insert(dt interface{}) error {
+	metas, err := t.GetTableMetas()
+	if err != nil {
+		return errors.Wrap(err, "GetTableMeta")
+	}
+	var lastDate time.Time
+	vs := reflectutils.FetchAllStructFieldValueSet(reflect.Indirect(reflect.ValueOf(dt)))
+	if lastDateV, ok := vs.GetValue(t.dateField); !ok {
+		return errors.Wrap(errors.ErrInvalidStatus, "no dateField found")
+	} else {
+		lastDate = lastDateV.Interface().(time.Time)
+	}
+
+	var lastRecIndex int64
+	var lastRecDate time.Time
+	var lastTableSpec *sqlchemy.STableSpec
+
+	newMeta := false
+	if len(metas) > 0 {
+		lastMeta := metas[len(metas)-1]
+		if lastDate.Sub(lastMeta.StartDate) > t.maxDuration {
+			lastTable := t.GetTableSpec(lastMeta)
+			ti := lastTable.Instance()
+			q := ti.Query(sqlchemy.MAX("last_index", ti.Field(t.indexField)), sqlchemy.MAX("last_date", ti.Field(t.dateField)))
+			r := q.Row()
+			err := r.Scan(&lastRecIndex, &lastRecDate)
+			if err != nil {
+				return errors.Wrap(err, "scan lastRecIndex and lastRecDate")
+			}
+			// seal last meta
+			_, err = t.metaSpec.Update(&lastMeta, func() error {
+				lastMeta.End = lastRecIndex
+				lastMeta.EndDate = lastRecDate
+				return nil
+			})
+			if err != nil {
+				return errors.Wrap(err, "Update last meta")
+			}
+			newMeta = true
+		} else {
+			lastTableSpec = t.GetTableSpec(lastMeta)
+		}
+	} else {
+		newMeta = true
+	}
+	if newMeta {
+		// insert a new metadata
+		meta := STableMetadata{
+			Table:     fmt.Sprintf("%s_%d", t.tableName, lastDate.Unix()),
+			Start:     lastRecIndex + 1,
+			StartDate: lastDate,
+		}
+		err := t.metaSpec.Insert(&meta)
+		if err != nil {
+			return errors.Wrap(err, "insert new meta")
+		}
+		// create new table
+		newTable := t.GetTableSpec(meta)
+		err = newTable.Sync()
+		if err != nil {
+			return errors.Wrap(err, "sync new table")
+		}
+		lastTableSpec = newTable
+	}
+	return lastTableSpec.Insert(dt)
+}

--- a/pkg/util/splitable/metadata.go
+++ b/pkg/util/splitable/metadata.go
@@ -1,0 +1,50 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splitable
+
+import (
+	"database/sql"
+	"time"
+
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/sqlchemy"
+)
+
+type STableMetadata struct {
+	Id        int64     `primary:"true" auto_increment:"true"`
+	Table     string    `width:"64" charset:"ascii"`
+	Start     int64     `nullable:"true"`
+	End       int64     `nullable:"true"`
+	StartDate time.Time `nullable:"true"`
+	EndDate   time.Time `nullable:"true"`
+	Deleted   bool      `nullable:"false"`
+	DeleteAt  time.Time `nullable:"true"`
+	CreatedAt time.Time `nullable:"false" created_at:"true"`
+}
+
+func (spec *SSplitTableSpec) GetTableMetas() ([]STableMetadata, error) {
+	q := spec.metaSpec.Query().Asc("id").IsFalse("deleted")
+	metas := make([]STableMetadata, 0)
+	err := q.All(&metas)
+	if err != nil && errors.Cause(err) != sql.ErrNoRows {
+		return nil, errors.Wrap(err, "query metadata")
+	}
+	return metas, nil
+}
+
+func (spec *SSplitTableSpec) GetTableSpec(meta STableMetadata) *sqlchemy.STableSpec {
+	tbSpec := *spec.tableSpec
+	return tbSpec.Clone(meta.Table, meta.Start)
+}

--- a/pkg/util/splitable/purge.go
+++ b/pkg/util/splitable/purge.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splitable
+
+import (
+	"fmt"
+	"time"
+
+	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/sqlchemy"
+)
+
+func (t *SSplitTableSpec) Purge() error {
+	if t.maxSegments <= 0 {
+		return nil
+	}
+	metas, err := t.GetTableMetas()
+	if err != nil {
+		return errors.Wrap(err, "GetTableMetas")
+	}
+	if t.maxSegments >= len(metas) {
+		return nil
+	}
+	for i := 0; i < len(metas)-t.maxSegments; i += 1 {
+		dropSQL := fmt.Sprintf("DROP TABLE `%s`", metas[i].Table)
+		log.Infof("Ready to drop table: %s", dropSQL)
+		_, err := sqlchemy.Exec(dropSQL)
+		if err != nil {
+			return errors.Wrap(err, "sqlchemy.Exec")
+		}
+		_, err = t.metaSpec.Update(&metas[i], func() error {
+			metas[i].DeleteAt = time.Now()
+			metas[i].Deleted = true
+			return nil
+		})
+		if err != nil {
+			return errors.Wrap(err, "metaSpec.Update")
+		}
+	}
+	return nil
+}

--- a/pkg/util/splitable/splitable.go
+++ b/pkg/util/splitable/splitable.go
@@ -1,0 +1,152 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splitable
+
+import (
+	"database/sql"
+	"fmt"
+	"reflect"
+	"time"
+
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/reflectutils"
+	"yunion.io/x/sqlchemy"
+)
+
+type SSplitTableSpec struct {
+	indexField  string
+	dateField   string
+	tableName   string
+	tableSpec   *sqlchemy.STableSpec
+	metaSpec    *sqlchemy.STableSpec
+	maxDuration time.Duration
+	maxSegments int
+}
+
+func (t *SSplitTableSpec) DataType() reflect.Type {
+	return t.tableSpec.DataType()
+}
+
+func (t *SSplitTableSpec) ColumnSpec(name string) sqlchemy.IColumnSpec {
+	return t.tableSpec.ColumnSpec(name)
+}
+
+func (t *SSplitTableSpec) Name() string {
+	return t.tableName
+}
+
+func (t *SSplitTableSpec) Columns() []sqlchemy.IColumnSpec {
+	return t.tableSpec.Columns()
+}
+
+func (t *SSplitTableSpec) PrimaryColumns() []sqlchemy.IColumnSpec {
+	return t.tableSpec.PrimaryColumns()
+}
+
+func (t *SSplitTableSpec) Expression() string {
+	metas, err := t.GetTableMetas()
+	if err != nil {
+		return fmt.Sprintf("`%s`", t.tableName)
+	}
+	tss := make([]sqlchemy.IQuery, 0)
+	for _, meta := range metas {
+		ts := t.GetTableSpec(meta)
+		tss = append(tss, ts.Query())
+	}
+	union, err := sqlchemy.UnionWithError(tss...)
+	if err != nil {
+		return fmt.Sprintf("`%s`", t.tableName)
+	}
+	return union.Expression()
+}
+
+func (t *SSplitTableSpec) Instance() *sqlchemy.STable {
+	return sqlchemy.NewTableInstance(t)
+}
+
+func (t *SSplitTableSpec) DropForeignKeySQL() []string {
+	return t.tableSpec.DropForeignKeySQL()
+}
+
+func (t *SSplitTableSpec) AddIndex(unique bool, cols ...string) bool {
+	metas, err := t.GetTableMetas()
+	if err != nil {
+		return false
+	}
+	var ret bool
+	for _, meta := range metas {
+		ts := t.GetTableSpec(meta)
+		if !ts.AddIndex(unique, cols...) {
+			ret = false
+			break
+		}
+	}
+	return ret
+}
+
+func (t *SSplitTableSpec) Fetch(dt interface{}) error {
+	vs := reflectutils.FetchStructFieldValueSet(reflect.Indirect(reflect.ValueOf(dt)))
+	idxVal, ok := vs.GetValue(t.indexField)
+	if !ok {
+		return errors.Wrap(errors.ErrNotFound, "GetValue")
+	}
+	idxInt := idxVal.Int()
+	metas, err := t.GetTableMetas()
+	if err != nil {
+		return errors.Wrap(err, "GetTableMetas")
+	}
+	for _, meta := range metas {
+		if idxInt >= meta.Start && (meta.End == 0 || meta.End >= idxInt) {
+			ts := t.GetTableSpec(meta)
+			return ts.Fetch(dt)
+		}
+	}
+	return sql.ErrNoRows
+}
+
+func NewSplitTableSpec(s interface{}, name string, indexField string, dateField string, maxDuration time.Duration, maxSegments int) (*SSplitTableSpec, error) {
+	spec := sqlchemy.NewTableSpecFromStruct(s, name)
+	indexCol := spec.ColumnSpec(indexField)
+	if indexCol == nil {
+		return nil, errors.Wrapf(errors.ErrNotFound, "indexField %s not found", indexField)
+	}
+	if !indexCol.IsPrimary() {
+		return nil, errors.Wrapf(errors.ErrInvalidStatus, "indexField %s not primary", indexField)
+	}
+	if intCol, ok := indexCol.(*sqlchemy.SIntegerColumn); !ok {
+		return nil, errors.Wrapf(errors.ErrInvalidStatus, "indexField %s not integer", indexField)
+	} else if !intCol.IsAutoIncrement {
+		return nil, errors.Wrapf(errors.ErrInvalidStatus, "indexField %s not auto_increment", indexField)
+	}
+	dateCol := spec.ColumnSpec(dateField)
+	if dateCol == nil {
+		return nil, errors.Wrapf(errors.ErrNotFound, "dateField %s not found", dateField)
+	}
+	if _, ok := dateCol.(*sqlchemy.SDateTimeColumn); !ok {
+		return nil, errors.Wrapf(errors.ErrInvalidStatus, "dateField %s not datetime column", dateField)
+	}
+
+	metaSpec := sqlchemy.NewTableSpecFromStruct(&STableMetadata{}, fmt.Sprintf("%s_metadata", name))
+
+	return &SSplitTableSpec{
+		indexField:  indexField,
+		dateField:   dateField,
+		tableName:   name,
+		tableSpec:   spec,
+		metaSpec:    metaSpec,
+		maxDuration: maxDuration,
+		maxSegments: maxSegments,
+	}, nil
+}

--- a/pkg/util/splitable/sync.go
+++ b/pkg/util/splitable/sync.go
@@ -1,0 +1,135 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splitable
+
+import (
+	"fmt"
+	"time"
+
+	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/pkg/util/timeutils"
+	"yunion.io/x/sqlchemy"
+)
+
+func (spec *SSplitTableSpec) Sync() error {
+	err := spec.metaSpec.Sync()
+	if err != nil {
+		return errors.Wrap(err, "metaSpec.Sync")
+	}
+	metas, err := spec.GetTableMetas()
+	if err != nil {
+		return errors.Wrap(err, "GetTableMetas")
+	}
+	if len(metas) == 0 {
+		// init the first metadata record
+		fakeMeta := STableMetadata{
+			Table: spec.tableName,
+		}
+		tbl := spec.GetTableSpec(fakeMeta)
+		if tbl.Exists() {
+			err := tbl.Sync()
+			if err != nil {
+				return errors.Wrap(err, "Sync")
+			}
+			var minIndex int64
+			var minDate time.Time
+			ti := tbl.Instance()
+			q := ti.Query(sqlchemy.MIN("min_index", ti.Field(spec.indexField)), sqlchemy.MIN("min_date", ti.Field(spec.dateField)))
+			r := q.Row()
+			err = r.Scan(&minIndex, &minDate)
+			if err != nil {
+				return errors.Wrap(err, "minIndex minDate")
+			}
+			fakeMeta.Start = minIndex
+			fakeMeta.StartDate = minDate
+			err = spec.metaSpec.Insert(&fakeMeta)
+			if err != nil {
+				return errors.Wrap(err, "insert init metadata")
+			}
+		}
+	} else {
+		for i := range metas {
+			subSpec := spec.GetTableSpec(metas[i])
+			err := subSpec.Sync()
+			if err != nil {
+				return errors.Wrap(err, "Sync")
+			}
+		}
+	}
+	return nil
+}
+
+func (spec *SSplitTableSpec) CheckSync() error {
+	err := spec.metaSpec.CheckSync()
+	if err != nil {
+		return errors.Wrap(err, "metaSpec.CheckSync")
+	}
+	metas, err := spec.GetTableMetas()
+	if err != nil {
+		return errors.Wrap(err, "GetTableMetas")
+	}
+	for i := range metas {
+		subSpec := spec.GetTableSpec(metas[i])
+		err := subSpec.CheckSync()
+		if err != nil {
+			return errors.Wrap(err, "GetTableSpec")
+		}
+	}
+	return nil
+}
+
+func (spec *SSplitTableSpec) SyncSQL() []string {
+	sqls := spec.metaSpec.SyncSQL()
+	if spec.metaSpec.Exists() {
+		metas, err := spec.GetTableMetas()
+		if err != nil {
+			log.Errorf("GetTableMetas fail %s", err)
+			return nil
+		} else if len(metas) > 0 {
+			for i := range metas {
+				subSpec := spec.GetTableSpec(metas[i])
+				nsql := subSpec.SyncSQL()
+				sqls = append(sqls, nsql...)
+			}
+			return sqls
+		}
+	}
+
+	fakeMeta := STableMetadata{
+		Table: spec.tableName,
+	}
+	tbl := spec.GetTableSpec(fakeMeta)
+	if tbl.Exists() {
+		nsql := tbl.SyncSQL()
+		if len(nsql) > 0 {
+			sqls = append(sqls, nsql...)
+		}
+		var minIndex int64
+		var minDate time.Time
+		ti := tbl.Instance()
+		q := ti.Query(sqlchemy.MIN("min_index", ti.Field(spec.indexField)), sqlchemy.MIN("min_date", ti.Field(spec.dateField)))
+		r := q.Row()
+		err := r.Scan(&minIndex, &minDate)
+		if err != nil {
+			log.Errorf("query minIndex minDate fail %s", err)
+		} else {
+			minDateStr := timeutils.MysqlTime(minDate)
+			sql := fmt.Sprintf("INSERT INTO `%s`(`table`, `start`, `start_date`, `deleted`, `created_at`) VALUES('%s', %d, '%s', 0, '%s')", spec.metaSpec.Name(), spec.tableName, minIndex, minDateStr, minDateStr)
+			sqls = append(sqls, sql)
+		}
+	}
+	return sqls
+}

--- a/pkg/util/splitable/update.go
+++ b/pkg/util/splitable/update.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splitable
+
+import (
+	"yunion.io/x/pkg/errors"
+	"yunion.io/x/sqlchemy"
+)
+
+func (t *SSplitTableSpec) InsertOrUpdate(dt interface{}) error {
+	return errors.ErrNotSupported
+}
+
+func (t *SSplitTableSpec) Update(dt interface{}, onUpdate func() error) (sqlchemy.UpdateDiffs, error) {
+	return nil, errors.ErrNotSupported
+}
+
+func (t *SSplitTableSpec) Increment(diff, target interface{}) error {
+	return errors.ErrNotSupported
+}
+
+func (t *SSplitTableSpec) Decrement(diff, target interface{}) error {
+	return errors.ErrNotSupported
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1149,7 +1149,7 @@ yunion.io/x/pkg/util/workqueue
 yunion.io/x/pkg/utils
 # yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 yunion.io/x/s3cli
-# yunion.io/x/sqlchemy v0.0.0-20201116041103-013e56cab959
+# yunion.io/x/sqlchemy v0.0.0-20201208011733-4adc2e143fde
 yunion.io/x/sqlchemy
 # yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce
 yunion.io/x/structarg

--- a/vendor/yunion.io/x/sqlchemy/functions.go
+++ b/vendor/yunion.io/x/sqlchemy/functions.go
@@ -103,6 +103,10 @@ func MAX(name string, field IQueryField) IQueryField {
 	return NewFunctionField(name, "MAX(%s)", field)
 }
 
+func MIN(name string, field IQueryField) IQueryField {
+	return NewFunctionField(name, "MIN(%s)", field)
+}
+
 func SUM(name string, field IQueryField) IQueryField {
 	return NewFunctionField(name, "SUM(%s)", field)
 }

--- a/vendor/yunion.io/x/sqlchemy/query.go
+++ b/vendor/yunion.io/x/sqlchemy/query.go
@@ -65,7 +65,7 @@ type IQueryField interface {
 }
 
 func (tbl *STable) Expression() string {
-	return fmt.Sprintf("`%s`", tbl.spec.name)
+	return tbl.spec.Expression()
 }
 
 func (tbl *STable) Alias() string {

--- a/vendor/yunion.io/x/sqlchemy/sql.go
+++ b/vendor/yunion.io/x/sqlchemy/sql.go
@@ -53,3 +53,7 @@ func GetTables() []string {
 	}
 	return ret
 }
+
+func Exec(sql string, args ...interface{}) (sql.Result, error) {
+	return _db.Exec(sql, args...)
+}

--- a/vendor/yunion.io/x/sqlchemy/sync.go
+++ b/vendor/yunion.io/x/sqlchemy/sync.go
@@ -276,10 +276,14 @@ func (ts *STableSpec) DropForeignKeySQL() []string {
 	return ret
 }
 
-func (ts *STableSpec) SyncSQL() []string {
+func (ts *STableSpec) Exists() bool {
 	tables := GetTables()
 	in, _ := utils.InStringArray(ts.name, tables)
-	if !in {
+	return in
+}
+
+func (ts *STableSpec) SyncSQL() []string {
+	if !ts.Exists() {
 		log.Debugf("table %s not created yet", ts.name)
 		sql := ts.CreateSQL()
 		return []string{sql}


### PR DESCRIPTION
automatically split opslog table, so as to delete obsolete event logs

**这个 PR 实现什么功能/修复什么问题**:
实现：将操作日志等日志表自动分隔为多个表，方便清理日志

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area util
/cc @yousong @zexi @wanyaoqi @ioito 