### PR TITLE
Automated cherry pick of #9579: fix(monitor): other servier create alert add used_by param as a agreement

### DIFF
--- a/pkg/apis/monitor/alert.go
+++ b/pkg/apis/monitor/alert.go
@@ -117,6 +117,7 @@ type AlertCreateInput struct {
 	NoDataState string `json:"no_data_state"`
 	// 报警执行错误将当前报警状态设置为对应的状态
 	ExecutionErrorState string `json:"execution_error_state"`
+	UsedBy              string `json:"used_by"`
 }
 
 type AlertUpdateInput struct {


### PR DESCRIPTION
Cherry pick of #9579 on release/3.6.

#9579: fix(monitor): other servier create alert add used_by param as a agreement