### PR TITLE
Automated cherry pick of #9230: fix(git,make): 修正 gitbranch 变量的获取方式，解决自动升级版本 tag 不统一的问题

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILD_SCRIPT := $(ROOT_DIR)/build/build.sh
 
 ifeq ($(ONECLOUD_CI_BUILD),)
 	GIT_COMMIT := $(shell git rev-parse --short HEAD)
-	GIT_BRANCH := $(shell git name-rev --name-only HEAD)
+	GIT_BRANCH := $(shell git branch -r --contains |head -1| xargs| sed -E -e "s%(origin|upstream)/?%%g")
 	GIT_VERSION := $(shell git describe --always --tags --abbrev=14 $(GIT_COMMIT)^{commit})
 	GIT_TREE_STATE := $(shell s=`git status --porcelain 2>/dev/null`; if [ -z "$$s" ]; then echo "clean"; else echo "dirty"; fi)
 	BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')


### PR DESCRIPTION
Cherry pick of #9230 on release/3.5.

#9230: fix(git,make): 修正 gitbranch 变量的获取方式，允许外部传入，解决自动升级版本 tag 不统一的问题