### PR TITLE
Automated cherry pick of #9744: fix(esxiagent): nicIndex should be incremented

### DIFF
--- a/pkg/multicloud/esxi/host.go
+++ b/pkg/multicloud/esxi/host.go
@@ -1025,6 +1025,7 @@ func (host *SHost) CloneVM(ctx context.Context, from *SVirtualMachine, snapshot 
 					Device:    dev,
 				})
 			}
+			nicIndex += 1
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #9744 on release/3.6.

#9744: fix(esxiagent): nicIndex should be incremented