### PR TITLE
Automated cherry pick of #9536: fix(keystone): ignore deleted policies when matching policies

### DIFF
--- a/pkg/keystone/models/rolepolicies.go
+++ b/pkg/keystone/models/rolepolicies.go
@@ -417,6 +417,9 @@ func (manager *SRolePolicyManager) GetPolicyGroupByIds(policyIds []string, nameO
 	for _, id := range policyIds {
 		policyObj, err := PolicyManager.FetchById(id)
 		if err != nil {
+			if errors.Cause(err) == sql.ErrNoRows {
+				continue
+			}
 			return nil, nil, errors.Wrapf(err, "FetchPolicy %s", id)
 		}
 		policy := policyObj.(*SPolicy)


### PR DESCRIPTION
Cherry pick of #9536 on release/3.6.

#9536: fix(keystone): ignore deleted policies when matching policies