### PR TITLE
Automated cherry pick of #9527: fix(cloudcommon): panic when query a splitable model manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ require (
 	yunion.io/x/ovsdb v0.0.0-20200526071744-27bf0940cbc7
 	yunion.io/x/pkg v0.0.0-20201123083159-ca3aea986ff2
 	yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
-	yunion.io/x/sqlchemy v0.0.0-20201218150209-7f971e45179f
+	yunion.io/x/sqlchemy v0.0.0-20201219153152-2d901261898c
 	yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce
 )
 

--- a/go.sum
+++ b/go.sum
@@ -931,7 +931,7 @@ yunion.io/x/pkg v0.0.0-20201123083159-ca3aea986ff2 h1:NeCr2J8HjcIuJvEhP0rwWA1UKP
 yunion.io/x/pkg v0.0.0-20201123083159-ca3aea986ff2/go.mod h1:t6rEGG2sQ4J7DhFxSZVOTjNd0YO/KlfWQyK1W4tog+E=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e h1:v+EzIadodSwkdZ/7bremd7J8J50Cise/HCylsOJngmo=
 yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e/go.mod h1:0iFKpOs1y4lbCxeOmq3Xx/0AcQoewVPwj62eRluioEo=
-yunion.io/x/sqlchemy v0.0.0-20201218150209-7f971e45179f h1:/kYVDTlHjq12EJLw3+zkrJA4psxRYAQ8MB461S9pkyg=
-yunion.io/x/sqlchemy v0.0.0-20201218150209-7f971e45179f/go.mod h1:FTdwPdGhMgh4E+UFXc9klI1Ok34fMuybTT+jLhOaIjI=
+yunion.io/x/sqlchemy v0.0.0-20201219153152-2d901261898c h1:71nVDQq1oUjvZknEUNfetdiOB1jZMEfmoQlMUaoPIJs=
+yunion.io/x/sqlchemy v0.0.0-20201219153152-2d901261898c/go.mod h1:FTdwPdGhMgh4E+UFXc9klI1Ok34fMuybTT+jLhOaIjI=
 yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce h1:kU8xE7O5uZ1GSJVMZHoJ+jrNL7csUQHYGyAPW9QfNpE=
 yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce/go.mod h1:EP6NSv2C0zzqBDTKumv8hPWLb3XvgMZDHQRfyuOrQng=

--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -611,7 +611,12 @@ func ListItems(manager IModelManager, ctx context.Context, userCred mcclient.Tok
 		}
 		union, err := sqlchemy.UnionWithError(subqs...)
 		if err != nil {
-			return nil, errors.Wrap(err, "sqlchemy.UnionWithError")
+			if errors.Cause(err) == sql.ErrNoRows {
+				emptyList := modulebase.ListResult{Data: []jsonutils.JSONObject{}}
+				return &emptyList, nil
+			} else {
+				return nil, errors.Wrap(err, "sqlchemy.UnionWithError")
+			}
 		}
 		q = union.Query()
 	} else {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1149,7 +1149,7 @@ yunion.io/x/pkg/util/workqueue
 yunion.io/x/pkg/utils
 # yunion.io/x/s3cli v0.0.0-20190917004522-13ac36d8687e
 yunion.io/x/s3cli
-# yunion.io/x/sqlchemy v0.0.0-20201218150209-7f971e45179f
+# yunion.io/x/sqlchemy v0.0.0-20201219153152-2d901261898c
 yunion.io/x/sqlchemy
 # yunion.io/x/structarg v0.0.0-20200720093445-9f850fa222ce
 yunion.io/x/structarg

--- a/vendor/yunion.io/x/sqlchemy/union.go
+++ b/vendor/yunion.io/x/sqlchemy/union.go
@@ -15,10 +15,12 @@
 package sqlchemy
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 
 	"yunion.io/x/log"
+	"yunion.io/x/pkg/errors"
 )
 
 type SUnionQueryField struct {
@@ -156,6 +158,10 @@ func Union(query ...IQuery) *SUnion {
 }
 
 func UnionWithError(query ...IQuery) (*SUnion, error) {
+	if len(query) == 0 {
+		return nil, errors.Wrap(sql.ErrNoRows, "empty union query")
+	}
+
 	fieldNames := make([]string, 0)
 	for _, f := range query[0].QueryFields() {
 		fieldNames = append(fieldNames, f.Name())


### PR DESCRIPTION
Cherry pick of #9527 on release/3.6.

#9527: fix(cloudcommon): panic when query a splitable model manager