### PR TITLE
fix(monitor): fix monitoroverview and meter send alerting info to  notify

### DIFF
--- a/pkg/monitor/alerting/conditions/query.go
+++ b/pkg/monitor/alerting/conditions/query.go
@@ -194,12 +194,10 @@ func (c *QueryCondition) Eval(context *alerting.EvalContext) (*alerting.Conditio
 func (c *QueryCondition) NewEvalMatch(context *alerting.EvalContext, series tsdb.TimeSeries,
 	meta *tsdb.QueryResultMeta, value *float64, valStrArr []string) (*monitor.EvalMatch, error) {
 	evalMatch := new(monitor.EvalMatch)
-	alert, err := models.CommonAlertManager.GetAlert(context.Rule.Id)
+	alertDetails, err := c.GetCommonAlertDetails(context)
 	if err != nil {
 		return nil, errors.Wrap(err, "GetAlert to NewEvalMatch error")
 	}
-	settings, _ := alert.GetSettings()
-	alertDetails := alert.GetCommonAlertMetricDetailsFromAlertCondition(c.Index, &settings.Conditions[c.Index])
 	evalMatch.Metric = fmt.Sprintf("%s.%s", alertDetails.Measurement, alertDetails.Field)
 	queryKeyInfo := ""
 	if len(alertDetails.MeasurementDisplayName) > 0 && len(alertDetails.FieldDescription.DisplayName) > 0 {
@@ -224,6 +222,16 @@ func (c *QueryCondition) NewEvalMatch(context *alerting.EvalContext, series tsdb
 	}
 	//c.newRuleDescription(context, alertDetails)
 	return evalMatch, nil
+}
+
+func (c *QueryCondition) GetCommonAlertDetails(context *alerting.EvalContext) (*monitor.CommonAlertMetricDetails, error) {
+	alert, err := models.CommonAlertManager.GetAlert(context.Rule.Id)
+	if err != nil {
+		return nil, errors.Wrap(err, "GetAlert to NewEvalMatch error")
+	}
+	settings, _ := alert.GetSettings()
+	alertDetails := alert.GetCommonAlertMetricDetailsFromAlertCondition(c.Index, &settings.Conditions[c.Index])
+	return alertDetails, nil
 }
 
 func (c *QueryCondition) jointPointStr(series tsdb.TimeSeries, value string, valStrArr []string) string {

--- a/pkg/monitor/alerting/eval_context.go
+++ b/pkg/monitor/alerting/eval_context.go
@@ -128,7 +128,17 @@ func (c *EvalContext) GetCallbackURLPrefix() string {
 		return ""
 	}
 	url, _ := config.GetString("config", "default", "api_server")
-	return url + "/alertrecord"
+	defaultWebUri := "alertrecord"
+	matchTag := map[string]string{}
+	if c.Firing {
+		matchTag = c.EvalMatches[0].Tags
+	} else {
+		matchTag = c.AlertOkEvalMatches[0].Tags
+	}
+	if uri, ok := matchTag["web_url"]; ok {
+		defaultWebUri = uri
+	}
+	return fmt.Sprintf("%s/%s", url, defaultWebUri)
 }
 
 // GetNewState returns the new state from the alert rule evaluation.

--- a/pkg/monitor/models/commonalert.go
+++ b/pkg/monitor/models/commonalert.go
@@ -226,9 +226,7 @@ func (alert *SCommonAlert) CustomizeCreate(
 	query jsonutils.JSONObject,
 	data jsonutils.JSONObject,
 ) error {
-	if err := alert.SAlert.CustomizeCreate(ctx, userCred, ownerId, query, data); err != nil {
-		return err
-	}
+	alert.State = string(monitor.AlertStateUnknown)
 	input := new(monitor.CommonAlertCreateInput)
 	if err := data.Unmarshal(input); err != nil {
 		return err


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

1.调整报警总览中今日报警数量计算逻辑
2.报警模版的web路径支持跳转到不同web页面：监控报警和meter
3.nodata 前端可配制功能fix

**是否需要 backport 到之前的 release 分支**:
- release/3.6
 - release/3.7

/cc @zexi 
/area monitor
