### PR TITLE
Automated cherry pick of #9347: fix(cloudcommon): perform public should check the sharing scope of

### DIFF
--- a/pkg/cloudcommon/db/sharablebase.go
+++ b/pkg/cloudcommon/db/sharablebase.go
@@ -472,6 +472,10 @@ func SharablePerformPublic(model ISharableBaseModel, ctx context.Context, userCr
 	if targetScope.HigherThan(allowScope) {
 		return errors.Wrapf(httperrors.ErrNotSufficientPrivilege, "require %s allow %s", targetScope, allowScope)
 	}
+	requireScope := model.GetPublicScope()
+	if requireScope.HigherThan(allowScope) {
+		return errors.Wrapf(httperrors.ErrNotSufficientPrivilege, "require %s allow %s", requireScope, allowScope)
+	}
 
 	_, err = Update(model, func() error {
 		model.SetShare(targetScope)


### PR DESCRIPTION
Cherry pick of #9347 on release/3.5.

#9347: fix(cloudcommon): perform public should check the sharing scope of