### PR TITLE
fix(keystone): do not expand match any role policy

### DIFF
--- a/pkg/keystone/models/policies.go
+++ b/pkg/keystone/models/policies.go
@@ -132,7 +132,8 @@ func (manager *SPolicyManager) initializeRolePolicyGroup() error {
 		failed := false
 		if len(policy.Roles) == 0 && len(policy.Projects) == 0 {
 			// match any
-			roles, err := policies[i].fetchMatchableRoles()
+			// ignore this case
+			/* roles, err := policies[i].fetchMatchableRoles()
 			if err != nil {
 				log.Errorf("policy fetchMatchableRoles fail %s", err)
 				failed = true
@@ -144,7 +145,7 @@ func (manager *SPolicyManager) initializeRolePolicyGroup() error {
 						failed = true
 					}
 				}
-			}
+			} */
 		} else if len(policy.Roles) > 0 && len(policy.Projects) == 0 {
 			for _, r := range policy.Roles {
 				role, err := RoleManager.FetchRoleByName(r, policies[i].DomainId, "")
@@ -159,7 +160,8 @@ func (manager *SPolicyManager) initializeRolePolicyGroup() error {
 				}
 			}
 		} else if len(policy.Roles) == 0 && len(policy.Projects) > 0 {
-			for _, p := range policy.Projects {
+			// ignore this case
+			/* for _, p := range policy.Projects {
 				project, err := ProjectManager.FetchProjectByName(p, policies[i].DomainId, "")
 				if err != nil {
 					log.Errorf("fetch porject %s fail %s", p, err)
@@ -178,7 +180,7 @@ func (manager *SPolicyManager) initializeRolePolicyGroup() error {
 						}
 					}
 				}
-			}
+			} */
 		} else if len(policy.Roles) > 0 && len(policy.Projects) > 0 {
 			for _, r := range policy.Roles {
 				role, err := RoleManager.FetchRoleByName(r, policies[i].DomainId, "")


### PR DESCRIPTION
do not expand match any role policy

**这个 PR 实现什么功能/修复什么问题**:
修正：policy初始化时，不扩展匹配任意角色的权限

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area keystone