### PR TITLE
fix(log): fail to submit action log

### DIFF
--- a/pkg/util/splitable/update.go
+++ b/pkg/util/splitable/update.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (t *SSplitTableSpec) InsertOrUpdate(dt interface{}) error {
-	return errors.ErrNotSupported
+	return t.Insert(dt)
 }
 
 func (t *SSplitTableSpec) Update(dt interface{}, onUpdate func() error) (sqlchemy.UpdateDiffs, error) {


### PR DESCRIPTION
Because splitable not implement InsertOrMethod method, fail to submit
action log

**这个 PR 实现什么功能/修复什么问题**:
修正：因为未实现InsertOrUpdate方法，导致action log提交失败

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6


<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area logger
/cc @zexi 