### PR TITLE
fix(cloudcommon): panic when query an empty splitable model manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -147,7 +147,7 @@ require (
 	yunion.io/x/ovsdb v0.0.0-20200526071744-27bf0940cbc7
 	yunion.io/x/pkg v0.0.0-20201123083159-ca3aea986ff2
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
-	yunion.io/x/sqlchemy v0.0.0-20201218150209-7f971e45179f
+	yunion.io/x/sqlchemy v0.0.0-20201219153152-2d901261898c
 	yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce
 )
 

--- a/go.sum
+++ b/go.sum
@@ -937,7 +937,7 @@ yunion.io/x/pkg v0.0.0-20201123083159-ca3aea986ff2 h1:NeCr2J8HjcIuJvEhP0rwWA1UKP
 yunion.io/x/pkg v0.0.0-20201123083159-ca3aea986ff2/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8J50Cise/HCylsOJngmo=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e/go.mod h1:0iFKpOs1y4lbCxeOmq3Xx/0AcQoewVPwj62eRluioEo=
-yunion.io/x/sqlchemy v0.0.0-20201218150209-7f971e45179f h1:/kYVDTlHjq12EJLw3+zkrJA4psxRYAQ8MB461S9pkyg=
-yunion.io/x/sqlchemy v0.0.0-20201218150209-7f971e45179f/go.mod h1:FTdwPdGhMgh4E+UFXc9klI1Ok34fMuybTT+jLhOaIjI=
+yunion.io/x/sqlchemy v0.0.0-20201219153152-2d901261898c h1:71nVDQq1oUjvZknEUNfetdiOB1jZMEfmoQlMUaoPIJs=
+yunion.io/x/sqlchemy v0.0.0-20201219153152-2d901261898c/go.mod h1:FTdwPdGhMgh4E+UFXc9klI1Ok34fMuybTT+jLhOaIjI=
 yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce h1:kU8xE7O5uZ1GSJVMZHoJ+jrNL7csUQHYGyAPW9QfNpE=
 yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce/go.mod h1:EP6NSv2C0zzqBDTKumv8hPWLb3XvgMZDHQRfyuOrQng=

--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -611,7 +611,12 @@ func ListItems(manager IModelManager, ctx context.Context, userCred mcclient.Tok
 		}
 		union, err := sqlchemy.UnionWithError(subqs...)
 		if err != nil {
-			return nil, errors.Wrap(err, "sqlchemy.UnionWithError")
+			if errors.Cause(err) == sql.ErrNoRows {
+				emptyList := modulebase.ListResult{Data: []jsonutils.JSONObject{}}
+				return &emptyList, nil
+			} else {
+				return nil, errors.Wrap(err, "sqlchemy.UnionWithError")
+			}
 		}
 		q = union.Query()
 	} else {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1152,7 +1152,7 @@ yunion.io/x/pkg/util/workqueue
 yunion.io/x/pkg/utils
 # yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 yunion.io/x/s3cli
-# yunion.io/x/sqlchemy v0.0.0-20201218150209-7f971e45179f
+# yunion.io/x/sqlchemy v0.0.0-20201219153152-2d901261898c
 yunion.io/x/sqlchemy
 # yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce
 yunion.io/x/structarg

--- a/vendor/yunion.io/x/sqlchemy/union.go
+++ b/vendor/yunion.io/x/sqlchemy/union.go
@@ -15,10 +15,12 @@
 package sqlchemy
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 )
 
 type SUnionQueryField struct {
@@ -156,6 +158,10 @@ func Union(query ...IQuery) *SUnion {
 }
 
 func UnionWithError(query ...IQuery) (*SUnion, error) {
+	if len(query) == 0 {
+		return nil, errors.Wrap(sql.ErrNoRows, "empty union query")
+	}
+
 	fieldNames := make([]string, 0)
 	for _, f := range query[0].QueryFields() {
 		fieldNames = append(fieldNames, f.Name())


### PR DESCRIPTION
fix panic when querying a empty splitable model manager, e.g. action-show

**这个 PR 实现什么功能/修复什么问题**:
修正：当查询空的splitable时，会报错out of index的panic

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @yousong 
/area util