### PR TITLE
feat(region): wait status 'ready' when stop vmware vm

### DIFF
--- a/pkg/compute/guestdrivers/esxi.go
+++ b/pkg/compute/guestdrivers/esxi.go
@@ -706,3 +706,26 @@ func (self *SESXiGuestDriver) StartDeleteGuestTask(ctx context.Context, userCred
 	params.Add(jsonutils.JSONTrue, "delete_snapshots")
 	return self.SBaseGuestDriver.StartDeleteGuestTask(ctx, userCred, guest, params, parentTaskId)
 }
+
+func (self *SESXiGuestDriver) RequestStopOnHost(ctx context.Context, guest *models.SGuest, host *models.SHost, task taskman.ITask) error {
+	taskman.LocalTaskRun(task, func() (jsonutils.JSONObject, error) {
+		ihost, err := host.GetIHost()
+		if err != nil {
+			return nil, errors.Wrapf(err, "host.GetIHost")
+		}
+		ivm, err := ihost.GetIVMById(guest.ExternalId)
+		if err != nil {
+			return nil, errors.Wrapf(err, "ihost.GetIVMById")
+		}
+		opts := &cloudprovider.ServerStopOptions{}
+		task.GetParams().Unmarshal(&opts)
+
+		err = ivm.StopVM(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		err = cloudprovider.WaitStatus(ivm, api.VM_READY, 2*time.Second, time.Second)
+		return nil, err
+	})
+	return nil
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
There are two ways to shut down virtual machine of VMware, namely shutting down the operating system and shutting down the power directly.
The first way does not have a wait mechanism, so it is possible to sync status when the machine has not been shut down. 
So this commit actively increases the wait mechanism

- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6
- release/3.5
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area region
/cc @swordqiu @ioito 