### PR TITLE
fix(region): AWS buckets in us-east-1 have null location

### DIFF
--- a/pkg/multicloud/aws/aws.go
+++ b/pkg/multicloud/aws/aws.go
@@ -54,6 +54,8 @@ const (
 
 	AWS_GLOBAL_ARN_PREFIX = "arn:aws:iam::aws:policy/"
 	AWS_CHINA_ARN_PREFIX  = "arn:aws-cn:iam::aws:policy/"
+
+	DEFAULT_S3_REGION_ID = "us-east-1"
 )
 
 var (
@@ -313,6 +315,11 @@ func (client *SAwsClient) fetchBuckets() error {
 		}
 
 		location := *output.LocationConstraint
+		if len(location) == 0 {
+			// https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html
+			// Buckets in Region us-east-1 have a LocationConstraint of null.
+			location = DEFAULT_S3_REGION_ID
+		}
 		region, err := client.getIRegionByRegionId(location)
 		if err != nil {
 			log.Errorf("client.getIRegionByRegionId %s fail %s", location, err)

--- a/pkg/multicloud/aws/region.go
+++ b/pkg/multicloud/aws/region.go
@@ -990,8 +990,11 @@ func (region *SRegion) CreateIBucket(name string, storageClassStr string, acl st
 	}
 	input := &s3.CreateBucketInput{}
 	input.SetBucket(name)
-	input.CreateBucketConfiguration = &s3.CreateBucketConfiguration{}
-	input.CreateBucketConfiguration.SetLocationConstraint(region.GetId())
+	if region.GetId() != DEFAULT_S3_REGION_ID {
+		location := region.GetId()
+		input.CreateBucketConfiguration = &s3.CreateBucketConfiguration{}
+		input.CreateBucketConfiguration.SetLocationConstraint(location)
+	}
 	_, err = s3cli.CreateBucket(input)
 	if err != nil {
 		return errors.Wrap(err, "CreateBucket")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：AWS在us-east-1的bucket的Location为空，需要兼容

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.5
- release/3.6
- release/3.7

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area region
/cc @zexi @yousong @ioito @tb365 