### PR TITLE
Try to repull contacts when changing notify config

### DIFF
--- a/pkg/notify/models/config.go
+++ b/pkg/notify/models/config.go
@@ -111,6 +111,10 @@ func (c *SConfig) ValidateUpdateData(ctx context.Context, userCred mcclient.Toke
 	if err != nil {
 		return input, err
 	}
+	// check if changed
+	if c.Content.Equals(input.Content) {
+		return input, nil
+	}
 	isValid, message, err := NotifyService.ValidateConfig(ctx, c.Type, configs)
 	if err != nil {
 		if errors.Cause(err) == errors.ErrNotImplemented {

--- a/pkg/notify/models/receiver.go
+++ b/pkg/notify/models/receiver.go
@@ -631,11 +631,9 @@ func (r *SReceiver) PostCreate(ctx context.Context, userCred mcclient.TokenCrede
 	// set status
 	r.SetStatus(userCred, api.RECEIVER_STATUS_PULLING, "")
 	logclient.AddActionLogWithContext(ctx, r, logclient.ACT_CREATE, nil, userCred, true)
-	task, err := taskman.TaskManager.NewTask(ctx, "SubcontactPullTask", r, userCred, nil, "", "")
+	err := r.StartSubcontactPullTask(ctx, userCred, nil, "")
 	if err != nil {
-		log.Errorf("ContactPullTask newTask error %v", err)
-	} else {
-		task.ScheduleRun(nil)
+		log.Errorf("unable to StartSubcontactPullTask: %v", err)
 	}
 }
 
@@ -729,12 +727,20 @@ func (r *SReceiver) PostUpdate(ctx context.Context, userCred mcclient.TokenCrede
 	// set status
 	r.SetStatus(userCred, api.RECEIVER_STATUS_PULLING, "")
 	logclient.AddActionLogWithContext(ctx, r, logclient.ACT_UPDATE, nil, userCred, true)
-	task, err := taskman.TaskManager.NewTask(ctx, "SubcontactPullTask", r, userCred, nil, "", "")
+	err := r.StartSubcontactPullTask(ctx, userCred, nil, "")
 	if err != nil {
-		log.Errorf("ContactPullTask newTask error %v", err)
-	} else {
-		task.ScheduleRun(nil)
+		log.Errorf("unable to StartSubcontactPullTask: %v", err)
 	}
+
+}
+
+func (r *SReceiver) StartSubcontactPullTask(ctx context.Context, userCred mcclient.TokenCredential, params *jsonutils.JSONDict, parentTaskId string) error {
+	task, err := taskman.TaskManager.NewTask(ctx, "SubcontactPullTask", r, userCred, params, parentTaskId, "")
+	if err != nil {
+		return err
+	}
+	task.ScheduleRun(nil)
+	return nil
 }
 
 func (r *SReceiver) Delete(ctx context.Context, userCred mcclient.TokenCredential) error {
@@ -770,13 +776,7 @@ func (r *SReceiver) PerformTriggerVerify(ctx context.Context, userCred mcclient.
 		r.SetStatus(userCred, api.RECEIVER_STATUS_PULLING, "")
 		params := jsonutils.NewDict()
 		params.Set("contact_types", jsonutils.NewArray(jsonutils.NewString(input.ContactType)))
-		task, err := taskman.TaskManager.NewTask(ctx, "SubcontactPullTask", r, userCred, params, "", "")
-		if err != nil {
-			log.Errorf("ContactPullTask newTask error %v", err)
-		} else {
-			task.ScheduleRun(nil)
-		}
-		return nil, nil
+		return nil, r.StartSubcontactPullTask(ctx, userCred, params, "")
 	}
 	_, err := VerificationManager.Create(ctx, r.Id, input.ContactType)
 	if err == ErrVerifyFrequently {

--- a/pkg/notify/tasks/repull_subcontact_task.go
+++ b/pkg/notify/tasks/repull_subcontact_task.go
@@ -1,0 +1,113 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/util/sets"
+	"yunion.io/x/pkg/utils"
+	"yunion.io/x/sqlchemy"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
+	"yunion.io/x/onecloud/pkg/notify/models"
+	"yunion.io/x/onecloud/pkg/util/logclient"
+)
+
+type RepullSuncontactTask struct {
+	taskman.STask
+}
+
+func init() {
+	taskman.RegisterTask(RepullSuncontactTask{})
+}
+
+func (self *RepullSuncontactTask) taskFailed(ctx context.Context, config *models.SConfig, reason string) {
+	logclient.AddActionLogWithContext(ctx, config, logclient.ACT_PULL_SUBCONTACT, reason, self.UserCred, false)
+	self.SetStageFailed(ctx, jsonutils.NewString(reason))
+}
+
+type repullFailedReason struct {
+	ReceiverId string
+	Reason     string
+}
+
+func (s repullFailedReason) String() string {
+	return fmt.Sprintf("receiver %q: %s", s.ReceiverId, s.Reason)
+}
+
+func (self *RepullSuncontactTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
+	config := obj.(*models.SConfig)
+	if !utils.IsInStringArray(config.Type, PullContactType) {
+		self.SetStageComplete(ctx, nil)
+		return
+	}
+	subq := models.SubContactManager.Query("receiver_id").Equals("type", config.Type).SubQuery()
+	q := models.ReceiverManager.Query()
+	q.Join(subq, sqlchemy.Equals(q.Field("id"), subq.Field("receiver_id")))
+	rs := make([]models.SReceiver, 0)
+	err := db.FetchModelObjects(models.ReceiverManager, q, &rs)
+	if err != nil {
+		self.taskFailed(ctx, config, fmt.Sprintf("unable to FetchModelObjects: %v", err))
+		return
+	}
+
+	var reasons []string
+	for i := range rs {
+		r := &rs[i]
+		lockman.LockObject(ctx, r)
+		// unverify
+		cts, err := r.GetVerifiedContactTypes()
+		if err != nil {
+			reasons = append(reasons, repullFailedReason{
+				ReceiverId: r.Id,
+				Reason:     fmt.Sprintf("unable to GetVerifiedContactTypes: %v", err),
+			}.String())
+		}
+		ctSets := sets.NewString(cts...)
+		if !ctSets.Has(config.Type) {
+			continue
+		}
+		ctSets.Delete(config.Type)
+		err = r.SetVerifiedContactTypes(ctSets.UnsortedList())
+		if err != nil {
+			reasons = append(reasons, repullFailedReason{
+				ReceiverId: r.Id,
+				Reason:     fmt.Sprintf("unable to SetVerifiedContactTypes: %v", err),
+			}.String())
+		}
+		// pull
+		params := jsonutils.NewDict()
+		params.Set("contact_types", jsonutils.NewArray(jsonutils.NewString(config.Type)))
+		err = r.StartSubcontactPullTask(ctx, self.UserCred, params, self.Id)
+		if err != nil {
+			reasons = append(reasons, repullFailedReason{
+				ReceiverId: r.Id,
+				Reason:     fmt.Sprintf("unable to StartSubcontactPullTask: %v", err),
+			}.String())
+		}
+		lockman.ReleaseObject(ctx, r)
+	}
+	if len(reasons) > 0 {
+		self.taskFailed(ctx, config, strings.Join(reasons, "; "))
+		return
+	}
+	self.SetStageComplete(ctx, nil)
+}

--- a/pkg/util/logclient/consts.go
+++ b/pkg/util/logclient/consts.go
@@ -184,6 +184,7 @@ const (
 	ACT_PULL_SUBCONTACT   = "pull_subcontact"
 	ACT_SEND_NOTIFICATION = "send_notification"
 	ACT_SEND_VERIFICATION = "send_verification"
+	ACT_REPULL_SUBCONTACT = "repull_subcontact"
 
 	ACT_SYNC_VPCS        = "sync_vpcs"
 	ACT_SYNC_RECORD_SETS = "sync_record_sets"


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

- refactor(notify): add StartSubcontactPullTask for receiver
- fix(notify): check for changes before updating config
- fix(notify): repull subcontact after changing config



- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6
- release/3.5
- release/3.4
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area notify
/cc @zexi
