### PR TITLE
fix(git,make): 修正 gitbranch 变量的获取方式，解决自动升级版本 tag 不统一的问题

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILD_SCRIPT := $(ROOT_DIR)/build/build.sh
 
 ifeq ($(ONECLOUD_CI_BUILD),)
 	GIT_COMMIT := $(shell git rev-parse --short HEAD)
-	GIT_BRANCH := $(shell git name-rev --name-only HEAD)
+	GIT_BRANCH := $(shell git branch -r --contains |head -1| xargs| sed -E -e "s%(origin|upstream)/?%%g")
 	GIT_VERSION := $(shell git describe --always --tags --abbrev=14 $(GIT_COMMIT)^{commit})
 	GIT_TREE_STATE := $(shell s=`git status --porcelain 2>/dev/null`; if [ -z "$$s" ]; then echo "clean"; else echo "dirty"; fi)
 	BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -45,7 +45,6 @@ build_bin() {
     local BUILD_CGO=$3
     case "$1" in
         baremetal-agent)
-        echo GOOS=linux make cmd/$1
             GOOS=linux make cmd/$1
             ;;
         climc)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

- 修正 gitbranch 变量的获取方式，解决自动升级版本 tag 不统一的问题

**是否需要 backport 到之前的 release 分支**:

- release/3.4
- release/3.5
- release/3.6