### PR TITLE
Webhook better describe the life cycle of the guest

### DIFF
--- a/pkg/cloudcommon/notifyclient/events.go
+++ b/pkg/cloudcommon/notifyclient/events.go
@@ -41,11 +41,12 @@ type SAction string
 var (
 	Event SEvent
 
-	ActionCreate       SAction = "create"
-	ActionUpdate       SAction = "update"
-	ActionDelete       SAction = "delete"
-	ActionRebuildRoot  SAction = "rebuild_root"
-	ActionChangeConfig SAction = "change_config"
+	ActionCreate        SAction = "create"
+	ActionUpdate        SAction = "update"
+	ActionDelete        SAction = "delete"
+	ActionPendingDelete SAction = "pending_delete"
+	ActionRebuildRoot   SAction = "rebuild_root"
+	ActionChangeConfig  SAction = "change_config"
 )
 
 type SEvent struct {

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -2659,6 +2659,7 @@ func (self *SGuest) DoCancelPendingDelete(ctx context.Context, userCred mcclient
 	if err != nil {
 		return err
 	}
+	notifyclient.NotifyWebhook(ctx, userCred, self, notifyclient.ActionCreate)
 	return nil
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1.  send webhook server_create when canceling pending delete
2. distinguish between pending delete and delete notification
3. 
- [x] 功能、bugfix描述
- [x] 冒烟测试

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6
- release/3.5
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/cc @swordqiu @zexi 