### PR TITLE
fix(keystone): oidc driver turn on debug mode if log-level is debug

### DIFF
--- a/pkg/keystone/driver/oidc/oidc.go
+++ b/pkg/keystone/driver/oidc/oidc.go
@@ -26,6 +26,7 @@ import (
 	api "yunion.io/x/onecloud/pkg/apis/identity"
 	"yunion.io/x/onecloud/pkg/keystone/driver"
 	"yunion.io/x/onecloud/pkg/keystone/models"
+	"yunion.io/x/onecloud/pkg/keystone/options"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/util/oidcutils"
 	"yunion.io/x/onecloud/pkg/util/oidcutils/client"
@@ -47,9 +48,13 @@ func NewOIDCDriver(idpId, idpName, template, targetDomainId string, conf api.TCo
 	if err != nil {
 		return nil, errors.Wrap(err, "NewBaseIdentityDriver")
 	}
+	isDebug := false
+	if options.Options.LogLevel == "debug" {
+		isDebug = true
+	}
 	drv := SOIDCDriver{
 		SBaseIdentityDriver: base,
-		isDebug:             false,
+		isDebug:             isDebug,
 	}
 	drv.SetVirtualObject(&drv)
 	err = drv.prepareConfig()


### PR DESCRIPTION
oidc driver turn on debug mode if log-level is debug

**这个 PR 实现什么功能/修复什么问题**:
修正：当打开debug日志时，打开oidc驱动的debug模式

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.5
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area keystone