### PR TITLE
fix(keystone): ignore service config update without changes

### DIFF
--- a/pkg/keystone/models/identity_provider.go
+++ b/pkg/keystone/models/identity_provider.go
@@ -342,12 +342,14 @@ func (ident *SIdentityProvider) PerformConfig(ctx context.Context, userCred mccl
 
 	opts := input.Config
 	action := input.Action
-	err = saveConfigs(userCred, action, ident, opts, nil, nil, api.SensitiveDomainConfigMap)
+	changed, err := saveConfigs(userCred, action, ident, opts, nil, nil, api.SensitiveDomainConfigMap)
 	if err != nil {
 		return nil, httperrors.NewInternalServerError("saveConfig fail %s", err)
 	}
-	ident.MarkDisconnected(ctx, userCred, fmt.Errorf("change config"))
-	submitIdpSyncTask(ctx, userCred, ident)
+	if changed {
+		ident.MarkDisconnected(ctx, userCred, fmt.Errorf("change config"))
+		submitIdpSyncTask(ctx, userCred, ident)
+	}
 	return ident.GetDetailsConfig(ctx, userCred, query)
 }
 
@@ -494,7 +496,7 @@ func (ident *SIdentityProvider) PostCreate(ctx context.Context, userCred mcclien
 		log.Errorf("parse config error %s", err)
 		return
 	}
-	err = saveConfigs(userCred, "", ident, opts, nil, nil, api.SensitiveDomainConfigMap)
+	_, err = saveConfigs(userCred, "", ident, opts, nil, nil, api.SensitiveDomainConfigMap)
 	if err != nil {
 		log.Errorf("saveConfig fail %s", err)
 		return


### PR DESCRIPTION
ignore service config updates that no changes happen. prevent service
config change infomrer messages from flushing the log.

**这个 PR 实现什么功能/修复什么问题**:
修正：忽略未更改服务配置的更新，避免过多的common服务配置更新日志

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6
- release/3.5
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area keystone
/cc @zexi 