### PR TITLE
fix(cloudcommon): add rbac_policy_refresh_internval_seconds option

### DIFF
--- a/pkg/cloudcommon/app/auth.go
+++ b/pkg/cloudcommon/app/auth.go
@@ -94,7 +94,7 @@ func InitAuth(options *common_options.CommonOptions, authComplete auth.AuthCompl
 func InitBaseAuth(options *common_options.BaseOptions) {
 	if options.EnableRbac {
 		policy.EnableGlobalRbac(
-			time.Second*time.Duration(options.RbacPolicySyncPeriodSeconds),
+			time.Second*time.Duration(options.RbacPolicyRefreshIntervalSeconds),
 			options.RbacDebug,
 		)
 	}

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -73,9 +73,9 @@ type BaseOptions struct {
 	NotifyAdminUsers  []string `default:"sysadmin" help:"System administrator user ID or name to notify system events, if domain is not default, specify domain as prefix ending with double backslash, e.g. domain\\\\user"`
 	NotifyAdminGroups []string `help:"System administrator group ID or name to notify system events, if domain is not default, specify domain as prefix ending with double backslash, e.g. domain\\\\group"`
 
-	EnableRbac                  bool `help:"Switch on Role-based Access Control" default:"true"`
-	RbacDebug                   bool `help:"turn on rbac debug log" default:"false"`
-	RbacPolicySyncPeriodSeconds int  `help:"policy sync interval in seconds, default half a minute" default:"30"`
+	EnableRbac                       bool `help:"Switch on Role-based Access Control" default:"true"`
+	RbacDebug                        bool `help:"turn on rbac debug log" default:"false"`
+	RbacPolicyRefreshIntervalSeconds int  `help:"policy refresh interval in seconds, default half a minute" default:"30"`
 	// RbacPolicySyncFailedRetrySeconds int  `help:"seconds to wait after a failed sync, default 30 seconds" default:"30"`
 
 	ConfigSyncPeriodSeconds int `help:"service config sync interval in seconds, default 30 minutes" default:"1800"`


### PR DESCRIPTION
Add new option rbac_policy_refresh_interval_seconds to control the
valid duration of a policy cache. The option is introduced at 3.6.
Replace option rbac_policy_sync_period_seconds.

**这个 PR 实现什么功能/修复什么问题**:
修正：从3.6开始增加选项 rbac_policy_refresh_interval_seconds  用于控制policy缓存的时间，替换选项 rbac_policy_sync_period_seconds （默认值为1800秒），这样3.4升级3.6不再受到rbac_policy_sync_period_seconds这个选项的值的影响。

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6
- 
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @yousong 
/area util
