### PR TITLE
fix(cloudcommon): query string may be modified in listItemQuery

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -576,7 +576,7 @@ func ListItems(manager IModelManager, ctx context.Context, userCred mcclient.Tok
 		for _, meta := range metas {
 			ts := splitable.GetTableSpec(meta)
 			subq := ts.Query()
-			subq, err = listItemQueryFiltersRaw(manager, ctx, subq, userCred, queryDict, policy.PolicyActionList, true, useRawQuery)
+			subq, err = listItemQueryFiltersRaw(manager, ctx, subq, userCred, queryDict.Copy(), policy.PolicyActionList, true, useRawQuery)
 			if err != nil {
 				return nil, errors.Wrap(err, "listItemQueryFiltersRaw")
 			}


### PR DESCRIPTION
query string may be modified in listItemQuery routine, which cause some query
filter is removed and hence ineffective when query over splitable

**这个 PR 实现什么功能/修复什么问题**:
修正：由于listItem过程中会修改query，导致查询splitable时，一些query filter被移除了，导致不生效

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area util