### PR TITLE
fix(region): cloudaccount: allow only one sync func in flight

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -2565,7 +2565,7 @@ func (account *SCloudaccount) SubmitSyncAccountTask(ctx context.Context, userCre
 	cloudaccountPendingSyncs[account.Id] = struct{}{}
 
 	RunSyncCloudAccountTask(ctx, func() {
-		func() {
+		defer func() {
 			cloudaccountPendingSyncsMutex.Lock()
 			defer cloudaccountPendingSyncsMutex.Unlock()
 			delete(cloudaccountPendingSyncs, account.Id)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

Ref https://github.com/yunionio/onecloud/pull/6859

**是否需要 backport 到之前的 release 分支**:

- release/3.4

/area region
/cc @ioito @swordqiu @zexi 