### PR TITLE
Automated cherry pick of #9742: fix(region): obtain ProviderFactory correctly

### DIFF
--- a/pkg/compute/models/storagecaches.go
+++ b/pkg/compute/models/storagecaches.go
@@ -618,7 +618,7 @@ func (self *SStoragecache) SyncCloudImages(
 
 	result := compare.SyncResult{}
 
-	driver, err := cloudprovider.GetProviderFactory(region.Provider)
+	driver, err := self.GetProviderFactory()
 	if err != nil {
 		result.Error(errors.Wrapf(err, "GetProviderFactory(%s)", region.Provider))
 		return result


### PR DESCRIPTION
Cherry pick of #9742 on release/3.7.

#9742: fix(region): obtain ProviderFactory correctly