### PR TITLE
Automated cherry pick of #9534: fix(cloudcommon): add rbac_policy_refresh_internval_seconds option

### DIFF
--- a/pkg/cloudcommon/app/auth.go
+++ b/pkg/cloudcommon/app/auth.go
@@ -94,7 +94,7 @@ func InitAuth(options *common_options.CommonOptions, authComplete auth.AuthCompl
 func InitBaseAuth(options *common_options.BaseOptions) {
 	if options.EnableRbac {
 		policy.EnableGlobalRbac(
-			time.Second*time.Duration(options.RbacPolicySyncPeriodSeconds),
+			time.Second*time.Duration(options.RbacPolicyRefreshIntervalSeconds),
 			options.RbacDebug,
 		)
 	}

--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -73,9 +73,9 @@ type BaseOptions struct {
 	NotifyAdminUsers  []string `default:"sysadmin" help:"System administrator user ID or name to notify system events, if domain is not default, specify domain as prefix ending with double backslash, e.g. domain\\\\user"`
 	NotifyAdminGroups []string `help:"System administrator group ID or name to notify system events, if domain is not default, specify domain as prefix ending with double backslash, e.g. domain\\\\group"`
 
-	EnableRbac                  bool `help:"Switch on Role-based Access Control" default:"true"`
-	RbacDebug                   bool `help:"turn on rbac debug log" default:"false"`
-	RbacPolicySyncPeriodSeconds int  `help:"policy sync interval in seconds, default half a minute" default:"30"`
+	EnableRbac                       bool `help:"Switch on Role-based Access Control" default:"true"`
+	RbacDebug                        bool `help:"turn on rbac debug log" default:"false"`
+	RbacPolicyRefreshIntervalSeconds int  `help:"policy refresh interval in seconds, default half a minute" default:"30"`
 	// RbacPolicySyncFailedRetrySeconds int  `help:"seconds to wait after a failed sync, default 30 seconds" default:"30"`
 
 	ConfigSyncPeriodSeconds int `help:"service config sync interval in seconds, default 30 minutes" default:"1800"`


### PR DESCRIPTION
Cherry pick of #9534 on release/3.6.

#9534: fix(cloudcommon): add rbac_policy_refresh_internval_seconds option