### PR TITLE
Automated cherry pick of #9452: fix(keystone): panic if request with an invalid token

### DIFF
--- a/pkg/cloudcommon/policy/policy.go
+++ b/pkg/cloudcommon/policy/policy.go
@@ -134,6 +134,9 @@ func getMaskedLoginIp(userCred mcclient.TokenCredential) string {
 }
 
 func policyKey(userCred mcclient.TokenCredential) string {
+	if userCred == nil || auth.IsGuestToken(userCred) {
+		return auth.GUEST_TOKEN
+	}
 	keys := []string{userCred.GetProjectId()}
 	roles := userCred.GetRoleIds()
 	if len(roles) > 0 {

--- a/pkg/mcclient/auth/middleware.go
+++ b/pkg/mcclient/auth/middleware.go
@@ -69,6 +69,7 @@ func AuthenticateWithDelayDecision(f appsrv.FilterHandler, delayDecision bool) a
 					httperrors.UnauthorizedError(ctx, w, "InvalidToken")
 					return
 				}
+				token = &GuestToken
 			}
 		}
 		ctx = context.WithValue(ctx, appctx.APP_CONTEXT_KEY_AUTH_TOKEN, token)


### PR DESCRIPTION
Cherry pick of #9452 on release/3.6.

#9452: fix(keystone): panic if request with an invalid token