### PR TITLE
Bugfix/scheduler SKU net

### DIFF
--- a/pkg/scheduler/algorithm/predicates/sku_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/sku_predicate.go
@@ -45,13 +45,25 @@ func (p *InstanceTypePredicate) Execute(u *core.Unit, c core.Candidater) (bool, 
 
 	d := u.SchedData()
 
+	regionId := c.Getter().Region().Id
+	regionName := c.Getter().Region().Name
 	zoneId := c.Getter().Zone().Id
 	zoneName := c.Getter().Zone().Name
 	instanceType := d.InstanceType
 
-	sku := skuman.GetByZone(instanceType, zoneId)
-	if sku == nil {
-		h.Exclude(fmt.Sprintf("Not found server sku %s at zone %s", instanceType, zoneName))
+	reqRegion := d.PreferRegion
+	reqZone := d.PreferZone
+
+	if reqRegion != "" && reqZone == "" {
+		sku := skuman.GetByRegion(instanceType, regionId)
+		if sku == nil {
+			h.Exclude(fmt.Sprintf("Not found server sku %s at region %s", instanceType, regionName))
+		}
+	} else {
+		sku := skuman.GetByZone(instanceType, zoneId)
+		if sku == nil {
+			h.Exclude(fmt.Sprintf("Not found server sku %s at zone %s", instanceType, zoneName))
+		}
 	}
 
 	return h.GetResult()

--- a/pkg/scheduler/cache/candidate/base.go
+++ b/pkg/scheduler/cache/candidate/base.go
@@ -281,8 +281,11 @@ func newBaseHostDesc(b *baseBuilder, host *computemodels.SHost) (*BaseHostDesc, 
 	if err := desc.fillNetworks(host); err != nil {
 		return nil, fmt.Errorf("Fill networks error: %v", err)
 	}
-	if err := desc.fillOnecloudVpcNetworks(); err != nil {
-		return nil, fmt.Errorf("Fill onecloud vpc networks error: %v", err)
+	// only onecloud host should fill onecloud vpc networks
+	if host.HostType == computeapi.HOST_TYPE_HYPERVISOR {
+		if err := desc.fillOnecloudVpcNetworks(); err != nil {
+			return nil, fmt.Errorf("Fill onecloud vpc networks error: %v", err)
+		}
 	}
 
 	if err := desc.fillZone(host); err != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1. 调度器根据 sku 过滤 host, 如果没有指定 zone ，则按 region 匹配
2. 只给 onecloud 的宿主机 fill onecloud vpc networks

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
- 3.4
/area scheduler
/cc @ioito @swordqiu @yousong 