### PR TITLE
fix(region): network reserved ip count not consider expiration of reserved ips

### DIFF
--- a/pkg/compute/models/reservedips.go
+++ b/pkg/compute/models/reservedips.go
@@ -244,10 +244,7 @@ func (manager *SReservedipManager) ListItemFilter(
 	}
 
 	if query.All == nil || *query.All == false {
-		q = q.Filter(sqlchemy.OR(
-			sqlchemy.IsNullOrEmpty(q.Field("expired_at")),
-			sqlchemy.GT(q.Field("expired_at"), time.Now().UTC()),
-		))
+		q = filterExpiredReservedIps(q)
 	}
 
 	if len(query.IpAddr) > 0 {
@@ -258,6 +255,13 @@ func (manager *SReservedipManager) ListItemFilter(
 	}
 
 	return q, nil
+}
+
+func filterExpiredReservedIps(q *sqlchemy.SQuery) *sqlchemy.SQuery {
+	return q.Filter(sqlchemy.OR(
+		sqlchemy.IsNullOrEmpty(q.Field("expired_at")),
+		sqlchemy.GT(q.Field("expired_at"), time.Now().UTC()),
+	))
 }
 
 func (manager *SReservedipManager) OrderByExtraFields(


### PR DESCRIPTION
network reserved ip count not consider expiration of reserved ips

**这个 PR 实现什么功能/修复什么问题**:
修正：预留IP有自动过期的预留IP，网络预留IP的计算未考虑这种情况

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.5
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area region
