### PR TITLE
fix(keystone): rolepolicies list panic if filter by domain scope

### DIFF
--- a/pkg/keystone/models/rolepolicies.go
+++ b/pkg/keystone/models/rolepolicies.go
@@ -167,7 +167,11 @@ func (manager *SRolePolicyManager) NamespaceScope() rbacutils.TRbacScope {
 }
 
 func (manager *SRolePolicyManager) FilterByOwner(q *sqlchemy.SQuery, owner mcclient.IIdentityProvider, scope rbacutils.TRbacScope) *sqlchemy.SQuery {
-	return PolicyManager.FilterByOwner(q, owner, scope)
+	policyQ := PolicyManager.Query()
+	policyQ = PolicyManager.FilterByOwner(policyQ, owner, scope)
+	subq := policyQ.SubQuery()
+	q = q.Join(subq, sqlchemy.Equals(q.Field("policy_id"), subq.Field("id")))
+	return q
 }
 
 func (manager *SRolePolicyManager) ListItemFilter(


### PR DESCRIPTION
rolepolicies list panic if filter by scope=domain

**这个 PR 实现什么功能/修复什么问题**:
修正：rolepolicies列表在域视图下panic

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area keystone