### PR TITLE
Automated cherry pick of #9176: fix(scheduler): select resource unordered

### DIFF
--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -477,11 +477,19 @@ func (p *BaseSchedtagPredicate) OnSelectEnd(sp ISchedtagPredicateInstance, u *co
 	inputRes := p.GetInputResourcesMap(c.IndexKey())
 	output := u.GetAllocatedResource(c.IndexKey())
 	inputs := sp.GetInputs(u)
-	for idx, res := range inputRes {
+
+	idxKeys := []int{}
+	// inputRes is unorder map, sorted it
+	for idx := range inputRes {
+		idxKeys = append(idxKeys, idx)
+	}
+	sort.Ints(idxKeys)
+
+	for idx := range idxKeys {
+		res := inputRes[idx]
 		selRes := p.selectResource(sp, c, inputs[idx], res)
 		sortRes := newSortCandidateResource(sp, selRes)
 		sort.Sort(sortRes)
-		//log.Debugf("sort result: %s", sortRes.DebugString())
 		sp.AddSelectResult(idx, inputs[idx], sortRes.res, output)
 	}
 }


### PR DESCRIPTION
Cherry pick of #9176 on release/3.5.

#9176: fix(scheduler): select resource unordered