### PR TITLE
Automated cherry pick of #9315: fix(host): check lease living on restart etcd session

### DIFF
--- a/pkg/cloudcommon/etcd/etcd.go
+++ b/pkg/cloudcommon/etcd/etcd.go
@@ -143,6 +143,10 @@ func (cli *SEtcdClient) GetClient() *clientv3.Client {
 	return cli.client
 }
 
+func (cli *SEtcdClient) SessionLiving() bool {
+	return cli.leaseLiving
+}
+
 func (cli *SEtcdClient) startSession() error {
 	ctx := context.TODO()
 

--- a/pkg/hostman/host_health/etcd.go
+++ b/pkg/hostman/host_health/etcd.go
@@ -112,8 +112,11 @@ func (c *SEtcdClient) OnKeepaliveFailure() {
 }
 
 func (c *SEtcdClient) Reconnect() {
+	if c.cli.SessionLiving() {
+		return
+	}
 	for {
-		if err := c.cli.RestartSession(); err != nil {
+		if err := c.cli.RestartSession(); err != nil && !c.cli.SessionLiving() {
 			log.Errorf("restart session failed %s", err)
 			time.Sleep(1 * time.Second)
 		} else {


### PR DESCRIPTION
Cherry pick of #9315 on release/3.6.

#9315: fix(host): check lease living on restart etcd session