### PR TITLE
fix(keystone): panic if request with an invalid token

### DIFF
--- a/pkg/cloudcommon/policy/policy.go
+++ b/pkg/cloudcommon/policy/policy.go
@@ -134,6 +134,9 @@ func getMaskedLoginIp(userCred mcclient.TokenCredential) string {
 }
 
 func policyKey(userCred mcclient.TokenCredential) string {
+	if userCred == nil || auth.IsGuestToken(userCred) {
+		return auth.GUEST_TOKEN
+	}
 	keys := []string{userCred.GetProjectId()}
 	roles := userCred.GetRoleIds()
 	if len(roles) > 0 {

--- a/pkg/mcclient/auth/middleware.go
+++ b/pkg/mcclient/auth/middleware.go
@@ -69,6 +69,7 @@ func AuthenticateWithDelayDecision(f appsrv.FilterHandler, delayDecision bool) a
 					httperrors.UnauthorizedError(ctx, w, "InvalidToken")
 					return
 				}
+				token = &GuestToken
 			}
 		}
 		ctx = context.WithValue(ctx, appctx.APP_CONTEXT_KEY_AUTH_TOKEN, token)


### PR DESCRIPTION
service report nil pointer panic if request with an invalid token string

**这个 PR 实现什么功能/修复什么问题**:
修正：当使用无效token访问服务时，报nil pointer panic

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area keystone