### PR TITLE
feature(climc): policy save data into file

### DIFF
--- a/cmd/climc/shell/identity/policies.go
+++ b/cmd/climc/shell/identity/policies.go
@@ -31,6 +31,7 @@ import (
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/mcclient/modules"
 	"yunion.io/x/onecloud/pkg/mcclient/options"
+	"yunion.io/x/onecloud/pkg/util/fileutils2"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
 	"yunion.io/x/onecloud/pkg/util/shellutils"
 )
@@ -205,6 +206,7 @@ func init() {
 	type PolicyShowOptions struct {
 		ID     string `help:"ID of policy"`
 		Format string `help:"policy format, default yaml" default:"yaml" choices:"yaml|json"`
+		Save   string `help:"save policy data into a file"`
 	}
 	R(&PolicyShowOptions{}, "policy-show", "Show policy", func(s *mcclient.ClientSession, args *PolicyShowOptions) error {
 		query := jsonutils.NewDict()
@@ -214,6 +216,15 @@ func init() {
 			return err
 		}
 		printObject(result)
+		if len(args.Save) > 0 {
+			if args.Format == "yaml" {
+				yaml, _ := result.GetString("policy")
+				fileutils2.FilePutContents(args.Save, yaml, false)
+			} else {
+				p, _ := result.Get("policy")
+				fileutils2.FilePutContents(args.Save, p.PrettyString(), false)
+			}
+		}
 		return nil
 	})
 


### PR DESCRIPTION
Allow saveing policy data into file

**这个 PR 实现什么功能/修复什么问题**:
改进：climc保存policy的数据到文件


<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.5
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area climc