### PR TITLE
Automated cherry pick of #9426: fix(vpcagent): ovn: stable dns A record value

### DIFF
--- a/pkg/vpcagent/ovn/keeper.go
+++ b/pkg/vpcagent/ovn/keeper.go
@@ -17,6 +17,7 @@ package ovn
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"yunion.io/x/log"
@@ -654,6 +655,7 @@ func (keeper *OVNNorthboundKeeper) ClaimVpcGuestDnsRecords(ctx context.Context, 
 			ocVersion = fmt.Sprintf("%s.%d", vpc.Id, vpc.UpdateVersion)
 		)
 		for name, addrs := range grs {
+			sort.Strings(addrs)
 			grs_[name] = strings.Join(addrs, " ")
 		}
 		dns := &ovn_nb.DNS{


### PR DESCRIPTION
Cherry pick of #9426 on release/3.3.

#9426: fix(vpcagent): ovn: stable dns A record value