### PR TITLE
fix(region): omit vpc quota check if vpc created by owner

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -3092,7 +3092,7 @@ func (self *SHost) PostCreate(
 		}
 	}
 
-	keys := GetHostQuotaKeysFromCreateInput(input)
+	keys := GetHostQuotaKeysFromCreateInput(ownerId, input)
 	quota := SInfrasQuota{Host: 1}
 	quota.SetKeys(keys)
 	err = quotas.CancelPendingUsage(ctx, userCred, &quota, &quota, true)
@@ -3386,7 +3386,7 @@ func (manager *SHostManager) ValidateCreateData(
 		return input, errors.Wrap(err, "SEnabledStatusInfrasResourceBaseManager.ValidateCreateData")
 	}
 
-	keys := GetHostQuotaKeysFromCreateInput(input)
+	keys := GetHostQuotaKeysFromCreateInput(ownerId, input)
 	quota := SInfrasQuota{Host: 1}
 	quota.SetKeys(keys)
 	err = quotas.CheckSetPendingQuota(ctx, userCred, &quota)
@@ -5622,8 +5622,8 @@ func (host *SHost) GetChangeOwnerRequiredDomainIds() []string {
 	return requires
 }
 
-func GetHostQuotaKeysFromCreateInput(input api.HostCreateInput) quotas.SDomainRegionalCloudResourceKeys {
-	ownerId := &db.SOwnerId{DomainId: input.ProjectDomainId}
+func GetHostQuotaKeysFromCreateInput(owner mcclient.IIdentityProvider, input api.HostCreateInput) quotas.SDomainRegionalCloudResourceKeys {
+	ownerId := &db.SOwnerId{DomainId: owner.GetProjectDomainId()}
 	var zone *SZone
 	if len(input.ZoneId) > 0 {
 		zone = ZoneManager.FetchZoneById(input.ZoneId)

--- a/pkg/compute/models/vpcs.go
+++ b/pkg/compute/models/vpcs.go
@@ -866,7 +866,7 @@ func (manager *SVpcManager) ValidateCreateData(
 		return input, httperrors.NewMissingParameterError("cidr")
 	}
 
-	keys := GetVpcQuotaKeysFromCreateInput(input)
+	keys := GetVpcQuotaKeysFromCreateInput(ownerId, input)
 	quota := &SInfrasQuota{Vpc: 1}
 	quota.SetKeys(keys)
 	err = quotas.CheckSetPendingQuota(ctx, userCred, quota)
@@ -884,7 +884,7 @@ func (self *SVpc) PostCreate(ctx context.Context, userCred mcclient.TokenCredent
 		log.Errorf("input unmarshal error %s", err)
 	} else {
 		pendingUsage := &SInfrasQuota{Vpc: 1}
-		keys := GetVpcQuotaKeysFromCreateInput(input)
+		keys := GetVpcQuotaKeysFromCreateInput(ownerId, input)
 		pendingUsage.SetKeys(keys)
 		quotas.CancelPendingUsage(ctx, userCred, pendingUsage, pendingUsage, true)
 	}
@@ -1290,8 +1290,8 @@ func (self *SVpc) initWire(ctx context.Context, zone *SZone) (*SWire, error) {
 	return wire, nil
 }
 
-func GetVpcQuotaKeysFromCreateInput(input api.VpcCreateInput) quotas.SDomainRegionalCloudResourceKeys {
-	ownerId := &db.SOwnerId{DomainId: input.ProjectDomainId}
+func GetVpcQuotaKeysFromCreateInput(owner mcclient.IIdentityProvider, input api.VpcCreateInput) quotas.SDomainRegionalCloudResourceKeys {
+	ownerId := &db.SOwnerId{DomainId: owner.GetProjectDomainId()}
 	var region *SCloudregion
 	if len(input.CloudregionId) > 0 {
 		region = CloudregionManager.FetchRegionById(input.CloudregionId)


### PR DESCRIPTION
Vpc quota check is omitted if vpc is create by owner user

**这个 PR 实现什么功能/修复什么问题**:
修正：当由owner创建vpc时，quota检查未生效

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.6
- release/3.5
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area region
/hold