### PR TITLE
Automated cherry pick of #9974: fix(region): cloudaccount: allow only one sync func in flight

### DIFF
--- a/pkg/compute/models/cloudaccounts.go
+++ b/pkg/compute/models/cloudaccounts.go
@@ -2532,7 +2532,7 @@ func (account *SCloudaccount) SubmitSyncAccountTask(ctx context.Context, userCre
 	cloudaccountPendingSyncs[account.Id] = struct{}{}
 
 	RunSyncCloudAccountTask(func() {
-		func() {
+		defer func() {
 			cloudaccountPendingSyncsMutex.Lock()
 			defer cloudaccountPendingSyncsMutex.Unlock()
 			delete(cloudaccountPendingSyncs, account.Id)


### PR DESCRIPTION
Cherry pick of #9974 on release/3.4.

#9974: fix(region): cloudaccount: allow only one sync func in flight