### PR TITLE
fix(monitor): domain view can list scope is domain or project alertrecords; fix nodata alert return info

### DIFF
--- a/pkg/monitor/models/monitorscoperesource.go
+++ b/pkg/monitor/models/monitorscoperesource.go
@@ -33,6 +33,22 @@ func (m *SMonitorScopedResourceManager) FilterByOwner(q *sqlchemy.SQuery, userCr
 	return q
 }
 
+func (s *SMonitorScopedResource) CustomizeCreate(ctx context.Context, userCred mcclient.TokenCredential, ownerId mcclient.IIdentityProvider, query jsonutils.JSONObject, data jsonutils.JSONObject) error {
+	scope, _ := data.GetString("scope")
+	switch rbacutils.TRbacScope(scope) {
+	case rbacutils.ScopeSystem:
+		s.DomainId = ""
+		s.ProjectId = ""
+	case rbacutils.ScopeDomain:
+		s.DomainId = ownerId.GetProjectDomainId()
+		s.ProjectId = ""
+	case rbacutils.ScopeProject:
+		s.DomainId = ownerId.GetProjectDomainId()
+		s.ProjectId = ownerId.GetProjectId()
+	}
+	return nil
+}
+
 func (manager *SMonitorScopedResourceManager) ResourceScope() rbacutils.TRbacScope {
 	return manager.SScopedResourceBaseManager.ResourceScope()
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. 修复域视图下报警记录显示不争取的问题
2. 修改nodata 报警策略返回信息


**是否需要 backport 到之前的 release 分支**:
- release/3.6
 - release/3.7

/cc @zexi 
/area monitor


