### PR TITLE
Automated cherry pick of #9515: fix(host): telegraf listen on local ipv4 address explicitly

### DIFF
--- a/pkg/hostman/hostmetrics/hostmetrics.go
+++ b/pkg/hostman/hostmetrics/hostmetrics.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	TelegrafServer     = "http://localhost:8087/write"
+	TelegrafServer     = "http://127.0.0.1:8087/write"
 	MeasurementsPrefix = "vm_"
 )
 

--- a/pkg/hostman/system_service/telegraf.go
+++ b/pkg/hostman/system_service/telegraf.go
@@ -177,7 +177,7 @@ func (s *STelegraf) GetConfig(kwargs map[string]interface{}) string {
 	conf += "  collect_memstats = false\n"
 	conf += "\n"
 	conf += "[[inputs.http_listener]]\n"
-	conf += "  service_address = \"localhost:8087\"\n"
+	conf += "  service_address = \"127.0.0.1:8087\"\n"
 	conf += "\n"
 	return conf
 }
@@ -211,7 +211,7 @@ func (s *STelegraf) BgReloadConf(kwargs map[string]interface{}) {
 
 func (s *STelegraf) ReloadTelegraf() error {
 	log.Infof("Start reolad telegraf...")
-	telegrafReoladUrl := "http://localhost:8087/reload"
+	telegrafReoladUrl := "http://127.0.0.1:8087/reload"
 	_, _, err := httputils.JSONRequest(
 		httputils.GetDefaultClient(), context.Background(),
 		"POST", telegrafReoladUrl, nil, nil, false,


### PR DESCRIPTION
Cherry pick of #9515 on release/3.6.

#9515: fix(host): telegraf listen on local ipv4 address explicitly