### PR TITLE
feat(notify): add webconsole in enabled contact types

### DIFF
--- a/pkg/notify/models/config.go
+++ b/pkg/notify/models/config.go
@@ -175,7 +175,7 @@ func (cm *SConfigManager) PerformGetTypes(ctx context.Context, userCred mcclient
 }
 
 var sortedCTypes = []string{
-	api.EMAIL, api.MOBILE, api.DINGTALK, api.FEISHU, api.WORKWX, api.DINGTALK_ROBOT, api.FEISHU_ROBOT, api.WORKWX_ROBOT,
+	api.WEBCONSOLE, api.EMAIL, api.MOBILE, api.DINGTALK, api.FEISHU, api.WORKWX, api.DINGTALK_ROBOT, api.FEISHU_ROBOT, api.WORKWX_ROBOT,
 }
 
 func sortContactType(ctypes []string) []string {

--- a/pkg/notify/models/receiver.go
+++ b/pkg/notify/models/receiver.go
@@ -286,9 +286,6 @@ func (r *SReceiver) IsEnabledContactType(ct string) (bool, error) {
 	if utils.IsInStringArray(ct, AllOkContactTypes) {
 		return true, nil
 	}
-	if ct == api.WEBCONSOLE {
-		return true, nil
-	}
 	cts, err := r.GetEnabledContactTypes()
 	if err != nil {
 		return false, errors.Wrap(err, "GetEnabledContactTypes")
@@ -324,6 +321,7 @@ func (r *SReceiver) GetEnabledContactTypes() ([]string, error) {
 			ret = append(ret, subct)
 		}
 	}
+	ret = append(ret, api.WEBCONSOLE)
 	return ret, nil
 }
 
@@ -435,6 +433,10 @@ func (r *SReceiver) getVerifiedInfos() ([]api.VerifiedInfo, error) {
 		{
 			ContactType: api.MOBILE,
 			Verified:    r.VerifiedMobile.Bool(),
+		},
+		{
+			ContactType: api.WEBCONSOLE,
+			Verified:    true,
 		},
 	}
 	for subct, subc := range r.subContactCache {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

webconsole 将被翻译为站内信，在每个 receiver 的 enabled contact types 中默认加入。

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6
- release/3.5

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area notify
/cc @zexi
