### PR TITLE
feat(monitor): add global alertrecord

### DIFF
--- a/pkg/apis/monitor/alertrecord.go
+++ b/pkg/apis/monitor/alertrecord.go
@@ -9,16 +9,18 @@ type AlertRecordListInput struct {
 	apis.EnabledResourceBaseListInput
 	apis.StatusStandaloneResourceListInput
 
-	AlertId string `json:"alert_id"`
-	Level   string `json:"level"`
-	State   string `json:"state"`
+	AlertId string   `json:"alert_id"`
+	Level   string   `json:"level"`
+	State   string   `json:"state"`
+	ResType []string `json:"res_type"`
 }
 
 type AlertRecordDetails struct {
 	apis.StatusStandaloneResourceDetails
 	apis.ScopedResourceBaseInfo
 
-	ResNum int64 `json:"res_num"`
+	ResNum    int64  `json:"res_num"`
+	AlertName string `json:"alert_name"`
 }
 
 type AlertRecordCreateInput struct {
@@ -28,6 +30,7 @@ type AlertRecordCreateInput struct {
 	// 报警级别
 	Level     string       `json:"level"`
 	State     string       `json:"state"`
+	ResType   string       `json:"res_type"`
 	EvalData  []*EvalMatch `json:"eval_data"`
 	AlertRule AlertRecordRule
 }

--- a/pkg/apis/monitor/commalert.go
+++ b/pkg/apis/monitor/commalert.go
@@ -82,7 +82,8 @@ type CommonAlertListInput struct {
 	// 监控指标名称
 	Metric string `json:"metric"`
 
-	Level string `json:"level"`
+	Level   string   `json:"level"`
+	ResType []string `json:"res_type"`
 }
 
 type CommonAlertUpdateInput struct {

--- a/pkg/monitor/alerting/notifier.go
+++ b/pkg/monitor/alerting/notifier.go
@@ -168,6 +168,7 @@ func (n *notificationService) createAlertRecordWhenNotify(evalCtx *EvalContext) 
 		EvalData:  matches,
 		AlertRule: newAlertRecordRule(evalCtx),
 	}
+	recordCreateInput.ResType = recordCreateInput.AlertRule.ResType
 	createData := recordCreateInput.JSON(recordCreateInput)
 	record, err := db.DoCreate(models.AlertRecordManager, evalCtx.Ctx, evalCtx.UserCred, jsonutils.NewDict(), createData, evalCtx.UserCred)
 	if err != nil {

--- a/pkg/monitor/alerting/rule.go
+++ b/pkg/monitor/alerting/rule.go
@@ -170,6 +170,7 @@ func NewRuleFromDBAlert(ruleDef *models.SAlert) (*Rule, error) {
 func newRuleDescription(rule *Rule, alertDetails *monitor.CommonAlertMetricDetails) {
 	ruleDes := RuleDescription{
 		AlertRecordRule: monitor.AlertRecordRule{
+			ResType:         alertDetails.ResType,
 			Metric:          fmt.Sprintf("%s.%s", alertDetails.Measurement, alertDetails.Field),
 			Measurement:     alertDetails.Measurement,
 			MeasurementDesc: alertDetails.MeasurementDisplayName,

--- a/pkg/monitor/service/service.go
+++ b/pkg/monitor/service/service.go
@@ -64,6 +64,8 @@ func StartService() {
 
 	cron := cronman.InitCronJobManager(true, opts.CronJobWorkerCount)
 	cron.AddJobAtIntervalsWithStartRun("InitAlertResourceAdminRoleUsers", time.Duration(opts.InitAlertResourceAdminRoleUsersIntervalSeconds)*time.Second, models.GetAlertResourceManager().GetAdminRoleUsers, true)
+	cron.AddJobEveryFewDays("DeleteRecordsOfThirtyDaysAgoRecords", 1, 0, 0, 0,
+		models.AlertRecordManager.DeleteRecordsOfThirtyDaysAgo, false)
 	cron.Start()
 	defer cron.Stop()
 

--- a/pkg/monitor/tasks/delete_alertrecord_task.go
+++ b/pkg/monitor/tasks/delete_alertrecord_task.go
@@ -1,0 +1,49 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+
+	"yunion.io/x/jsonutils"
+	"yunion.io/x/pkg/errors"
+
+	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	"yunion.io/x/onecloud/pkg/cloudcommon/db/taskman"
+	"yunion.io/x/onecloud/pkg/monitor/models"
+	"yunion.io/x/onecloud/pkg/util/logclient"
+)
+
+type DeleteAlertRecordTask struct {
+	taskman.STask
+}
+
+func init() {
+	taskman.RegisterTask(&DeleteAlertRecordTask{})
+}
+
+func (self *DeleteAlertRecordTask) OnInit(ctx context.Context, obj db.IStandaloneModel, body jsonutils.JSONObject) {
+	alert := obj.(*models.SCommonAlert)
+	errs := alert.DeleteAttachAlertRecords(ctx, self.GetUserCred())
+	if len(errs) != 0 {
+		msg := jsonutils.NewString(fmt.Sprintf("fail to DeleteAttachAlertRecords:%s.err:%v", alert.Name, errors.NewAggregate(errs)))
+		self.taskFail(ctx, alert, msg)
+		return
+	}
+
+	err := alert.RealDelete(ctx, self.UserCred)
+	if err != nil {
+		msg := fmt.Sprintf("delete SCommonAlert err:%v", err)
+		self.taskFail(ctx, alert, jsonutils.NewString(msg))
+		return
+	}
+	db.OpsLog.LogEvent(alert, db.ACT_DELETE, nil, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, alert, logclient.ACT_DELETE, nil, self.UserCred, true)
+	self.SetStageComplete(ctx, nil)
+}
+
+func (self *DeleteAlertRecordTask) taskFail(ctx context.Context, alert *models.SCommonAlert, msg jsonutils.JSONObject) {
+	db.OpsLog.LogEvent(alert, db.ACT_DELETE_FAIL, msg, self.GetUserCred())
+	logclient.AddActionLogWithStartable(self, alert, logclient.ACT_DELETE, msg, self.UserCred, false)
+	self.SetStageFailed(ctx, msg)
+	return
+}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1.支持时间、资源类型、报警级别、报警状态的过滤
2.报警记录删除时，删除关联的报警记录

**是否需要 backport 到之前的 release 分支**:
- release/3.6

/cc @zexi 
/area monitor

