### PR TITLE
Automated cherry pick of #9872: fix(region): AWS buckets in us-east-1 have null location

### DIFF
--- a/pkg/multicloud/aws/aws.go
+++ b/pkg/multicloud/aws/aws.go
@@ -54,6 +54,8 @@ const (
 
 	AWS_GLOBAL_ARN_PREFIX = "arn:aws:iam::aws:policy/"
 	AWS_CHINA_ARN_PREFIX  = "arn:aws-cn:iam::aws:policy/"
+
+	DEFAULT_S3_REGION_ID = "us-east-1"
 )
 
 var (
@@ -304,6 +306,11 @@ func (client *SAwsClient) fetchBuckets() error {
 		}
 
 		location := *output.LocationConstraint
+		if len(location) == 0 {
+			// https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html
+			// Buckets in Region us-east-1 have a LocationConstraint of null.
+			location = DEFAULT_S3_REGION_ID
+		}
 		region, err := client.getIRegionByRegionId(location)
 		if err != nil {
 			log.Errorf("client.getIRegionByRegionId %s fail %s", location, err)

--- a/pkg/multicloud/aws/region.go
+++ b/pkg/multicloud/aws/region.go
@@ -992,8 +992,11 @@ func (region *SRegion) CreateIBucket(name string, storageClassStr string, acl st
 	}
 	input := &s3.CreateBucketInput{}
 	input.SetBucket(name)
-	input.CreateBucketConfiguration = &s3.CreateBucketConfiguration{}
-	input.CreateBucketConfiguration.SetLocationConstraint(region.GetId())
+	if region.GetId() != DEFAULT_S3_REGION_ID {
+		location := region.GetId()
+		input.CreateBucketConfiguration = &s3.CreateBucketConfiguration{}
+		input.CreateBucketConfiguration.SetLocationConstraint(location)
+	}
 	_, err = s3cli.CreateBucket(input)
 	if err != nil {
 		return errors.Wrap(err, "CreateBucket")


### PR DESCRIPTION
Cherry pick of #9872 on release/3.6.

#9872: fix(region): AWS buckets in us-east-1 have null location