### PR TITLE
fix(climc): use printObjectRecursive for PerformXxx calls

### DIFF
--- a/cmd/climc/shell/helper.go
+++ b/cmd/climc/shell/helper.go
@@ -325,7 +325,7 @@ func (cmd ResourceCmd) PerformWithKeyword(keyword, action string, args IPerformO
 		if err != nil {
 			return err
 		}
-		printObject(ret)
+		printObjectRecursive(ret)
 		return nil
 	}
 	cmd.Run(keyword, args, callback)
@@ -342,7 +342,7 @@ func (cmd ResourceCmd) PerformClassWithKeyword(keyword, action string, args IOpt
 		if err != nil {
 			return err
 		}
-		printObject(ret)
+		printObjectRecursive(ret)
 		return nil
 	}
 	cmd.Run(keyword, args, callback)
@@ -363,7 +363,7 @@ func (cmd ResourceCmd) PerformClass(action string, args IOpt) {
 		if err != nil {
 			return err
 		}
-		printObject(ret)
+		printObjectRecursive(ret)
 		return nil
 	}
 	cmd.Run(action, args, callback)


### PR DESCRIPTION

**这个 PR 实现什么功能/修复什么问题**:

```
Original

	+----------+-----------------------------------------------------------------------------------------------------+
	|  Field   |                                                Value                                                |
	+----------+-----------------------------------------------------------------------------------------------------+
	| forwards | [{"addr":"192.168.2.252","port":22,"proto":"tcp","proxy_addr":"10.168.222.196","proxy_port":33908}, |
	|          | {"addr":"192.168.2.252","port":22,"proto":"tcp","proxy_addr":"10.168.222.196","proxy_port":45490}]  |
	+----------+-----------------------------------------------------------------------------------------------------+

After

	+-----------------------+----------------+
	|         Field         |     Value      |
	+-----------------------+----------------+
	| forwards.0.addr       | 192.168.2.252  |
	| forwards.0.port       | 22             |
	| forwards.0.proto      | tcp            |
	| forwards.0.proxy_addr | 10.168.222.196 |
	| forwards.0.proxy_port | 33908          |
	| forwards.1.addr       | 192.168.2.252  |
	| forwards.1.port       | 22             |
	| forwards.1.proto      | tcp            |
	| forwards.1.proxy_addr | 10.168.222.196 |
	| forwards.1.proxy_port | 45490          |
	+-----------------------+----------------+
```

- [x] 冒烟测试

**是否需要 backport 到之前的 release 分支**:

NONE

/area climc
/cc @swordqiu @zexi @wanyaoqi 