### PR TITLE
Hotfix/baremetal pxe net alloc

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -4333,7 +4333,17 @@ func (self *SHost) EnableNetif(ctx context.Context, userCred mcclient.TokenCrede
 	} else if net.WireId != wire.Id {
 		return fmt.Errorf("conflict??? candiate net is not on wire")
 	}
-	bn, err = self.Attach2Network(ctx, userCred, netif, net, ipAddr, allocDir, reserve, requireDesignatedIp)
+
+	attachOpt := &hostAttachNetworkOption{
+		netif:               netif,
+		net:                 net,
+		ipAddr:              ipAddr,
+		allocDir:            allocDir,
+		reserved:            reserve,
+		requireDesignatedIp: requireDesignatedIp,
+	}
+
+	bn, err = self.Attach2Network(ctx, userCred, attachOpt)
 	if err != nil {
 		return errors.Wrap(err, "self.Attach2Network")
 	}
@@ -4389,11 +4399,79 @@ func (self *SHost) DisableNetif(ctx context.Context, userCred mcclient.TokenCred
 	return err
 }
 
-func (self *SHost) Attach2Network(ctx context.Context, userCred mcclient.TokenCredential, netif *SNetInterface, net *SNetwork, ipAddr, allocDir string, reserved, requireDesignatedIp bool) (*SHostnetwork, error) {
+type hostAttachNetworkOption struct {
+	netif               *SNetInterface
+	net                 *SNetwork
+	ipAddr              string
+	allocDir            string
+	reserved            bool
+	requireDesignatedIp bool
+}
+
+func (self *SHost) IsIpAddrWithinConvertedGuest(ctx context.Context, userCred mcclient.TokenCredential, ipAddr string, netif *SNetInterface) error {
+	if !self.IsBaremetal {
+		return httperrors.NewNotAcceptableError("Not a baremetal")
+	}
+
+	if self.HostType == api.HOST_TYPE_KVM {
+		return httperrors.NewNotAcceptableError("Not being convert to hypervisor")
+	}
+
+	bmServer := self.GetBaremetalServer()
+	if bmServer == nil {
+		return httperrors.NewNotAcceptableError("Not found baremetal server record")
+	}
+
+	guestNics, err := bmServer.GetNetworks("")
+	if err != nil {
+		return errors.Wrap(err, "Get guest networks")
+	}
+	var findNic *SGuestnetwork
+	for idx := range guestNics {
+		nic := guestNics[idx]
+		if nic.MacAddr == netif.Mac {
+			findNic = &nic
+			break
+		}
+	}
+	if findNic == nil {
+		return httperrors.NewNotFoundError("Not found guest nic by mac %s", netif.Mac)
+	}
+
+	if findNic.IpAddr != ipAddr {
+		return httperrors.NewNotAcceptableError("Guest nic ip addr %s not equal %s", findNic.IpAddr, ipAddr)
+	}
+
+	return nil
+}
+
+func (self *SHost) Attach2Network(
+	ctx context.Context,
+	userCred mcclient.TokenCredential,
+	opt *hostAttachNetworkOption,
+) (*SHostnetwork, error) {
+	netif := opt.netif
+	net := opt.net
+	ipAddr := opt.ipAddr
+	allocDir := opt.allocDir
+	reserved := opt.reserved
+	requireDesignatedIp := opt.requireDesignatedIp
+
 	lockman.LockObject(ctx, net)
 	defer lockman.ReleaseObject(ctx, net)
 
-	freeIp, err := net.GetFreeIP(ctx, userCred, nil, nil, ipAddr, api.IPAllocationDirection(allocDir), reserved)
+	usedAddrs := net.GetUsedAddresses()
+	if ipAddr != "" {
+		// converted baremetal can resuse related guest network ip
+		if err := self.IsIpAddrWithinConvertedGuest(ctx, userCred, ipAddr, netif); err == nil {
+			// force remove used server addr for reuse
+			delete(usedAddrs, ipAddr)
+		} else {
+			log.Warningf("check IsIpAddrWithinConvertedGuest: %v", err)
+		}
+	}
+
+	freeIp, err := net.GetFreeIP(ctx, userCred, usedAddrs, nil, ipAddr, api.IPAllocationDirection(allocDir), reserved)
 	if err != nil {
 		return nil, errors.Wrap(err, "net.GetFreeIP")
 	}

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -804,12 +804,28 @@ func chooseNetworkByAddressCount(nets []*SNetwork) (*SNetwork, *SNetwork) {
 }
 
 func ChooseCandidateNetworks(nets []SNetwork, isExit bool, serverTypes []string) *SNetwork {
+	matchingNets := make([]*SNetwork, 0)
+	notMatchingNets := make([]*SNetwork, 0)
+
 	for _, s := range serverTypes {
 		net := chooseCandidateNetworksByNetworkType(nets, isExit, s)
 		if net != nil {
-			return net
+			if utils.IsInStringArray(net.ServerType, serverTypes) {
+				matchingNets = append(matchingNets, net)
+			} else {
+				notMatchingNets = append(notMatchingNets, net)
+			}
 		}
 	}
+
+	if len(matchingNets) >= 1 {
+		return matchingNets[0]
+	}
+
+	if len(notMatchingNets) >= 1 {
+		return notMatchingNets[0]
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复两个问题：

1. 物理机转换成宿主机后，如果管理口网卡被 remove 了，系统重启会 pxe 分配一个另外的 ip ，没有服用宿主机记录的 access_ip
2. 在没有 PXE 类型的 network 的情况下，region 会从其他类型的 network 里面分配 ip 给 pxe 请求的网卡，原因是 ChooseCandidateNetworks 没有根据传入的 serverTypes 参数选取合适 network

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/area baremetal region
/cc @swordqiu @wanyaoqi 
- 3.4