### PR TITLE
Automated cherry pick of #9893: refactor(climc): remove dependence for `yunion.io/x/pkg/cloudcommon/db`

### DIFF
--- a/pkg/apis/cloudcommon/db/doc.go
+++ b/pkg/apis/cloudcommon/db/doc.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db // import "yunion.io/x/onecloud/pkg/apis/cloudcommon/db"

--- a/pkg/apis/cloudcommon/db/metadata.go
+++ b/pkg/apis/cloudcommon/db/metadata.go
@@ -1,0 +1,21 @@
+// Copyright 2019 Yunion
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+const (
+	CLOUD_TAG_PREFIX     = "ext:"
+	USER_TAG_PREFIX      = "user:"
+	SYS_CLOUD_TAG_PREFIX = "sys:"
+)

--- a/pkg/cloudcommon/db/metadata.go
+++ b/pkg/cloudcommon/db/metadata.go
@@ -29,6 +29,7 @@ import (
 	"yunion.io/x/sqlchemy"
 
 	"yunion.io/x/onecloud/pkg/apis"
+	dbapi "yunion.io/x/onecloud/pkg/apis/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/consts"
 	"yunion.io/x/onecloud/pkg/cloudcommon/db/lockman"
 	"yunion.io/x/onecloud/pkg/cloudcommon/policy"
@@ -41,9 +42,9 @@ import (
 const (
 	SYSTEM_ADMIN_PREFIX  = "__sys_"
 	SYS_TAG_PREFIX       = "__"
-	CLOUD_TAG_PREFIX     = "ext:"
-	USER_TAG_PREFIX      = "user:"
-	SYS_CLOUD_TAG_PREFIX = "sys:"
+	CLOUD_TAG_PREFIX     = dbapi.CLOUD_TAG_PREFIX
+	USER_TAG_PREFIX      = dbapi.USER_TAG_PREFIX
+	SYS_CLOUD_TAG_PREFIX = dbapi.SYS_CLOUD_TAG_PREFIX
 
 	// TAG_DELETE_RANGE_USER  = "user"
 	// TAG_DELETE_RANGE_CLOUD = CLOUD_TAG_PREFIX // "cloud"

--- a/pkg/mcclient/options/base.go
+++ b/pkg/mcclient/options/base.go
@@ -24,7 +24,7 @@ import (
 	"yunion.io/x/pkg/gotypes"
 	"yunion.io/x/pkg/util/reflectutils"
 
-	"yunion.io/x/onecloud/pkg/cloudcommon/db"
+	dbapi "yunion.io/x/onecloud/pkg/apis/cloudcommon/db"
 )
 
 // Int returns a pointer to int type with the same value as the argument.  This
@@ -288,14 +288,14 @@ func (opts *BaseListOptions) Params() (*jsonutils.JSONDict, error) {
 		tagIdx++
 	}
 	for _, tag := range opts.UserTags {
-		err = opts.addTag(db.USER_TAG_PREFIX, tag, tagIdx, params)
+		err = opts.addTag(dbapi.USER_TAG_PREFIX, tag, tagIdx, params)
 		if err != nil {
 			return nil, err
 		}
 		tagIdx++
 	}
 	for _, tag := range opts.CloudTags {
-		err = opts.addTag(db.CLOUD_TAG_PREFIX, tag, tagIdx, params)
+		err = opts.addTag(dbapi.CLOUD_TAG_PREFIX, tag, tagIdx, params)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Cherry pick of #9893 on release/3.7.

#9893: refactor(climc): remove dependence for `yunion.io/x/pkg/cloudcommon/db`