### PR TITLE
fix(cloudevent): adjust cloudevents resource scope

### DIFF
--- a/pkg/cloudevent/policy/resources.go
+++ b/pkg/cloudevent/policy/resources.go
@@ -20,9 +20,7 @@ import (
 )
 
 var (
-	cloudeventSystemResources = []string{
-		"cloudevents",
-	}
+	cloudeventSystemResources = []string{}
 	cloudeventDomainResources = []string{}
 	cloudeventUserResources   = []string{}
 )


### PR DESCRIPTION
Change cloudevents resource scope from system to project.

**这个 PR 实现什么功能/修复什么问题**:
修正：更正cloudevent的资源范围从system改为project

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area cloudevents