### PR TITLE
Automated cherry pick of #9594: chore(util): update centos build version to 1.1-3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ mod:
 	go mod vendor -v
 
 
-DOCKER_CENTOS_BUILD_IMAGE?=registry.cn-beijing.aliyuncs.com/yunionio/centos-build:1.1-2
+DOCKER_CENTOS_BUILD_IMAGE?=registry.cn-beijing.aliyuncs.com/yunionio/centos-build:1.1-3
 
 define dockerCentOSBuildCmd
 set -o xtrace

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -60,7 +60,7 @@ build_bin() {
                 -v $SRC_DIR:/root/go/src/yunion.io/x/onecloud \
                 -v $SRC_DIR/_output/alpine-build:/root/go/src/yunion.io/x/onecloud/_output \
                 -v $SRC_DIR/_output/alpine-build/_cache:/root/.cache \
-                registry.cn-beijing.aliyuncs.com/yunionio/centos-build:1.1-2 \
+                registry.cn-beijing.aliyuncs.com/yunionio/centos-build:1.1-3 \
                 /bin/sh -c "set -ex; cd /root/go/src/yunion.io/x/onecloud; $BUILD_ARCH $BUILD_CGO GOOS=linux make cmd/$1; chown -R $(id -u):$(id -g) _output"
             ;;
         *)


### PR DESCRIPTION
Cherry pick of #9594 on release/3.6.

#9594: chore(util): update centos build version to 1.1-3