### PR TITLE
Automated cherry pick of #9538: fix(cloudcommon): query string may be modified in listItemQuery

### DIFF
--- a/pkg/cloudcommon/db/db_dispatcher.go
+++ b/pkg/cloudcommon/db/db_dispatcher.go
@@ -576,7 +576,7 @@ func ListItems(manager IModelManager, ctx context.Context, userCred mcclient.Tok
 		for _, meta := range metas {
 			ts := splitable.GetTableSpec(meta)
 			subq := ts.Query()
-			subq, err = listItemQueryFiltersRaw(manager, ctx, subq, userCred, queryDict, policy.PolicyActionList, true, useRawQuery)
+			subq, err = listItemQueryFiltersRaw(manager, ctx, subq, userCred, queryDict.Copy(), policy.PolicyActionList, true, useRawQuery)
 			if err != nil {
 				return nil, errors.Wrap(err, "listItemQueryFiltersRaw")
 			}


### PR DESCRIPTION
Cherry pick of #9538 on release/3.6.

#9538: fix(cloudcommon): query string may be modified in listItemQuery