### PR TITLE
fix(keystone): ignore deleted policies when matching policies

### DIFF
--- a/pkg/keystone/models/rolepolicies.go
+++ b/pkg/keystone/models/rolepolicies.go
@@ -417,6 +417,9 @@ func (manager *SRolePolicyManager) GetPolicyGroupByIds(policyIds []string, nameO
 	for _, id := range policyIds {
 		policyObj, err := PolicyManager.FetchById(id)
 		if err != nil {
+			if errors.Cause(err) == sql.ErrNoRows {
+				continue
+			}
 			return nil, nil, errors.Wrapf(err, "FetchPolicy %s", id)
 		}
 		policy := policyObj.(*SPolicy)


### PR DESCRIPTION
ignore deleted policies when matching policies

**这个 PR 实现什么功能/修复什么问题**:
修正：查找匹配的策略时应该忽略被删除的策略

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area keystone
/hold