### PR TITLE
fix(keystone): service config ignore deploy server socket path

### DIFF
--- a/pkg/apis/identity/consts.go
+++ b/pkg/apis/identity/consts.go
@@ -205,6 +205,10 @@ var (
 			// "status_probe_interval_seconds",
 			// "log_fetch_interval_seconds",
 			// "send_metrics_interval_seconds",
+			// ############################
+			// glance blacklist options
+			// ############################
+			"deploy_server_socket_path",
 		},
 	}
 )

--- a/pkg/image/service/service.go
+++ b/pkg/image/service/service.go
@@ -99,6 +99,7 @@ func StartService() {
 	go models.CheckImages()
 
 	if len(options.Options.DeployServerSocketPath) > 0 {
+		log.Infof("deploy server socket path: %s", options.Options.DeployServerSocketPath)
 		deployclient.Init(options.Options.DeployServerSocketPath)
 	}
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
fix(keystone): service config ignore deploy server socket path
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
release/3.6
/cc @swordqiu @zexi 
/area keystone
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
