### PR TITLE
Automated cherry pick of #9426: fix(vpcagent): ovn: stable dns A record value

### DIFF
--- a/pkg/vpcagent/ovn/keeper.go
+++ b/pkg/vpcagent/ovn/keeper.go
@@ -664,6 +664,7 @@ func (keeper *OVNNorthboundKeeper) ClaimVpcGuestDnsRecords(ctx context.Context, 
 			ocVersion = fmt.Sprintf("%s.%d", vpc.Id, vpc.UpdateVersion)
 		)
 		for name, addrs := range grs {
+			sort.Strings(addrs)
 			grs_[name] = strings.Join(addrs, " ")
 		}
 		dns := &ovn_nb.DNS{


### PR DESCRIPTION
Cherry pick of #9426 on release/3.6.

#9426: fix(vpcagent): ovn: stable dns A record value