### PR TITLE
fix(region): inspect invalid guest template

### DIFF
--- a/pkg/compute/models/guest_template.go
+++ b/pkg/compute/models/guest_template.go
@@ -791,6 +791,7 @@ func (gt *SGuestTemplate) inspect(ctx context.Context, userCred mcclient.TokenCr
 	_, err := GuestTemplateManager.validateContent(ctx, userCred, gt.GetOwnerId(), jsonutils.NewDict(), gt.Content.(*jsonutils.JSONDict))
 	if err == nil {
 		gt.updateCheckTime()
+		gt.SetStatus(userCred, computeapis.GT_READY, "inspect successfully")
 		logclient.AddSimpleActionLog(gt, logclient.ACT_HEALTH_CHECK, "", userCred, true)
 		return nil
 	}
@@ -804,7 +805,7 @@ func (gt *SGuestTemplate) inspect(ctx context.Context, userCred mcclient.TokenCr
 
 func (gm *SGuestTemplateManager) InspectAllTemplate(ctx context.Context, userCred mcclient.TokenCredential, isStart bool) {
 	lastCheckTime := time.Now().Add(time.Duration(-options.Options.GuestTemplateCheckInterval) * time.Hour)
-	q := gm.Query().Equals("status", computeapis.GT_READY)
+	q := gm.Query()
 	q = q.Filter(sqlchemy.OR(sqlchemy.IsNull(q.Field("last_check_time")), sqlchemy.LE(q.Field("last_check_time"),
 		lastCheckTime)))
 	gts := make([]SGuestTemplate, 0, 10)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

The glance service hangs and other external reasons may cause the guest template to be judged as invalid.
Therefore, health inspection should be performed on time for invalid guest templates.

- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6
- release/3.5
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @swordqiu @zexi

