### PR TITLE
Automated cherry pick of #9481: fix(keystone): service config ignore deploy server socket path

### DIFF
--- a/pkg/apis/identity/consts.go
+++ b/pkg/apis/identity/consts.go
@@ -205,6 +205,10 @@ var (
 			// "status_probe_interval_seconds",
 			// "log_fetch_interval_seconds",
 			// "send_metrics_interval_seconds",
+			// ############################
+			// glance blacklist options
+			// ############################
+			"deploy_server_socket_path",
 		},
 	}
 )

--- a/pkg/image/service/service.go
+++ b/pkg/image/service/service.go
@@ -99,6 +99,7 @@ func StartService() {
 	go models.CheckImages()
 
 	if len(options.Options.DeployServerSocketPath) > 0 {
+		log.Infof("deploy server socket path: %s", options.Options.DeployServerSocketPath)
 		deployclient.Init(options.Options.DeployServerSocketPath)
 	}
 


### PR DESCRIPTION
Cherry pick of #9481 on release/3.6.

#9481: fix(keystone): service config ignore deploy server socket path