### PR TITLE
Automated cherry pick of #9230: fix(git,make): 修正 gitbranch 变量的获取方式，允许外部传入，解决自动升级版本 tag 不统一的问题

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILD_SCRIPT := $(ROOT_DIR)/build/build.sh
 
 ifeq ($(ONECLOUD_CI_BUILD),)
 	GIT_COMMIT := $(shell git rev-parse --short HEAD)
-	GIT_BRANCH := $(shell git name-rev --name-only HEAD)
+	GIT_BRANCH ?= $(shell git name-rev --name-only HEAD)
 	GIT_VERSION := $(shell git describe --always --tags --abbrev=14 $(GIT_COMMIT)^{commit})
 	GIT_TREE_STATE := $(shell s=`git status --porcelain 2>/dev/null`; if [ -z "$$s" ]; then echo "clean"; else echo "dirty"; fi)
 	BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -43,23 +43,24 @@ build_bin() {
     local BUILD_CGO=$4
     case "$1" in
         baremetal-agent)
-            GOOS=linux make cmd/$1
+        echo GOOS=linux GIT_BRANCH=$TAG GIT_BRANCH=$TAG make cmd/$1
+            GOOS=linux GIT_BRANCH=$TAG make cmd/$1
             ;;
         climc)
             docker run --rm \
                 -v $SRC_DIR:/root/go/src/yunion.io/x/onecloud \
                 -v $SRC_DIR/_output/alpine-build:/root/go/src/yunion.io/x/onecloud/_output \
                 -v $SRC_DIR/_output/alpine-build/_cache:/root/.cache \
-                registry.cn-beijing.aliyuncs.com/yunionio/alpine-build:1.0-3 \
-                /bin/sh -c "set -ex; cd /root/go/src/yunion.io/x/onecloud; $BUILD_ARCH $BUILD_CC $BUILD_CGO GOOS=linux make cmd/$1 cmd/*cli; chown -R $(id -u):$(id -g) _output"
+                registry.cn-beijing.aliyuncs.com/yunionio/alpine-build:1.0-5 \
+                /bin/sh -c "set -ex; cd /root/go/src/yunion.io/x/onecloud; $BUILD_ARCH $BUILD_CGO GOOS=linux GIT_BRANCH=$TAG make cmd/$1 cmd/*cli; chown -R $(id -u):$(id -g) _output"
             ;;
         *)
             docker run --rm \
                 -v $SRC_DIR:/root/go/src/yunion.io/x/onecloud \
                 -v $SRC_DIR/_output/alpine-build:/root/go/src/yunion.io/x/onecloud/_output \
                 -v $SRC_DIR/_output/alpine-build/_cache:/root/.cache \
-                registry.cn-beijing.aliyuncs.com/yunionio/alpine-build:1.0-3 \
-                /bin/sh -c "set -ex; cd /root/go/src/yunion.io/x/onecloud; $BUILD_ARCH $BUILD_CC $BUILD_CGO GOOS=linux make cmd/$1; chown -R $(id -u):$(id -g) _output"
+                registry.cn-beijing.aliyuncs.com/yunionio/alpine-build:1.0-5 \
+                /bin/sh -c "set -ex; cd /root/go/src/yunion.io/x/onecloud; $BUILD_ARCH $BUILD_CGO GOOS=linux GIT_BRANCH=$TAG make cmd/$1; chown -R $(id -u):$(id -g) _output"
             ;;
     esac
 }


### PR DESCRIPTION
Cherry pick of #9230 on release/3.4.

#9230: fix(git,make): 修正 gitbranch 变量的获取方式，允许外部传入，解决自动升级版本 tag 不统一的问题