### PR TITLE
fix(keystone): always upload&refresh service config whenever service …

### DIFF
--- a/pkg/cloudcommon/options/manager.go
+++ b/pkg/cloudcommon/options/manager.go
@@ -124,10 +124,10 @@ func (manager *SOptionManager) DoSync(first bool) (time.Duration, error) {
 			appsrv.SetExitFlag()
 		}
 		copyOptions(manager.options, newOpts)
-		if first {
-			// upload config for the first time ONLY
-			manager.session.Upload()
-		}
+		// if first {
+		// upload config
+		manager.session.Upload()
+		// }
 	}
 	return manager.refreshInterval, nil
 }

--- a/pkg/cloudcommon/options/mergeconf.go
+++ b/pkg/cloudcommon/options/mergeconf.go
@@ -66,6 +66,8 @@ type mcclientServiceConfigSession struct {
 	session   *mcclient.ClientSession
 	serviceId string
 	config    *jsonutils.JSONDict
+
+	commonServiceId string
 }
 
 func newServiceConfigSession() IServiceConfigSession {
@@ -88,12 +90,12 @@ func (s *mcclientServiceConfigSession) Merge(opts interface{}, serviceType strin
 			merged = true
 		} else {
 			// not initialized
-			s.Upload()
+			// s.Upload()
 		}
 	}
-	commonServiceId, _ := getServiceIdByType(s.session, consts.COMMON_SERVICE, "")
-	if len(commonServiceId) > 0 {
-		commonConf, err := getServiceConfig(s.session, commonServiceId)
+	s.commonServiceId, _ = getServiceIdByType(s.session, consts.COMMON_SERVICE, "")
+	if len(s.commonServiceId) > 0 {
+		commonConf, err := getServiceConfig(s.session, s.commonServiceId)
 		if err != nil {
 			log.Errorf("getServiceConfig for %s failed: %s", consts.COMMON_SERVICE, err)
 		} else if commonConf != nil {
@@ -122,6 +124,11 @@ func (s *mcclientServiceConfigSession) Upload() {
 		if err != nil {
 			// ignore the error
 			log.Errorf("fail to save config: %s", err)
+		}
+		_, err = modules.ServicesV3.PerformAction(s.session, s.commonServiceId, "config", nconf)
+		if err != nil {
+			// ignore the error
+			log.Errorf("fail to save common config: %s", err)
 		}
 	}
 }

--- a/pkg/keystone/models/configs.go
+++ b/pkg/keystone/models/configs.go
@@ -426,6 +426,8 @@ func saveConfigs(userCred mcclient.TokenCredential, action string, model db.IMod
 type dbServiceConfigSession struct {
 	config  *jsonutils.JSONDict
 	service *SService
+
+	commonService *SService
 }
 
 func NewServiceConfigSession() common_options.IServiceConfigSession {
@@ -446,12 +448,12 @@ func (s *dbServiceConfigSession) Merge(opts interface{}, serviceType string, ser
 			merged = true
 		} else {
 			// not initialized
-			uploadConfig(s.service, s.config)
+			// uploadConfig(s.service, s.config)
 		}
 	}
-	commonService, _ := ServiceManager.fetchServiceByType(consts.COMMON_SERVICE)
-	if commonService != nil {
-		commonConf, err := GetConfigs(commonService, false, nil, nil)
+	s.commonService, _ = ServiceManager.fetchServiceByType(consts.COMMON_SERVICE)
+	if s.commonService != nil {
+		commonConf, err := GetConfigs(s.commonService, false, nil, nil)
 		if err != nil {
 			log.Errorf("GetConfigs for %s fail: %s", consts.COMMON_SERVICE, err)
 		} else if commonConf != nil {
@@ -460,7 +462,7 @@ func (s *dbServiceConfigSession) Merge(opts interface{}, serviceType string, ser
 			merged = true
 		} else {
 			// common not initialized
-			uploadConfig(commonService, s.config)
+			// uploadConfig(commonService, s.config)
 		}
 	}
 	if merged {
@@ -478,6 +480,7 @@ func (s *dbServiceConfigSession) Upload() {
 		return
 	}
 	uploadConfig(s.service, s.config)
+	uploadConfig(s.commonService, s.config)
 }
 
 func (s *dbServiceConfigSession) IsRemote() bool {


### PR DESCRIPTION
…restart

Always upload&refresh service config whenever service restart

**这个 PR 实现什么功能/修复什么问题**:
 修正：服务重启时，总是刷新上传服务的配置信息

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.5
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area keystone