### PR TITLE
fix(region): remove default value of diskConfig.Medium

### DIFF
--- a/pkg/cloudcommon/cmdline/helper_test.go
+++ b/pkg/cloudcommon/cmdline/helper_test.go
@@ -49,7 +49,6 @@ func TestFetchServerConfigsByJSON(t *testing.T) {
 						Index:   0,
 						SizeMb:  1024,
 						ImageId: "centos",
-						Medium:  "hybrid",
 					},
 				},
 				Networks: []*compute.NetworkConfig{

--- a/pkg/cloudcommon/cmdline/parser.go
+++ b/pkg/cloudcommon/cmdline/parser.go
@@ -88,7 +88,7 @@ func ParseDiskConfig(diskStr string, idx int) (*compute.DiskConfig, error) {
 
 	// default backend and medium type
 	diskConfig.Backend = "" // STORAGE_LOCAL
-	diskConfig.Medium = compute.DISK_TYPE_HYBRID
+	diskConfig.Medium = ""
 
 	parts := strings.Split(diskStr, ":")
 	for _, p := range parts {

--- a/pkg/cloudcommon/cmdline/parser_test.go
+++ b/pkg/cloudcommon/cmdline/parser_test.go
@@ -164,7 +164,6 @@ func TestFetchDiskConfigsByJSON(t *testing.T) {
 					Index:      0,
 					SizeMb:     10 * 1024,
 					Mountpoint: "/data1",
-					Medium:     compute.DISK_TYPE_HYBRID,
 				},
 				{
 					Index:  1,


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
在 #8830 中，对调度器增加了通过请求磁盘的介质类型过滤存储的功能。

如果使用 climc 创建虚拟机且不要求磁盘有固定的介质类型，将
只能分配到 hybrid 的存储；进一步，如果没有 hybrid 的存储，将会调度失败。

- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6
- release/3.5
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @yousong @zexi
