### PR TITLE
fix(host): telegraf listen on local ipv4 address explicitly

### DIFF
--- a/pkg/hostman/hostmetrics/hostmetrics.go
+++ b/pkg/hostman/hostmetrics/hostmetrics.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	TelegrafServer     = "http://localhost:8087/write"
+	TelegrafServer     = "http://127.0.0.1:8087/write"
 	MeasurementsPrefix = "vm_"
 )
 

--- a/pkg/hostman/system_service/system_service.go
+++ b/pkg/hostman/system_service/system_service.go
@@ -100,6 +100,8 @@ func (s *SBaseSystemService) reloadConf(conf, conFile string) (bool, error) {
 	oldConf := string(output)
 	if strings.TrimSpace(conf) != strings.TrimSpace(oldConf) {
 		log.Debugf("Reload service %s ...", s.name)
+		log.Debugf("oldConf: [%s]", oldConf)
+		log.Debugf("newConf: [%s]", conf)
 		err := procutils.NewRemoteCommandAsFarAsPossible("rm", "-f", conFile).Run()
 		if err != nil {
 			return false, err

--- a/pkg/hostman/system_service/telegraf.go
+++ b/pkg/hostman/system_service/telegraf.go
@@ -177,7 +177,7 @@ func (s *STelegraf) GetConfig(kwargs map[string]interface{}) string {
 	conf += "  collect_memstats = false\n"
 	conf += "\n"
 	conf += "[[inputs.http_listener]]\n"
-	conf += "  service_address = \"localhost:8087\"\n"
+	conf += "  service_address = \"127.0.0.1:8087\"\n"
 	conf += "\n"
 	return conf
 }
@@ -211,7 +211,7 @@ func (s *STelegraf) BgReloadConf(kwargs map[string]interface{}) {
 
 func (s *STelegraf) ReloadTelegraf() error {
 	log.Infof("Start reolad telegraf...")
-	telegrafReoladUrl := "http://localhost:8087/reload"
+	telegrafReoladUrl := "http://127.0.0.1:8087/reload"
 	_, _, err := httputils.JSONRequest(
 		httputils.GetDefaultClient(), context.Background(),
 		"POST", telegrafReoladUrl, nil, nil, false,


### PR DESCRIPTION
Ensure telegraf listen on local IPv4 address explicityly and host send
metrics to telegraf local IPv4 address explicityly.

**这个 PR 实现什么功能/修复什么问题**:
修正：telgraf明确监听127.0.0.1，host也明确向127.0.0.1发送监控数据，避免host向::1的ipv6地址发送监控数据

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.3
- release/3.4
- release/3.5
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @wanyaoqi 
/area host