### PR TITLE
Automated cherry pick of #9974: fix(region): cloudaccount: allow only one sync func in flight

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -2548,7 +2548,7 @@ func (account *SCloudaccount) SubmitSyncAccountTask(ctx context.Context, userCre
 	cloudaccountPendingSyncs[account.Id] = struct{}{}
 
 	RunSyncCloudAccountTask(func() {
-		func() {
+		defer func() {
 			cloudaccountPendingSyncsMutex.Lock()
 			defer cloudaccountPendingSyncsMutex.Unlock()
 			delete(cloudaccountPendingSyncs, account.Id)


### PR DESCRIPTION
Cherry pick of #9974 on release/3.5.

#9974: fix(region): cloudaccount: allow only one sync func in flight