### PR TITLE
fix(keystone): update user attributes whenever user login

### DIFF
--- a/pkg/keystone/models/identity_provider.go
+++ b/pkg/keystone/models/identity_provider.go
@@ -1234,13 +1234,13 @@ func (idp *SIdentityProvider) TryUserJoinProject(attrConf api.SIdpAttributeOptio
 	}
 	// update user attributes
 	_, err := db.Update(usr, func() error {
-		if v, ok := attrs[attrConf.UserDisplaynameAttribtue]; ok && len(v) > 0 && len(v[0]) > 0 && len(usr.Displayname) == 0 {
+		if v, ok := attrs[attrConf.UserDisplaynameAttribtue]; ok && len(v) > 0 && len(v[0]) > 0 && usr.Displayname != v[0] {
 			usr.Displayname = v[0]
 		}
-		if v, ok := attrs[attrConf.UserEmailAttribute]; ok && len(v) > 0 && len(v[0]) > 0 && len(usr.Email) == 0 {
+		if v, ok := attrs[attrConf.UserEmailAttribute]; ok && len(v) > 0 && len(v[0]) > 0 && usr.Email != v[0] {
 			usr.Email = v[0]
 		}
-		if v, ok := attrs[attrConf.UserMobileAttribute]; ok && len(v) > 0 && len(v[0]) > 0 && len(usr.Mobile) == 0 {
+		if v, ok := attrs[attrConf.UserMobileAttribute]; ok && len(v) > 0 && len(v[0]) > 0 && usr.Mobile != v[0] {
 			usr.Mobile = v[0]
 		}
 		return nil


### PR DESCRIPTION
update user attribtues whenever user login

**这个 PR 实现什么功能/修复什么问题**:
修正：keystone当用户登入时，如果用户属性变化则修改

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.5
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area keystone