### PR TITLE
fix(keystone): allow delete sso imported non-local user

### DIFF
--- a/locales/locales.go
+++ b/locales/locales.go
@@ -43,3792 +43,3672 @@ func init() {
 }
 
 var messageKeyToIndex = map[string]int{
-	"%s %s %s not found":                                                 105,
-	"%s %s %s not support %s":                                            482,
-	"%s %s not found":                                                    529,
-	"%s %s not support policy value %s":                                  488,
-	"%s %s not supported dns type %s":                                    480,
-	"%s %s not supported policy type %s":                                 481,
-	"%s allow %s %s not found":                                           111,
-	"%s answer is incorrect":                                             19,
-	"%s backend group not support change port":                           1321,
-	"%s backend group not support change port or weight":                 1322,
-	"%s cannot be set to 0":                                              1339,
-	"%s disk cannot exceed 8":                                            216,
-	"%s does not currently support creating loadbalancer":                1380,
-	"%s does not currently support creating loadbalancer acl":            1375,
-	"%s does not currently support creating loadbalancer certificate":    1376,
-	"%s does not support creating loadbalancer":                          1384,
-	"%s does not support creating loadbalancer acl":                      1385,
-	"%s does not support creating loadbalancer certificate":              1386,
-	"%s for %s features are not compatible for creating instance":        217,
-	"%s is not modifiable":                                               562,
-	"%s is not mount point %s":                                           264,
-	"%s is out of network IP ranges":                                     881,
-	"%s is reserved for aliyun %s, please use another":                   1358,
-	"%s length must less 500 letters":                                    1330,
-	"%s listener port %d is already taken by listener %s(%s)":            1051,
-	"%s method not found":                                                83,
-	"%s method params length not match, expected %d, input %d":           84,
-	"%s not allow to %s %s":                                              112,
-	"%s not allow to get property %s":                                    102,
-	"%s not allow to get spec %s":                                        106,
-	"%s not support":                                                     363,
-	"%s not support cdrom params":                                        227,
-	"%s not support close tcp or udp loadbalancer listener health check": 1340,
-	"%s not support create account":                                      1413,
-	"%s not support create eip":                                          210,
-	"%s not support create eip, it only support bind eip":                228,
-	"%s not support create subscription":                                 364,
-	"%s not support create virtual machine with eip":                     229,
-	"%s not support policy type %s":                                      487,
-	"%s not support rebuild root with a different image":                 641,
-	"%s not support recovery":                                            1406,
-	"%s not support saml auth":                                           339,
-	"%s not support this operation":                                      423,
-	"%s only support aliyun %s":                                          1362,
-	"%s only support aliyun %s or %s":                                    1361,
-	"%s only supports eip charge type %q":                                1428,
-	"%s rds Support up to %d security groups":                            408,
-	"%s rds not support secgroup":                                        407,
-	"%s request the mask range should be between 16 and 28":              1379,
-	"%s request the mask range should be between 8 and 29":               1381,
-	"%s request the mask range should be less than or equal to 29":       1449,
-	"%s require disk size must in 40 ~ 4000 GB":                          1394,
-	"%s requires that the eip bandwidth must be less than 100Mbps":       193,
-	"%s requires the virtual machine state to be %s before it can be added backendgroup, but current state of the virtual machine is %s": 1025,
-	"%s reset disk required guest status is running or ready":                                                                            256,
-	"%s shall bind up to %d security groups":                                                                                             831,
-	"%s supported secgroup count is %d":                                                                                                  431,
-	"%s(%s) not allow to delete":                                                                                                         115,
-	"%s: %s cannot be ip address: %s":                                                                                                    518,
-	"%s: %s must be domain name: %s":                                                                                                     517,
-	"%s: Invalid IP address %s":                                                                                                          1108,
-	"%s: bad base64 encoded string: %s":                                                                                                  990,
-	"%s: bad template: %s":                                                                                                               991,
-	"%s: invalid domain name: %s":                                                                                                        511,
-	"%s: name cannot be ip address: %s":                                                                                                  514,
-	"%s: new time is in the future: %s > %s":                                                                                             996,
-	"%s: time error: %s":                                                                                                                 995,
-	"%s: unknown record type":                                                                                                            519,
-	"A: record value must be ipv4 address: %s":                                                                                           515,
-	"AAAA: record value must be ipv6 address: %s":                                                                                        516,
-	"Access address located in different zone than specified":                                                                            886,
-	"Access ip %s has been used":                                                                                                         884,
-	"Access network has no zone???":                                                                                                      885,
-	"Account %s(%s) does not have database %s(%s) permissions":                                                                           393,
-	"Account auto sync enabled":                                                                                                          353,
-	"Account disabled":                                                                                                                   352,
-	"Account status is not %s current status is %s":                                                                                      390,
-	"Action %s not found":                                                                                                                123,
-	"ActionNotFoundError":                                                                                                                1470,
-	"Active download session not expired":                                                                                                1261,
-	"Address %s has been used":                                                                                                           1091,
-	"Address %s not in network":                                                                                                          1095,
-	"Address %s not in range":                                                                                                            1088,
-	"Address %s not reserved":                                                                                                            1090,
-	"Address been assigned out of new range":                                                                                             1120,
-	"Alert is already paused":                                                                                                            1639,
-	"Alert is already un-paused":                                                                                                         1638,
-	"Alert is missing conditions":                                                                                                        1673,
-	"Alert notification used by %d alert":                                                                                                1661,
-	"Alert resource driver duplicate match":                                                                                              1649,
-	"Alert resource driver not found":                                                                                                    1648,
-	"Aliyun %s not support recovery":                                                                                                     1342,
-	"Aliyun %s only 8.0 and 5.7 high_availability local_ssd or 5.6 high_availability support recovery from it self backups": 1344,
-	"Aliyun %s only support recover from it self backups":                                                                   1343,
-	"Aliyun DBInstance account name length shoud be 2~16 characters":                                                        1357,
-	"Aliyun instance weight must be in the range of 0 ~ 100":                                                                1317,
-	"Aliyun not allow to change certificate":                                                                                1313,
-	"Aliyun reset disk required guest status is running or ready":                                                           246,
-	"Already have backup server":                                                                                            707,
-	"At least two networks are required under vpc %s(%s) with aliyun %s(%s)":                                                1355,
-	"Attach nfs storage require host status is online":                                                                      263,
-	"Attach rbd storage require host status is online":                                                                      260,
-	"Aws not support reset disk, you can create new disk with snapshot":                                                     247,
-	"Azure Mv2-series instance sku only support UEFI image":                                                                 196,
-	"Azure UEFI image %s not support this instance sku":                                                                     197,
-	"Azure not support reset disk, you can create new disk with snapshot":                                                   249,
-	"Backup host is offline":                                                                                                715,
-	"Backup only support hypervisor kvm":                                                                                    709,
-	"BadGateway":                                                                                                            1463,
-	"BadRequestError":                                                                                                       1486,
-	"Bandwidth limit cannot exceed %dMbps":                                                                                  1092,
-	"Bandwidth must be non-negative":                                                                                        673,
-	"Baremetal %s is not ready":                                                                                             203,
-	"Baremetal %s is occupied":                                                                                              204,
-	"Baremetal %s not enabled":                                                                                              850,
-	"Baremetal agent not found":                                                                                             275,
-	"Baremetal host is aleady occupied":                                                                                     933,
-	"Baremetal package not prepared":                                                                                        276,
-	"BgpType attribute is only useful for eip network":                                                                      1141,
-	"Bucket has %d task active, can't sync status":                                                                          308,
-	"CD-ROM not empty, please eject first":                                                                                  622,
-	"CNAME cannot mix with other types":                                                                                     509,
-	"CPU core count must be 1 ~ %d":                                                                                         809,
-	"Can not delete disk snapshots, have manual snapshot":                                                                   1257,
-	"Can not get disk snapshot":                                                                                             447,
-	"Can not rebuild root with with diff uefi image":                                                                        639,
-	"Can't clone guest with backup guest":                                                                                   604,
-	"Can't do instance snapshot with backup guest":                                                                          764,
-	"Can't trigger scaling policy without status 'ready'":                                                                   1174,
-	"Cannot Delete disk %s snapshots, disk exist":                                                                           1255,
-	"Cannot add security groups for hypervisor %s":                                                                          626,
-	"Cannot add security groups in status %s":                                                                               551,
-	"Cannot assign security rules in status %s":                                                                             631,
-	"Cannot attach network in status %s":                                                                                    671,
-	"Cannot cache image with no checksum":                                                                                   930,
-	"Cannot change bandwidth in status %s":                                                                                  672,
-	"Cannot change config for baremtal":                                                                                     199,
-	"Cannot change config in %s":                                                                                            677,
-	"Cannot change config in status %s":                                                                                     424,
-	"Cannot change config with different instance family":                                                                   678,
-	"Cannot change network ip_addr in status %s":                                                                            666,
-	"Cannot change server sku name":                                                                                         1229,
-	"Cannot change setting in status %s":                                                                                    674,
-	"Cannot change state on pause alert":                                                                                    1636,
-	"Cannot clone VM in status %s":                                                                                          606,
-	"Cannot create backup with isolated device":                                                                             827,
-	"Cannot create backup with isolated devices":                                                                            710,
-	"Cannot create backup with shared storage":                                                                              708,
-	"Cannot create backup with snapshot":                                                                                    712,
-	"Cannot create disk with disabled storage[%s]":                                                                          440,
-	"Cannot create disk with offline storage[%s]":                                                                           441,
-	"Cannot delete keypair used by servers":                                                                                 975,
-	"Cannot delete server disk %s must not have snapshots.":                                                                 807,
-	"Cannot delete server on disabled host":                                                                                 805,
-	"Cannot delete server on offline host":                                                                                  806,
-	"Cannot delete snapshot in status %s":                                                                                   1250,
-	"Cannot delete snapshot on disk reset":                                                                                  1253,
-	"Cannot delete system alert":                                                                                            1653,
-	"Cannot delete the last cache":                                                                                          1262,
-	"Cannot deploy in status %s":                                                                                            608,
-	"Cannot detach network in status %s":                                                                                    670,
-	"Cannot detach sys disk":                                                                                                650,
-	"Cannot do Ipmi-probe in status %s":                                                                                     903,
-	"Cannot do eject-iso in status %s":                                                                                      947,
-	"Cannot do initialization in status %s":                                                                                 904,
-	"Cannot do insert-iso in status %s":                                                                                     946,
-	"Cannot do io throttle in status %s":                                                                                    750,
-	"Cannot do live migrate, too low qemu version":                                                                          225,
-	"Cannot do maintenance in status %s":                                                                                    895,
-	"Cannot do maintenance while guest status %s":                                                                           896,
-	"Cannot do reboot dbinstance in status %s":                                                                              415,
-	"Cannot do recovery dbinstance in status %s required status %s":                                                         409,
-	"Cannot do renew dbinstance in status %s required status %s":                                                            417,
-	"Cannot do restart elasticcache instance in status %s":                                                                  534,
-	"Cannot do restart server in status %s":                                                                                 689,
-	"Cannot do snapshot when VM in status %s":                                                                               1459,
-	"Cannot do start server in status %s":                                                                                   621,
-	"Cannot do unmaintenance in status %s":                                                                                  897,
-	"Cannot enable deleting account":                                                                                        338,
-	"Cannot keep detached disk":                                                                                             651,
-	"Cannot live migrate in status %s":                                                                                      603,
-	"Cannot live migrate with cdrom":                                                                                        223,
-	"Cannot live migrate with isolated devices":                                                                             224,
-	"Cannot migrate with isolated devices":                                                                                  222,
-	"Cannot mix different types of records, %s != %s":                                                                       523,
-	"Cannot modify Memory and CPU in status %s":                                                                             810,
-	"Cannot modify memory for baremetal":                                                                                    811,
-	"Cannot normal migrate guest in status %s, try rescue mode or server-live-migrate?":                                     220,
-	"Cannot perform cache image in status %s":                                                                               928,
-	"Cannot prepare baremetal in server status %s":                                                                          902,
-	"Cannot prepare baremetal in status %s":                                                                                 901,
-	"Cannot purge elastic_ip on enabled cloud provider":                                                                     588,
-	"Cannot purge network on enabled cloud provider":                                                                        1124,
-	"Cannot purge route_table on enabled cloud provider":                                                                    1148,
-	"Cannot purge server on enabled host":                                                                                   634,
-	"Cannot purge snapshot on enabled cloud provider":                                                                       1258,
-	"Cannot purge vpc on enabled cloud provider":                                                                            1296,
-	"Cannot reduce disk size":                                                                                               685,
-	"Cannot reset VM in status %s":                                                                                          686,
-	"Cannot reset baremetal in status %s":                                                                                   926,
-	"Cannot reset baremetal with active guest":                                                                              927,
-	"Cannot reset disk %s(%s),Snapshot is belong to disk %s":                                                                452,
-	"Cannot reset disk in status %s":                                                                                        450,
-	"Cannot reset disk with snapshot in status %s":                                                                          451,
-	"Cannot reset root in status %s":                                                                                        642,
-	"Cannot resize disk for baremtal":                                                                                       200,
-	"Cannot resume VM in status %s":                                                                                         618,
-	"Cannot revoke security groups in status %s":                                                                            629,
-	"Cannot save image for baremtal":                                                                                        205,
-	"Cannot save image in status %s":                                                                                        599,
-	"Cannot send command in status %s":                                                                                      597,
-	"Cannot send keys in status %s":                                                                                         690,
-	"Cannot set default strategy of %s":                                                                                     1189,
-	"Cannot set security group for this guest %s":                                                                           633,
-	"Cannot set security rules in status %s":                                                                                632,
-	"Cannot start a non-baremetal host":                                                                                     890,
-	"Cannot start baremetal with active guest":                                                                              891,
-	"Cannot stop a non-baremetal host":                                                                                      892,
-	"Cannot stop baremetal with active guest":                                                                               894,
-	"Cannot stop baremetal with non-active guest":                                                                           893,
-	"Cannot stop server in status %s":                                                                                       688,
-	"Cannot suspend VM in status %s":                                                                                        617,
-	"Cannot switch OS between %s-%s":                                                                                        638,
-	"Cannot swith to backup when guest in status %s":                                                                        700,
-	"Cannot sync config a non-baremetal host":                                                                               948,
-	"Cannot sync in status %s":                                                                                              602,
-	"Cannot sync status a non-baremetal host":                                                                               925,
-	"Cannot uncache in status %s":                                                                                           1263,
-	"Cannot unconvert in status %s":                                                                                         940,
-	"Cannot update external resource":                                                                                       382,
-	"Check input guests is exist":                                                                                           762,
-	"Check set pending quota error %s":                                                                                      742,
-	"Cloudaccount disabled":                                                                                                 372,
-	"Cloudprovider disabled":                                                                                                371,
-	"Condition is missing the threshold parameter":                                                                          1669,
-	"Condition is missing the type parameter":                                                                               1670,
-	"Conflict address space with existing networks":                                                                         1119,
-	"Conflict address space with existing networks in vpc %q":                                                               1117,
-	"Conflict manager_uri %s":                                                                                               278,
-	"ConflictError":                                                                                                         1494,
-	"Connot convert hypervisor in status %s":                                                                                934,
-	"Container not support %s":                                                                                              209,
-	"Content-Length negative %d":                                                                                            301,
-	"Convert error: %s":                                                                                                     938,
-	"Couldn't delete snapshot policy binding to disks":                                                                      1243,
-	"Currently only kvm platform supports creating wire":                                                                    1303,
-	"DBInstance %s(%s) status is %s require status is %s":                                                                   385,
-	"DBInstance backup has %d task active, can't sync status":                                                               395,
-	"DBInstance has %d task active, can't sync status":                                                                      416,
-	"DBInstance has opened the outer network connection":                                                                    421,
-	"DBInstance is locked, cannot delete":                                                                                   427,
-	"DBinstance has not valid cloudprovider":                                                                                394,
-	"DIRECT setting cannot be changed":                                                                                      129,
-	"DIRECT setting cannot be deleted":                                                                                      130,
-	"DISK Index %d has been occupied":                                                                                       793,
-	"Data disk size must be an integer multiple of 10G":                                                                     236,
-	"Database status is not %s current is %s":                                                                               392,
-	"Default data source not found":                                                                                         1655,
-	"Default quota %s not allow to delete":                                                                                  135,
-	"Description can not start with http:// or https://":                                                                    1356,
-	"Directly creating cloudprovider is not supported, create cloudaccount instead":                                         368,
-	"Disk %s and guest not belong to the same account":                                                                      609,
-	"Disk %s and guest not belong to the same zone":                                                                         610,
-	"Disk %s don't need convert snapshots":                                                                                  446,
-	"Disk %s dose not have snapshot":                                                                                        1256,
-	"Disk %s dosen't attach guest ?":                                                                                        1457,
-	"Disk %s has been attached":                                                                                             612,
-	"Disk %s not attached":                                                                                                  653,
-	"Disk %s not belong the guest's host":                                                                                   613,
-	"Disk %s not found":                                                                                                     616,
-	"Disk %s snapshot full, cannot take any more":                                                                           1461,
-	"Disk attach muti guests":                                                                                               265,
-	"Disk attached Guest has backup, Can't create snapshot":                                                                 1458,
-	"Disk attached guest status must be ready":                                                                              266,
-	"Disk cannot be thrink":                                                                                                 454,
-	"Disk dosen't attach guest":                                                                                             267,
-	"Disk has %d task active, can't sync status":                                                                            474,
-	"Disk in %s not able to attach":                                                                                         614,
-	"Disk must be detached":                                                                                                 258,
-	"Disk must be dettached":                                                                                                255,
-	"Diskinfo index %d: both imageID and size are absent":                                                                   470,
-	"Do not need to update":                                                                                                 1242,
-	"Duplicate ID %s %s":                                                                                                    1507,
-	"Duplicate image name %s":                                                                                               459,
-	"Duplicate manager_uri %s":                                                                                              279,
-	"Duplicate name %s":                                                                                                     1132,
-	"Duplicate name %s %s":                                                                                                  1506,
-	"Duplicate sku %s":                                                                                                      1226,
-	"DuplicateIdError":                                                                                                      183,
-	"DuplicateNameError":                                                                                                    1492,
-	"DuplicateResourceError":                                                                                                1493,
-	"Duration %s invalid":                                                                                                   1093,
-	"Eject ISO not allowed in status %s":                                                                                    625,
-	"Elastic cache is locked, cannot delete":                                                                                535,
-	"Elastic cache is not expired, cannot delete":                                                                           536,
-	"Elasticcache has %d task active, can't sync status":                                                                    548,
-	"Empty import disks":                                                                                                    727,
-	"Empty import nics":                                                                                                     724,
-	"Empty record":                                                                                                          520,
-	"Empty spec query key":                                                                                                  1450,
-	"EmptyRequestError":                                                                                                     1487,
-	"ErrAddressCountExceed":                                                                                                 190,
-	"Fail to mark cache status: %s":                                                                                         1268,
-	"Failed fetching secgroup %s":                                                                                           1205,
-	"Failed to found database %s for dbinstance %s(%s): %v":                                                                 388,
-	"Failed to unmarshal input: %v":                                                                                         1204,
-	"Fetch guest error %s":                                                                                                  706,
-	"Fetch instance snapshot error %s":                                                                                      1251,
-	"Fetch netif error %s":                                                                                                  924,
-	"Fetch snapshot count failed %s":                                                                                        445,
-	"FetchCustomizeColumns return incorrect number of results":                                                              95,
-	"FetchCustomizeColumns returns incorrect results":                                                                       99,
-	"For default vpc, only system level sharing can be set":                                                                 1298,
-	"ForbiddenError":                                                                                                        1490,
-	"General error: general error for %q: %s":                                                                               167,
-	"Generate ifname hint failed %s":                                                                                        1134,
-	"Generate snapshot name failed %s":                                                                                      772,
-	"Generate xml failed: %s":                                                                                               736,
-	"GenerateName fail %s":                                                                                                  1133,
-	"Get convert snapshot failed: %s":                                                                                       448,
-	"Get object error: %v":                                                                                                  1452,
-	"GetAllocatedNicCount fail %s":                                                                                          1077,
-	"GetDiskCount fail %s":                                                                                                  871,
-	"GetGuestCount fail %s":                                                                                                 244,
-	"GetGuestDiskCount fail %s":                                                                                             960,
-	"GetGuestDiskCount for disk %s fail %s":                                                                                 467,
-	"GetGuestnicsCount fail %s":                                                                                             961,
-	"GetGuestsCount fail %s":                                                                                                1211,
-	"GetHostCount fail %s":                                                                                                  1273,
-	"GetIObject error %s":                                                                                                   302,
-	"GetIObject fail %s":                                                                                                    292,
-	"GetLinkedGuestsCount failed %s":                                                                                        974,
-	"GetNatgatewayCount fail %v":                                                                                            1291,
-	"GetNetworkCount fail %s":                                                                                               1289,
-	"GetObjectCount fail %s":                                                                                                1190,
-	"GetRequesterVpcPeeringConnections fail %v":                                                                             1293,
-	"GetRuningGuestCount fail %s":                                                                                           461,
-	"GetSnapshotCount fail %s":                                                                                              475,
-	"GetVpcCount fail %s":                                                                                                   378,
-	"GetZoneCount fail %s":                                                                                                  377,
-	"Google dbinstance not support prepaid billing type":                                                                    1387,
-	"Guest %s can't hot remove nic":                                                                                         226,
-	"Guest %s not found":                                                                                                    705,
-	"Guest %s not support attach disk in status %s":                                                                         615,
-	"Guest '%s' don't belong to ScalingGroup '%s'":                                                                          1168,
-	"Guest Insert error: %s":                                                                                                906,
-	"Guest backup host not found":                                                                                           714,
-	"Guest can't switch to backup, mirror job not ready":                                                                    702,
-	"Guest has %d task active, can't sync status":                                                                           687,
-	"Guest have backup not allow to change config":                                                                          676,
-	"Guest have backup, can't migrate":                                                                                      219,
-	"Guest hypervisor %s does not support clone":                                                                            605,
-	"Guest nic ip addr %s not equal %s":                                                                                     922,
-	"Guest no backup host":                                                                                                  701,
-	"Guest without backup":                                                                                                  713,
-	"GuestDisksHasSnapshot fail %s":                                                                                         711,
-	"Handler not found":                                                                                                     77,
-	"Host %s already have mount point %s with other storage":                                                                262,
-	"Host %s can't migrate guests %s in status %s":                                                                          945,
-	"Host %s is not a baremetal":                                                                                            202,
-	"Host %s is not online":                                                                                                 243,
-	"Host %s not found":                                                                                                     218,
-	"Host is a converted baremetal, should be unconverted before delete":                                                    867,
-	"Host is not disabled":                                                                                                  868,
-	"Host missing":                                                                                                          595,
-	"Host should be disabled":                                                                                               939,
-	"HostCount fail %s":                                                                                                     1304,
-	"Huawei %s rds not support recovery from it self rds backup":                                                            1407,
-	"Huawei DBInstance Disk cannot be thrink":                                                                               1401,
-	"Huawei DBInstance backup name length shoud be 4~64 characters":                                                         1399,
-	"Huawei DBInstance category cannot change":                                                                              1402,
-	"Huawei DBInstance storage type cannot change":                                                                          1403,
-	"Huawei current not support reset dbinstance account password":                                                          1404,
-	"Huawei dbinstance name length shoud be 4~64 characters":                                                                1393,
-	"Huawei only %s engine support databases recovery":                                                                      1408,
-	"Huawei only supports specified databases with %s":                                                                      1400,
-	"Huawei rds password cannot be in the same reverse order as the account":                                                1397,
-	"Hypervisor %s can't do io throttle":                                                                                    749,
-	"Hypervisor %s can't generate libvirt xml":                                                                              735,
-	"Hypervisor %s not supported":                                                                                           855,
-	"IP %s not attach to any wire":                                                                                          912,
-	"IP %s not attach to wire %s":                                                                                           911,
-	"IPMI address located in different zone than specified":                                                                 883,
-	"IPMI has no password information":                                                                                      875,
-	"IPMI infomation not configured":                                                                                        905,
-	"IPMI network has no zone???":                                                                                           882,
-	"IPMI network has not zone???":                                                                                          888,
-	"Illegal Content-Length %s":                                                                                             300,
-	"Image %s not found":                                                                                                    1504,
-	"Image is in use":                                                                                                       1260,
-	"Image name is required":                                                                                                463,
-	"Image status is not active":                                                                                            473,
-	"ImageNotFoundError":                                                                                                    1467,
-	"Inconsistent: local storage is not empty???":                                                                           873,
-	"Incontinuity Network for %s and %s":                                                                                    1127,
-	"Influxdb invalid status":                                                                                               1667,
-	"InformerBackend not init":                                                                                              162,
-	"InputParameterError":                                                                                                   1475,
-	"Insert ISO not allowed in status %s":                                                                                   623,
-	"Insert shared resource failed %s":                                                                                      149,
-	"Instance sanpshot not ready":                                                                                           769,
-	"Instance snapshot not ready":                                                                                           815,
-	"Instance status is not %s current status is %s":                                                                        391,
-	"InsufficientResourceError":                                                                                             1478,
-	"Interface %s not exist":                                                                                                915,
-	"Interface %s not exists":                                                                                               917,
-	"Internal server error":                                                                                                 75,
-	"Internal server error: %s":                                                                                             74,
-	"InternalServerError":                                                                                                   1464,
-	"Invaild mac address":                                                                                                   907,
-	"Invald %s return value":                                                                                                101,
-	"Invald CustomizeDelete return value":                                                                                   93,
-	"Invald ListItemFilter return value count %d":                                                                           86,
-	"Invald OrderByExtraFields return value count %d":                                                                       87,
-	"Invald ValidateCreateData return value":                                                                                85,
-	"Invald ValidateUpdateData return value":                                                                                92,
-	"Invalid FetchCustomizeColumns return value count %d":                                                                   89,
-	"Invalid FetchCustomizeColumns return value type, not a slice!":                                                         90,
-	"Invalid FetchCustomizeColumns return value, inconsistent obj count: input %d != output %d": 91,
-	"Invalid GetExtraDetails return value count %d":                                             88,
-	"Invalid IP %s": 1129,
-	"Invalid Target Network %s: inconsist %s":                           1126,
-	"Invalid bandwidth":                                                 587,
-	"Invalid choice error: invalid %q, want %s, got %s":                 169,
-	"Invalid condition evaluator type":                                  1671,
-	"Invalid data JSONObject":                                           113,
-	"Invalid default stragegy %s":                                       1188,
-	"Invalid desc: %s":                                                  720,
-	"Invalid handler %s":                                                76,
-	"Invalid host ip %s":                                                731,
-	"Invalid interval format: %s":                                       1665,
-	"Invalid length error: %q too long, got %d, max %d":                 171,
-	"Invalid length error: %q too short, got %d, min %d":                170,
-	"Invalid level format: %s":                                          1650,
-	"Invalid mac address":                                               923,
-	"Invalid masklen %d":                                                1104,
-	"Invalid medium type %s":                                            1271,
-	"Invalid period format: %s":                                         1651,
-	"Invalid raid config: %v":                                           201,
-	"Invalid refresh format: %s":                                        1640,
-	"Invalid request header: %v":                                        79,
-	"Invalid root image: %s":                                            819,
-	"Invalid schedtag %s":                                               1187,
-	"Invalid server ip address %s":                                      733,
-	"Invalid server mac address %s":                                     732,
-	"Invalid server_type: %s":                                           1099,
-	"Invalid start ip: %s %s":                                           1105,
-	"Invalid storage type %s":                                           1270,
-	"Invalid type error: expecting %s type for %q: %s":                  168,
-	"Invalid userdata: %v":                                              832,
-	"Invalid value error: invalid %q: ":                                 175,
-	"Invalid value error: invalid %q: %s":                               173,
-	"Invalid value error: invalid %q: %v":                               174,
-	"InvalidCredentialError":                                            1489,
-	"InvalidFormatError":                                                1474,
-	"InvalidProvider":                                                   188,
-	"InvalidStatusError":                                                184,
-	"InvalidToken":                                                      1605,
-	"Ip %s not in network %s(%s) range":                                 400,
-	"Isolated device %s not found":                                      656,
-	"Isolated device already attached to another guest: %s":             970,
-	"Isolated device is not attached to this guest":                     657,
-	"Isolated device used by server":                                    968,
-	"Isolated device used by server: %s":                                971,
-	"IsolatedDevice %s not found":                                       969,
-	"Keypair %s not found":                                              829,
-	"Kvm snapshot missing storage ??":                                   1433,
-	"Loadbalancer's manager %s does not match vpc's(%s(%s)) (%s)":       1369,
-	"Loadbalancer's manager (%s(%s)) does not match vpc's(%s(%s)) (%s)": 1312,
-	"Local host storage is not empty???":                                872,
-	"Master dbinstance memory <64GB, up to 5 read-only instances are allowed to be created":  1354,
-	"Master dbinstance memory ≥64GB, up to 10 read-only instances are allowed to be created": 1353,
-	"Memory size must be 8MB ~ %d GB":                           808,
-	"Memory size must be number[+unit], like 256M, 1G or 256":   680,
-	"Miss operating system???":                                  822,
-	"Missing isolated device":                                   655,
-	"Missing key error: missing %q":                             166,
-	"Missing name or generate_name":                             109,
-	"Missing parameter %s":                                      40,
-	"MissingParameterError":                                     1477,
-	"Model manager error: failed getting model manager for %q":  176,
-	"Model not found error: cannot find %q with id/name %q":     177,
-	"Model not found error: cannot find %q with id/name %q: %s": 178,
-	"Must be a baremetal host":                                  932,
-	"NIC Index %d has been occupied":                            796,
-	"Name %s not found":                                         1606,
-	"Nat gateway has %d task active, can't sync status":         1063,
-	"Network %s not found":                                      1125,
-	"Network %s not found: %v":                                  1087,
-	"Network not found":                                         274,
-	"Network not in range of VPC cidrblock %s":                  1115,
-	"NetworkCount fail %s":                                      1306,
-	"New IPMI address located in another zone!":                 889,
-	"New databases name can not be one of %s":                   1409,
-	"NewTask error: %s":                                         734,
-	"No Disk Info Provided":                                     644,
-	"No ISO to eject":                                           624,
-	"No context manager":                                        96,
-	"No disk information provided":                              818,
-	"No eip to dissociate":                                      698,
-	"No host for server":                                        598,
-	"No id list found":                                          60,
-	"No ipmi information was found for host %s":                 874,
-	"No login key: %s":                                          1621,
-	"No login secret found":                                     1607,
-	"No need to grant or revoke privilege for admin account":    1405,
-	"No password found":                                         1611,
-	"No previous deployment info available":                     1011,
-	"No request key: %s":                                        78,
-	"No return value, so why query?":                            103,
-	"No root image":                                             600,
-	"No ssh password: %s":                                       1612,
-	"No such context %s(%s)":                                    97,
-	"No such eip":                                               1062,
-	"No template for root disk, cannot rebuild root":            640,
-	"No token in header":                                        56,
-	"No token in header: %v":                                    39,
-	"No valid host":                                             645,
-	"No valid storage on current host":                          646,
-	"No zone for this disk":                                     458,
-	"NoBalancePermission":                                       189,
-	"NoProjectError":                                            1498,
-	"Not Implement RequestAttachStorage":                        253,
-	"Not Implement RequestDetachStorage":                        254,
-	"Not Implement ValidateAttachStorage":                       252,
-	"Not Implement ValidateCreateEip":                           206,
-	"Not Implement ValidateResetDisk":                           251,
-	"Not Implemented":                                           398,
-	"Not Implemented GetProvider":                               181,
-	"Not a baremetal":                                           918,
-	"Not a prepaid recycle host":                                863,
-	"Not allow empty records":                                   81,
-	"Not allow for hypervisor %s":                               207,
-	"Not allow set scope to domain %s":                          146,
-	"Not allow set scope to project %s":                         147,
-	"Not allow set scope to system":                             145,
-	"Not allow to attach":                                       116,
-	"Not allow to change config":                                675,
-	"Not allow to create item":                                  107,
-	"Not allow to get details":                                  104,
-	"Not allow to update item":                                  114,
-	"Not an converted hypervisor":                               941,
-	"Not an empty host":                                         870,
-	"Not being convert to hypervisor":                           919,
-	"Not enough free space":                                     444,
-	"Not eough storage space on current host":                   647,
-	"Not find executor for data source":                         1668,
-	"Not found baremetal server record":                         920,
-	"Not found guest nic by mac %s":                             921,
-	"Not found key in query: %v":                                1623,
-	"Not found kind in query: %v":                               1622,
-	"Not found network by ip %s":                                726,
-	"Not in range error: invalid %q: %d, want [%d,%d]":          172,
-	"Not support":                                               489,
-	"Not support %s for account %s, supported %s":               492,
-	"Not support %s for vpc %s, supported %s":                   491,
-	"Not support associate type %s, only support %s":            565,
-	"Not support brand %s, only support %s":                     345,
-	"Not support cache classic security group":                  1208,
-	"Not support create %s storage":                             1272,
-	"Not support create Qcloud databases":                       1447,
-	"Not support create account for huawei cloud %s instance":   1396,
-	"Not support create database for huawei cloud %s instance":  1398,
-	"Not support create local storage disks":                    240,
-	"Not support create public cloud sku":                       1224,
-	"Not support create read-only dbinstance for %s":            1392,
-	"Not support create readonly dbinstance for MySQL %s":       1349,
-	"Not support create readonly dbinstance for MySQL %s %s":    1347,
-	"Not support create readonly dbinstance for MySQL %s %s with storage type %s, only support %s": 1348,
-	"Not support create readonly dbinstance with master dbinstance engine %s":                      1352,
-	"Not support modify routetable for provider %s":                                                1147,
-	"Not support resource %s tag filter":                                                           122,
-	"Not support resource_type %s":                                                                 1183,
-	"Not supported, please use kubectl":                                                            208,
-	"NotAcceptableError":                                                                           1491,
-	"NotEmptyError":                                                                                1485,
-	"NotFoundError":                                                                                182,
-	"NotImplementedError":                                                                          186,
-	"NotSufficientPrivilegeError":                                                                  1483,
-	"NotSupportedError":                                                                            187,
-	"Object %s %s has attached %s %s":                                                              117,
-	"Only %s dbinstance support this operation":                                                    420,
-	"Only %s elastic cache support renew operation":                                                561,
-	"Only %s elastic cache support set auto renew operation":                                       559,
-	"Only %s guest support this operation":                                                         782,
-	"Only %s support cache for account":                                                            497,
-	"Only ADMIN and IPMI nic can be enable":                                                        916,
-	"Only allowed to attach isolated device when guest is ready":                                   654,
-	"Only one of that sourceCIDR and netword_id is needed":                                         1064,
-	"Only support on premise network":                                                              1137,
-	"Only support server type %s":                                                                  1136,
-	"Only system admin allowed to use reserved ip":                                                 1089,
-	"Only system admin can assign host":                                                            955,
-	"OpenStack not support reset disk, you can create new disk with snapshot":                      268,
-	"Out of IP address":                                                                            1085,
-	"Out of eip quota: %s":                                                                         699,
-	"OutOfLimit":                                                                                   1482,
-	"OutOfQuotaError":                                                                              1480,
-	"OutOfRange":                                                                                   1481,
-	"OutOfResource":                                                                                1479,
-	"PTR cannot mix with other types":                                                              510,
-	"PTR: invalid ptr record name: %s":                                                             513,
-	"Params vcpu_count parse error":                                                                679,
-	"Params vmem_size parse error":                                                                 681,
-	"Parse Ip Failed":                                                                              1123,
-	"Parse disk info error: %s":                                                                    684,
-	"Parse query: %v":                                                                              38,
-	"Parse remote ip error %s":                                                                     273,
-	"Parse spec key %s error: %v":                                                                  1451,
-	"PaymentError":                                                                                 1466,
-	"Please disable this ScalingGroup firstly":                                                     1165,
-	"Please input new disk backend type":                                                           241,
-	"PolicyDefinitionError":                                                                        1503,
-	"Port value error":                                                                             1058,
-	"Prohibit making default vpc private":                                                          1299,
-	"Project %s(%s) not belong to domain %s(%s)":                                                   344,
-	"ProtectedResourceError":                                                                       1497,
-	"Qcloud Basic MySQL instance not support create backup":                                        1446,
-	"Qcloud reset disk required guest status is running or read":                                   269,
-	"Query database error %s":                                                                      126,
-	"Query host storage error %s":                                                                  261,
-	"Quota %s not found":                                                                           134,
-	"Records limit exceeded.":                                                                      82,
-	"Region %s not found":                                                                          369,
-	"RequireLicenseError":                                                                          1496,
-	"Rescue mode requires all disk store in shared storages":                                       221,
-	"Resize disk when disk is READY":                                                               453,
-	"Resource %s %s not found":                                                                     1197,
-	"Resource type %s not support":                                                                 527,
-	"ResourceBusyError":                                                                            1495,
-	"ResourceNotFoundError":                                                                        1468,
-	"ResourceNotReadyError":                                                                        1465,
-	"ResourceType %q not support":                                                                  1181,
-	"Retention days must in 1~%d or -1":                                                            1237,
-	"Retention days must in 1~65535 or -1":                                                         1241,
-	"SQL Server cannot have more than seven read-only dbinstances":                                 1351,
-	"SQL Server only support create readonly dbinstance for 2017_ent":                              1350,
-	"SRV cannot mix with other types":                                                              508,
-	"SRV: insufficient param: %s":                                                                  502,
-	"SRV: invalid port number: %s":                                                                 503,
-	"SRV: invalid priority number: %s":                                                             506,
-	"SRV: invalid srv record name: %s":                                                             512,
-	"SRV: invalid weight number: %s":                                                               504,
-	"SRV: priority number %d not in range [0,65535]":                                               507,
-	"SRV: weight number %d not in range [0,65535]":                                                 505,
-	"Save disk when disk is READY":                                                                 460,
-	"Save disk when not being USED":                                                                462,
-	"ScalingGroup should have some networks":                                                       1154,
-	"Schedtag %s":                                                                                  1184,
-	"Schedtag %s ResourceType is %s, not match %s":                                                 1196,
-	"Schedtag %s not found":                                                                        865,
-	"Schedtag %s resource_type mismatch: %s != %s":                                                 1185,
-	"Secgroup %s not found":                                                                        830,
-	"Server %s already exists":                                                                     723,
-	"Server %s must in status ready":                                                               257,
-	"Server Id is empty":                                                                           721,
-	"Server Name is empty":                                                                         722,
-	"Server in %s not able to detach disk":                                                         652,
-	"ServerStatusError":                                                                            1473,
-	"SetLimit error %s":                                                                            325,
-	"Snapshot %s dose not have convert snapshot":                                                   449,
-	"Snapshot %s not found":                                                                        471,
-	"Snapshot %s storage %s not found, is public cloud?":                                           472,
-	"Snapshot error: disk index %d > 0 but disk type is %s":                                        824,
-	"Snapshot for %s name can't start with auto, http:// or https://":                              1341,
-	"Snapshot has %d task active, can't sync status":                                               1254,
-	"Snapshot reference(by disk) count > 0, can not delete":                                        1455,
-	"Some disk not ready":                                                                          620,
-	"Some host config missing host ip":                                                             730,
-	"Some host config missing xml_file_path":                                                       729,
-	"SpecNotFoundError":                                                                            1469,
-	"Split IP %s is the start ip":                                                                  1130,
-	"Split IP %s out of range":                                                                     1131,
-	"Storage %s not found":                                                                         437,
-	"Storage type[%s] not match backend %s":                                                        442,
-	"StorageInUse":                                                                                 956,
-	"Storage[%s] must attach to a host":                                                            443,
-	"Support only by KVM Hypervisor":                                                               601,
-	"System disk does not support %s disk":                                                         215,
-	"System disk does not support iso image, please consider using cdrom parameter": 820,
-	"TOTP recovery questions do not exist":                                          17,
-	"Tag is associated with %s":                                                     1191,
-	"TenantNotFoundError":                                                           1471,
-	"The %s disk size must be in the range of %dGB ~ %dGB":                          192,
-	"The %s disk size must be in the range of 100GB ~ 16000GB":                      233,
-	"The %s disk size must be in the range of 10GB ~ 16000GB":                       231,
-	"The %s disk size must be in the range of 20GB ~ 32000GB":                       234,
-	"The %s disk size must be in the range of 50GB ~ 16000GB":                       232,
-	"The %s guest not support public ip to eip operation":                           781,
-	"The account %s(%s) has permission %s to the database %s(%s)":                   389,
-	"The account has been registered":                                               347,
-	"The backend %s is already registered on port %d":                               1378,
-	"The dbinstance status need be %s, current is %s":                               419,
-	"The disk is locally stored and does not support detach":                        242,
-	"The disk_size_gb must be an integer multiple of 10":                            1395,
-	"The elastic cache status need be %s, current is %s":                            558,
-	"The extranet connection is not open":                                           422,
-	"The guest %s does not have any public IP":                                      779,
-	"The guest status need be %s or %s, current is %s":                              780,
-	"The image has been cached on storages":                                         330,
-	"The secgroup name %s does not meet the requirements, please change the name":   556,
-	"The specified Scheduler %s is invalid for performance sharing loadbalancer":    1335,
-	"The system disk is locally stored and does not support changing configuration": 239,
-	"There are some guests in this ScalingGroup, please delete them firstly":        1166,
-	"This RBD Storage[%s/%s] has already exist":                                     1462,
-	"This scheduled task is being executed now, please try later":                   1202,
-	"TimeoutError":            185,
-	"Token expired":           58,
-	"Token in header invalid": 57,
-	"TooLargeEntity":          1499,
-	"TooManyFailedAttempts":   1500,
-	"TooManyRequests":         1501,
-	"Ucloud only support data disk reset operation":             271,
-	"Ucloud reset disk operation required disk not be attached": 270,
-	"Unauthorized":                                                                      1604,
-	"UnauthorizedError":                                                                 1488,
-	"Unavailable IP %s: occupied":                                                       746,
-	"Unknown alert condition":                                                           1672,
-	"Unknown backend group type %s":                                                     1323,
-	"Unknown google storage type %s":                                                    214,
-	"Unknown privilege %s":                                                              1363,
-	"Unknown sticky_session_type, only support %s or %s":                                1333,
-	"Unkown alert condition type: %s":                                                   1680,
-	"Unkown operator %s":                                                                1675,
-	"Unmarshal data error %s":                                                           728,
-	"Unmarshal disks configure error %s":                                                683,
-	"Unmarshal input error %s":                                                          607,
-	"Unmarshal input error: %v":                                                         425,
-	"Unmarshal input failed %s":                                                         1057,
-	"Unmarshel input failed %s":                                                         1240,
-	"Unreachable IP %s: %s":                                                             745,
-	"Unsupport attach %s storage for %s host":                                           259,
-	"Unsupport backendgorup type %s":                                                    1315,
-	"Unsupport driver type %s":                                                          936,
-	"UnsupportOperationError":                                                           1484,
-	"Unsupported %s":                                                                    570,
-	"Unsupported action %s":                                                             41,
-	"Unsupported notification type":                                                     1666,
-	"Unsupported provider %s":                                                           343,
-	"Unsupported scheme %s":                                                             972,
-	"UnsupportedProtocol":                                                               1502,
-	"Update error %s":                                                                   326,
-	"UserNotFoundError":                                                                 1472,
-	"VPC %s not found":                                                                  381,
-	"VPC not empty, please delete nat gateway first":                                    1292,
-	"VPC not empty, please delete network first":                                        1290,
-	"VPC not ready":                                                                     1112,
-	"VPC peering not empty, please delete vpc peering first":                            1294,
-	"ValidateDeleteCondition error %s":                                                  329,
-	"Virtual disk %s(%s) used by virtual servers":                                       468,
-	"Virtual resource freezed, can't do %s":                                             158,
-	"Virtual resource type %s not support":                                              528,
-	"Virtual server is locked, cannot delete":                                           803,
-	"WeakPasswordError":                                                                 1476,
-	"Wire %s not found":                                                                 854,
-	"Wrong content type %s, want %s":                                                    42,
-	"Wrong guest status %s":                                                             898,
-	"ZStack reset disk operation requried guest status is ready":                        272,
-	"Zone %s not found":                                                                 370,
-	"a recycle host shoud not allocate more than 1 guest":                               861,
-	"account %s conflict":                                                               358,
-	"account %s has been cached":                                                        498,
-	"account %s not enable saml auth":                                                   334,
-	"account %s not share for domain %s":                                                589,
-	"account is enabled":                                                                335,
-	"account is not idle":                                                               336,
-	"account name '%s' is not allowed":                                                  1437,
-	"account name can not start or end with _":                                          1360,
-	"account_privilege %s only support redis version 4.0":                               1365,
-	"acl %s is still referred to by %d %s":                                              983,
-	"acl cidr duplicate %s":                                                             980,
-	"address %s is already occupied":                                                    1081,
-	"address %s is not in the range of network %s(%s)":                                  1079,
-	"alert already attached to notification":                                            1637,
-	"alert condition type is empty":                                                     1679,
-	"all networks should in the same vpc. (%s).":                                        1370,
-	"allocate ip addr: %v":                                                              1075,
-	"allow only internal zone, got %s(%s)":                                              1039,
-	"already associate with eip":                                                        692,
-	"already has one network in the zone %s. (%s).":                                     1371,
-	"app_id is empty":                                                                   1629,
-	"app_secret is empty":                                                               1630,
-	"attach devices is not string array":                                                661,
-	"auth mode aready in status %s":                                                     542,
-	"authenticate error: %v":                                                            1008,
-	"back and instance not in same cloudaccount":                                        412,
-	"backend group %s is default backend group":                                         1022,
-	"backend group %s is still referred by %d %s":                                       1024,
-	"backend group %s(%s) belongs to loadbalancer %s instead of %s":                     1325,
-	"backend group %s(%s) belongs to loadbalancer %s, not %s":                           1053,
-	"backend group type must be normal":                                                 1326,
-	"backend_group argument is missing":                                                 1424,
-	"backendgroup %s not support this operation":                                        1319,
-	"backup %s(%s) not contain database %s":                                             410,
-	"backup and instance not in same cloudregion":                                       413,
-	"bad gateway ip: %v":                                                                1109,
-	"bad ip":                                                                            1686,
-	"bad network type %q, want %q":                                                      1430,
-	"bandwidth must be greater than 0":                                                  1301,
-	"batch create is not supported for external resources":                              1071,
-	"beyond security group quantity limit, max items %d.":                               555,
-	"body is not a json?":                                                               108,
-	"bps must > 0":                                                                      751,
-	"bucket.GetQuotaKeys %s":                                                            294,
-	"bucket.GetQuotaKeys fail %s":                                                       304,
-	"can not bind guest from disabled guest":                                            591,
-	"can not bind or unbind disabled instance group":                                    778,
-	"can not change specification in status %s":                                         541,
-	"can not find dashboard:%s":                                                         1644,
-	"can not make backup in status %s":                                                  1438,
-	"can not recover data from diff rds engine":                                         414,
-	"can not sync record sets in %s":                                                    495,
-	"can not unbind guest from disabled guest":                                          592,
-	"can not update instance_type for public cloud %s":                                  1228,
-	"can't delete instance snapshot with wrong status":                                  963,
-	"can't detach host in status online":                                                1279,
-	"can't find instance snapshot %s":                                                   813,
-	"can't get string field":                                                            124,
-	"can't open file":                                                                   43,
-	"can't parse file":                                                                  44,
-	"can't rebuild root for a guest with instance snapshots":                            213,
-	"can't rescue geust %s with local storage":                                          756,
-	"can't resize disk for guest with instance snapshots":                               211,
-	"can't restore elastic cache in status %s":                                          530,
-	"candidate %s out of range":                                                         1084,
-	"cannot allocate ifname":                                                            794,
-	"cannot alter name of role":                                                         1561,
-	"cannot alter sysadmin user name":                                                   1572,
-	"cannot alter system project name":                                                  1558,
-	"cannot associate eip and instance in different provider":                           697,
-	"cannot associate eip and instance in different region":                             695,
-	"cannot associate eip and instance in different zone":                               696,
-	"cannot associate eip in status %s":                                                 691,
-	"cannot associate eip with same network":                                            574,
-	"cannot associate pending delete server":                                            571,
-	"cannot associate server in status %s":                                              573,
-	"cannot assoicate with eip %s: different cloudprovider":                             845,
-	"cannot assoicate with eip %s: different region":                                    846,
-	"cannot change CPU/Memory spec in status %s":                                        682,
-	"cannot change bandwidth in status %s":                                              586,
-	"cannot change loadbalancer listener listener_port":                                 1436,
-	"cannot change loadbalancer listener listener_type":                                 1435,
-	"cannot change mac when guest is running":                                           667,
-	"cannot change to a different domain from a private cloud account":                  374,
-	"cannot create prepaid server on prepaid resource type":                             825,
-	"cannot delete a recycle host without active instance":                              860,
-	"cannot delete default SQL identity provider":                                       1544,
-	"cannot delete default domain":                                                      1521,
-	"cannot delete enabled idp":                                                         1545,
-	"cannot delete enabled policy":                                                      1553,
-	"cannot delete non-local user":                                                      1574,
-	"cannot delete system policy":                                                       1552,
-	"cannot delete system project":                                                      1554,
-	"cannot delete system role":                                                         1562,
-	"cannot delete system user":                                                         1576,
-	"cannot derive valid ifname hint: %v":                                               1101,
-	"cannot enable auto sync in status %s":                                              361,
-	"cannot fetch network of guestnetwork %d":                                           1070,
-	"cannot find region info":                                                           1052,
-	"cannot join read-only group":                                                       1578,
-	"cannot join user and group in differnt domain":                                     1577,
-	"cannot leave read-only group":                                                      1579,
-	"cannot migrate with cdrom":                                                         759,
-	"cannot recycle in status %s":                                                       856,
-	"cannot remove current user from current project":                                   1515,
-	"cannot run hypervisor %s on specified host with type %s":                           851,
-	"cannot support change azure disk name":                                             248,
-	"cannot support change azure instance name":                                         198,
-	"cannot support more than 1 nic":                                                    191,
-	"cannot uncache non-customized images":                                              1266,
-	"cannot undo a recycle host with pending_deleted guest":                             862,
-	"cannot undo recycle in status %s":                                                  857,
-	"cannot update config when enabled and connected":                                   1537,
-	"cannot update config when not idle":                                                1538,
-	"cannot update in sync status":                                                      1548,
-	"certificate %s is still referred to by %d %s":                                      1034,
-	"channel is empty":                                                                  1631,
-	"charge type %s not supported":                                                      566,
-	"check %s duplication fail %s":                                                      876,
-	"check access_mac duplication fail %s":                                              879,
-	"check account_id duplication error %s":                                             350,
-	"check agent uniqness fail %s":                                                      277,
-	"check disk index uniqueness fail %s":                                               792,
-	"check disk snapshot count fail %s":                                                 1460,
-	"check instance":                                                                    1230,
-	"check isAttach2Disk fail %s":                                                       649,
-	"check mac uniqueness fail %s":                                                      668,
-	"check name duplication error: %s":                                                  120,
-	"check name duplication fail %s":                                                    1689,
-	"check uniqness fail %s":                                                            346,
-	"check uniqueness fail %s":                                                          357,
-	"checkout guestdisk count fail %s":                                                  800,
-	"checkout nic index uniqueness fail %s":                                             795,
-	"checkout server sku name duplicate error: %v":                                      1225,
-	"cidr %s is not in range vpc %s":                                                    1065,
-	"cloud account %s is not available":                                                 465,
-	"cloud provider %s is not available":                                                464,
-	"cloudprovider %s %s %s %s %s not supported CrossCloud vpcpeering":                  1284,
-	"cloudprovider %s %s %s %s %s not supported CrossRegion vpcpeering":                 1285,
-	"cloudprovider %s not available":                                                    438,
-	"cloudprovider %s(%s) is not available":                                             401,
-	"cloudprovider.SetBucketCORS error %s":                                              315,
-	"cloudregion %s not support create %s rds":                                          405,
-	"cloudregion %s not support create rds":                                             404,
-	"cloudregion %s(%s) not support %s scheduler":                                       1337,
-	"cluster wire affiliation does not match network's: %s != %s":                       1055,
-	"cluster zone %s does not match network zone %s ":                                   1054,
-	"comment contains non-printable char: %v":                                           979,
-	"comment too long (%d>=%d)":                                                         978,
-	"condition values limit (5 per rule). %d given.":                                    1047,
-	"conflict database %s for instance %s(%s)":                                          411,
-	"conflict with lbagent %s(%s): %v":                                                  993,
-	"count must > 0":                                                                    771,
-	"cpu_core_count should be range of 1~256":                                           1221,
-	"create instance snapshot failed: %s":                                               767,
-	"dashboard_id is empty":                                                             1643,
-	"data disk not support storage type %s":                                             230,
-	"dbinstance billing type %s not support cancel expire":                              429,
-	"dbinstance billing type is %s":                                                     428,
-	"default domain is protected":                                                       1530,
-	"delete sku %s failed.":                                                             1236,
-	"desire_instance_number should between min_instance_number and max_instance_number": 1152,
-	"detach devices is not string array":                                                662,
-	"disabled user":                                                                     1512,
-	"disk %s has too many snapshot policy attached":                                     1246,
-	"disk %s not attached to server":                                                    748,
-	"disk %s not found":                                                                 799,
-	"disk and snapshotpolicy should have same domain":                                   1382,
-	"disk and snapshotpolicy should have same project":                                  1383,
-	"disk has no valid storage":                                                         455,
-	"disk need at least one of snapshot as backing file":                                1456,
-	"disk size gb must in range 10 ~ 30720 Gb":                                          1388,
-	"disk.GetQuotaKeys fail %s":                                                         456,
-	"dns zone can not cache in status %s":                                               496,
-	"dns zone can not uncache in status %s":                                             499,
-	"domain contains external resources":                                                1528,
-	"domain is disabled":                                                                1549,
-	"domain is enabled":                                                                 1522,
-	"domain is in use by group":                                                         1524,
-	"domain is in use by policy":                                                        1527,
-	"domain is in use by project":                                                       1525,
-	"domain is in use by role":                                                          1526,
-	"domain is in use by user":                                                          1523,
-	"driver %s already exists":                                                          1543,
-	"driver %s not supported":                                                           1542,
-	"duplicate %s %s":                                                                   877,
-	"duplicate access_mac %s":                                                           880,
-	"duplicate instanceType %s":                                                         1234,
-	"duplicate route cidr %s":                                                           73,
-	"duplicate username":                                                                1594,
-	"duplicated dnsrecord with existed dnsrecord can not distinguish by %s policy":      485,
-	"duplicated dnsrecord with existed dnsrecord not support":                           486,
-	"duplicated with CNAME dnsrecord name not support":                                  484,
-	"eip %s has been associated":                                                        844,
-	"eip %s not found":                                                                  693,
-	"eip %s status invalid %s":                                                          843,
-	"eip and server are not in the same region":                                         577,
-	"eip and server are not in the same zone":                                           578,
-	"eip cannot associate in status %s":                                                 568,
-	"eip cannot dissociate in status %s":                                                581,
-	"eip has been associated":                                                           694,
-	"eip has been associated with instance":                                             567,
-	"eip has been binding to another instance":                                          1060,
-	"eip has been binding to dnat rules":                                                1066,
-	"eip has been binding to snat rules":                                                1061,
-	"eip network can only exist in default vpc, got %s(%s)":                             1113,
-	"eip not supported for %s":                                                          842,
-	"eip region is not found???":                                                        576,
-	"eip's manager (%s(%s)) does not match vpc's(%s(%s)) (%s)":                          1389,
-	"elastic cache no related region found":                                             560,
-	"elastic cache sku zone (%s) and subnet zone (%s) mismatch":                         1411,
-	"elasticcache billing type %s not support cancel expire":                            550,
-	"elasticcache billing type is %s":                                                   549,
-	"empty DN":                                                                          1509,
-	"empty auth request":                                                                1587,
-	"empty directory name":                                                              290,
-	"empty external user id":                                                            32,
-	"empty file content":                                                                46,
-	"empty host %s field":                                                               1007,
-	"empty host name":                                                                   999,
-	"empty id":                                                                          1510,
-	"empty idp_id or idp_entity_id":                                                     33,
-	"empty ip list":                                                                     744,
-	"empty keys":                                                                        296,
-	"empty name":                                                                        1511,
-	"empty project_id/tenant_id":                                                        1453,
-	"enabled domain %s cannot be deleted":                                               1547,
-	"encrypt error %s":                                                                  1520,
-	"endpoint is enabled":                                                               1532,
-	"engine version mismatch: instance version %s, sku version %s":                      540,
-	"error getting host of guest %s":                                                    1420,
-	"error loadbalancer of backend group %s":                                            1421,
-	"esxi guest migrate require prefer_host":                                            212,
-	"every scaling policy belong to a scaling group":                                    1169,
-	"exceed address count limit: %v":                                                    1076,
-	"expire time is before current expire at":                                           281,
-	"expired access key":                                                                1590,
-	"expired token":                                                                     1583,
-	"fail to GetNetworks of vpc: %v":                                                    1116,
-	"fail to decode body":                                                               133,
-	"fail to decode policy data":                                                        1551,
-	"fail to decode request body":                                                       1593,
-	"fail to fetch hostwire by mac %s: %s":                                              914,
-	"fail to fetch netif by mac %s: %s":                                                 913,
-	"fail to find storage for disk %s":                                                  457,
-	"fail to generate temp url: %s":                                                     289,
-	"fail to get http response writer from context":                                     98,
-	"fail to get objects: %s":                                                           287,
-	"fail to get provider driver %s":                                                    375,
-	"fail to mkdir: %s":                                                                 295,
-	"fail to parse icon url '%s'":                                                       1215,
-	"failed getting guest %s":                                                           1027,
-	"failed parsing url %q: %v":                                                         1685,
-	"failed to change project":                                                          1,
-	"failed to find %s":                                                                 635,
-	"failed to find %s %s":                                                              1434,
-	"failed to find SecurityGroup %s":                                                   1682,
-	"failed to find cloudregion for zone %s(%s)":                                        1233,
-	"failed to find disk %s":                                                            648,
-	"failed to find guest %s":                                                           1015,
-	"failed to find host %s":                                                            1017,
-	"failed to find host %s to attach storage":                                          958,
-	"failed to find host for storage %s with disk %s":                                   436,
-	"failed to find loadbalancer's %s(%s) region":                                       1334,
-	"failed to find region for loadbalancer %s":                                         1020,
-	"failed to find region for loadbalancer listener %s":                                1049,
-	"failed to find region for loadbalancer listener rule %s":                           1050,
-	"failed to find storage %s to attach host":                                          957,
-	"failed to find storage for disk %s":                                                435,
-	"failed to find subformat vhd for image %s, please append 'vhd' for glance options(target_image_formats)": 195,
-	"failed to found backendgroup for backend %s(%s)":                                                         1031,
-	"failed to found cloudregion %s":                                                                          1309,
-	"failed to found dbinstance %s":                                                                           384,
-	"failed to found dbinstance %s(%s) account %s: %v":                                                        397,
-	"failed to found dbinstance %s(%s) database %s: %v":                                                       387,
-	"failed to found disk %s":                                                                                 1248,
-	"failed to found guest %s":                                                                                703,
-	"failed to found loadbalancer for listener %s(%s)":                                                        1336,
-	"failed to found provider factory error: %v":                                                              355,
-	"failed to found region for dbinstance %s(%s)":                                                            386,
-	"failed to found region for disk's storage %s(%s)":                                                        1249,
-	"failed to found region for loadbalancer backend %s":                                                      1030,
-	"failed to found storage for disk %s(%s)":                                                                 238,
-	"failed to found storagecache %s":                                                                         332,
-	"failed to found system disk error: %v":                                                                   237,
-	"failed to found vpc for network %s(%s)":                                                                  1431,
-	"failed to match any skus for change config":                                                              426,
-	"failed to match any skus in the network %s(%s) zone %s(%s)":                                              1346,
-	"failed to unmarshal input params: %v":                                                                    356,
-	"fetch disk size failed":                                                                                  847,
-	"fetch form data error: %s":                                                                               29,
-	"fetch gpu failed %s":                                                                                     659,
-	"fetch guest %s: %v":                                                                                      1068,
-	"fetch guest nic: %v":                                                                                     1069,
-	"fetch instance snapshot error %s":                                                                        814,
-	"fetch json for request: %v":                                                                              6,
-	"fetch lbagents of other clusters: %v":                                                                    992,
-	"fetchAuthInfo fail: %s":                                                                                  9,
-	"field %s is readonly":                                                                                    1531,
-	"find Wire %s error: %s":                                                                                  908,
-	"find guest %s: %v":                                                                                       1002,
-	"find host %s: %v":                                                                                        1000,
-	"find listener of listener rule %s(%s)":                                                                   976,
-	"fixed eip cannot be associated":                                                                          569,
-	"fixed eip cannot sync status":                                                                            585,
-	"fixed public eip cannot be dissociated":                                                                  582,
-	"forbidden":                                                                                               156,
-	"found %d wires for zone %s and vpc %s":                                                                   1097,
-	"gateway ip must be in the same subnet as start, end ip":                                                  1110,
-	"generate totp qrcode failed":                                                                             14,
-	"get %s service %s url: %v":                                                                               1010,
-	"get acl count fail %s":                                                                                   982,
-	"get admin credential is nil":                                                                             24,
-	"get certificate refcount fail %s":                                                                        1033,
-	"get isDefault fail %s":                                                                                   1021,
-	"get lbcluster refcount fail %v":                                                                          1042,
-	"get password in body":                                                                                    2,
-	"get proxysetting refcount fail %s":                                                                       131,
-	"get refCount fail %s":                                                                                    1023,
-	"get reserved ip error":                                                                                   1096,
-	"get sensitive config requires admin priviliges":                                                          1536,
-	"getDynamicSchedtagCount fail %s":                                                                         1192,
-	"getFreeAddressCount fail %s":                                                                             1082,
-	"getGuestCount fail %s":                                                                                   869,
-	"getReferenceCount fail %s":                                                                               1259,
-	"getSchedPoliciesCount fail %s":                                                                           1194,
-	"global-settings not found":                                                                               1625,
-	"got unknown parent type %q, expect %s":                                                                   1074,
-	"got unknown type %q, expect %s":                                                                          1073,
-	"group %s not found":                                                                                      802,
-	"group and guest should belong to same project":                                                           777,
-	"guest %q not found":                                                                                      432,
-	"guest %s band to up to %d security groups":                                                               627,
-	"guest %s has backup, can't migrate":                                                                      754,
-	"guest %s has isolated device, can't migrate":                                                             755,
-	"guest %s host %s isolated device not enough":                                                             660,
-	"guest %s hypervisor %s can't migrate":                                                                    753,
-	"guest %s not found":                                                                                      1247,
-	"guest %s status %s can't migrate":                                                                        757,
-	"guest %s status %s can't migrate with local storage":                                                     760,
-	"guest %s status %s has isolated device, can't do migrate":                                                758,
-	"guest %s unsupport postpaid expire":                                                                      719,
-	"guest %s(%s) is already in the backendgroup %s(%s)":                                                      1029,
-	"guest %s(%s) vpc %s(%s) not same as loadbalancer vpc %s":                                                 1026,
-	"guest %s(%s) vpc %s(%s) not same as vpc %s(%s)":                                                          1028,
-	"guest and instance group should belong to same project":                                                  594,
-	"guest attach gpu count must > 0":                                                                         658,
-	"guest billing type %s not support cancel expire":                                                         717,
-	"guest billing type is %s":                                                                                718,
-	"guest can't do snapshot in status %s":                                                                    765,
-	"guest doesn't need reconcile backup":                                                                     716,
-	"guest has been converted":                                                                                739,
-	"guest has no vpc ip":                                                                                     783,
-	"guest hypervisor %s can't create instance snapshot":                                                      763,
-	"guest on the host are using networks on this wire":                                                       962,
-	"guest status must be ready":                                                                              741,
-	"guest template %s used by scalig group %s":                                                               791,
-	"guest template %s used by service catalog %s":                                                            790,
-	"guests disk %d snapshot full, can't take anymore":                                                        766,
-	"health_check_domain must be in the range of 1 ~ 80":                                                      1329,
-	"host %s can't reserve %d cpu for each isolated device, not enough":                                       952,
-	"host %s can't reserve %dM memory for each isolated device, not enough":                                   953,
-	"host %s can't reserve %dM storage for each isolated device, not enough":                                  954,
-	"host %s has no access ip":                                                                                1419,
-	"host %s is not kvm host":                                                                                 740,
-	"host %s not found":                                                                                       797,
-	"host %s storage %s not found":                                                                            1280,
-	"host has been occupied":                                                                                  245,
-	"host is not a baremetal":                                                                                 775,
-	"host is not a prepaid recycle host":                                                                      859,
-	"host missing %s field":                                                                                   1006,
-	"host not found???":                                                                                       743,
-	"host should be disabled":                                                                                 858,
-	"host status %s and enabled %v, can't do server %s":                                                       596,
-	"host status %s can't exit maintenance":                                                                   942,
-	"host type %s can't do host maintenance":                                                                  943,
-	"host virtual memory not enough":                                                                          619,
-	"host_type must be specified":                                                                             931,
-	"http or https listener only supportd default or normal backendgroup":                                     1328,
-	"huawei %s mode elastic not support create backup":                                                        1414,
-	"iBucket.DeleteCORS error %s":                                                                             316,
-	"iBucket.DeletePolicy error %s":                                                                           323,
-	"iBucket.DeleteWebSiteConf error %s":                                                                      313,
-	"iBucket.GetCORSRules error %s":                                                                           317,
-	"iBucket.GetCdnDomains error %s":                                                                          318,
-	"iBucket.GetIObject error %s":                                                                             328,
-	"iBucket.GetIObjects error %s":                                                                            311,
-	"iBucket.GetPolicy error %s":                                                                              321,
-	"iBucket.GetRefer error %s":                                                                               320,
-	"iBucket.GetWebsiteConf error %s":                                                                         314,
-	"iBucket.SetPolicy error %s":                                                                              322,
-	"iBucket.SetRefer error %s":                                                                               319,
-	"iBucket.SetWebsite error %s":                                                                             312,
-	"identity provider with projects":                                                                         1546,
-	"illegal region %s, please contact admin":                                                                 26,
-	"image %s do not belong to guest image %s":                                                                848,
-	"image %s not found":                                                                                      929,
-	"image size exceeds root disk size":                                                                       637,
-	"inconsistent account_id, previous '%s' and now '%s'":                                                     359,
-	"inconsistent domain for project and roles":                                                               1567,
-	"inconsistent export keys and texts":                                                                      62,
-	"input condition is empty":                                                                                1674,
-	"input data contains invalid cloudregion id":                                                              1218,
-	"input data not key value dict":                                                                           704,
-	"input key too long > %d":                                                                                 153,
-	"input not json dict":                                                                                     1662,
-	"input parameter error":                                                                                   16,
-	"input value too long > %d":                                                                               154,
-	"instance is already associated with eip":                                                                 572,
-	"instance specs list query error":                                                                         1227,
-	"instance_type_category shoud be one of %s":                                                               1223,
-	"internal error: unexpected backend type %s":                                                              1318,
-	"internal server error":                                                                                   51,
-	"internal server error %s":                                                                                1598,
-	"intranet loadbalancer not support bandwidth charge type":                                                 1311,
-	"invalid %s,required int":                                                                                 1338,
-	"invalid CannedAction %s ":                                                                                64,
-	"invalid Effect %s ":                                                                                      65,
-	"invalid access key id":                                                                                   1589,
-	"invalid addr %s":                                                                                         977,
-	"invalid address: %s":                                                                                     399,
-	"invalid aggregate_strategy: %s":                                                                          853,
-	"invalid any_mac address":                                                                                 864,
-	"invalid auth methods":                                                                                    1585,
-	"invalid billing_cycle %s":                                                                                532,
-	"invalid bucket name %s: %s":                                                                              284,
-	"invalid bucket name(%s): %s":                                                                             285,
-	"invalid category %s for policy definition %s(%s)":                                                        839,
-	"invalid cert pubkey algorithm: %s, want %s":                                                              179,
-	"invalid character %s for account name":                                                                   1359,
-	"invalid characters %s":                                                                                   1688,
-	"invalid cidr %s":                                                                                         1144,
-	"invalid cidr range %s":                                                                                   1439,
-	"invalid cidr range %s, mask length should less than or equal to 24":                                      1366,
-	"invalid cidr_block %s":                                                                                   1295,
-	"invalid cloud account info error: %s":                                                                    349,
-	"invalid condition":                                                                                       524,
-	"invalid conditions format,required json":                                                                 1045,
-	"invalid conditions fromat,required json array":                                                           1046,
-	"invalid content_length %s":                                                                               55,
-	"invalid credential":                                                                                      5,
-	"invalid domain":                                                                                          1599,
-	"invalid domain %s for CNAME record":                                                                      72,
-	"invalid domain %s for MX record":                                                                         69,
-	"invalid domain name %s":                                                                                  490,
-	"invalid duration %s":                                                                                     402,
-	"invalid duration %s: %s":                                                                                 282,
-	"invalid end ip: %s %s":                                                                                   1106,
-	"invalid external_access_mode %q, want %s":                                                                1287,
-	"invalid fernet token":                                                                                    1584,
-	"invalid form":                                                                                            34,
-	"invalid format":                                                                                          163,
-	"invalid guest %s":                                                                                        1316,
-	"invalid image size":                                                                                      37,
-	"invalid input %s":                                                                                        354,
-	"invalid input format":                                                                                    165,
-	"invalid internal ip address: %s":                                                                         1059,
-	"invalid ip address: %s":                                                                                  1209,
-	"invalid ipaddr %s":                                                                                       909,
-	"invalid ipv4 %s ":                                                                                        66,
-	"invalid ipv4 %s for A record":                                                                            70,
-	"invalid ipv6 %s for AAAA record":                                                                         71,
-	"invalid joint resources %s":                                                                              94,
-	"invalid key %s: %s":                                                                                      291,
-	"invalid loadbalancer backend port '%d'":                                                                  1163,
-	"invalid loadbalancer backend weight '%d'":                                                                1164,
-	"invalid loadbalancer_spec %s":                                                                            1374,
-	"invalid local certificate, certificate is empty.":                                                        1036,
-	"invalid local certificate, private key is empty.":                                                        1035,
-	"invalid macAddr %s":                                                                                      878,
-	"invalid multipart form":                                                                                  54,
-	"invalid object key: %s":                                                                                  298,
-	"invalid parameter backendgroup %s":                                                                       1373,
-	"invalid parameter format. json dict required":                                                            547,
-	"invalid parameter loadbalancer_spec %s":                                                                  1372,
-	"invalid parameters for policy definition %s":                                                             833,
-	"invalid passcode":                                                                                        13,
-	"invalid passcode: %v":                                                                                    21,
-	"invalid password: %s":                                                                                    1573,
-	"invalid policy definition %s(%s) condition %s":                                                           836,
-	"invalid project":                                                                                         1597,
-	"invalid proxy setting %s":                                                                                340,
-	"invalid public error: %v":                                                                                973,
-	"invalid public_ip_charge_type %s":                                                                        841,
-	"invalid record name %s":                                                                                  483,
-	"invalid request":                                                                                         31,
-	"invalid resources format":                                                                                1613,
-	"invalid scope %s":                                                                                        143,
-	"invalid share_mode %s":                                                                                   67,
-	"invalid status %s":                                                                                       1140,
-	"invalid strategy %s":                                                                                     1180,
-	"invalid template":                                                                                        1540,
-	"invalid token":                                                                                           1601,
-	"invalid token %s":                                                                                        1602,
-	"invalid ttl: %d":                                                                                         522,
-	"invalid ttl: %s":                                                                                         521,
-	"invalid url: %v":                                                                                         1627,
-	"invalid user":                                                                                            1596,
-	"invalid vrrp advert_int %d: want [1,255]":                                                                988,
-	"invalid vrrp authentication pass size: %d, want [1,8]":                                                   985,
-	"invalid vrrp interface %q":                                                                               984,
-	"invalid vrrp priority %d: want [1,255]":                                                                  986,
-	"invalid vrrp virtual_router_id %d: want [1,255]":                                                         987,
-	"invalid wire_level_for_vmware %q, accept %s":                                                             341,
-	"invlid image":                                                                                            636,
-	"iops must > 0":                                                                                           752,
-	"ip":                                                                                                      1135,
-	"ip %s not found":                                                                                         663,
-	"ip %s or mac %s has been registered":                                                                     725,
-	"ip_prefix error: %s":                                                                                     1102,
-	"ipv4 range overlap":                                                                                      1283,
-	"isAddressUsed fail %s":                                                                                   1080,
-	"isAlterNameUnique fail %s":                                                                               937,
-	"isAttached check failed %s":                                                                              611,
-	"join group into project of default domain or identical domain":                                           1516,
-	"join user into project of default domain or identical domain":                                            1513,
-	"keypair %s not found":                                                                                    643,
-	"lbagent cannot be deployed on managed host":                                                              1001,
-	"lbagent cannot be deployed on public guests":                                                             1003,
-	"lbcluster %s(%s) already has virtual_router_id %d":                                                       994,
-	"lbcluster %s(%s) is still referred to by %d %s":                                                          1043,
-	"lbclusters %s(%s) and %s(%s) has conflict virtual_router_id: %d ":                                        1044,
-	"listener type must be http/https, got %s":                                                                1324,
-	"loadbalancer aready associated with fourth layer listener %s":                                            1442,
-	"loadbalancer backendgroup aready associate with other %s listener":                                       1441,
-	"loadbalancer is locked, cannot delete":                                                                   1056,
-	"loadbalancer is using by %d backendgroup.":                                                               1391,
-	"loadbalancer is using by %d listener.":                                                                   1390,
-	"loadbalancer listener %s is already updating":                                                            1440,
-	"loadbalancer listener %s related loadbalancer %s not found":                                              1377,
-	"loadbalancerlistenerrule %s(%s): fetching listener %s failed":                                            1327,
-	"login_account is longer than 32 chars":                                                                   817,
-	"mac %s not found":                                                                                        664,
-	"mac addr %s has been occupied":                                                                           669,
-	"maintain time has no change":                                                                             544,
-	"managed network cannot change status":                                                                    1139,
-	"mapped ip exhausted":                                                                                     1300,
-	"master slave backendgorup must contain two backend":                                                      1314,
-	"memory_size_mb, shoud be range of 512~%d":                                                                1222,
-	"metdata must less then 20":                                                                               816,
-	"metric %s is invalid format, usage <measurement>.<field>":                                                1635,
-	"min_instance_number should not be bigger than max_instance_number":                                       1151,
-	"min_instance_number should not be smaller than 0":                                                        1150,
-	"mismatched alarm id":                                                                                     1175,
-	"miss some subimage of guest image":                                                                       849,
-	"missing Content-Length":                                                                                  299,
-	"missing access_mac and uuid in no_probe mode":                                                            887,
-	"missing credential":                                                                                      4,
-	"missing driver":                                                                                          1541,
-	"missing duration/expire_time":                                                                            280,
-	"missing export keys":                                                                                     61,
-	"missing guest id":                                                                                        761,
-	"missing id":                                                                                              8,
-	"missing image id or name":                                                                                1269,
-	"missing image name":                                                                                      35,
-	"missing image size":                                                                                      36,
-	"missing input field blob":                                                                                1519,
-	"missing input field id":                                                                                  1560,
-	"missing input field interface":                                                                           1533,
-	"missing input field service/service_id":                                                                  1534,
-	"missing input field type":                                                                                1518,
-	"missing key":                                                                                             288,
-	"missing manager?":                                                                                        327,
-	"missing name":                                                                                            283,
-	"missing new domain":                                                                                      119,
-	"missing new project/tenant":                                                                              161,
-	"missing pid in pids":                                                                                     1617,
-	"missing pids":                                                                                            1616,
-	"missing rid":                                                                                             1619,
-	"missing rid in pids":                                                                                     1618,
-	"missing uid":                                                                                             1615,
-	"missong duration":                                                                                        418,
-	"model has no field %s":                                                                                   125,
-	"mtu must be range of 0~1000000":                                                                          1302,
-	"mx_priority range limited to [1,50]":                                                                     68,
-	"name is too short":                                                                                       812,
-	"name longer than %d":                                                                                     151,
-	"name starts with letter, and contains letter, number and - only":                                         127,
-	"name starts with letter, and contains letter, number and ._@- only":                                      150,
-	"need scheduled task":                                                                                     1203,
-	"need valid access_mac and uuid to do prepare":                                                            900,
-	"network %s associated route table has no internet gateway attached.":                                     194,
-	"network %s related vpc not found":                                                                        1364,
-	"network %s(%s) does not belong to %s":                                                                    1432,
-	"network %s(%s) has no free addresses":                                                                    1083,
-	"network '%s' not in vpc '%s'":                                                                            1156,
-	"network server_type %s not support auto alloc":                                                           1122,
-	"new password mismatch":                                                                                   10,
-	"no admin account found for elastic cache %s":                                                             543,
-	"no allow to access network %s":                                                                           1086,
-	"no available eip network":                                                                                1429,
-	"no cloudregion found to sync skus":                                                                       1219,
-	"no either ip_addr or mac specified":                                                                      665,
-	"no external bucket":                                                                                      286,
-	"no networks on wire %s":                                                                                  910,
-	"no recovery secrets for %s":                                                                              1609,
-	"no revocery questions.":                                                                                  22,
-	"no such ScalingGroup '%s'":                                                                               1167,
-	"no such cloud region %s":                                                                                 1153,
-	"no such disk %s":                                                                                         1244,
-	"no such driver":                                                                                          1508,
-	"no such group %s":                                                                                        776,
-	"no such guest template":                                                                                  1214,
-	"no such guest template %s":                                                                               1157,
-	"no such guest_template %s":                                                                               1216,
-	"no such loadbalancer backend group '%s'":                                                                 1162,
-	"no such model %s":                                                                                        593,
-	"no such network":                                                                                         1067,
-	"no such provider":                                                                                        180,
-	"no such provider %s":                                                                                     348,
-	"no such scaling group %s":                                                                                1170,
-	"no such snapshotpolicy %s":                                                                               479,
-	"no support for instance snapshot in guest template for now":                                              784,
-	"no totp for %s":                                                                                          1608,
-	"no usable regions, please contact admin":                                                                 25,
-	"no valid endpoint":                                                                                       1683,
-	"no valid host":                                                                                           774,
-	"no valid storage on host":                                                                                852,
-	"no viable lbcluster":                                                                                     1418,
-	"non http listener must have backend group set":                                                           1427,
-	"non redirect lblistener rule must have backend_group set":                                                1425,
-	"non-admin user not allowed to create system object":                                                      157,
-	"not a baremetal":                                                                                         899,
-	"not a baremetal server":                                                                                  773,
-	"not a valid ip address %s: %s":                                                                           1094,
-	"not allow create %s in scope %s":                                                                         144,
-	"not allow to auth":                                                                                       1600,
-	"not allow to change project across domain":                                                               373,
-	"not allow to create":                                                                                     365,
-	"not allow to delete %s disk with snapshots":                                                              478,
-	"not allow to delete default cloud region":                                                                380,
-	"not allow to delete default security group":                                                              1213,
-	"not allow to delete default vpc":                                                                         1288,
-	"not allow to delete log":                                                                                 128,
-	"not allow to delete prepaid disk in valid status":                                                        469,
-	"not allow to delete prepaid server in valid status":                                                      804,
-	"not allow to delete public cloud instance_type: %s":                                                      1232,
-	"not allow to delete. Virtual disk must not have snapshots":                                               477,
-	"not allow to get usage":                                                                                  1603,
-	"not allow to list domain quotas":                                                                         137,
-	"not allow to list project quotas":                                                                        139,
-	"not allow to perform %s":                                                                                 110,
-	"not allow to purge. Virtual disk must not have snapshots":                                                476,
-	"not allow to query system capability":                                                                    333,
-	"not allow to set system key, please remove the underscore at the beginning": 152,
-	"not allow update rds account name":                                          383,
-	"not allow update rds database name":                                         396,
-	"not allowed update content of certificate":                                  1038,
-	"not an empty bucket":                                                        309,
-	"not an empty network %s":                                                    1078,
-	"not empty cloud region":                                                     379,
-	"not empty zone":                                                             1308,
-	"not enough privilege":                                                       1145,
-	"not enough privilege (require:%s,allow:%s)":                                 142,
-	"not enough privilege (require:%s,allow:%s,query:%s)":                        121,
-	"not enough privilege (require:%s,allow:%s:resource:%s)":                     141,
-	"not enough privilleges":                                                     136,
-	"not find alert %s":                                                          1641,
-	"not find notification %s":                                                   1642,
-	"not found alert notification used by %s":                                    1659,
-	"not found cert %s":                                                          1535,
-	"not found signature":                                                        1663,
-	"not found tenantId in body":                                                 0,
-	"not implement":                                                              250,
-	"not match any dbinstance sku":                                               406,
-	"not support %s":                                                             738,
-	"not support create":                                                         1142,
-	"not support create %s zone":                                                 1310,
-	"not support create definition":                                              1143,
-	"not support database":                                                       1656,
-	"not support for cloudaccount with provider '%s'":                            342,
-	"not support hypervisor %s":                                                  737,
-	"not support reset user password":                                            11,
-	"not support type %q":                                                        1657,
-	"not support update disk_type %s":                                            434,
-	"not supported bind security group":                                          554,
-	"not supported hypervisor %s":                                                866,
-	"not supported next hop type":                                                1146,
-	"not supported secondary update context %s":                                  1568,
-	"not supported update context":                                               1565,
-	"not supported update context %s":                                            1566,
-	"now allow to delete inuse instance_type.please remove related servers first: %s": 1231,
-	"object %s not found":                        310,
-	"object count limit exceeds":                 293,
-	"object key should not ends with /":          297,
-	"object size limit exceeds":                  303,
-	"on-premise network cannot sync status":      1138,
-	"on-premise vpc cannot sync status":          1297,
-	"only on premise support this operation":     1128,
-	"only sysadmin can specify host as backend":  1016,
-	"operation not allowed":                      164,
-	"out of privileges":                          138,
-	"parameter %s is empty":                      1632,
-	"parse cdrom device info error %s":           821,
-	"parse disk description error %s":            823,
-	"parse form data error: %s":                  30,
-	"parse isolated device description error %s": 828,
-	"parse network description error %s":         826,
-	"parse query string error: %s":               28,
-	"passcode is a 6-digits string":              20,
-	"password must be 12 chars of at least one digit, letter, uppercase letter and punctuate": 1505,
-	"path can not be emtpy":                                         1443,
-	"peer lbagent %s(%s) already has vrrp priority %d":              997,
-	"please retry after unbind all guests in group":                 590,
-	"policy definition %s require cloudregion in %s":                834,
-	"policy definition %s require cloudregion not in %s":            835,
-	"policy definition %s require except tag %s":                    838,
-	"policy definition %s require must contains tag %s":             837,
-	"policy is referenced":                                          1690,
-	"port %d not support, only support range 1 ~ 65535":             1014,
-	"project %s not found":                                          360,
-	"project contains external resources":                           1555,
-	"project contains group":                                        1557,
-	"project contains user":                                         1556,
-	"project disabled":                                              1581,
-	"project in non-default domain is prohibited":                   118,
-	"project is not found":                                          1620,
-	"provider %s: %v":                                               337,
-	"provider is enabled":                                           366,
-	"provider is not idle":                                          367,
-	"provider is shared outside of domain":                          362,
-	"provider mismatch: %s instance can't use %s sku":               537,
-	"proxysetting %s is still referred to by %d %s":                 132,
-	"public connection aready allocated":                            545,
-	"public ip not supported for %s":                                840,
-	"put object error %s":                                           305,
-	"query all networks fail":                                       1118,
-	"query backend group releated resource failed.":                 1012,
-	"query duration `to` err: %s":                                   1678,
-	"query duration err: from: %s, to:%s":                           1677,
-	"query error %s":                                                1517,
-	"query quotas %s":                                               140,
-	"query sku list failed.":                                        1235,
-	"questions not found":                                           18,
-	"readonly":                                                      1529,
-	"recv invalid data":                                             63,
-	"redirect can only be enabled for http/https listener":          1426,
-	"redirect must have at least one of scheme, host, path changed": 1423,
-	"redis version 2.8 not support create account":                  1448,
-	"referered by storages":                                         1265,
-	"reflect call %s fail %s":                                       100,
-	"region":                                                        552,
-	"region contains endpoints":                                     1559,
-	"region mismatch: instance region %s, sku region %s":            538,
-	"region of backend %d does not match that of lb's":              1019,
-	"region of host %q (%s) != region of loadbalancer %q (%s)":      1422,
-	"region of host %q (%s) != region of loadbalancer %q (%s))":     1320,
-	"regiondriver":                                                  553,
-	"release public connection aready released":                     546,
-	"repeat_weekdays only contains %d days at most":                 1238,
-	"request body is empty":                                         7,
-	"request body is too large.":                                    53,
-	"request process timeout":                                       80,
-	"require system previleges to convert host in other domain":     935,
-	"require validated qcloud cross region vpcPeering bandwidth values:[10, 20, 50, 100, 200, 500, 1000],unit Mbps": 1684,
-	"required at least %d subnet with at least 8 free ip.":                                                          1368,
-	"required at least %d subnet.": 1367,
-	"reserved cpu must >= 0":       949,
-	"reserved memory must >= 0":    950,
-	"reserved storage must >= 0":   951,
-	"resource %s in vpc %s external access mode %s is not support accociate eip": 563,
-	"resource %s is not support sync skus":                                       1217,
-	"resource %s module not exists":                                              59,
-	"resource is enabled":                                                        1550,
-	"role is being assigned to group":                                            1564,
-	"role is being assigned to user":                                             1563,
-	"row %d domain is empty":                                                     48,
-	"row %d duplicate name %s":                                                   49,
-	"row %d name is empty":                                                       47,
-	"rule %d is invalid: %s":                                                     1206,
-	"rule %s/%s already occupied by rule %s(%s)":                                 1048,
-	"saveConfigs fail %s":                                                        1539,
-	"schedtag %s not found":                                                      525,
-	"schedtag_id not provide":                                                    1182,
-	"secgroup %s not found":                                                      798,
-	"secgroup %s rules not equals %s rules":                                      1210,
-	"secgroups will be empty after update.":                                      557,
-	"security group %s has already been assigned to guest %s":                    628,
-	"security group %s not assigned to guest %s":                                 630,
-	"security group id should not be empty":                                      1681,
-	"select for nothing in query":                                                1676,
-	"server %s not found":                                                        564,
-	"server %s with port %d already in used":                                     1444,
-	"server %s with port %d aready used by other %s listener":                    1445,
-	"server and eip are not managed by the same provider":                        580,
-	"server host is not found???":                                                579,
-	"server is in %q state, want %q":                                             1004,
-	"server region is not found???":                                              575,
-	"service %s not found error: %v":                                             1614,
-	"service contains endpoints":                                                 1569,
-	"service is enabled":                                                         1570,
-	"session expires, missing %s":                                                27,
-	"setAcl error %s":                                                            306,
-	"sharing is limited to domains %s":                                           148,
-	"signature error":                                                            1664,
-	"sku %s is soldout":                                                          1412,
-	"slave dbinstance not support prepaid billing type":                          1345,
-	"snapshot referenced by instance snapshot":                                   1252,
-	"snapshotpolicy %s not found: %s":                                            433,
-	"snapshotpolicy disk has been exist":                                         1245,
-	"some disk missing!!!":                                                       747,
-	"some networks not exist":                                                    1155,
-	"start and end ip not in the same subnet":                                    1107,
-	"start and end ip when masked are not in the same cidr subnet":               1114,
-	"start create snapshot task failed: %s":                                      768,
-	"start snapshot reset failed %s":                                             770,
-	"start, end ip must be in the same subnet":                                   1121,
-	"sticky_session_cookie can only contain letters, Numbers, '_' and '-'":       1332,
-	"sticky_session_cookie length must within 1~200":                             1331,
-	"storage %s can not be data disk":                                            235,
-	"storage %s(%s) need online and attach host for create disk":                 439,
-	"storage cache is missing":                                                   1277,
-	"storage cache not empty":                                                    1264,
-	"storage classes not supported":                                              376,
-	"storage has associate hosts":                                                1274,
-	"storage has disks":                                                          1275,
-	"storage has snapshots":                                                      1276,
-	"storage is enabled":                                                         1278,
-	"storage not cache image":                                                    1267,
-	"storage of disk %s no valid host":                                           466,
-	"subnet masklen should be smaller than 30":                                   1103,
-	"syncWithCloudBucket error %s":                                               307,
-	"sysadmin is protected":                                                      1514,
-	"tag has dynamic rules":                                                      1193,
-	"tag is associate with sched policies":                                       1195,
-	"telegraf params: invalid influxdb url: %s":                                  989,
-	"template file is invalid. please check.":                                    45,
-	"template not found %s":                                                      52,
-	"template_id":                                                                50,
-	"tenant/project %s not found":                                                1454,
-	"the %s %q in guest template is not a public resource":                       787,
-	"the %s %q in guest template is not a public resource in %s scope":           789,
-	"the %s in guest template is not a public resource":                          786,
-	"the %s in guest template is not a public resource in %s scope":              788,
-	"the AlertType is illegal:%s":                                                1652,
-	"the Comparator is illegal: %s":                                              1645,
-	"the account has been registerd %s":                                          351,
-	"the acl cache in region %s aready exists.":                                  1032,
-	"the associated natgateway has corresponding dnat rules with eip %s, please delete them firstly": 584,
-	"the associated natgateway has corresponding snat rules with eip %s, please delete them firstly": 583,
-	"the certificate cache in region %s aready exists.":                                              1037,
-	"the guest template %s is not valid in cloudregion %s, reason: %s":                               1158,
-	"the image reference session has not been expired!":                                              331,
-	"the min value of cycle in alarm is 300":                                                         1179,
-	"the reduce is illegal %s":                                                                       1646,
-	"the reduce is illegal: %s":                                                                      1647,
-	"the security group is in use":                                                                   1212,
-	"there is no such secgroup %s descripted by guest template":                                      785,
-	"this operation requires rds state to be %s":                                                     430,
-	"threshold:%s should be number type":                                                             1654,
-	"time_points only contains %d points at most":                                                    1239,
-	"top level public domain name %s not support":                                                    493,
-	"totp secret exists":                                                                             1610,
-	"uid is empty":                                                                                   15,
-	"unauthorized %s":                                                                                1592,
-	"unexpected backend type %s":                                                                     1018,
-	"unknown parent object id spec":                                                                  1072,
-	"unknown server type %s":                                                                         801,
-	"unknown zone type %s":                                                                           494,
-	"unkown expansion principle %s":                                                                  1159,
-	"unkown health check mode %s":                                                                    1161,
-	"unkown indicator in alarm %s":                                                                   1177,
-	"unkown label type '%s'":                                                                         1201,
-	"unkown operator in alarm %s":                                                                    1176,
-	"unkown resource operation '%s'":                                                                 1200,
-	"unkown resource type '%s'":                                                                      1199,
-	"unkown scaling policy action %s":                                                                1172,
-	"unkown scaling policy unit %s":                                                                  1173,
-	"unkown scheduled type '%s'":                                                                     1198,
-	"unkown shrink principle %s":                                                                     1160,
-	"unkown trigger type %s":                                                                         1171,
-	"unkown wrapper in alarm %s":                                                                     1178,
-	"unmarshal JoinResourceBaseCreateInput fail %s":                                                  959,
-	"unmarshal JointResourceCreateInput fail %s":                                                     1186,
-	"unmarshal SharableVirtualResourceCreateInput fail %s":                                           981,
-	"unmarshal StandaloneResourceCreateInput fail %s":                                                526,
-	"unmarshal VirtualResourceCreateInput fail %s":                                                   533,
-	"unmarshal input fail %s":                                                                        1687,
-	"unmarshal input: %v":                                                                            1005,
-	"unmarshal limit error %s":                                                                       324,
-	"unmarshal questions: %v":                                                                        23,
-	"unmarshaling cidrs failed: %s":                                                                  1149,
-	"unrecognized input %s":                                                                          1591,
-	"unsupport delete %s backups":                                                                    531,
-	"unsupport on host status %s":                                                                    944,
-	"unsupport type: %s":                                                                             1628,
-	"unsupported action %s":                                                                          1624,
-	"unsupported duration %s":                                                                        403,
-	"unsupported execution_error_state %s":                                                           1634,
-	"unsupported no_data_state %s":                                                                   1633,
-	"unsupported notification type %s":                                                               1660,
-	"unsupported resource type %s":                                                                   1658,
-	"update config version fail %s":                                                                  1571,
-	"url is empty":                                                                                   1626,
-	"use yum requires valid repo_base_url":                                                           998,
-	"user %s not found":                                                                              155,
-	"user contains external resources":                                                               1575,
-	"user disabled":                                                                                  1582,
-	"user must have system admin privileges":                                                         1009,
-	"user not found":                                                                                 1586,
-	"user not found or not enabled":                                                                  1595,
-	"user not in project":                                                                            1588,
-	"username or password is empty":                                                                  3,
-	"valid vlan id":                                                                                  1100,
-	"version mismatch":                                                                               1580,
-	"virtual resource already freezed":                                                               159,
-	"virtual resource not freezed":                                                                   160,
-	"vpc %s already connected to a interVpcNetwork":                                                  966,
-	"vpc %s and vpc %s have already connected":                                                       1286,
-	"vpc %s has already in this dns zone":                                                            500,
-	"vpc %s is not connected to this interVpcNetwork":                                                967,
-	"vpc %s not in dns zone":                                                                         501,
-	"vpc %s(%s) is not a managed resouce":                                                            1207,
-	"vpc joint interVpcNetwork on different cloudEnv is not supported":                               965,
-	"vpc joint interVpcNetwork on different cloudprovider is not supported":                          964,
-	"vpc lb is not allowed for now":                                                                  1416,
-	"vpc on different cloudprovider peering is not supported":                                        1282,
-	"vpc_id": 1281,
-	"weight %d not support, only support range 0 ~ 256":        1013,
-	"wire contains hosts":                                      1305,
-	"wire contains networks":                                   1307,
-	"wire not found for zone %s and vpc %s":                    1098,
-	"wire zone must match zone parameter, got %s, want %s(%s)": 1040,
-	"wrong password":                                           12,
-	"zone %s not in cloudregion %s":                            1220,
-	"zone %s(%s) has no lbcluster":                             1417,
-	"zone and vpc info required when wire is absent":           1111,
-	"zone info missing":                                        1415,
-	"zone mismatch, elastic cache sku zone %s != %s":           1410,
-	"zone mismatch: instance zone %s, sku zone %s":             539,
-	"zone of wire must be %s, got %s":                          1041,
+	"%s %s %s not found":                                                 41,
+	"%s %s %s not support %s":                                            418,
+	"%s %s not found":                                                    465,
+	"%s %s not support policy value %s":                                  424,
+	"%s %s not supported dns type %s":                                    416,
+	"%s %s not supported policy type %s":                                 417,
+	"%s allow %s %s not found":                                           47,
+	"%s backend group not support change port":                           1258,
+	"%s backend group not support change port or weight":                 1259,
+	"%s cannot be set to 0":                                              1276,
+	"%s disk cannot exceed 8":                                            152,
+	"%s does not currently support creating loadbalancer":                1317,
+	"%s does not currently support creating loadbalancer acl":            1312,
+	"%s does not currently support creating loadbalancer certificate":    1313,
+	"%s does not support creating loadbalancer":                          1321,
+	"%s does not support creating loadbalancer acl":                      1322,
+	"%s does not support creating loadbalancer certificate":              1323,
+	"%s for %s features are not compatible for creating instance":        153,
+	"%s is not modifiable":                                               498,
+	"%s is not mount point %s":                                           200,
+	"%s is out of network IP ranges":                                     818,
+	"%s is reserved for aliyun %s, please use another":                   1295,
+	"%s length must less 500 letters":                                    1267,
+	"%s listener port %d is already taken by listener %s(%s)":            988,
+	"%s method not found":                                                19,
+	"%s method params length not match, expected %d, input %d":           20,
+	"%s not allow to %s %s":                                              48,
+	"%s not allow to get property %s":                                    38,
+	"%s not allow to get spec %s":                                        42,
+	"%s not support":                                                     299,
+	"%s not support cdrom params":                                        163,
+	"%s not support close tcp or udp loadbalancer listener health check": 1277,
+	"%s not support create account":                                      1350,
+	"%s not support create eip":                                          146,
+	"%s not support create eip, it only support bind eip":                164,
+	"%s not support create subscription":                                 300,
+	"%s not support create virtual machine with eip":                     165,
+	"%s not support policy type %s":                                      423,
+	"%s not support rebuild root with a different image":                 577,
+	"%s not support recovery":                                            1343,
+	"%s not support saml auth":                                           275,
+	"%s not support this operation":                                      359,
+	"%s only support aliyun %s":                                          1299,
+	"%s only support aliyun %s or %s":                                    1298,
+	"%s only supports eip charge type %q":                                1365,
+	"%s rds Support up to %d security groups":                            344,
+	"%s rds not support secgroup":                                        343,
+	"%s request the mask range should be between 16 and 28":              1316,
+	"%s request the mask range should be between 8 and 29":               1318,
+	"%s request the mask range should be less than or equal to 29":       1386,
+	"%s require disk size must in 40 ~ 4000 GB":                          1331,
+	"%s requires that the eip bandwidth must be less than 100Mbps":       129,
+	"%s requires the virtual machine state to be %s before it can be added backendgroup, but current state of the virtual machine is %s": 962,
+	"%s reset disk required guest status is running or ready":                                                                            192,
+	"%s shall bind up to %d security groups":                                                                                             768,
+	"%s supported secgroup count is %d":                                                                                                  367,
+	"%s(%s) not allow to delete":                                                                                                         51,
+	"%s: %s cannot be ip address: %s":                                                                                                    454,
+	"%s: %s must be domain name: %s":                                                                                                     453,
+	"%s: Invalid IP address %s":                                                                                                          1045,
+	"%s: bad base64 encoded string: %s":                                                                                                  927,
+	"%s: bad template: %s":                                                                                                               928,
+	"%s: invalid domain name: %s":                                                                                                        447,
+	"%s: name cannot be ip address: %s":                                                                                                  450,
+	"%s: new time is in the future: %s > %s":                                                                                             933,
+	"%s: time error: %s":                                                                                                                 932,
+	"%s: unknown record type":                                                                                                            455,
+	"A: record value must be ipv4 address: %s":                                                                                           451,
+	"AAAA: record value must be ipv6 address: %s":                                                                                        452,
+	"Access address located in different zone than specified":                                                                            823,
+	"Access ip %s has been used":                                                                                                         821,
+	"Access network has no zone???":                                                                                                      822,
+	"Account %s(%s) does not have database %s(%s) permissions":                                                                           329,
+	"Account auto sync enabled":                                                                                                          289,
+	"Account disabled":                                                                                                                   288,
+	"Account status is not %s current status is %s":                                                                                      326,
+	"Action %s not found":                                                                                                                59,
+	"ActionNotFoundError":                                                                                                                1407,
+	"Active download session not expired":                                                                                                1198,
+	"Address %s has been used":                                                                                                           1028,
+	"Address %s not in network":                                                                                                          1032,
+	"Address %s not in range":                                                                                                            1025,
+	"Address %s not reserved":                                                                                                            1027,
+	"Address been assigned out of new range":                                                                                             1057,
+	"Alert is already paused":                                                                                                            1578,
+	"Alert is already un-paused":                                                                                                         1577,
+	"Alert is missing conditions":                                                                                                        1612,
+	"Alert notification used by %d alert":                                                                                                1600,
+	"Alert resource driver duplicate match":                                                                                              1588,
+	"Alert resource driver not found":                                                                                                    1587,
+	"Aliyun %s not support recovery":                                                                                                     1279,
+	"Aliyun %s only 8.0 and 5.7 high_availability local_ssd or 5.6 high_availability support recovery from it self backups": 1281,
+	"Aliyun %s only support recover from it self backups":                                                                   1280,
+	"Aliyun DBInstance account name length shoud be 2~16 characters":                                                        1294,
+	"Aliyun instance weight must be in the range of 0 ~ 100":                                                                1254,
+	"Aliyun not allow to change certificate":                                                                                1250,
+	"Aliyun reset disk required guest status is running or ready":                                                           182,
+	"Already have backup server":                                                                                            643,
+	"At least two networks are required under vpc %s(%s) with aliyun %s(%s)":                                                1292,
+	"Attach nfs storage require host status is online":                                                                      199,
+	"Attach rbd storage require host status is online":                                                                      196,
+	"Aws not support reset disk, you can create new disk with snapshot":                                                     183,
+	"Azure Mv2-series instance sku only support UEFI image":                                                                 132,
+	"Azure UEFI image %s not support this instance sku":                                                                     133,
+	"Azure not support reset disk, you can create new disk with snapshot":                                                   185,
+	"Backup host is offline":                                                                                                651,
+	"Backup only support hypervisor kvm":                                                                                    645,
+	"BadGateway":                                                                                                            1400,
+	"BadRequestError":                                                                                                       1423,
+	"Bandwidth limit cannot exceed %dMbps":                                                                                  1029,
+	"Bandwidth must be non-negative":                                                                                        609,
+	"Baremetal %s is not ready":                                                                                             139,
+	"Baremetal %s is occupied":                                                                                              140,
+	"Baremetal %s not enabled":                                                                                              787,
+	"Baremetal agent not found":                                                                                             211,
+	"Baremetal host is aleady occupied":                                                                                     870,
+	"Baremetal package not prepared":                                                                                        212,
+	"BgpType attribute is only useful for eip network":                                                                      1078,
+	"Bucket has %d task active, can't sync status":                                                                          244,
+	"CD-ROM not empty, please eject first":                                                                                  558,
+	"CNAME cannot mix with other types":                                                                                     445,
+	"CPU core count must be 1 ~ %d":                                                                                         745,
+	"Can not delete disk snapshots, have manual snapshot":                                                                   1194,
+	"Can not get disk snapshot":                                                                                             383,
+	"Can not rebuild root with with diff uefi image":                                                                        575,
+	"Can't clone guest with backup guest":                                                                                   540,
+	"Can't do instance snapshot with backup guest":                                                                          700,
+	"Can't trigger scaling policy without status 'ready'":                                                                   1111,
+	"Cannot Delete disk %s snapshots, disk exist":                                                                           1192,
+	"Cannot add security groups for hypervisor %s":                                                                          562,
+	"Cannot add security groups in status %s":                                                                               487,
+	"Cannot assign security rules in status %s":                                                                             567,
+	"Cannot attach network in status %s":                                                                                    607,
+	"Cannot cache image with no checksum":                                                                                   867,
+	"Cannot change bandwidth in status %s":                                                                                  608,
+	"Cannot change config for baremtal":                                                                                     135,
+	"Cannot change config in %s":                                                                                            613,
+	"Cannot change config in status %s":                                                                                     360,
+	"Cannot change config with different instance family":                                                                   614,
+	"Cannot change network ip_addr in status %s":                                                                            602,
+	"Cannot change server sku name":                                                                                         1166,
+	"Cannot change setting in status %s":                                                                                    610,
+	"Cannot change state on pause alert":                                                                                    1575,
+	"Cannot clone VM in status %s":                                                                                          542,
+	"Cannot create backup with isolated device":                                                                             764,
+	"Cannot create backup with isolated devices":                                                                            646,
+	"Cannot create backup with shared storage":                                                                              644,
+	"Cannot create backup with snapshot":                                                                                    648,
+	"Cannot create disk with disabled storage[%s]":                                                                          376,
+	"Cannot create disk with offline storage[%s]":                                                                           377,
+	"Cannot delete keypair used by servers":                                                                                 912,
+	"Cannot delete server disk %s must not have snapshots.":                                                                 743,
+	"Cannot delete server on disabled host":                                                                                 741,
+	"Cannot delete server on offline host":                                                                                  742,
+	"Cannot delete snapshot in status %s":                                                                                   1187,
+	"Cannot delete snapshot on disk reset":                                                                                  1190,
+	"Cannot delete system alert":                                                                                            1592,
+	"Cannot delete the last cache":                                                                                          1199,
+	"Cannot deploy in status %s":                                                                                            544,
+	"Cannot detach network in status %s":                                                                                    606,
+	"Cannot detach sys disk":                                                                                                586,
+	"Cannot do Ipmi-probe in status %s":                                                                                     840,
+	"Cannot do eject-iso in status %s":                                                                                      884,
+	"Cannot do initialization in status %s":                                                                                 841,
+	"Cannot do insert-iso in status %s":                                                                                     883,
+	"Cannot do io throttle in status %s":                                                                                    686,
+	"Cannot do live migrate, too low qemu version":                                                                          161,
+	"Cannot do maintenance in status %s":                                                                                    832,
+	"Cannot do maintenance while guest status %s":                                                                           833,
+	"Cannot do reboot dbinstance in status %s":                                                                              351,
+	"Cannot do recovery dbinstance in status %s required status %s":                                                         345,
+	"Cannot do renew dbinstance in status %s required status %s":                                                            353,
+	"Cannot do restart elasticcache instance in status %s":                                                                  470,
+	"Cannot do restart server in status %s":                                                                                 625,
+	"Cannot do snapshot when VM in status %s":                                                                               1396,
+	"Cannot do start server in status %s":                                                                                   557,
+	"Cannot do unmaintenance in status %s":                                                                                  834,
+	"Cannot enable deleting account":                                                                                        274,
+	"Cannot keep detached disk":                                                                                             587,
+	"Cannot live migrate in status %s":                                                                                      539,
+	"Cannot live migrate with cdrom":                                                                                        159,
+	"Cannot live migrate with isolated devices":                                                                             160,
+	"Cannot migrate with isolated devices":                                                                                  158,
+	"Cannot mix different types of records, %s != %s":                                                                       459,
+	"Cannot modify Memory and CPU in status %s":                                                                             746,
+	"Cannot modify memory for baremetal":                                                                                    747,
+	"Cannot normal migrate guest in status %s, try rescue mode or server-live-migrate?":                                     156,
+	"Cannot perform cache image in status %s":                                                                               865,
+	"Cannot prepare baremetal in server status %s":                                                                          839,
+	"Cannot prepare baremetal in status %s":                                                                                 838,
+	"Cannot purge elastic_ip on enabled cloud provider":                                                                     524,
+	"Cannot purge network on enabled cloud provider":                                                                        1061,
+	"Cannot purge route_table on enabled cloud provider":                                                                    1085,
+	"Cannot purge server on enabled host":                                                                                   570,
+	"Cannot purge snapshot on enabled cloud provider":                                                                       1195,
+	"Cannot purge vpc on enabled cloud provider":                                                                            1233,
+	"Cannot reduce disk size":                                                                                               621,
+	"Cannot reset VM in status %s":                                                                                          622,
+	"Cannot reset baremetal in status %s":                                                                                   863,
+	"Cannot reset baremetal with active guest":                                                                              864,
+	"Cannot reset disk %s(%s),Snapshot is belong to disk %s":                                                                388,
+	"Cannot reset disk in status %s":                                                                                        386,
+	"Cannot reset disk with snapshot in status %s":                                                                          387,
+	"Cannot reset root in status %s":                                                                                        578,
+	"Cannot resize disk for baremtal":                                                                                       136,
+	"Cannot resume VM in status %s":                                                                                         554,
+	"Cannot revoke security groups in status %s":                                                                            565,
+	"Cannot save image for baremtal":                                                                                        141,
+	"Cannot save image in status %s":                                                                                        535,
+	"Cannot send command in status %s":                                                                                      533,
+	"Cannot send keys in status %s":                                                                                         626,
+	"Cannot set default strategy of %s":                                                                                     1126,
+	"Cannot set security group for this guest %s":                                                                           569,
+	"Cannot set security rules in status %s":                                                                                568,
+	"Cannot start a non-baremetal host":                                                                                     827,
+	"Cannot start baremetal with active guest":                                                                              828,
+	"Cannot stop a non-baremetal host":                                                                                      829,
+	"Cannot stop baremetal with active guest":                                                                               831,
+	"Cannot stop baremetal with non-active guest":                                                                           830,
+	"Cannot stop server in status %s":                                                                                       624,
+	"Cannot suspend VM in status %s":                                                                                        553,
+	"Cannot switch OS between %s-%s":                                                                                        574,
+	"Cannot swith to backup when guest in status %s":                                                                        636,
+	"Cannot sync config a non-baremetal host":                                                                               885,
+	"Cannot sync in status %s":                                                                                              538,
+	"Cannot sync status a non-baremetal host":                                                                               862,
+	"Cannot uncache in status %s":                                                                                           1200,
+	"Cannot unconvert in status %s":                                                                                         877,
+	"Cannot update external resource":                                                                                       318,
+	"Check input guests is exist":                                                                                           698,
+	"Check set pending quota error %s":                                                                                      678,
+	"Cloudaccount disabled":                                                                                                 308,
+	"Cloudprovider disabled":                                                                                                307,
+	"Condition is missing the threshold parameter":                                                                          1608,
+	"Condition is missing the type parameter":                                                                               1609,
+	"Conflict address space with existing networks":                                                                         1056,
+	"Conflict address space with existing networks in vpc %q":                                                               1054,
+	"Conflict manager_uri %s":                                                                                               214,
+	"ConflictError":                                                                                                         1431,
+	"Connot convert hypervisor in status %s":                                                                                871,
+	"Container not support %s":                                                                                              145,
+	"Content-Length negative %d":                                                                                            237,
+	"Convert error: %s":                                                                                                     875,
+	"Couldn't delete snapshot policy binding to disks":                                                                      1180,
+	"Currently only kvm platform supports creating wire":                                                                    1240,
+	"DBInstance %s(%s) status is %s require status is %s":                                                                   321,
+	"DBInstance backup has %d task active, can't sync status":                                                               331,
+	"DBInstance has %d task active, can't sync status":                                                                      352,
+	"DBInstance has opened the outer network connection":                                                                    357,
+	"DBInstance is locked, cannot delete":                                                                                   363,
+	"DBinstance has not valid cloudprovider":                                                                                330,
+	"DIRECT setting cannot be changed":                                                                                      65,
+	"DIRECT setting cannot be deleted":                                                                                      66,
+	"DISK Index %d has been occupied":                                                                                       729,
+	"Data disk size must be an integer multiple of 10G":                                                                     172,
+	"Database status is not %s current is %s":                                                                               328,
+	"Default data source not found":                                                                                         1594,
+	"Default quota %s not allow to delete":                                                                                  71,
+	"Description can not start with http:// or https://":                                                                    1293,
+	"Directly creating cloudprovider is not supported, create cloudaccount instead":                                         304,
+	"Disk %s and guest not belong to the same account":                                                                      545,
+	"Disk %s and guest not belong to the same zone":                                                                         546,
+	"Disk %s don't need convert snapshots":                                                                                  382,
+	"Disk %s dose not have snapshot":                                                                                        1193,
+	"Disk %s dosen't attach guest ?":                                                                                        1394,
+	"Disk %s has been attached":                                                                                             548,
+	"Disk %s not attached":                                                                                                  589,
+	"Disk %s not belong the guest's host":                                                                                   549,
+	"Disk %s not found":                                                                                                     552,
+	"Disk %s snapshot full, cannot take any more":                                                                           1398,
+	"Disk attach muti guests":                                                                                               201,
+	"Disk attached Guest has backup, Can't create snapshot":                                                                 1395,
+	"Disk attached guest status must be ready":                                                                              202,
+	"Disk cannot be thrink":                                                                                                 390,
+	"Disk dosen't attach guest":                                                                                             203,
+	"Disk has %d task active, can't sync status":                                                                            410,
+	"Disk in %s not able to attach":                                                                                         550,
+	"Disk must be detached":                                                                                                 194,
+	"Disk must be dettached":                                                                                                191,
+	"Diskinfo index %d: both imageID and size are absent":                                                                   406,
+	"Do not need to update":                                                                                                 1179,
+	"Duplicate ID %s %s":                                                                                                    1447,
+	"Duplicate image name %s":                                                                                               395,
+	"Duplicate manager_uri %s":                                                                                              215,
+	"Duplicate name %s":                                                                                                     1069,
+	"Duplicate name %s %s":                                                                                                  1446,
+	"Duplicate sku %s":                                                                                                      1163,
+	"DuplicateIdError":                                                                                                      119,
+	"DuplicateNameError":                                                                                                    1429,
+	"DuplicateResourceError":                                                                                                1430,
+	"Duration %s invalid":                                                                                                   1030,
+	"Eject ISO not allowed in status %s":                                                                                    561,
+	"Elastic cache is locked, cannot delete":                                                                                471,
+	"Elastic cache is not expired, cannot delete":                                                                           472,
+	"Elasticcache has %d task active, can't sync status":                                                                    484,
+	"Empty import disks":                                                                                                    663,
+	"Empty import nics":                                                                                                     660,
+	"Empty record":                                                                                                          456,
+	"Empty spec query key":                                                                                                  1387,
+	"EmptyRequestError":                                                                                                     1424,
+	"ErrAddressCountExceed":                                                                                                 126,
+	"Fail to mark cache status: %s":                                                                                         1205,
+	"Failed fetching secgroup %s":                                                                                           1142,
+	"Failed to found database %s for dbinstance %s(%s): %v":                                                                 324,
+	"Failed to unmarshal input: %v":                                                                                         1141,
+	"Fetch guest error %s":                                                                                                  642,
+	"Fetch instance snapshot error %s":                                                                                      1188,
+	"Fetch netif error %s":                                                                                                  861,
+	"Fetch snapshot count failed %s":                                                                                        381,
+	"FetchCustomizeColumns return incorrect number of results":                                                              31,
+	"FetchCustomizeColumns returns incorrect results":                                                                       35,
+	"For default vpc, only system level sharing can be set":                                                                 1235,
+	"ForbiddenError":                                                                                                        1427,
+	"General error: general error for %q: %s":                                                                               103,
+	"Generate ifname hint failed %s":                                                                                        1071,
+	"Generate snapshot name failed %s":                                                                                      708,
+	"Generate xml failed: %s":                                                                                               672,
+	"GenerateName fail %s":                                                                                                  1070,
+	"Get convert snapshot failed: %s":                                                                                       384,
+	"Get object error: %v":                                                                                                  1389,
+	"GetAllocatedNicCount fail %s":                                                                                          1014,
+	"GetDiskCount fail %s":                                                                                                  808,
+	"GetGuestCount fail %s":                                                                                                 180,
+	"GetGuestDiskCount fail %s":                                                                                             897,
+	"GetGuestDiskCount for disk %s fail %s":                                                                                 403,
+	"GetGuestnicsCount fail %s":                                                                                             898,
+	"GetGuestsCount fail %s":                                                                                                1148,
+	"GetHostCount fail %s":                                                                                                  1210,
+	"GetIObject error %s":                                                                                                   238,
+	"GetIObject fail %s":                                                                                                    228,
+	"GetLinkedGuestsCount failed %s":                                                                                        911,
+	"GetNatgatewayCount fail %v":                                                                                            1228,
+	"GetNetworkCount fail %s":                                                                                               1226,
+	"GetObjectCount fail %s":                                                                                                1127,
+	"GetRequesterVpcPeeringConnections fail %v":                                                                             1230,
+	"GetRuningGuestCount fail %s":                                                                                           397,
+	"GetSnapshotCount fail %s":                                                                                              411,
+	"GetVpcCount fail %s":                                                                                                   314,
+	"GetZoneCount fail %s":                                                                                                  313,
+	"Google dbinstance not support prepaid billing type":                                                                    1324,
+	"Guest %s can't hot remove nic":                                                                                         162,
+	"Guest %s not found":                                                                                                    641,
+	"Guest %s not support attach disk in status %s":                                                                         551,
+	"Guest '%s' don't belong to ScalingGroup '%s'":                                                                          1105,
+	"Guest Insert error: %s":                                                                                                843,
+	"Guest backup host not found":                                                                                           650,
+	"Guest can't switch to backup, mirror job not ready":                                                                    638,
+	"Guest has %d task active, can't sync status":                                                                           623,
+	"Guest have backup not allow to change config":                                                                          612,
+	"Guest have backup, can't migrate":                                                                                      155,
+	"Guest hypervisor %s does not support clone":                                                                            541,
+	"Guest nic ip addr %s not equal %s":                                                                                     859,
+	"Guest no backup host":                                                                                                  637,
+	"Guest without backup":                                                                                                  649,
+	"GuestDisksHasSnapshot fail %s":                                                                                         647,
+	"Handler not found":                                                                                                     13,
+	"Host %s already have mount point %s with other storage":                                                                198,
+	"Host %s can't migrate guests %s in status %s":                                                                          882,
+	"Host %s is not a baremetal":                                                                                            138,
+	"Host %s is not online":                                                                                                 179,
+	"Host %s not found":                                                                                                     154,
+	"Host is a converted baremetal, should be unconverted before delete":                                                    804,
+	"Host is not disabled":                                                                                                  805,
+	"Host missing":                                                                                                          531,
+	"Host should be disabled":                                                                                               876,
+	"HostCount fail %s":                                                                                                     1241,
+	"Huawei %s rds not support recovery from it self rds backup":                                                            1344,
+	"Huawei DBInstance Disk cannot be thrink":                                                                               1338,
+	"Huawei DBInstance backup name length shoud be 4~64 characters":                                                         1336,
+	"Huawei DBInstance category cannot change":                                                                              1339,
+	"Huawei DBInstance storage type cannot change":                                                                          1340,
+	"Huawei current not support reset dbinstance account password":                                                          1341,
+	"Huawei dbinstance name length shoud be 4~64 characters":                                                                1330,
+	"Huawei only %s engine support databases recovery":                                                                      1345,
+	"Huawei only supports specified databases with %s":                                                                      1337,
+	"Huawei rds password cannot be in the same reverse order as the account":                                                1334,
+	"Hypervisor %s can't do io throttle":                                                                                    685,
+	"Hypervisor %s can't generate libvirt xml":                                                                              671,
+	"Hypervisor %s not supported":                                                                                           792,
+	"IP %s not attach to any wire":                                                                                          849,
+	"IP %s not attach to wire %s":                                                                                           848,
+	"IPMI address located in different zone than specified":                                                                 820,
+	"IPMI has no password information":                                                                                      812,
+	"IPMI infomation not configured":                                                                                        842,
+	"IPMI network has no zone???":                                                                                           819,
+	"IPMI network has not zone???":                                                                                          825,
+	"Illegal Content-Length %s":                                                                                             236,
+	"Image %s not found":                                                                                                    1443,
+	"Image is in use":                                                                                                       1197,
+	"Image name is required":                                                                                                399,
+	"Image status is not active":                                                                                            409,
+	"ImageNotFoundError":                                                                                                    1404,
+	"Inconsistent: local storage is not empty???":                                                                           810,
+	"Incontinuity Network for %s and %s":                                                                                    1064,
+	"Influxdb invalid status":                                                                                               1606,
+	"InformerBackend not init":                                                                                              98,
+	"InputParameterError":                                                                                                   1412,
+	"Insert ISO not allowed in status %s":                                                                                   559,
+	"Insert shared resource failed %s":                                                                                      85,
+	"Instance sanpshot not ready":                                                                                           705,
+	"Instance snapshot not ready":                                                                                           751,
+	"Instance status is not %s current status is %s":                                                                        327,
+	"InsufficientResourceError":                                                                                             1415,
+	"Interface %s not exist":                                                                                                852,
+	"Interface %s not exists":                                                                                               854,
+	"Internal server error":                                                                                                 11,
+	"Internal server error: %s":                                                                                             10,
+	"InternalServerError":                                                                                                   1401,
+	"Invaild mac address":                                                                                                   844,
+	"Invald %s return value":                                                                                                37,
+	"Invald CustomizeDelete return value":                                                                                   29,
+	"Invald ListItemFilter return value count %d":                                                                           22,
+	"Invald OrderByExtraFields return value count %d":                                                                       23,
+	"Invald ValidateCreateData return value":                                                                                21,
+	"Invald ValidateUpdateData return value":                                                                                28,
+	"Invalid FetchCustomizeColumns return value count %d":                                                                   25,
+	"Invalid FetchCustomizeColumns return value type, not a slice!":                                                         26,
+	"Invalid FetchCustomizeColumns return value, inconsistent obj count: input %d != output %d": 27,
+	"Invalid GetExtraDetails return value count %d":                                             24,
+	"Invalid IP %s": 1066,
+	"Invalid Target Network %s: inconsist %s":                           1063,
+	"Invalid bandwidth":                                                 523,
+	"Invalid choice error: invalid %q, want %s, got %s":                 105,
+	"Invalid condition evaluator type":                                  1610,
+	"Invalid data JSONObject":                                           49,
+	"Invalid default stragegy %s":                                       1125,
+	"Invalid desc: %s":                                                  656,
+	"Invalid handler %s":                                                12,
+	"Invalid host ip %s":                                                667,
+	"Invalid interval format: %s":                                       1604,
+	"Invalid length error: %q too long, got %d, max %d":                 107,
+	"Invalid length error: %q too short, got %d, min %d":                106,
+	"Invalid level format: %s":                                          1589,
+	"Invalid mac address":                                               860,
+	"Invalid masklen %d":                                                1041,
+	"Invalid medium type %s":                                            1208,
+	"Invalid period format: %s":                                         1590,
+	"Invalid raid config: %v":                                           137,
+	"Invalid refresh format: %s":                                        1579,
+	"Invalid request header: %v":                                        15,
+	"Invalid root image: %s":                                            755,
+	"Invalid schedtag %s":                                               1124,
+	"Invalid server ip address %s":                                      669,
+	"Invalid server mac address %s":                                     668,
+	"Invalid server_type: %s":                                           1036,
+	"Invalid start ip: %s %s":                                           1042,
+	"Invalid storage type %s":                                           1207,
+	"Invalid type error: expecting %s type for %q: %s":                  104,
+	"Invalid userdata: %v":                                              769,
+	"Invalid value error: invalid %q: ":                                 111,
+	"Invalid value error: invalid %q: %s":                               109,
+	"Invalid value error: invalid %q: %v":                               110,
+	"InvalidCredentialError":                                            1426,
+	"InvalidFormatError":                                                1411,
+	"InvalidProvider":                                                   124,
+	"InvalidStatusError":                                                120,
+	"InvalidToken":                                                      1545,
+	"Ip %s not in network %s(%s) range":                                 336,
+	"Isolated device %s not found":                                      592,
+	"Isolated device already attached to another guest: %s":             907,
+	"Isolated device is not attached to this guest":                     593,
+	"Isolated device used by server":                                    905,
+	"Isolated device used by server: %s":                                908,
+	"IsolatedDevice %s not found":                                       906,
+	"Keypair %s not found":                                              766,
+	"Kvm snapshot missing storage ??":                                   1370,
+	"Loadbalancer's manager %s does not match vpc's(%s(%s)) (%s)":       1306,
+	"Loadbalancer's manager (%s(%s)) does not match vpc's(%s(%s)) (%s)": 1249,
+	"Local host storage is not empty???":                                809,
+	"Master dbinstance memory <64GB, up to 5 read-only instances are allowed to be created":  1291,
+	"Master dbinstance memory ≥64GB, up to 10 read-only instances are allowed to be created": 1290,
+	"Memory size must be 8MB ~ %d GB":                           744,
+	"Memory size must be number[+unit], like 256M, 1G or 256":   616,
+	"Miss operating system???":                                  758,
+	"Missing isolated device":                                   591,
+	"Missing key error: missing %q":                             102,
+	"Missing name or generate_name":                             45,
+	"Missing parameter %s":                                      1445,
+	"MissingParameterError":                                     1414,
+	"Model manager error: failed getting model manager for %q":  112,
+	"Model not found error: cannot find %q with id/name %q":     113,
+	"Model not found error: cannot find %q with id/name %q: %s": 114,
+	"Must be a baremetal host":                                  869,
+	"NIC Index %d has been occupied":                            732,
+	"Name %s not found":                                         1546,
+	"Nat gateway has %d task active, can't sync status":         1000,
+	"Network %s not found":                                      1062,
+	"Network %s not found: %v":                                  1024,
+	"Network not found":                                         210,
+	"Network not in range of VPC cidrblock %s":                  1052,
+	"NetworkCount fail %s":                                      1243,
+	"New IPMI address located in another zone!":                 826,
+	"New databases name can not be one of %s":                   1346,
+	"NewTask error: %s":                                         670,
+	"No Disk Info Provided":                                     580,
+	"No ISO to eject":                                           560,
+	"No context manager":                                        32,
+	"No disk information provided":                              754,
+	"No eip to dissociate":                                      634,
+	"No host for server":                                        534,
+	"No ipmi information was found for host %s":                 811,
+	"No login key: %s":                                          1561,
+	"No login secret found":                                     1547,
+	"No need to grant or revoke privilege for admin account":    1342,
+	"No password found":                                         1551,
+	"No previous deployment info available":                     948,
+	"No request key: %s":                                        14,
+	"No return value, so why query?":                            39,
+	"No root image":                                             536,
+	"No ssh password: %s":                                       1552,
+	"No such context %s(%s)":                                    33,
+	"No such eip":                                               999,
+	"No template for root disk, cannot rebuild root":            576,
+	"No valid host":                                             581,
+	"No valid storage on current host":                          582,
+	"No zone for this disk":                                     394,
+	"NoBalancePermission":                                       125,
+	"NoProjectError":                                            1435,
+	"Not Implement RequestAttachStorage":                        189,
+	"Not Implement RequestDetachStorage":                        190,
+	"Not Implement ValidateAttachStorage":                       188,
+	"Not Implement ValidateCreateEip":                           142,
+	"Not Implement ValidateResetDisk":                           187,
+	"Not Implemented":                                           334,
+	"Not Implemented GetProvider":                               117,
+	"Not a baremetal":                                           855,
+	"Not a prepaid recycle host":                                800,
+	"Not allow empty records":                                   17,
+	"Not allow for hypervisor %s":                               143,
+	"Not allow set scope to domain %s":                          82,
+	"Not allow set scope to project %s":                         83,
+	"Not allow set scope to system":                             81,
+	"Not allow to attach":                                       52,
+	"Not allow to change config":                                611,
+	"Not allow to create item":                                  43,
+	"Not allow to get details":                                  40,
+	"Not allow to update item":                                  50,
+	"Not an converted hypervisor":                               878,
+	"Not an empty host":                                         807,
+	"Not being convert to hypervisor":                           856,
+	"Not enough free space":                                     380,
+	"Not eough storage space on current host":                   583,
+	"Not find executor for data source":                         1607,
+	"Not found baremetal server record":                         857,
+	"Not found guest nic by mac %s":                             858,
+	"Not found key in query: %v":                                1563,
+	"Not found kind in query: %v":                               1562,
+	"Not found network by ip %s":                                662,
+	"Not in range error: invalid %q: %d, want [%d,%d]":          108,
+	"Not support":                                               425,
+	"Not support %s for account %s, supported %s":               428,
+	"Not support %s for vpc %s, supported %s":                   427,
+	"Not support associate type %s, only support %s":            501,
+	"Not support brand %s, only support %s":                     281,
+	"Not support cache classic security group":                  1145,
+	"Not support create %s storage":                             1209,
+	"Not support create Qcloud databases":                       1384,
+	"Not support create account for huawei cloud %s instance":   1333,
+	"Not support create database for huawei cloud %s instance":  1335,
+	"Not support create local storage disks":                    176,
+	"Not support create public cloud sku":                       1161,
+	"Not support create read-only dbinstance for %s":            1329,
+	"Not support create readonly dbinstance for MySQL %s":       1286,
+	"Not support create readonly dbinstance for MySQL %s %s":    1284,
+	"Not support create readonly dbinstance for MySQL %s %s with storage type %s, only support %s": 1285,
+	"Not support create readonly dbinstance with master dbinstance engine %s":                      1289,
+	"Not support modify routetable for provider %s":                                                1084,
+	"Not support resource %s tag filter":                                                           58,
+	"Not support resource_type %s":                                                                 1120,
+	"Not supported, please use kubectl":                                                            144,
+	"NotAcceptableError":                                                                           1428,
+	"NotEmptyError":                                                                                1422,
+	"NotFoundError":                                                                                118,
+	"NotImplementedError":                                                                          122,
+	"NotSufficientPrivilegeError":                                                                  1420,
+	"NotSupportedError":                                                                            123,
+	"Object %s %s has attached %s %s":                                                              53,
+	"Only %s dbinstance support this operation":                                                    356,
+	"Only %s elastic cache support renew operation":                                                497,
+	"Only %s elastic cache support set auto renew operation":                                       495,
+	"Only %s guest support this operation":                                                         718,
+	"Only %s support cache for account":                                                            433,
+	"Only ADMIN and IPMI nic can be enable":                                                        853,
+	"Only allowed to attach isolated device when guest is ready":                                   590,
+	"Only one of that sourceCIDR and netword_id is needed":                                         1001,
+	"Only support on premise network":                                                              1074,
+	"Only support server type %s":                                                                  1073,
+	"Only system admin allowed to use reserved ip":                                                 1026,
+	"Only system admin can assign host":                                                            892,
+	"OpenStack not support reset disk, you can create new disk with snapshot":                      204,
+	"Out of IP address":                                                                            1022,
+	"Out of eip quota: %s":                                                                         635,
+	"OutOfLimit":                                                                                   1419,
+	"OutOfQuotaError":                                                                              1417,
+	"OutOfRange":                                                                                   1418,
+	"OutOfResource":                                                                                1416,
+	"PTR cannot mix with other types":                                                              446,
+	"PTR: invalid ptr record name: %s":                                                             449,
+	"Params vcpu_count parse error":                                                                615,
+	"Params vmem_size parse error":                                                                 617,
+	"Parse Ip Failed":                                                                              1060,
+	"Parse disk info error: %s":                                                                    620,
+	"Parse remote ip error %s":                                                                     209,
+	"Parse spec key %s error: %v":                                                                  1388,
+	"PaymentError":                                                                                 1403,
+	"Please disable this ScalingGroup firstly":                                                     1102,
+	"Please input new disk backend type":                                                           177,
+	"PolicyDefinitionError":                                                                        1442,
+	"Port value error":                                                                             995,
+	"Prohibit making default vpc private":                                                          1236,
+	"Project %s(%s) not belong to domain %s(%s)":                                                   280,
+	"ProtectedResourceError":                                                                       1434,
+	"Qcloud Basic MySQL instance not support create backup":                                        1383,
+	"Qcloud reset disk required guest status is running or read":                                   205,
+	"Query database error %s":                                                                      62,
+	"Query host storage error %s":                                                                  197,
+	"Quota %s not found":                                                                           70,
+	"Records limit exceeded.":                                                                      18,
+	"Region %s not found":                                                                          305,
+	"RequireLicenseError":                                                                          1433,
+	"Rescue mode requires all disk store in shared storages":                                       157,
+	"Resize disk when disk is READY":                                                               389,
+	"Resource %s %s not found":                                                                     1134,
+	"Resource type %s not support":                                                                 463,
+	"ResourceBusyError":                                                                            1432,
+	"ResourceNotFoundError":                                                                        1405,
+	"ResourceNotReadyError":                                                                        1402,
+	"ResourceType %q not support":                                                                  1118,
+	"Retention days must in 1~%d or -1":                                                            1174,
+	"Retention days must in 1~65535 or -1":                                                         1178,
+	"SQL Server cannot have more than seven read-only dbinstances":                                 1288,
+	"SQL Server only support create readonly dbinstance for 2017_ent":                              1287,
+	"SRV cannot mix with other types":                                                              444,
+	"SRV: insufficient param: %s":                                                                  438,
+	"SRV: invalid port number: %s":                                                                 439,
+	"SRV: invalid priority number: %s":                                                             442,
+	"SRV: invalid srv record name: %s":                                                             448,
+	"SRV: invalid weight number: %s":                                                               440,
+	"SRV: priority number %d not in range [0,65535]":                                               443,
+	"SRV: weight number %d not in range [0,65535]":                                                 441,
+	"Save disk when disk is READY":                                                                 396,
+	"Save disk when not being USED":                                                                398,
+	"ScalingGroup should have some networks":                                                       1091,
+	"Schedtag %s":                                                                                  1121,
+	"Schedtag %s ResourceType is %s, not match %s":                                                 1133,
+	"Schedtag %s not found":                                                                        802,
+	"Schedtag %s resource_type mismatch: %s != %s":                                                 1122,
+	"Secgroup %s not found":                                                                        767,
+	"Server %s already exists":                                                                     659,
+	"Server %s must in status ready":                                                               193,
+	"Server Id is empty":                                                                           657,
+	"Server Name is empty":                                                                         658,
+	"Server in %s not able to detach disk":                                                         588,
+	"ServerStatusError":                                                                            1410,
+	"SetLimit error %s":                                                                            261,
+	"Snapshot %s dose not have convert snapshot":                                                   385,
+	"Snapshot %s not found":                                                                        407,
+	"Snapshot %s storage %s not found, is public cloud?":                                           408,
+	"Snapshot error: disk index %d > 0 but disk type is %s":                                        761,
+	"Snapshot for %s name can't start with auto, http:// or https://":                              1278,
+	"Snapshot has %d task active, can't sync status":                                               1191,
+	"Snapshot reference(by disk) count > 0, can not delete":                                        1392,
+	"Some disk not ready":                                                                          556,
+	"Some host config missing host ip":                                                             666,
+	"Some host config missing xml_file_path":                                                       665,
+	"SpecNotFoundError":                                                                            1406,
+	"Split IP %s is the start ip":                                                                  1067,
+	"Split IP %s out of range":                                                                     1068,
+	"Storage %s not found":                                                                         373,
+	"Storage type[%s] not match backend %s":                                                        378,
+	"StorageInUse":                                                                                 893,
+	"Storage[%s] must attach to a host":                                                            379,
+	"Support only by KVM Hypervisor":                                                               537,
+	"System disk does not support %s disk":                                                         151,
+	"System disk does not support iso image, please consider using cdrom parameter": 756,
+	"Tag is associated with %s":                                                     1128,
+	"TenantNotFoundError":                                                           1408,
+	"The %s disk size must be in the range of %dGB ~ %dGB":                          128,
+	"The %s disk size must be in the range of 100GB ~ 16000GB":                      169,
+	"The %s disk size must be in the range of 10GB ~ 16000GB":                       167,
+	"The %s disk size must be in the range of 20GB ~ 32000GB":                       170,
+	"The %s disk size must be in the range of 50GB ~ 16000GB":                       168,
+	"The %s guest not support public ip to eip operation":                           717,
+	"The account %s(%s) has permission %s to the database %s(%s)":                   325,
+	"The account has been registered":                                               283,
+	"The backend %s is already registered on port %d":                               1315,
+	"The dbinstance status need be %s, current is %s":                               355,
+	"The disk is locally stored and does not support detach":                        178,
+	"The disk_size_gb must be an integer multiple of 10":                            1332,
+	"The elastic cache status need be %s, current is %s":                            494,
+	"The extranet connection is not open":                                           358,
+	"The guest %s does not have any public IP":                                      715,
+	"The guest status need be %s or %s, current is %s":                              716,
+	"The image has been cached on storages":                                         266,
+	"The secgroup name %s does not meet the requirements, please change the name":   492,
+	"The specified Scheduler %s is invalid for performance sharing loadbalancer":    1272,
+	"The system disk is locally stored and does not support changing configuration": 175,
+	"There are some guests in this ScalingGroup, please delete them firstly":        1103,
+	"This RBD Storage[%s/%s] has already exist":                                     1399,
+	"This scheduled task is being executed now, please try later":                   1139,
+	"TimeoutError":          121,
+	"TooLargeEntity":        1436,
+	"TooManyFailedAttempts": 1437,
+	"TooManyRequests":       1438,
+	"Ucloud only support data disk reset operation":             207,
+	"Ucloud reset disk operation required disk not be attached": 206,
+	"Unauthorized":                                                                      1544,
+	"UnauthorizedError":                                                                 1425,
+	"Unavailable IP %s: occupied":                                                       682,
+	"Unknown alert condition":                                                           1611,
+	"Unknown backend group type %s":                                                     1260,
+	"Unknown google storage type %s":                                                    150,
+	"Unknown privilege %s":                                                              1300,
+	"Unknown sticky_session_type, only support %s or %s":                                1270,
+	"Unkown alert condition type: %s":                                                   1619,
+	"Unkown operator %s":                                                                1614,
+	"Unmarshal data error %s":                                                           664,
+	"Unmarshal disks configure error %s":                                                619,
+	"Unmarshal input error %s":                                                          543,
+	"Unmarshal input error: %v":                                                         361,
+	"Unmarshal input failed %s":                                                         994,
+	"Unmarshel input failed %s":                                                         1177,
+	"Unreachable IP %s: %s":                                                             681,
+	"Unsupport attach %s storage for %s host":                                           195,
+	"Unsupport backendgorup type %s":                                                    1252,
+	"Unsupport driver type %s":                                                          873,
+	"UnsupportOperationError":                                                           1421,
+	"Unsupported %s":                                                                    506,
+	"Unsupported notification type":                                                     1605,
+	"Unsupported provider %s":                                                           279,
+	"Unsupported scheme %s":                                                             909,
+	"UnsupportedProtocol":                                                               1441,
+	"Update error %s":                                                                   262,
+	"User Disabled":                                                                     1440,
+	"User Locked":                                                                       1439,
+	"UserNotFoundError":                                                                 1409,
+	"VPC %s not found":                                                                  317,
+	"VPC not empty, please delete nat gateway first":                                    1229,
+	"VPC not empty, please delete network first":                                        1227,
+	"VPC not ready":                                                                     1049,
+	"VPC peering not empty, please delete vpc peering first":                            1231,
+	"ValidateDeleteCondition error %s":                                                  265,
+	"Virtual disk %s(%s) used by virtual servers":                                       404,
+	"Virtual resource freezed, can't do %s":                                             94,
+	"Virtual resource type %s not support":                                              464,
+	"Virtual server is locked, cannot delete":                                           739,
+	"WeakPasswordError":                                                                 1413,
+	"Wire %s not found":                                                                 791,
+	"Wrong guest status %s":                                                             835,
+	"ZStack reset disk operation requried guest status is ready":                        208,
+	"Zone %s not found":                                                                 306,
+	"a recycle host shoud not allocate more than 1 guest":                               798,
+	"account %s conflict":                                                               294,
+	"account %s has been cached":                                                        434,
+	"account %s not enable saml auth":                                                   270,
+	"account %s not share for domain %s":                                                525,
+	"account is enabled":                                                                271,
+	"account is not idle":                                                               272,
+	"account name '%s' is not allowed":                                                  1374,
+	"account name can not start or end with _":                                          1297,
+	"account_privilege %s only support redis version 4.0":                               1302,
+	"acl %s is still referred to by %d %s":                                              920,
+	"acl cidr duplicate %s":                                                             917,
+	"address %s is already occupied":                                                    1018,
+	"address %s is not in the range of network %s(%s)":                                  1016,
+	"alert already attached to notification":                                            1576,
+	"alert condition type is empty":                                                     1618,
+	"all networks should in the same vpc. (%s).":                                        1307,
+	"allocate ip addr: %v":                                                              1012,
+	"allow only internal zone, got %s(%s)":                                              976,
+	"already associate with eip":                                                        628,
+	"already has one network in the zone %s. (%s).":                                     1308,
+	"app_id is empty":                                                                   1568,
+	"app_secret is empty":                                                               1569,
+	"attach devices is not string array":                                                597,
+	"auth mode aready in status %s":                                                     478,
+	"authenticate error: %v":                                                            945,
+	"back and instance not in same cloudaccount":                                        348,
+	"backend group %s is default backend group":                                         959,
+	"backend group %s is still referred by %d %s":                                       961,
+	"backend group %s(%s) belongs to loadbalancer %s instead of %s":                     1262,
+	"backend group %s(%s) belongs to loadbalancer %s, not %s":                           990,
+	"backend group type must be normal":                                                 1263,
+	"backend_group argument is missing":                                                 1361,
+	"backendgroup %s not support this operation":                                        1256,
+	"backup %s(%s) not contain database %s":                                             346,
+	"backup and instance not in same cloudregion":                                       349,
+	"bad gateway ip: %v":                                                                1046,
+	"bad ip":                                                                            1625,
+	"bad network type %q, want %q":                                                      1367,
+	"bandwidth must be greater than 0":                                                  1238,
+	"batch create is not supported for external resources":                              1008,
+	"beyond security group quantity limit, max items %d.":                               491,
+	"body is not a json?":                                                               44,
+	"bps must > 0":                                                                      687,
+	"bucket.GetQuotaKeys %s":                                                            230,
+	"bucket.GetQuotaKeys fail %s":                                                       240,
+	"can not bind guest from disabled guest":                                            527,
+	"can not bind or unbind disabled instance group":                                    714,
+	"can not change specification in status %s":                                         477,
+	"can not find dashboard:%s":                                                         1583,
+	"can not make backup in status %s":                                                  1375,
+	"can not recover data from diff rds engine":                                         350,
+	"can not sync record sets in %s":                                                    431,
+	"can not unbind guest from disabled guest":                                          528,
+	"can not update instance_type for public cloud %s":                                  1165,
+	"can't delete instance snapshot with wrong status":                                  900,
+	"can't detach host in status online":                                                1216,
+	"can't find instance snapshot %s":                                                   749,
+	"can't get string field":                                                            60,
+	"can't rebuild root for a guest with instance snapshots":                            149,
+	"can't rescue geust %s with local storage":                                          692,
+	"can't resize disk for guest with instance snapshots":                               147,
+	"can't restore elastic cache in status %s":                                          466,
+	"candidate %s out of range":                                                         1021,
+	"cannot allocate ifname":                                                            730,
+	"cannot alter name of role":                                                         1501,
+	"cannot alter sysadmin user name":                                                   1512,
+	"cannot alter system project name":                                                  1498,
+	"cannot associate eip and instance in different provider":                           633,
+	"cannot associate eip and instance in different region":                             631,
+	"cannot associate eip and instance in different zone":                               632,
+	"cannot associate eip in status %s":                                                 627,
+	"cannot associate eip with same network":                                            510,
+	"cannot associate pending delete server":                                            507,
+	"cannot associate server in status %s":                                              509,
+	"cannot assoicate with eip %s: different cloudprovider":                             782,
+	"cannot assoicate with eip %s: different region":                                    783,
+	"cannot change CPU/Memory spec in status %s":                                        618,
+	"cannot change bandwidth in status %s":                                              522,
+	"cannot change loadbalancer listener listener_port":                                 1373,
+	"cannot change loadbalancer listener listener_type":                                 1372,
+	"cannot change mac when guest is running":                                           603,
+	"cannot change to a different domain from a private cloud account":                  310,
+	"cannot create prepaid server on prepaid resource type":                             762,
+	"cannot delete a recycle host without active instance":                              797,
+	"cannot delete default SQL identity provider":                                       1484,
+	"cannot delete default domain":                                                      1461,
+	"cannot delete enabled idp":                                                         1485,
+	"cannot delete enabled policy":                                                      1493,
+	"cannot delete non-local non-sso user":                                              1514,
+	"cannot delete system policy":                                                       1492,
+	"cannot delete system project":                                                      1494,
+	"cannot delete system role":                                                         1502,
+	"cannot delete system user":                                                         1516,
+	"cannot derive valid ifname hint: %v":                                               1038,
+	"cannot enable auto sync in status %s":                                              297,
+	"cannot fetch network of guestnetwork %d":                                           1007,
+	"cannot find region info":                                                           989,
+	"cannot join read-only group":                                                       1518,
+	"cannot join user and group in differnt domain":                                     1517,
+	"cannot leave read-only group":                                                      1519,
+	"cannot migrate with cdrom":                                                         695,
+	"cannot recycle in status %s":                                                       793,
+	"cannot remove current user from current project":                                   1455,
+	"cannot run hypervisor %s on specified host with type %s":                           788,
+	"cannot support change azure disk name":                                             184,
+	"cannot support change azure instance name":                                         134,
+	"cannot support more than 1 nic":                                                    127,
+	"cannot uncache non-customized images":                                              1203,
+	"cannot undo a recycle host with pending_deleted guest":                             799,
+	"cannot undo recycle in status %s":                                                  794,
+	"cannot update config when enabled and connected":                                   1477,
+	"cannot update config when not idle":                                                1478,
+	"cannot update in sync status":                                                      1488,
+	"certificate %s is still referred to by %d %s":                                      971,
+	"channel is empty":                                                                  1570,
+	"charge type %s not supported":                                                      502,
+	"check %s duplication fail %s":                                                      813,
+	"check access_mac duplication fail %s":                                              816,
+	"check account_id duplication error %s":                                             286,
+	"check agent uniqness fail %s":                                                      213,
+	"check disk index uniqueness fail %s":                                               728,
+	"check disk snapshot count fail %s":                                                 1397,
+	"check instance":                                                                    1167,
+	"check isAttach2Disk fail %s":                                                       585,
+	"check mac uniqueness fail %s":                                                      604,
+	"check name duplication error: %s":                                                  56,
+	"check name duplication fail %s":                                                    1628,
+	"check uniqness fail %s":                                                            282,
+	"check uniqueness fail %s":                                                          293,
+	"checkout guestdisk count fail %s":                                                  736,
+	"checkout nic index uniqueness fail %s":                                             731,
+	"checkout server sku name duplicate error: %v":                                      1162,
+	"cidr %s is not in range vpc %s":                                                    1002,
+	"cloud account %s is not available":                                                 401,
+	"cloud provider %s is not available":                                                400,
+	"cloudprovider %s %s %s %s %s not supported CrossCloud vpcpeering":                  1221,
+	"cloudprovider %s %s %s %s %s not supported CrossRegion vpcpeering":                 1222,
+	"cloudprovider %s not available":                                                    374,
+	"cloudprovider %s(%s) is not available":                                             337,
+	"cloudprovider.SetBucketCORS error %s":                                              251,
+	"cloudregion %s not support create %s rds":                                          341,
+	"cloudregion %s not support create rds":                                             340,
+	"cloudregion %s(%s) not support %s scheduler":                                       1274,
+	"cluster wire affiliation does not match network's: %s != %s":                       992,
+	"cluster zone %s does not match network zone %s ":                                   991,
+	"comment contains non-printable char: %v":                                           916,
+	"comment too long (%d>=%d)":                                                         915,
+	"condition values limit (5 per rule). %d given.":                                    984,
+	"conflict database %s for instance %s(%s)":                                          347,
+	"conflict with lbagent %s(%s): %v":                                                  930,
+	"count must > 0":                                                                    707,
+	"cpu_core_count should be range of 1~256":                                           1158,
+	"create instance snapshot failed: %s":                                               703,
+	"dashboard_id is empty":                                                             1582,
+	"data disk not support storage type %s":                                             166,
+	"dbinstance billing type %s not support cancel expire":                              365,
+	"dbinstance billing type is %s":                                                     364,
+	"default domain is protected":                                                       1470,
+	"delete sku %s failed.":                                                             1173,
+	"desire_instance_number should between min_instance_number and max_instance_number": 1089,
+	"detach devices is not string array":                                                598,
+	"disabled user":                                                                     1452,
+	"disk %s has too many snapshot policy attached":                                     1183,
+	"disk %s not attached to server":                                                    684,
+	"disk %s not found":                                                                 735,
+	"disk and snapshotpolicy should have same domain":                                   1319,
+	"disk and snapshotpolicy should have same project":                                  1320,
+	"disk has no valid storage":                                                         391,
+	"disk need at least one of snapshot as backing file":                                1393,
+	"disk size gb must in range 10 ~ 30720 Gb":                                          1325,
+	"disk.GetQuotaKeys fail %s":                                                         392,
+	"dns zone can not cache in status %s":                                               432,
+	"dns zone can not uncache in status %s":                                             435,
+	"domain contains external resources":                                                1468,
+	"domain is disabled":                                                                1489,
+	"domain is enabled":                                                                 1462,
+	"domain is in use by group":                                                         1464,
+	"domain is in use by policy":                                                        1467,
+	"domain is in use by project":                                                       1465,
+	"domain is in use by role":                                                          1466,
+	"domain is in use by user":                                                          1463,
+	"driver %s already exists":                                                          1483,
+	"driver %s not supported":                                                           1482,
+	"duplicate %s %s":                                                                   814,
+	"duplicate access_mac %s":                                                           817,
+	"duplicate instanceType %s":                                                         1171,
+	"duplicate route cidr %s":                                                           9,
+	"duplicate username":                                                                1534,
+	"duplicated dnsrecord with existed dnsrecord can not distinguish by %s policy":      421,
+	"duplicated dnsrecord with existed dnsrecord not support":                           422,
+	"duplicated with CNAME dnsrecord name not support":                                  420,
+	"eip %s has been associated":                                                        781,
+	"eip %s not found":                                                                  629,
+	"eip %s status invalid %s":                                                          780,
+	"eip and server are not in the same region":                                         513,
+	"eip and server are not in the same zone":                                           514,
+	"eip cannot associate in status %s":                                                 504,
+	"eip cannot dissociate in status %s":                                                517,
+	"eip has been associated":                                                           630,
+	"eip has been associated with instance":                                             503,
+	"eip has been binding to another instance":                                          997,
+	"eip has been binding to dnat rules":                                                1003,
+	"eip has been binding to snat rules":                                                998,
+	"eip network can only exist in default vpc, got %s(%s)":                             1050,
+	"eip not supported for %s":                                                          779,
+	"eip region is not found???":                                                        512,
+	"eip's manager (%s(%s)) does not match vpc's(%s(%s)) (%s)":                          1326,
+	"elastic cache no related region found":                                             496,
+	"elastic cache sku zone (%s) and subnet zone (%s) mismatch":                         1348,
+	"elasticcache billing type %s not support cancel expire":                            486,
+	"elasticcache billing type is %s":                                                   485,
+	"empty DN":                                                                          1449,
+	"empty auth request":                                                                1527,
+	"empty directory name":                                                              226,
+	"empty host %s field":                                                               944,
+	"empty host name":                                                                   936,
+	"empty id":                                                                          1450,
+	"empty ip list":                                                                     680,
+	"empty keys":                                                                        232,
+	"empty name":                                                                        1451,
+	"empty project_id/tenant_id":                                                        1390,
+	"enabled domain %s cannot be deleted":                                               1487,
+	"encrypt error %s":                                                                  1460,
+	"endpoint is enabled":                                                               1472,
+	"engine version mismatch: instance version %s, sku version %s":                      476,
+	"error getting host of guest %s":                                                    1357,
+	"error loadbalancer of backend group %s":                                            1358,
+	"esxi guest migrate require prefer_host":                                            148,
+	"every scaling policy belong to a scaling group":                                    1106,
+	"exceed address count limit: %v":                                                    1013,
+	"expire time is before current expire at":                                           217,
+	"expired access key":                                                                1530,
+	"expired token":                                                                     1523,
+	"fail to GetNetworks of vpc: %v":                                                    1053,
+	"fail to decode body":                                                               69,
+	"fail to decode policy data":                                                        1491,
+	"fail to decode request body":                                                       1533,
+	"fail to fetch hostwire by mac %s: %s":                                              851,
+	"fail to fetch netif by mac %s: %s":                                                 850,
+	"fail to find storage for disk %s":                                                  393,
+	"fail to generate temp url: %s":                                                     225,
+	"fail to get http response writer from context":                                     34,
+	"fail to get objects: %s":                                                           223,
+	"fail to get provider driver %s":                                                    311,
+	"fail to mkdir: %s":                                                                 231,
+	"fail to parse icon url '%s'":                                                       1152,
+	"failed getting guest %s":                                                           964,
+	"failed parsing url %q: %v":                                                         1624,
+	"failed to find %s":                                                                 571,
+	"failed to find %s %s":                                                              1371,
+	"failed to find SecurityGroup %s":                                                   1621,
+	"failed to find cloudregion for zone %s(%s)":                                        1170,
+	"failed to find disk %s":                                                            584,
+	"failed to find guest %s":                                                           952,
+	"failed to find host %s":                                                            954,
+	"failed to find host %s to attach storage":                                          895,
+	"failed to find host for storage %s with disk %s":                                   372,
+	"failed to find loadbalancer's %s(%s) region":                                       1271,
+	"failed to find region for loadbalancer %s":                                         957,
+	"failed to find region for loadbalancer listener %s":                                986,
+	"failed to find region for loadbalancer listener rule %s":                           987,
+	"failed to find storage %s to attach host":                                          894,
+	"failed to find storage for disk %s":                                                371,
+	"failed to find subformat vhd for image %s, please append 'vhd' for glance options(target_image_formats)": 131,
+	"failed to found backendgroup for backend %s(%s)":                                                         968,
+	"failed to found cloudregion %s":                                                                          1246,
+	"failed to found dbinstance %s":                                                                           320,
+	"failed to found dbinstance %s(%s) account %s: %v":                                                        333,
+	"failed to found dbinstance %s(%s) database %s: %v":                                                       323,
+	"failed to found disk %s":                                                                                 1185,
+	"failed to found guest %s":                                                                                639,
+	"failed to found loadbalancer for listener %s(%s)":                                                        1273,
+	"failed to found provider factory error: %v":                                                              291,
+	"failed to found region for dbinstance %s(%s)":                                                            322,
+	"failed to found region for disk's storage %s(%s)":                                                        1186,
+	"failed to found region for loadbalancer backend %s":                                                      967,
+	"failed to found storage for disk %s(%s)":                                                                 174,
+	"failed to found storagecache %s":                                                                         268,
+	"failed to found system disk error: %v":                                                                   173,
+	"failed to found vpc for network %s(%s)":                                                                  1368,
+	"failed to match any skus for change config":                                                              362,
+	"failed to match any skus in the network %s(%s) zone %s(%s)":                                              1283,
+	"failed to unmarshal input params: %v":                                                                    292,
+	"fetch disk size failed":                                                                                  784,
+	"fetch gpu failed %s":                                                                                     595,
+	"fetch guest %s: %v":                                                                                      1005,
+	"fetch guest nic: %v":                                                                                     1006,
+	"fetch instance snapshot error %s":                                                                        750,
+	"fetch lbagents of other clusters: %v":                                                                    929,
+	"field %s is readonly":                                                                                    1471,
+	"find Wire %s error: %s":                                                                                  845,
+	"find guest %s: %v":                                                                                       939,
+	"find host %s: %v":                                                                                        937,
+	"find listener of listener rule %s(%s)":                                                                   913,
+	"fixed eip cannot be associated":                                                                          505,
+	"fixed eip cannot sync status":                                                                            521,
+	"fixed public eip cannot be dissociated":                                                                  518,
+	"forbidden":                                                                                               92,
+	"found %d wires for zone %s and vpc %s":                                                                   1034,
+	"gateway ip must be in the same subnet as start, end ip":                                                  1047,
+	"get %s service %s url: %v":                                                                               947,
+	"get acl count fail %s":                                                                                   919,
+	"get certificate refcount fail %s":                                                                        970,
+	"get isDefault fail %s":                                                                                   958,
+	"get lbcluster refcount fail %v":                                                                          979,
+	"get proxysetting refcount fail %s":                                                                       67,
+	"get refCount fail %s":                                                                                    960,
+	"get reserved ip error":                                                                                   1033,
+	"get sensitive config requires admin priviliges":                                                          1476,
+	"getDynamicSchedtagCount fail %s":                                                                         1129,
+	"getFreeAddressCount fail %s":                                                                             1019,
+	"getGuestCount fail %s":                                                                                   806,
+	"getReferenceCount fail %s":                                                                               1196,
+	"getSchedPoliciesCount fail %s":                                                                           1131,
+	"got unknown parent type %q, expect %s":                                                                   1011,
+	"got unknown type %q, expect %s":                                                                          1010,
+	"group %s not found":                                                                                      738,
+	"group and guest should belong to same project":                                                           713,
+	"guest %q not found":                                                                                      368,
+	"guest %s band to up to %d security groups":                                                               563,
+	"guest %s has backup, can't migrate":                                                                      690,
+	"guest %s has isolated device, can't migrate":                                                             691,
+	"guest %s host %s isolated device not enough":                                                             596,
+	"guest %s hypervisor %s can't migrate":                                                                    689,
+	"guest %s not found":                                                                                      1184,
+	"guest %s status %s can't migrate":                                                                        693,
+	"guest %s status %s can't migrate with local storage":                                                     696,
+	"guest %s status %s has isolated device, can't do migrate":                                                694,
+	"guest %s unsupport postpaid expire":                                                                      655,
+	"guest %s(%s) is already in the backendgroup %s(%s)":                                                      966,
+	"guest %s(%s) vpc %s(%s) not same as loadbalancer vpc %s":                                                 963,
+	"guest %s(%s) vpc %s(%s) not same as vpc %s(%s)":                                                          965,
+	"guest and instance group should belong to same project":                                                  530,
+	"guest attach gpu count must > 0":                                                                         594,
+	"guest billing type %s not support cancel expire":                                                         653,
+	"guest billing type is %s":                                                                                654,
+	"guest can't do snapshot in status %s":                                                                    701,
+	"guest doesn't need reconcile backup":                                                                     652,
+	"guest has been converted":                                                                                675,
+	"guest has no vpc ip":                                                                                     719,
+	"guest hypervisor %s can't create instance snapshot":                                                      699,
+	"guest on the host are using networks on this wire":                                                       899,
+	"guest status must be ready":                                                                              677,
+	"guest template %s used by scalig group %s":                                                               727,
+	"guest template %s used by service catalog %s":                                                            726,
+	"guests disk %d snapshot full, can't take anymore":                                                        702,
+	"health_check_domain must be in the range of 1 ~ 80":                                                      1266,
+	"host %s can't reserve %d cpu for each isolated device, not enough":                                       889,
+	"host %s can't reserve %dM memory for each isolated device, not enough":                                   890,
+	"host %s can't reserve %dM storage for each isolated device, not enough":                                  891,
+	"host %s has no access ip":                                                                                1356,
+	"host %s is not kvm host":                                                                                 676,
+	"host %s not found":                                                                                       733,
+	"host %s storage %s not found":                                                                            1217,
+	"host has been occupied":                                                                                  181,
+	"host is not a baremetal":                                                                                 711,
+	"host is not a prepaid recycle host":                                                                      796,
+	"host missing %s field":                                                                                   943,
+	"host not found???":                                                                                       679,
+	"host should be disabled":                                                                                 795,
+	"host status %s and enabled %v, can't do server %s":                                                       532,
+	"host status %s can't exit maintenance":                                                                   879,
+	"host type %s can't do host maintenance":                                                                  880,
+	"host virtual memory not enough":                                                                          555,
+	"host_type must be specified":                                                                             868,
+	"http or https listener only supportd default or normal backendgroup":                                     1265,
+	"huawei %s mode elastic not support create backup":                                                        1351,
+	"iBucket.DeleteCORS error %s":                                                                             252,
+	"iBucket.DeletePolicy error %s":                                                                           259,
+	"iBucket.DeleteWebSiteConf error %s":                                                                      249,
+	"iBucket.GetCORSRules error %s":                                                                           253,
+	"iBucket.GetCdnDomains error %s":                                                                          254,
+	"iBucket.GetIObject error %s":                                                                             264,
+	"iBucket.GetIObjects error %s":                                                                            247,
+	"iBucket.GetPolicy error %s":                                                                              257,
+	"iBucket.GetRefer error %s":                                                                               256,
+	"iBucket.GetWebsiteConf error %s":                                                                         250,
+	"iBucket.SetPolicy error %s":                                                                              258,
+	"iBucket.SetRefer error %s":                                                                               255,
+	"iBucket.SetWebsite error %s":                                                                             248,
+	"identity provider with projects":                                                                         1486,
+	"image %s do not belong to guest image %s":                                                                785,
+	"image %s not found":                                                                                      866,
+	"image size exceeds root disk size":                                                                       573,
+	"inconsistent account_id, previous '%s' and now '%s'":                                                     295,
+	"inconsistent domain for project and roles":                                                               1507,
+	"input condition is empty":                                                                                1613,
+	"input data contains invalid cloudregion id":                                                              1155,
+	"input data not key value dict":                                                                           640,
+	"input key too long > %d":                                                                                 89,
+	"input not json dict":                                                                                     1601,
+	"input value too long > %d":                                                                               90,
+	"instance is already associated with eip":                                                                 508,
+	"instance specs list query error":                                                                         1164,
+	"instance_type_category shoud be one of %s":                                                               1160,
+	"internal error: unexpected backend type %s":                                                              1255,
+	"internal server error %s":                                                                                1538,
+	"intranet loadbalancer not support bandwidth charge type":                                                 1248,
+	"invalid %s,required int":                                                                                 1275,
+	"invalid CannedAction %s ":                                                                                0,
+	"invalid Effect %s ":                                                                                      1,
+	"invalid access key id":                                                                                   1529,
+	"invalid addr %s":                                                                                         914,
+	"invalid address: %s":                                                                                     335,
+	"invalid aggregate_strategy: %s":                                                                          790,
+	"invalid any_mac address":                                                                                 801,
+	"invalid auth methods":                                                                                    1525,
+	"invalid billing_cycle %s":                                                                                468,
+	"invalid bucket name %s: %s":                                                                              220,
+	"invalid bucket name(%s): %s":                                                                             221,
+	"invalid category %s for policy definition %s(%s)":                                                        776,
+	"invalid cert pubkey algorithm: %s, want %s":                                                              115,
+	"invalid character %s for account name":                                                                   1296,
+	"invalid characters %s":                                                                                   1627,
+	"invalid cidr %s":                                                                                         1081,
+	"invalid cidr range %s":                                                                                   1376,
+	"invalid cidr range %s, mask length should less than or equal to 24":                                      1303,
+	"invalid cidr_block %s":                                                                                   1232,
+	"invalid cloud account info error: %s":                                                                    285,
+	"invalid condition":                                                                                       460,
+	"invalid conditions format,required json":                                                                 982,
+	"invalid conditions fromat,required json array":                                                           983,
+	"invalid domain":                                                                                          1539,
+	"invalid domain %s for CNAME record":                                                                      8,
+	"invalid domain %s for MX record":                                                                         5,
+	"invalid domain name %s":                                                                                  426,
+	"invalid duration %s":                                                                                     338,
+	"invalid duration %s: %s":                                                                                 218,
+	"invalid end ip: %s %s":                                                                                   1043,
+	"invalid external_access_mode %q, want %s":                                                                1224,
+	"invalid fernet token":                                                                                    1524,
+	"invalid format":                                                                                          99,
+	"invalid guest %s":                                                                                        1253,
+	"invalid input %s":                                                                                        290,
+	"invalid input format":                                                                                    101,
+	"invalid internal ip address: %s":                                                                         996,
+	"invalid ip address: %s":                                                                                  1146,
+	"invalid ipaddr %s":                                                                                       846,
+	"invalid ipv4 %s ":                                                                                        2,
+	"invalid ipv4 %s for A record":                                                                            6,
+	"invalid ipv6 %s for AAAA record":                                                                         7,
+	"invalid joint resources %s":                                                                              30,
+	"invalid key %s: %s":                                                                                      227,
+	"invalid loadbalancer backend port '%d'":                                                                  1100,
+	"invalid loadbalancer backend weight '%d'":                                                                1101,
+	"invalid loadbalancer_spec %s":                                                                            1311,
+	"invalid local certificate, certificate is empty.":                                                        973,
+	"invalid local certificate, private key is empty.":                                                        972,
+	"invalid macAddr %s":                                                                                      815,
+	"invalid object key: %s":                                                                                  234,
+	"invalid parameter backendgroup %s":                                                                       1310,
+	"invalid parameter format. json dict required":                                                            483,
+	"invalid parameter loadbalancer_spec %s":                                                                  1309,
+	"invalid parameters for policy definition %s":                                                             770,
+	"invalid password: %s":                                                                                    1513,
+	"invalid policy definition %s(%s) condition %s":                                                           773,
+	"invalid project":                                                                                         1537,
+	"invalid proxy setting %s":                                                                                276,
+	"invalid public error: %v":                                                                                910,
+	"invalid public_ip_charge_type %s":                                                                        778,
+	"invalid record name %s":                                                                                  419,
+	"invalid resources format":                                                                                1553,
+	"invalid scope %s":                                                                                        79,
+	"invalid share_mode %s":                                                                                   3,
+	"invalid status %s":                                                                                       1077,
+	"invalid strategy %s":                                                                                     1117,
+	"invalid template":                                                                                        1480,
+	"invalid token":                                                                                           1541,
+	"invalid token %s":                                                                                        1542,
+	"invalid ttl: %d":                                                                                         458,
+	"invalid ttl: %s":                                                                                         457,
+	"invalid url: %v":                                                                                         1566,
+	"invalid user":                                                                                            1536,
+	"invalid vrrp advert_int %d: want [1,255]":                                                                925,
+	"invalid vrrp authentication pass size: %d, want [1,8]":                                                   922,
+	"invalid vrrp interface %q":                                                                               921,
+	"invalid vrrp priority %d: want [1,255]":                                                                  923,
+	"invalid vrrp virtual_router_id %d: want [1,255]":                                                         924,
+	"invalid wire_level_for_vmware %q, accept %s":                                                             277,
+	"invlid image":                                                                                            572,
+	"iops must > 0":                                                                                           688,
+	"ip":                                                                                                      1072,
+	"ip %s not found":                                                                                         599,
+	"ip %s or mac %s has been registered":                                                                     661,
+	"ip_prefix error: %s":                                                                                     1039,
+	"ipv4 range overlap":                                                                                      1220,
+	"isAddressUsed fail %s":                                                                                   1017,
+	"isAlterNameUnique fail %s":                                                                               874,
+	"isAttached check failed %s":                                                                              547,
+	"join group into project of default domain or identical domain":                                           1456,
+	"join user into project of default domain or identical domain":                                            1453,
+	"keypair %s not found":                                                                                    579,
+	"lbagent cannot be deployed on managed host":                                                              938,
+	"lbagent cannot be deployed on public guests":                                                             940,
+	"lbcluster %s(%s) already has virtual_router_id %d":                                                       931,
+	"lbcluster %s(%s) is still referred to by %d %s":                                                          980,
+	"lbclusters %s(%s) and %s(%s) has conflict virtual_router_id: %d ":                                        981,
+	"listener type must be http/https, got %s":                                                                1261,
+	"loadbalancer aready associated with fourth layer listener %s":                                            1379,
+	"loadbalancer backendgroup aready associate with other %s listener":                                       1378,
+	"loadbalancer is locked, cannot delete":                                                                   993,
+	"loadbalancer is using by %d backendgroup.":                                                               1328,
+	"loadbalancer is using by %d listener.":                                                                   1327,
+	"loadbalancer listener %s is already updating":                                                            1377,
+	"loadbalancer listener %s related loadbalancer %s not found":                                              1314,
+	"loadbalancerlistenerrule %s(%s): fetching listener %s failed":                                            1264,
+	"login_account is longer than 32 chars":                                                                   753,
+	"mac %s not found":                                                                                        600,
+	"mac addr %s has been occupied":                                                                           605,
+	"maintain time has no change":                                                                             480,
+	"managed network cannot change status":                                                                    1076,
+	"mapped ip exhausted":                                                                                     1237,
+	"master slave backendgorup must contain two backend":                                                      1251,
+	"memory_size_mb, shoud be range of 512~%d":                                                                1159,
+	"metdata must less then 20":                                                                               752,
+	"metric %s is invalid format, usage <measurement>.<field>":                                                1574,
+	"min_instance_number should not be bigger than max_instance_number":                                       1088,
+	"min_instance_number should not be smaller than 0":                                                        1087,
+	"mismatched alarm id":                                                                                     1112,
+	"miss some subimage of guest image":                                                                       786,
+	"missing Content-Length":                                                                                  235,
+	"missing access_mac and uuid in no_probe mode":                                                            824,
+	"missing driver":                                                                                          1481,
+	"missing duration/expire_time":                                                                            216,
+	"missing guest id":                                                                                        697,
+	"missing image id or name":                                                                                1206,
+	"missing input field blob":                                                                                1459,
+	"missing input field id":                                                                                  1500,
+	"missing input field interface":                                                                           1473,
+	"missing input field service/service_id":                                                                  1474,
+	"missing input field type":                                                                                1458,
+	"missing key":                                                                                             224,
+	"missing manager?":                                                                                        263,
+	"missing name":                                                                                            219,
+	"missing new domain":                                                                                      55,
+	"missing new project/tenant":                                                                              97,
+	"missing pid in pids":                                                                                     1557,
+	"missing pids":                                                                                            1556,
+	"missing rid":                                                                                             1559,
+	"missing rid in pids":                                                                                     1558,
+	"missing uid":                                                                                             1555,
+	"missong duration":                                                                                        354,
+	"model has no field %s":                                                                                   61,
+	"mtu must be range of 0~1000000":                                                                          1239,
+	"mx_priority range limited to [1,50]":                                                                     4,
+	"name is too short":                                                                                       748,
+	"name longer than %d":                                                                                     87,
+	"name starts with letter, and contains letter, number and - only":                                         63,
+	"name starts with letter, and contains letter, number and ._@- only":                                      86,
+	"need scheduled task":                                                                                     1140,
+	"need valid access_mac and uuid to do prepare":                                                            837,
+	"network %s associated route table has no internet gateway attached.":                                     130,
+	"network %s related vpc not found":                                                                        1301,
+	"network %s(%s) does not belong to %s":                                                                    1369,
+	"network %s(%s) has no free addresses":                                                                    1020,
+	"network '%s' not in vpc '%s'":                                                                            1093,
+	"network server_type %s not support auto alloc":                                                           1059,
+	"no admin account found for elastic cache %s":                                                             479,
+	"no allow to access network %s":                                                                           1023,
+	"no available eip network":                                                                                1366,
+	"no cloudregion found to sync skus":                                                                       1156,
+	"no either ip_addr or mac specified":                                                                      601,
+	"no external bucket":                                                                                      222,
+	"no networks on wire %s":                                                                                  847,
+	"no recovery secrets for %s":                                                                              1549,
+	"no such ScalingGroup '%s'":                                                                               1104,
+	"no such cloud region %s":                                                                                 1090,
+	"no such disk %s":                                                                                         1181,
+	"no such driver":                                                                                          1448,
+	"no such group %s":                                                                                        712,
+	"no such guest template":                                                                                  1151,
+	"no such guest template %s":                                                                               1094,
+	"no such guest_template %s":                                                                               1153,
+	"no such loadbalancer backend group '%s'":                                                                 1099,
+	"no such model %s":                                                                                        529,
+	"no such network":                                                                                         1004,
+	"no such provider":                                                                                        116,
+	"no such provider %s":                                                                                     284,
+	"no such scaling group %s":                                                                                1107,
+	"no such snapshotpolicy %s":                                                                               415,
+	"no support for instance snapshot in guest template for now":                                              720,
+	"no totp for %s":                                                                                          1548,
+	"no valid endpoint":                                                                                       1622,
+	"no valid host":                                                                                           710,
+	"no valid storage on host":                                                                                789,
+	"no viable lbcluster":                                                                                     1355,
+	"non http listener must have backend group set":                                                           1364,
+	"non redirect lblistener rule must have backend_group set":                                                1362,
+	"non-admin user not allowed to create system object":                                                      93,
+	"not a baremetal":                                                                                         836,
+	"not a baremetal server":                                                                                  709,
+	"not a valid ip address %s: %s":                                                                           1031,
+	"not allow create %s in scope %s":                                                                         80,
+	"not allow to auth":                                                                                       1540,
+	"not allow to change project across domain":                                                               309,
+	"not allow to create":                                                                                     301,
+	"not allow to delete %s disk with snapshots":                                                              414,
+	"not allow to delete default cloud region":                                                                316,
+	"not allow to delete default security group":                                                              1150,
+	"not allow to delete default vpc":                                                                         1225,
+	"not allow to delete log":                                                                                 64,
+	"not allow to delete prepaid disk in valid status":                                                        405,
+	"not allow to delete prepaid server in valid status":                                                      740,
+	"not allow to delete public cloud instance_type: %s":                                                      1169,
+	"not allow to delete. Virtual disk must not have snapshots":                                               413,
+	"not allow to get usage":                                                                                  1543,
+	"not allow to list domain quotas":                                                                         73,
+	"not allow to list project quotas":                                                                        75,
+	"not allow to perform %s":                                                                                 46,
+	"not allow to purge. Virtual disk must not have snapshots":                                                412,
+	"not allow to query system capability":                                                                    269,
+	"not allow to set system key, please remove the underscore at the beginning":                              88,
+	"not allow update rds account name":                                                                       319,
+	"not allow update rds database name":                                                                      332,
+	"not allowed update content of certificate":                                                               975,
+	"not an empty bucket":                                                                                     245,
+	"not an empty network %s":                                                                                 1015,
+	"not empty cloud region":                                                                                  315,
+	"not empty zone":                                                                                          1245,
+	"not enough privilege":                                                                                    1082,
+	"not enough privilege (require:%s,allow:%s)":                                                              78,
+	"not enough privilege (require:%s,allow:%s,query:%s)":                                                     57,
+	"not enough privilege (require:%s,allow:%s:resource:%s)":                                                  77,
+	"not enough privilleges":                                                                                  72,
+	"not find alert %s":                                                                                       1580,
+	"not find notification %s":                                                                                1581,
+	"not found alert notification used by %s":                                                                 1598,
+	"not found cert %s":                                                                                       1475,
+	"not found signature":                                                                                     1602,
+	"not implement":                                                                                           186,
+	"not match any dbinstance sku":                                                                            342,
+	"not support %s":                                                                                          674,
+	"not support create":                                                                                      1079,
+	"not support create %s zone":                                                                              1247,
+	"not support create definition":                                                                           1080,
+	"not support database":                                                                                    1595,
+	"not support for cloudaccount with provider '%s'":                                                         278,
+	"not support hypervisor %s":                                                                               673,
+	"not support type %q":                                                                                     1596,
+	"not support update disk_type %s":                                                                         370,
+	"not supported bind security group":                                                                       490,
+	"not supported hypervisor %s":                                                                             803,
+	"not supported next hop type":                                                                             1083,
+	"not supported secondary update context %s":                                                               1508,
+	"not supported update context":                                                                            1505,
+	"not supported update context %s":                                                                         1506,
+	"now allow to delete inuse instance_type.please remove related servers first: %s": 1168,
+	"object %s not found":                        246,
+	"object count limit exceeds":                 229,
+	"object key should not ends with /":          233,
+	"object size limit exceeds":                  239,
+	"on-premise network cannot sync status":      1075,
+	"on-premise vpc cannot sync status":          1234,
+	"only on premise support this operation":     1065,
+	"only sysadmin can specify host as backend":  953,
+	"operation not allowed":                      100,
+	"out of privileges":                          74,
+	"parameter %s is empty":                      1571,
+	"parse cdrom device info error %s":           757,
+	"parse disk description error %s":            760,
+	"parse isolated device description error %s": 765,
+	"parse network description error %s":         763,
+	"password must be 12 chars of at least one digit, letter, uppercase letter and punctuate": 1444,
+	"path can not be emtpy":                                         1380,
+	"peer lbagent %s(%s) already has vrrp priority %d":              934,
+	"please retry after unbind all guests in group":                 526,
+	"policy definition %s require cloudregion in %s":                771,
+	"policy definition %s require cloudregion not in %s":            772,
+	"policy definition %s require except tag %s":                    775,
+	"policy definition %s require must contains tag %s":             774,
+	"policy is referenced":                                          1629,
+	"port %d not support, only support range 1 ~ 65535":             951,
+	"project %s not found":                                          296,
+	"project contains external resources":                           1495,
+	"project contains group":                                        1497,
+	"project contains user":                                         1496,
+	"project disabled":                                              1521,
+	"project in non-default domain is prohibited":                   54,
+	"project is not found":                                          1560,
+	"provider %s: %v":                                               273,
+	"provider is enabled":                                           302,
+	"provider is not idle":                                          303,
+	"provider is shared outside of domain":                          298,
+	"provider mismatch: %s instance can't use %s sku":               473,
+	"proxysetting %s is still referred to by %d %s":                 68,
+	"public connection aready allocated":                            481,
+	"public ip not supported for %s":                                777,
+	"put object error %s":                                           241,
+	"query all networks fail":                                       1055,
+	"query backend group releated resource failed.":                 949,
+	"query duration `to` err: %s":                                   1617,
+	"query duration err: from: %s, to:%s":                           1616,
+	"query error %s":                                                1457,
+	"query quotas %s":                                               76,
+	"query sku list failed.":                                        1172,
+	"readonly":                                                      1469,
+	"redirect can only be enabled for http/https listener":          1363,
+	"redirect must have at least one of scheme, host, path changed": 1360,
+	"redis version 2.8 not support create account":                  1385,
+	"referered by storages":                                         1202,
+	"reflect call %s fail %s":                                       36,
+	"region":                                                        488,
+	"region contains endpoints":                                     1499,
+	"region mismatch: instance region %s, sku region %s":            474,
+	"region of backend %d does not match that of lb's":              956,
+	"region of host %q (%s) != region of loadbalancer %q (%s)":      1359,
+	"region of host %q (%s) != region of loadbalancer %q (%s))":     1257,
+	"regiondriver":                                                  489,
+	"release public connection aready released":                     482,
+	"repeat_weekdays only contains %d days at most":                 1175,
+	"request process timeout":                                       16,
+	"require system previleges to convert host in other domain":     872,
+	"require validated qcloud cross region vpcPeering bandwidth values:[10, 20, 50, 100, 200, 500, 1000],unit Mbps": 1623,
+	"required at least %d subnet with at least 8 free ip.":                                                          1305,
+	"required at least %d subnet.": 1304,
+	"reserved cpu must >= 0":       886,
+	"reserved memory must >= 0":    887,
+	"reserved storage must >= 0":   888,
+	"resource %s in vpc %s external access mode %s is not support accociate eip": 499,
+	"resource %s is not support sync skus":                                       1154,
+	"resource is enabled":                                                        1490,
+	"role is being assigned to group":                                            1504,
+	"role is being assigned to user":                                             1503,
+	"root disk image(%s) and sku(%s) architecture mismatch":                      759,
+	"rule %d is invalid: %s":                                                     1143,
+	"rule %s/%s already occupied by rule %s(%s)":                                 985,
+	"saveConfigs fail %s":                                                        1479,
+	"schedtag %s not found":                                                      461,
+	"schedtag_id not provide":                                                    1119,
+	"secgroup %s not found":                                                      734,
+	"secgroup %s rules not equals %s rules":                                      1147,
+	"secgroups will be empty after update.":                                      493,
+	"security group %s has already been assigned to guest %s":                    564,
+	"security group %s not assigned to guest %s":                                 566,
+	"security group id should not be empty":                                      1620,
+	"select for nothing in query":                                                1615,
+	"server %s not found":                                                        500,
+	"server %s with port %d already in used":                                     1381,
+	"server %s with port %d aready used by other %s listener":                    1382,
+	"server and eip are not managed by the same provider":                        516,
+	"server host is not found???":                                                515,
+	"server is in %q state, want %q":                                             941,
+	"server region is not found???":                                              511,
+	"service %s not found error: %v":                                             1554,
+	"service contains endpoints":                                                 1509,
+	"service is enabled":                                                         1510,
+	"setAcl error %s":                                                            242,
+	"sharing is limited to domains %s":                                           84,
+	"signature error":                                                            1603,
+	"sku %s is soldout":                                                          1349,
+	"slave dbinstance not support prepaid billing type":                          1282,
+	"snapshot referenced by instance snapshot":                                   1189,
+	"snapshotpolicy %s not found: %s":                                            369,
+	"snapshotpolicy disk has been exist":                                         1182,
+	"some disk missing!!!":                                                       683,
+	"some networks not exist":                                                    1092,
+	"start and end ip not in the same subnet":                                    1044,
+	"start and end ip when masked are not in the same cidr subnet":               1051,
+	"start create snapshot task failed: %s":                                      704,
+	"start snapshot reset failed %s":                                             706,
+	"start, end ip must be in the same subnet":                                   1058,
+	"sticky_session_cookie can only contain letters, Numbers, '_' and '-'":       1269,
+	"sticky_session_cookie length must within 1~200":                             1268,
+	"storage %s can not be data disk":                                            171,
+	"storage %s(%s) need online and attach host for create disk":                 375,
+	"storage cache is missing":                                                   1214,
+	"storage cache not empty":                                                    1201,
+	"storage classes not supported":                                              312,
+	"storage has associate hosts":                                                1211,
+	"storage has disks":                                                          1212,
+	"storage has snapshots":                                                      1213,
+	"storage is enabled":                                                         1215,
+	"storage not cache image":                                                    1204,
+	"storage of disk %s no valid host":                                           402,
+	"subnet masklen should be smaller than 30":                                   1040,
+	"syncWithCloudBucket error %s":                                               243,
+	"sysadmin is protected":                                                      1454,
+	"tag has dynamic rules":                                                      1130,
+	"tag is associate with sched policies":                                       1132,
+	"telegraf params: invalid influxdb url: %s":                                  926,
+	"tenant/project %s not found":                                                1391,
+	"the %s %q in guest template is not a public resource":                       723,
+	"the %s %q in guest template is not a public resource in %s scope":           725,
+	"the %s in guest template is not a public resource":                          722,
+	"the %s in guest template is not a public resource in %s scope":              724,
+	"the AlertType is illegal:%s":                                                1591,
+	"the Comparator is illegal: %s":                                              1584,
+	"the account has been registerd %s":                                          287,
+	"the acl cache in region %s aready exists.":                                  969,
+	"the associated natgateway has corresponding dnat rules with eip %s, please delete them firstly": 520,
+	"the associated natgateway has corresponding snat rules with eip %s, please delete them firstly": 519,
+	"the certificate cache in region %s aready exists.":                                              974,
+	"the guest template %s is not valid in cloudregion %s, reason: %s":                               1095,
+	"the image reference session has not been expired!":                                              267,
+	"the min value of cycle in alarm is 300":                                                         1116,
+	"the reduce is illegal %s":                                                                       1585,
+	"the reduce is illegal: %s":                                                                      1586,
+	"the security group is in use":                                                                   1149,
+	"there is no such secgroup %s descripted by guest template":                                      721,
+	"this operation requires rds state to be %s":                                                     366,
+	"threshold:%s should be number type":                                                             1593,
+	"time_points only contains %d points at most":                                                    1176,
+	"top level public domain name %s not support":                                                    429,
+	"totp secret exists":                                                                             1550,
+	"unauthorized %s":                                                                                1532,
+	"unexpected backend type %s":                                                                     955,
+	"unknown parent object id spec":                                                                  1009,
+	"unknown server type %s":                                                                         737,
+	"unknown zone type %s":                                                                           430,
+	"unkown expansion principle %s":                                                                  1096,
+	"unkown health check mode %s":                                                                    1098,
+	"unkown indicator in alarm %s":                                                                   1114,
+	"unkown label type '%s'":                                                                         1138,
+	"unkown operator in alarm %s":                                                                    1113,
+	"unkown resource operation '%s'":                                                                 1137,
+	"unkown resource type '%s'":                                                                      1136,
+	"unkown scaling policy action %s":                                                                1109,
+	"unkown scaling policy unit %s":                                                                  1110,
+	"unkown scheduled type '%s'":                                                                     1135,
+	"unkown shrink principle %s":                                                                     1097,
+	"unkown trigger type %s":                                                                         1108,
+	"unkown wrapper in alarm %s":                                                                     1115,
+	"unmarshal JoinResourceBaseCreateInput fail %s":                                                  896,
+	"unmarshal JointResourceCreateInput fail %s":                                                     1123,
+	"unmarshal SharableVirtualResourceCreateInput fail %s":                                           918,
+	"unmarshal StandaloneResourceCreateInput fail %s":                                                462,
+	"unmarshal VirtualResourceCreateInput fail %s":                                                   469,
+	"unmarshal input fail %s":                                                                        1626,
+	"unmarshal input: %v":                                                                            942,
+	"unmarshal limit error %s":                                                                       260,
+	"unmarshaling cidrs failed: %s":                                                                  1086,
+	"unrecognized input %s":                                                                          1531,
+	"unsupport delete %s backups":                                                                    467,
+	"unsupport on host status %s":                                                                    881,
+	"unsupport type: %s":                                                                             1567,
+	"unsupported action %s":                                                                          1564,
+	"unsupported duration %s":                                                                        339,
+	"unsupported execution_error_state %s":                                                           1573,
+	"unsupported no_data_state %s":                                                                   1572,
+	"unsupported notification type %s":                                                               1599,
+	"unsupported resource type %s":                                                                   1597,
+	"update config version fail %s":                                                                  1511,
+	"url is empty":                                                                                   1565,
+	"use yum requires valid repo_base_url":                                                           935,
+	"user %s not found":                                                                              91,
+	"user contains external resources":                                                               1515,
+	"user disabled":                                                                                  1522,
+	"user must have system admin privileges":                                                         946,
+	"user not found":                                                                                 1526,
+	"user not found or not enabled":                                                                  1535,
+	"user not in project":                                                                            1528,
+	"valid vlan id":                                                                                  1037,
+	"version mismatch":                                                                               1520,
+	"virtual resource already freezed":                                                               95,
+	"virtual resource not freezed":                                                                   96,
+	"vpc %s already connected to a interVpcNetwork":                                                  903,
+	"vpc %s and vpc %s have already connected":                                                       1223,
+	"vpc %s has already in this dns zone":                                                            436,
+	"vpc %s is not connected to this interVpcNetwork":                                                904,
+	"vpc %s not in dns zone":                                                                         437,
+	"vpc %s(%s) is not a managed resouce":                                                            1144,
+	"vpc joint interVpcNetwork on different cloudEnv is not supported":                               902,
+	"vpc joint interVpcNetwork on different cloudprovider is not supported":                          901,
+	"vpc lb is not allowed for now":                                                                  1353,
+	"vpc on different cloudprovider peering is not supported":                                        1219,
+	"vpc_id": 1218,
+	"weight %d not support, only support range 0 ~ 256":        950,
+	"wire contains hosts":                                      1242,
+	"wire contains networks":                                   1244,
+	"wire not found for zone %s and vpc %s":                    1035,
+	"wire zone must match zone parameter, got %s, want %s(%s)": 977,
+	"zone %s not in cloudregion %s":                            1157,
+	"zone %s(%s) has no lbcluster":                             1354,
+	"zone and vpc info required when wire is absent":           1048,
+	"zone info missing":                                        1352,
+	"zone mismatch, elastic cache sku zone %s != %s":           1347,
+	"zone mismatch: instance zone %s, sku zone %s":             475,
+	"zone of wire must be %s, got %s":                          978,
 }
 
-var en_USIndex = []uint32{ // 1692 elements
+var en_USIndex = []uint32{ // 1631 elements
 	// Entry 0 - 1F
-	0x00000000, 0x0000001b, 0x00000034, 0x00000049,
-	0x00000067, 0x0000007a, 0x0000008d, 0x000000a8,
-	0x000000be, 0x000000c9, 0x000000e0, 0x000000f6,
-	0x00000116, 0x00000125, 0x00000136, 0x00000152,
-	0x0000015f, 0x00000175, 0x0000019a, 0x000001ae,
-	0x000001c5, 0x000001e3, 0x000001f8, 0x0000020f,
-	0x00000227, 0x00000243, 0x0000026b, 0x00000293,
-	0x000002af, 0x000002cc, 0x000002e6, 0x00000300,
+	0x00000000, 0x0000001e, 0x00000036, 0x0000004c,
+	0x00000062, 0x00000086, 0x000000a6, 0x000000c3,
+	0x000000e3, 0x00000106, 0x0000011e, 0x00000138,
+	0x0000014e, 0x00000161, 0x00000173, 0x00000186,
+	0x000001a1, 0x000001b9, 0x000001d1, 0x000001e9,
+	0x000001fd, 0x00000236, 0x0000025d, 0x00000289,
+	0x000002b9, 0x000002e7, 0x0000031b, 0x00000359,
+	0x000003b3, 0x000003da, 0x000003fe, 0x00000419,
 	// Entry 20 - 3F
-	0x00000310, 0x00000327, 0x00000345, 0x00000352,
-	0x00000365, 0x00000378, 0x0000038b, 0x0000039b,
-	0x000003b2, 0x000003c7, 0x000003dd, 0x000003fc,
-	0x0000040c, 0x0000041d, 0x00000445, 0x00000458,
-	0x0000046d, 0x00000484, 0x0000049d, 0x000004a9,
-	0x000004bf, 0x000004d5, 0x000004f0, 0x00000507,
-	0x00000521, 0x00000534, 0x0000054c, 0x0000055a,
-	0x00000578, 0x00000589, 0x0000059d, 0x000005c0,
+	0x00000452, 0x00000465, 0x0000047c, 0x000004aa,
+	0x000004da, 0x000004f2, 0x00000509, 0x00000529,
+	0x00000548, 0x00000561, 0x00000574, 0x00000590,
+	0x000005a9, 0x000005bd, 0x000005db, 0x000005f3,
+	0x0000060c, 0x00000622, 0x0000063a, 0x00000653,
+	0x0000066e, 0x00000682, 0x000006a2, 0x000006ce,
+	0x000006e1, 0x00000702, 0x00000736, 0x00000759,
+	0x0000076d, 0x00000784, 0x0000079a, 0x000007b2,
 	// Entry 40 - 5F
-	0x000005d2, 0x000005f0, 0x00000608, 0x0000061e,
-	0x00000634, 0x00000658, 0x00000678, 0x00000695,
-	0x000006b5, 0x000006d8, 0x000006f0, 0x0000070a,
-	0x00000720, 0x00000733, 0x00000745, 0x00000758,
-	0x00000773, 0x0000078b, 0x000007a3, 0x000007bb,
-	0x000007cf, 0x00000808, 0x0000082f, 0x0000085b,
-	0x0000088b, 0x000008b9, 0x000008ed, 0x0000092b,
-	0x00000985, 0x000009ac, 0x000009d0, 0x000009eb,
+	0x000007f2, 0x0000080a, 0x0000082b, 0x0000084c,
+	0x0000086e, 0x0000089c, 0x000008b0, 0x000008c3,
+	0x000008e8, 0x000008ff, 0x0000091f, 0x00000931,
+	0x00000952, 0x00000962, 0x00000999, 0x000009c4,
+	0x000009d5, 0x000009f5, 0x00000a13, 0x00000a34,
+	0x00000a56, 0x00000a77, 0x00000a98, 0x00000adb,
+	0x00000aef, 0x00000b3a, 0x00000b52, 0x00000b6c,
+	0x00000b7e, 0x00000b88, 0x00000bbb, 0x00000be1,
 	// Entry 60 - 7F
-	0x00000a24, 0x00000a37, 0x00000a4e, 0x00000a7c,
-	0x00000aac, 0x00000ac4, 0x00000adb, 0x00000afb,
-	0x00000b1a, 0x00000b33, 0x00000b46, 0x00000b62,
-	0x00000b7b, 0x00000b8f, 0x00000bad, 0x00000bc5,
-	0x00000bde, 0x00000bf4, 0x00000c0c, 0x00000c25,
-	0x00000c40, 0x00000c54, 0x00000c74, 0x00000ca0,
-	0x00000cb3, 0x00000cd4, 0x00000d08, 0x00000d2b,
-	0x00000d3f, 0x00000d56, 0x00000d6c, 0x00000d84,
+	0x00000c02, 0x00000c1f, 0x00000c3a, 0x00000c53,
+	0x00000c62, 0x00000c78, 0x00000c8d, 0x00000cab,
+	0x00000cd3, 0x00000d04, 0x00000d36, 0x00000d69,
+	0x00000d9b, 0x00000dcc, 0x00000df0, 0x00000e14,
+	0x00000e3b, 0x00000e74, 0x00000eaa, 0x00000ee4,
+	0x00000f0f, 0x00000f20, 0x00000f3c, 0x00000f4a,
+	0x00000f5b, 0x00000f6e, 0x00000f7b, 0x00000f8f,
+	0x00000fa1, 0x00000fb1, 0x00000fc5, 0x00000fdb,
 	// Entry 80 - 9F
-	0x00000dc4, 0x00000ddc, 0x00000dfd, 0x00000e1e,
-	0x00000e40, 0x00000e6e, 0x00000e82, 0x00000e95,
-	0x00000eba, 0x00000ed1, 0x00000ef1, 0x00000f03,
-	0x00000f24, 0x00000f34, 0x00000f6b, 0x00000f96,
-	0x00000fa7, 0x00000fc7, 0x00000fe5, 0x00001006,
-	0x00001028, 0x00001049, 0x0000106a, 0x000010ad,
-	0x000010c1, 0x0000110c, 0x00001124, 0x0000113e,
-	0x00001150, 0x0000115a, 0x0000118d, 0x000011b3,
+	0x00000ffa, 0x0000102f, 0x0000106c, 0x000010b0,
+	0x00001118, 0x0000114e, 0x00001180, 0x000011aa,
+	0x000011cc, 0x000011ec, 0x00001204, 0x0000121f,
+	0x00001239, 0x00001252, 0x00001271, 0x00001291,
+	0x000012ad, 0x000012cf, 0x000012e8, 0x00001302,
+	0x00001336, 0x0000135d, 0x00001394, 0x000013b3,
+	0x000013d8, 0x000013f0, 0x0000142c, 0x0000143e,
+	0x0000145f, 0x000014b1, 0x000014e8, 0x0000150d,
 	// Entry A0 - BF
-	0x000011d4, 0x000011f1, 0x0000120c, 0x00001225,
-	0x00001234, 0x0000124a, 0x0000125f, 0x0000127d,
-	0x000012a5, 0x000012d6, 0x00001308, 0x0000133b,
-	0x0000136d, 0x0000139e, 0x000013c2, 0x000013e6,
-	0x0000140d, 0x00001446, 0x0000147c, 0x000014b6,
-	0x000014e1, 0x000014f2, 0x0000150e, 0x0000151c,
-	0x0000152d, 0x00001540, 0x0000154d, 0x00001561,
-	0x00001573, 0x00001583, 0x00001597, 0x000015ad,
+	0x0000152c, 0x00001556, 0x00001583, 0x000015a1,
+	0x000015bd, 0x000015f1, 0x00001620, 0x00001646,
+	0x0000167e, 0x000016b6, 0x000016ef, 0x00001727,
+	0x00001747, 0x00001779, 0x0000179f, 0x000017c7,
+	0x00001815, 0x0000183c, 0x0000185f, 0x00001896,
+	0x000018ac, 0x000018c2, 0x000018d9, 0x00001915,
+	0x00001957, 0x0000197d, 0x000019c1, 0x000019cf,
+	0x000019ef, 0x00001a13, 0x00001a36, 0x00001a59,
 	// Entry C0 - DF
-	0x000015cc, 0x00001601, 0x0000163e, 0x00001682,
-	0x000016ea, 0x00001720, 0x00001752, 0x0000177c,
-	0x0000179e, 0x000017be, 0x000017d6, 0x000017f1,
-	0x0000180b, 0x00001824, 0x00001843, 0x00001863,
-	0x0000187f, 0x000018a1, 0x000018ba, 0x000018d4,
-	0x00001908, 0x0000192f, 0x00001966, 0x00001985,
-	0x000019aa, 0x000019c2, 0x000019fe, 0x00001a10,
-	0x00001a31, 0x00001a83, 0x00001aba, 0x00001adf,
+	0x00001a70, 0x00001aa8, 0x00001ac7, 0x00001add,
+	0x00001b05, 0x00001b36, 0x00001b52, 0x00001b89,
+	0x00001bba, 0x00001bd3, 0x00001beb, 0x00001c14,
+	0x00001c2e, 0x00001c76, 0x00001cb1, 0x00001ceb,
+	0x00001d19, 0x00001d54, 0x00001d6d, 0x00001d7f,
+	0x00001d99, 0x00001db8, 0x00001dd5, 0x00001ded,
+	0x00001e06, 0x00001e23, 0x00001e4b, 0x00001e63,
+	0x00001e70, 0x00001e8b, 0x00001ea7, 0x00001eba,
 	// Entry E0 - FF
-	0x00001afe, 0x00001b28, 0x00001b55, 0x00001b73,
-	0x00001b8f, 0x00001bc3, 0x00001bf2, 0x00001c18,
-	0x00001c50, 0x00001c88, 0x00001cc1, 0x00001cf9,
-	0x00001d19, 0x00001d4b, 0x00001d71, 0x00001d99,
-	0x00001de7, 0x00001e0e, 0x00001e31, 0x00001e68,
-	0x00001e7e, 0x00001e94, 0x00001eab, 0x00001ee7,
-	0x00001f29, 0x00001f4f, 0x00001f93, 0x00001fa1,
-	0x00001fc1, 0x00001fe5, 0x00002008, 0x0000202b,
+	0x00001ed2, 0x00001ede, 0x00001efc, 0x00001f11,
+	0x00001f24, 0x00001f37, 0x00001f52, 0x00001f69,
+	0x00001f7b, 0x00001f86, 0x00001fa8, 0x00001fbf,
+	0x00001fd6, 0x00001ff0, 0x0000200b, 0x0000201f,
+	0x00002039, 0x00002055, 0x00002069, 0x00002079,
+	0x00002096, 0x000020c3, 0x000020d7, 0x000020eb,
+	0x00002108, 0x00002124, 0x00002147, 0x00002167,
+	0x0000218c, 0x000021a8, 0x000021c6, 0x000021e5,
 	// Entry 100 - 11F
-	0x00002042, 0x0000207a, 0x00002099, 0x000020af,
-	0x000020d7, 0x00002108, 0x00002124, 0x0000215b,
-	0x0000218c, 0x000021a5, 0x000021bd, 0x000021e6,
-	0x00002200, 0x00002248, 0x00002283, 0x000022bd,
-	0x000022eb, 0x00002326, 0x0000233f, 0x00002351,
-	0x0000236b, 0x0000238a, 0x000023a7, 0x000023bf,
-	0x000023d8, 0x000023f5, 0x0000241d, 0x00002435,
-	0x00002442, 0x0000245d, 0x00002479, 0x0000248c,
+	0x000021ff, 0x00002219, 0x00002234, 0x0000224f,
+	0x0000226d, 0x00002286, 0x00002298, 0x000022a8,
+	0x000022b9, 0x000022d5, 0x000022f6, 0x0000231c,
+	0x0000234e, 0x0000236e, 0x00002393, 0x000023b3,
+	0x000023c6, 0x000023da, 0x000023ea, 0x00002409,
+	0x00002422, 0x0000243b, 0x00002467, 0x00002497,
+	0x000024af, 0x000024da, 0x00002500, 0x00002517,
+	0x00002537, 0x0000254b, 0x00002570, 0x00002596,
 	// Entry 120 - 13F
-	0x000024a4, 0x000024b0, 0x000024ce, 0x000024e3,
-	0x000024f6, 0x00002509, 0x00002524, 0x0000253b,
-	0x0000254d, 0x00002558, 0x0000257a, 0x00002591,
-	0x000025a8, 0x000025c2, 0x000025dd, 0x000025f1,
-	0x0000260b, 0x00002627, 0x0000263b, 0x0000264b,
-	0x00002668, 0x00002695, 0x000026a9, 0x000026bd,
-	0x000026da, 0x000026f6, 0x00002719, 0x00002739,
-	0x0000275e, 0x0000277a, 0x00002798, 0x000027b7,
+	0x000025b8, 0x000025c9, 0x000025e3, 0x000025f4,
+	0x0000261f, 0x00002644, 0x0000265d, 0x00002671,
+	0x000026a5, 0x000026ba, 0x000026df, 0x00002704,
+	0x00002713, 0x00002736, 0x0000274a, 0x0000275e,
+	0x00002773, 0x000027c1, 0x000027d5, 0x000027e7,
+	0x000027fe, 0x00002814, 0x0000283e, 0x0000287f,
+	0x0000289e, 0x000028bc, 0x000028d1, 0x000028e5,
+	0x000028fc, 0x00002925, 0x00002936, 0x00002956,
 	// Entry 140 - 15F
-	0x000027d1, 0x000027eb, 0x00002806, 0x00002821,
-	0x0000283f, 0x00002858, 0x0000286a, 0x0000287a,
-	0x0000288b, 0x000028a7, 0x000028c8, 0x000028ee,
-	0x00002920, 0x00002940, 0x00002965, 0x00002985,
-	0x00002998, 0x000029ac, 0x000029bc, 0x000029db,
-	0x000029f4, 0x00002a0d, 0x00002a39, 0x00002a69,
-	0x00002a81, 0x00002aac, 0x00002ad2, 0x00002ae9,
-	0x00002b09, 0x00002b1d, 0x00002b42, 0x00002b68,
+	0x00002978, 0x00002996, 0x000029ca, 0x000029f7,
+	0x00002a29, 0x00002a5f, 0x00002a9b, 0x00002ac9,
+	0x00002af8, 0x00002b20, 0x00002b59, 0x00002b80,
+	0x00002bb8, 0x00002bdb, 0x00002c0c, 0x00002c1c,
+	0x00002c30, 0x00002c52, 0x00002c78, 0x00002c8c,
+	0x00002ca4, 0x00002cca, 0x00002cf3, 0x00002d10,
+	0x00002d2c, 0x00002d54, 0x00002d92, 0x00002db8,
+	0x00002de1, 0x00002e0c, 0x00002e38, 0x00002e62,
 	// Entry 160 - 17F
-	0x00002b8a, 0x00002b9b, 0x00002bb5, 0x00002bc6,
-	0x00002bf1, 0x00002c16, 0x00002c2f, 0x00002c43,
-	0x00002c77, 0x00002c8c, 0x00002cb1, 0x00002cd6,
-	0x00002ce5, 0x00002d08, 0x00002d1c, 0x00002d30,
-	0x00002d45, 0x00002d93, 0x00002da7, 0x00002db9,
-	0x00002dd0, 0x00002de6, 0x00002e10, 0x00002e51,
-	0x00002e70, 0x00002e8e, 0x00002ea3, 0x00002eb7,
-	0x00002ece, 0x00002ef7, 0x00002f08, 0x00002f28,
+	0x00002e8b, 0x00002ebc, 0x00002ef7, 0x00002f08,
+	0x00002f38, 0x00002f62, 0x00002f95, 0x00002fb9,
+	0x00002fd7, 0x00002ff9, 0x00003013, 0x0000303e,
+	0x00003062, 0x00003080, 0x000030b5, 0x000030e0,
+	0x00003102, 0x00003115, 0x00003135, 0x00003155,
+	0x00003178, 0x000031a8, 0x000031bd, 0x000031dc,
+	0x00003217, 0x00003244, 0x00003270, 0x00003296,
+	0x000032b8, 0x000032ce, 0x000032ed, 0x00003312,
 	// Entry 180 - 19F
-	0x00002f4a, 0x00002f68, 0x00002f9c, 0x00002fc9,
-	0x00002ffb, 0x00003031, 0x0000306d, 0x0000309b,
-	0x000030ca, 0x000030f2, 0x0000312b, 0x00003152,
-	0x0000318a, 0x000031ad, 0x000031de, 0x000031ee,
-	0x00003202, 0x00003224, 0x0000324a, 0x0000325e,
-	0x00003276, 0x0000329c, 0x000032c5, 0x000032e2,
-	0x000032fe, 0x00003326, 0x00003364, 0x0000338a,
-	0x000033b3, 0x000033de, 0x0000340a, 0x00003434,
+	0x0000332c, 0x0000334c, 0x00003377, 0x00003396,
+	0x000033c3, 0x000033fa, 0x00003419, 0x0000342f,
+	0x00003449, 0x00003463, 0x00003484, 0x0000349a,
+	0x000034b2, 0x000034cf, 0x000034eb, 0x00003509,
+	0x00003520, 0x00003543, 0x00003565, 0x00003586,
+	0x000035ac, 0x000035d8, 0x00003609, 0x0000363d,
+	0x00003653, 0x00003686, 0x000036a1, 0x000036cc,
+	0x000036e5, 0x0000371e, 0x00003758, 0x00003783,
 	// Entry 1A0 - 1BF
-	0x0000345d, 0x0000348e, 0x000034c9, 0x000034da,
-	0x0000350a, 0x00003534, 0x00003567, 0x0000358b,
-	0x000035a9, 0x000035cb, 0x000035e5, 0x00003610,
-	0x00003634, 0x00003652, 0x00003687, 0x000036b2,
-	0x000036d4, 0x000036e7, 0x00003707, 0x00003727,
-	0x0000374a, 0x0000377a, 0x0000378f, 0x000037ae,
-	0x000037e9, 0x00003816, 0x00003842, 0x00003868,
-	0x0000388a, 0x000038a0, 0x000038bf, 0x000038e4,
+	0x0000379d, 0x000037bd, 0x000037e0, 0x000037f8,
+	0x0000380f, 0x00003840, 0x0000388d, 0x000038c5,
+	0x000038e3, 0x00003905, 0x00003911, 0x00003928,
+	0x00003950, 0x0000397c, 0x000039a8, 0x000039bd,
+	0x000039dc, 0x00003a00, 0x00003a22, 0x00003a3d,
+	0x00003a63, 0x00003a87, 0x00003a9e, 0x00003aba,
+	0x00003ad7, 0x00003af6, 0x00003b23, 0x00003b44,
+	0x00003b73, 0x00003b93, 0x00003bb5, 0x00003bd5,
 	// Entry 1C0 - 1DF
-	0x000038fe, 0x0000391e, 0x00003949, 0x00003968,
-	0x00003995, 0x000039cc, 0x000039eb, 0x00003a01,
-	0x00003a1b, 0x00003a35, 0x00003a56, 0x00003a6c,
-	0x00003a84, 0x00003aa1, 0x00003abd, 0x00003adb,
-	0x00003af2, 0x00003b15, 0x00003b37, 0x00003b58,
-	0x00003b7e, 0x00003baa, 0x00003bdb, 0x00003c0f,
-	0x00003c25, 0x00003c58, 0x00003c73, 0x00003c9e,
-	0x00003cb7, 0x00003cf0, 0x00003d2a, 0x00003d55,
+	0x00003bf1, 0x00003c12, 0x00003c33, 0x00003c55,
+	0x00003c7e, 0x00003caa, 0x00003cc9, 0x00003ce9,
+	0x00003d01, 0x00003d0e, 0x00003d1e, 0x00003d2e,
+	0x00003d5e, 0x00003d70, 0x00003d86, 0x00003db6,
+	0x00003dd3, 0x00003df8, 0x00003e08, 0x00003e31,
+	0x00003e4d, 0x00003e66, 0x00003e93, 0x00003ec8,
+	0x00003eef, 0x00003f1b, 0x00003f4b, 0x00003f7e,
+	0x00003fab, 0x00003fe8, 0x00004012, 0x00004030,
 	// Entry 1E0 - 1FF
-	0x00003d6f, 0x00003d8f, 0x00003db2, 0x00003dca,
-	0x00003de1, 0x00003e12, 0x00003e5f, 0x00003e97,
-	0x00003eb5, 0x00003ed7, 0x00003ee3, 0x00003efa,
-	0x00003f22, 0x00003f4e, 0x00003f7a, 0x00003f8f,
-	0x00003fae, 0x00003fd2, 0x00003ff4, 0x0000400f,
-	0x00004035, 0x00004059, 0x00004070, 0x0000408c,
-	0x000040a9, 0x000040c8, 0x000040f5, 0x00004116,
-	0x00004145, 0x00004165, 0x00004187, 0x000041a7,
+	0x0000405c, 0x00004078, 0x0000409b, 0x000040c5,
+	0x000040f2, 0x00004125, 0x00004145, 0x0000417c,
+	0x000041a4, 0x000041ab, 0x000041b8, 0x000041da,
+	0x0000420e, 0x0000425a, 0x00004280, 0x000042b3,
+	0x000042ea, 0x00004310, 0x0000433e, 0x00004353,
+	0x0000439e, 0x000043b2, 0x000043e1, 0x000043fe,
+	0x00004424, 0x00004446, 0x00004465, 0x00004474,
+	0x0000449b, 0x000044c3, 0x000044e8, 0x0000450f,
 	// Entry 200 - 21F
-	0x000041c3, 0x000041e4, 0x00004205, 0x00004227,
-	0x00004250, 0x0000427c, 0x0000429b, 0x000042bb,
-	0x000042d3, 0x000042e0, 0x000042f0, 0x00004300,
-	0x00004330, 0x00004342, 0x00004358, 0x00004388,
-	0x000043a5, 0x000043ca, 0x000043da, 0x00004403,
-	0x0000441f, 0x00004438, 0x00004465, 0x0000449a,
-	0x000044c1, 0x000044ed, 0x0000451d, 0x00004550,
-	0x0000457d, 0x000045ba, 0x000045e4, 0x00004602,
+	0x0000452d, 0x00004548, 0x00004572, 0x0000459a,
+	0x000045b6, 0x000045ea, 0x0000460d, 0x00004634,
+	0x00004693, 0x000046f2, 0x0000470f, 0x00004734,
+	0x00004746, 0x00004778, 0x0000479b, 0x000047c9,
+	0x000047f0, 0x00004819, 0x0000482a, 0x00004861,
+	0x0000486e, 0x000048a0, 0x000048c1, 0x000048d4,
+	0x000048f3, 0x00004901, 0x00004920, 0x00004939,
+	0x0000495a, 0x0000497e, 0x000049a9, 0x000049c6,
 	// Entry 220 - 23F
-	0x0000462e, 0x0000464a, 0x0000466d, 0x00004697,
-	0x000046c4, 0x000046f7, 0x00004717, 0x0000474e,
-	0x00004776, 0x0000477d, 0x0000478a, 0x000047ac,
-	0x000047e0, 0x0000482c, 0x00004852, 0x00004885,
-	0x000048bc, 0x000048e2, 0x00004910, 0x00004925,
-	0x00004970, 0x00004984, 0x000049b3, 0x000049d0,
-	0x000049f6, 0x00004a18, 0x00004a37, 0x00004a46,
-	0x00004a6d, 0x00004a95, 0x00004aba, 0x00004ae1,
+	0x000049df, 0x000049fa, 0x00004a2b, 0x00004a59,
+	0x00004a74, 0x00004a8e, 0x00004ab2, 0x00004ad0,
+	0x00004afe, 0x00004b10, 0x00004b2f, 0x00004b4d,
+	0x00004b6c, 0x00004b80, 0x00004ba4, 0x00004bc9,
+	0x00004bed, 0x00004bfd, 0x00004c20, 0x00004c4d,
+	0x00004c77, 0x00004caf, 0x00004cda, 0x00004d05,
+	0x00004d2f, 0x00004d56, 0x00004d82, 0x00004da6,
+	0x00004db8, 0x00004dc5, 0x00004de7, 0x00004e06,
 	// Entry 240 - 25F
-	0x00004aff, 0x00004b1a, 0x00004b44, 0x00004b6c,
-	0x00004b88, 0x00004bbc, 0x00004bdf, 0x00004c06,
-	0x00004c65, 0x00004cc4, 0x00004ce1, 0x00004d06,
-	0x00004d18, 0x00004d4a, 0x00004d6d, 0x00004d9b,
-	0x00004dc2, 0x00004deb, 0x00004dfc, 0x00004e33,
-	0x00004e40, 0x00004e72, 0x00004e93, 0x00004ea6,
-	0x00004ec5, 0x00004ed3, 0x00004ef2, 0x00004f0b,
-	0x00004f2c, 0x00004f50, 0x00004f7b, 0x00004f98,
+	0x00004e35, 0x00004e64, 0x00004e97, 0x00004eb6,
+	0x00004ecb, 0x00004ee1, 0x00004eef, 0x00004f10,
+	0x00004f38, 0x00004f4f, 0x00004f6b, 0x00004f82,
+	0x00004f9c, 0x00004fc1, 0x00004fd6, 0x00005011,
+	0x00005029, 0x00005046, 0x00005074, 0x00005094,
+	0x000050a8, 0x000050d4, 0x000050f7, 0x0000511a,
+	0x0000512a, 0x0000513b, 0x0000515e, 0x00005189,
+	0x000051b1, 0x000051ce, 0x000051ec, 0x0000520f,
 	// Entry 260 - 27F
-	0x00004fb1, 0x00004fcc, 0x00004ffd, 0x0000502b,
-	0x00005046, 0x00005060, 0x00005084, 0x000050a2,
-	0x000050d0, 0x000050e2, 0x00005101, 0x0000511f,
-	0x0000513e, 0x00005152, 0x00005176, 0x0000519b,
-	0x000051bf, 0x000051cf, 0x000051f2, 0x0000521f,
-	0x00005249, 0x00005281, 0x000052ac, 0x000052d7,
-	0x00005301, 0x00005328, 0x00005354, 0x00005378,
-	0x0000538a, 0x00005397, 0x000053b9, 0x000053d8,
+	0x00005232, 0x00005257, 0x00005276, 0x00005299,
+	0x000052b4, 0x000052e1, 0x000052fc, 0x00005330,
+	0x0000534e, 0x00005386, 0x000053a3, 0x000053ce,
+	0x000053f1, 0x0000540b, 0x00005423, 0x00005440,
+	0x0000546c, 0x0000548c, 0x000054b2, 0x000054d0,
+	0x000054f2, 0x0000550d, 0x0000551e, 0x00005536,
+	0x0000556c, 0x000055a0, 0x000055d8, 0x000055ed,
+	0x00005602, 0x00005631, 0x00005646, 0x00005679,
 	// Entry 280 - 29F
-	0x00005407, 0x00005436, 0x00005469, 0x00005488,
-	0x0000549d, 0x000054b3, 0x000054c1, 0x000054e2,
-	0x0000550a, 0x00005521, 0x0000553d, 0x00005554,
-	0x0000556e, 0x00005593, 0x000055a8, 0x000055e3,
-	0x000055fb, 0x00005618, 0x00005646, 0x00005666,
-	0x0000567a, 0x000056a6, 0x000056c9, 0x000056ec,
-	0x000056fc, 0x0000570d, 0x00005730, 0x0000575b,
-	0x00005783, 0x000057a0, 0x000057be, 0x000057e1,
+	0x00005692, 0x000056b0, 0x000056c3, 0x000056d8,
+	0x000056f3, 0x0000571c, 0x0000573f, 0x0000576a,
+	0x00005788, 0x000057ab, 0x000057c0, 0x000057dc,
+	0x000057f3, 0x00005817, 0x00005847, 0x00005860,
+	0x00005883, 0x00005894, 0x000058a7, 0x000058bc,
+	0x000058d5, 0x000058e7, 0x0000590b, 0x00005926,
+	0x00005939, 0x00005951, 0x00005978, 0x00005999,
+	0x000059ac, 0x000059ca, 0x000059e7, 0x000059f9,
 	// Entry 2A0 - 2BF
-	0x00005804, 0x00005829, 0x00005848, 0x0000586b,
-	0x00005886, 0x000058b3, 0x000058ce, 0x00005902,
-	0x00005920, 0x00005958, 0x00005975, 0x000059a0,
-	0x000059c3, 0x000059dd, 0x000059f5, 0x00005a12,
-	0x00005a3e, 0x00005a5e, 0x00005a84, 0x00005aa2,
-	0x00005ac4, 0x00005adf, 0x00005af0, 0x00005b08,
-	0x00005b3e, 0x00005b72, 0x00005baa, 0x00005bbf,
-	0x00005bd4, 0x00005c03, 0x00005c18, 0x00005c4b,
+	0x00005a22, 0x00005a3a, 0x00005a54, 0x00005a63,
+	0x00005a7c, 0x00005a94, 0x00005aaf, 0x00005ad0,
+	0x00005ae2, 0x00005af0, 0x00005b06, 0x00005b22,
+	0x00005b37, 0x00005b56, 0x00005b79, 0x00005b9c,
+	0x00005ba9, 0x00005bb7, 0x00005bdc, 0x00005bff,
+	0x00005c2b, 0x00005c54, 0x00005c75, 0x00005cae,
+	0x00005cc8, 0x00005cfc, 0x00005d0d, 0x00005d29,
+	0x00005d5c, 0x00005d89, 0x00005dae, 0x00005ddf,
 	// Entry 2C0 - 2DF
-	0x00005c64, 0x00005c82, 0x00005c95, 0x00005caa,
-	0x00005cc5, 0x00005cee, 0x00005d11, 0x00005d3c,
-	0x00005d5a, 0x00005d7d, 0x00005d92, 0x00005dae,
-	0x00005dc5, 0x00005de9, 0x00005e19, 0x00005e32,
-	0x00005e55, 0x00005e66, 0x00005e79, 0x00005e8e,
-	0x00005ea7, 0x00005eb9, 0x00005edd, 0x00005ef8,
-	0x00005f0b, 0x00005f23, 0x00005f4a, 0x00005f6b,
-	0x00005f7e, 0x00005f9c, 0x00005fb9, 0x00005fcb,
+	0x00005e03, 0x00005e29, 0x00005e45, 0x00005e64,
+	0x00005e73, 0x00005e94, 0x00005eab, 0x00005eb9,
+	0x00005ed1, 0x00005ee2, 0x00005f10, 0x00005f3f,
+	0x00005f68, 0x00005f99, 0x00005fcd, 0x00005ff2,
+	0x00006006, 0x00006041, 0x0000607b, 0x000060ad,
+	0x000060e2, 0x00006120, 0x00006161, 0x0000618e,
+	0x000061b8, 0x000061dc, 0x000061fc, 0x00006213,
+	0x00006239, 0x00006258, 0x0000626a, 0x00006280,
 	// Entry 2E0 - 2FF
-	0x00005ff4, 0x0000600c, 0x00006026, 0x00006035,
-	0x0000604e, 0x00006066, 0x00006081, 0x000060a2,
-	0x000060b4, 0x000060c2, 0x000060d8, 0x000060f4,
-	0x00006109, 0x00006128, 0x0000614b, 0x0000616e,
-	0x0000617b, 0x00006189, 0x000061ae, 0x000061d1,
-	0x000061fd, 0x00006226, 0x00006247, 0x00006280,
-	0x0000629a, 0x000062ce, 0x000062df, 0x000062fb,
-	0x0000632e, 0x0000635b, 0x00006380, 0x000063b1,
+	0x00006292, 0x000062b3, 0x000062ca, 0x000062dd,
+	0x00006305, 0x00006338, 0x0000635e, 0x00006383,
+	0x000063b9, 0x000063d9, 0x000063f7, 0x00006421,
+	0x00006444, 0x00006456, 0x00006476, 0x00006497,
+	0x000064b3, 0x000064cd, 0x000064f3, 0x00006510,
+	0x00006527, 0x00006575, 0x00006596, 0x000065af,
+	0x000065e5, 0x00006605, 0x0000663b, 0x00006671,
+	0x00006694, 0x000066be, 0x000066e9, 0x000066fe,
 	// Entry 300 - 31F
-	0x000063d5, 0x000063fb, 0x00006417, 0x00006436,
-	0x00006445, 0x00006466, 0x0000647d, 0x0000648b,
-	0x000064a3, 0x000064b4, 0x000064e2, 0x00006511,
-	0x0000653a, 0x0000656b, 0x0000659f, 0x000065c4,
-	0x000065d8, 0x00006613, 0x0000664d, 0x0000667f,
-	0x000066b4, 0x000066f2, 0x00006733, 0x00006760,
-	0x0000678a, 0x000067ae, 0x000067ce, 0x000067e5,
-	0x0000680b, 0x0000682a, 0x0000683c, 0x00006852,
+	0x00006714, 0x0000673b, 0x00006750, 0x0000677c,
+	0x000067ab, 0x000067de, 0x0000680c, 0x0000683e,
+	0x00006869, 0x0000689a, 0x000068b9, 0x000068da,
+	0x000068f3, 0x0000690c, 0x00006927, 0x0000695d,
+	0x0000698c, 0x000069a3, 0x000069cc, 0x000069ee,
+	0x00006a07, 0x00006a3f, 0x00006a58, 0x00006a77,
+	0x00006a89, 0x00006aa5, 0x00006ac1, 0x00006ae2,
+	0x00006afa, 0x00006b1d, 0x00006b52, 0x00006b86,
 	// Entry 320 - 33F
-	0x00006864, 0x00006885, 0x0000689c, 0x000068af,
-	0x000068d7, 0x0000690a, 0x00006930, 0x00006955,
-	0x0000698b, 0x000069ab, 0x000069c9, 0x000069f3,
-	0x00006a16, 0x00006a28, 0x00006a48, 0x00006a69,
-	0x00006a85, 0x00006a9f, 0x00006ac5, 0x00006ae2,
-	0x00006af9, 0x00006b47, 0x00006b68, 0x00006b81,
-	0x00006ba1, 0x00006bd7, 0x00006c0d, 0x00006c30,
-	0x00006c5a, 0x00006c85, 0x00006c9a, 0x00006cb0,
+	0x00006bbc, 0x00006bd7, 0x00006bef, 0x00006c05,
+	0x00006c21, 0x00006c64, 0x00006c79, 0x00006c8f,
+	0x00006ca1, 0x00006cb6, 0x00006cd9, 0x00006d05,
+	0x00006d2f, 0x00006d50, 0x00006d6d, 0x00006d7d,
+	0x00006d90, 0x00006db5, 0x00006dcd, 0x00006dec,
+	0x00006e08, 0x00006e3e, 0x00006e59, 0x00006e77,
+	0x00006eaf, 0x00006edc, 0x00006ef9, 0x00006f23,
+	0x00006f45, 0x00006f6e, 0x00006f8f, 0x00006fbb,
 	// Entry 340 - 35F
-	0x00006cd7, 0x00006cec, 0x00006d18, 0x00006d47,
-	0x00006d7a, 0x00006da8, 0x00006dda, 0x00006e05,
-	0x00006e36, 0x00006e55, 0x00006e76, 0x00006e8f,
-	0x00006ea8, 0x00006ec3, 0x00006ef9, 0x00006f28,
-	0x00006f3f, 0x00006f68, 0x00006f8a, 0x00006fa3,
-	0x00006fdb, 0x00006ff4, 0x00007013, 0x00007025,
-	0x00007041, 0x0000705d, 0x0000707e, 0x00007096,
-	0x000070b9, 0x000070ee, 0x00007122, 0x00007158,
+	0x00006fe3, 0x00007006, 0x00007032, 0x00007057,
+	0x0000706d, 0x0000707d, 0x000070aa, 0x000070d0,
+	0x000070fd, 0x0000711f, 0x00007145, 0x00007164,
+	0x0000717b, 0x0000718f, 0x000071a6, 0x000071b8,
+	0x000071cf, 0x000071eb, 0x00007208, 0x0000722a,
+	0x0000724f, 0x00007266, 0x0000728c, 0x000072a4,
+	0x000072b4, 0x000072d4, 0x000072f6, 0x00007314,
+	0x00007336, 0x0000734a, 0x0000735f, 0x00007387,
 	// Entry 360 - 37F
-	0x00007173, 0x0000718b, 0x000071a1, 0x000071bd,
-	0x00007200, 0x00007215, 0x0000722b, 0x0000723d,
-	0x00007252, 0x00007275, 0x000072a1, 0x000072cb,
-	0x000072ec, 0x00007309, 0x00007319, 0x0000732c,
-	0x00007351, 0x00007369, 0x00007388, 0x000073a4,
-	0x000073da, 0x000073f5, 0x00007413, 0x0000744b,
-	0x00007478, 0x00007495, 0x000074bf, 0x000074e1,
-	0x0000750a, 0x0000752b, 0x00007557, 0x0000757f,
+	0x000073ab, 0x000073d4, 0x000073fc, 0x0000740f,
+	0x00007433, 0x0000744f, 0x00007468, 0x0000748a,
+	0x000074b1, 0x000074eb, 0x00007504, 0x0000751e,
+	0x00007530, 0x00007548, 0x00007566, 0x00007582,
+	0x000075a8, 0x000075cf, 0x000075eb, 0x00007618,
+	0x0000763a, 0x0000765b, 0x00007683, 0x0000769a,
+	0x000076b4, 0x000076cf, 0x00007711, 0x00007757,
+	0x0000779e, 0x000077c0, 0x000077cd, 0x000077f6,
 	// Entry 380 - 39F
-	0x000075a2, 0x000075ce, 0x000075f3, 0x00007609,
-	0x00007619, 0x00007646, 0x0000766c, 0x00007699,
-	0x000076bb, 0x000076e1, 0x00007700, 0x00007717,
-	0x0000772b, 0x00007742, 0x00007754, 0x0000776b,
-	0x00007787, 0x000077a4, 0x000077c6, 0x000077eb,
-	0x00007802, 0x00007828, 0x00007840, 0x00007850,
-	0x00007870, 0x00007892, 0x000078b0, 0x000078d2,
-	0x000078e6, 0x000078fb, 0x00007923, 0x00007947,
+	0x0000781f, 0x0000784d, 0x00007867, 0x00007881,
+	0x000078b3, 0x000078e4, 0x0000792a, 0x0000796b,
+	0x00007999, 0x000079c9, 0x000079e8, 0x00007a04,
+	0x00007a3a, 0x00007a5d, 0x00007a73, 0x00007a8c,
+	0x00007aab, 0x00007ad1, 0x00007af7, 0x00007b07,
+	0x00007b21, 0x00007b49, 0x00007b5f, 0x00007b94,
+	0x00007baa, 0x00007bcf, 0x00007be9, 0x00007c1f,
+	0x00007c46, 0x00007c76, 0x00007c9f, 0x00007cc9,
 	// Entry 3A0 - 3BF
-	0x00007970, 0x00007998, 0x000079ab, 0x000079cf,
-	0x000079eb, 0x00007a04, 0x00007a26, 0x00007a4d,
-	0x00007a87, 0x00007aa0, 0x00007aba, 0x00007acc,
-	0x00007ae4, 0x00007b02, 0x00007b1e, 0x00007b44,
-	0x00007b6b, 0x00007b87, 0x00007bb4, 0x00007bd6,
-	0x00007bf7, 0x00007c1f, 0x00007c36, 0x00007c50,
-	0x00007c6b, 0x00007cad, 0x00007cf3, 0x00007d3a,
-	0x00007d5c, 0x00007d69, 0x00007d92, 0x00007dbb,
+	0x00007ceb, 0x00007d00, 0x00007d25, 0x00007d46,
+	0x00007d78, 0x00007d8b, 0x00007db2, 0x00007de3,
+	0x00007e08, 0x00007e18, 0x00007e29, 0x00007e54,
+	0x00007e66, 0x00007e92, 0x00007eb1, 0x00007ec5,
+	0x00007edb, 0x00007eef, 0x00007f06, 0x00007f2d,
+	0x00007f47, 0x00007f6d, 0x00007f9b, 0x00007fcd,
+	0x00007fff, 0x00008017, 0x00008041, 0x00008058,
+	0x00008073, 0x000080a4, 0x000080ce, 0x000080e4,
 	// Entry 3C0 - 3DF
-	0x00007de9, 0x00007e03, 0x00007e1d, 0x00007e4f,
-	0x00007e80, 0x00007ec6, 0x00007f07, 0x00007f35,
-	0x00007f65, 0x00007f84, 0x00007fa0, 0x00007fd6,
-	0x00007ff9, 0x0000800f, 0x00008028, 0x00008047,
-	0x0000806d, 0x00008093, 0x000080a3, 0x000080bd,
-	0x000080e5, 0x000080fb, 0x00008130, 0x00008146,
-	0x0000816b, 0x00008185, 0x000081bb, 0x000081e2,
-	0x00008212, 0x0000823b, 0x00008265, 0x00008287,
+	0x0000810e, 0x00008123, 0x0000814f, 0x000081d2,
+	0x0000820a, 0x00008222, 0x00008251, 0x00008284,
+	0x000082b7, 0x000082e7, 0x00008311, 0x00008332,
+	0x0000835f, 0x00008390, 0x000083c1, 0x000083f3,
+	0x0000841d, 0x00008442, 0x0000847b, 0x0000849b,
+	0x000084ba, 0x000084e9, 0x0000852f, 0x00008557,
+	0x00008585, 0x000085b4, 0x000085df, 0x00008612,
+	0x0000864a, 0x00008682, 0x0000869a, 0x000086d2,
 	// Entry 3E0 - 3FF
-	0x0000829c, 0x000082c1, 0x000082e2, 0x00008314,
-	0x00008327, 0x0000834e, 0x0000837f, 0x000083a4,
-	0x000083b4, 0x000083c5, 0x000083f0, 0x00008402,
-	0x0000842e, 0x0000844d, 0x00008461, 0x00008477,
-	0x0000848b, 0x000084a2, 0x000084c9, 0x000084e3,
-	0x00008509, 0x00008537, 0x00008569, 0x0000859b,
-	0x000085b3, 0x000085dd, 0x000085f4, 0x0000860f,
-	0x00008640, 0x0000866a, 0x00008680, 0x000086aa,
+	0x00008707, 0x00008743, 0x00008769, 0x00008783,
+	0x00008794, 0x000087b4, 0x000087dd, 0x00008800,
+	0x0000880c, 0x0000883e, 0x00008873, 0x00008892,
+	0x000088b5, 0x000088c5, 0x000088d8, 0x000088ec,
+	0x00008914, 0x00008949, 0x00008967, 0x00008986,
+	0x000089ac, 0x000089c1, 0x000089e0, 0x000089fd,
+	0x00008a15, 0x00008a46, 0x00008a5c, 0x00008a7b,
+	0x00008a97, 0x00008abc, 0x00008ad6, 0x00008ae8,
 	// Entry 400 - 41F
-	0x000086bf, 0x000086eb, 0x0000876e, 0x000087a6,
-	0x000087be, 0x000087ed, 0x00008820, 0x00008853,
-	0x00008883, 0x000088ad, 0x000088ce, 0x000088fb,
-	0x0000892c, 0x0000895d, 0x0000898f, 0x000089b9,
-	0x000089de, 0x00008a17, 0x00008a37, 0x00008a56,
-	0x00008a85, 0x00008acb, 0x00008af3, 0x00008b21,
-	0x00008b50, 0x00008b7b, 0x00008bae, 0x00008be6,
-	0x00008c1e, 0x00008c36, 0x00008c6e, 0x00008ca3,
+	0x00008b06, 0x00008b1f, 0x00008b37, 0x00008b64,
+	0x00008b7c, 0x00008b95, 0x00008bba, 0x00008bce,
+	0x00008bec, 0x00008c06, 0x00008c1c, 0x00008c42,
+	0x00008c68, 0x00008c80, 0x00008c8e, 0x00008cb2,
+	0x00008cc6, 0x00008cef, 0x00008d02, 0x00008d1a,
+	0x00008d30, 0x00008d58, 0x00008d72, 0x00008d85,
+	0x00008dbc, 0x00008deb, 0x00008df9, 0x00008e2f,
+	0x00008e6c, 0x00008e95, 0x00008eb4, 0x00008eec,
 	// Entry 420 - 43F
-	0x00008cdf, 0x00008d05, 0x00008d1f, 0x00008d30,
-	0x00008d50, 0x00008d79, 0x00008d9c, 0x00008da8,
-	0x00008dda, 0x00008e0f, 0x00008e2e, 0x00008e51,
-	0x00008e61, 0x00008e74, 0x00008e88, 0x00008eb0,
-	0x00008ee5, 0x00008f03, 0x00008f22, 0x00008f48,
-	0x00008f5d, 0x00008f7c, 0x00008f99, 0x00008fb1,
-	0x00008fe2, 0x00008ff8, 0x00009017, 0x00009033,
-	0x00009058, 0x00009072, 0x00009084, 0x000090a2,
+	0x00008f04, 0x00008f32, 0x00008f59, 0x00008f82,
+	0x00008fb0, 0x00008fc0, 0x00008fef, 0x00009004,
+	0x0000902c, 0x0000904f, 0x00009076, 0x00009084,
+	0x000090a0, 0x000090b9, 0x000090cb, 0x000090e0,
+	0x000090ff, 0x00009102, 0x0000911e, 0x0000913e,
+	0x00009164, 0x00009189, 0x0000919b, 0x000091cc,
+	0x000091df, 0x000091fd, 0x0000920d, 0x00009222,
+	0x0000923e, 0x0000926c, 0x0000929f, 0x000092bd,
 	// Entry 440 - 45F
-	0x000090bb, 0x000090d3, 0x00009100, 0x00009118,
-	0x00009131, 0x00009156, 0x0000916a, 0x00009188,
-	0x000091a2, 0x000091b8, 0x000091de, 0x00009204,
-	0x0000921c, 0x0000922a, 0x0000924e, 0x00009262,
-	0x0000928b, 0x0000929e, 0x000092b6, 0x000092cc,
-	0x000092f4, 0x0000930e, 0x00009321, 0x00009358,
-	0x00009387, 0x00009395, 0x000093cb, 0x00009408,
-	0x00009431, 0x00009450, 0x00009488, 0x000094a0,
+	0x000092ee, 0x00009330, 0x00009382, 0x0000939a,
+	0x000093c1, 0x000093d9, 0x000093f6, 0x00009410,
+	0x00009451, 0x0000946f, 0x0000948a, 0x000094a6,
+	0x000094ce, 0x000094f5, 0x0000951e, 0x00009547,
+	0x0000958e, 0x000095a8, 0x000095d5, 0x00009604,
+	0x0000961d, 0x00009634, 0x00009654, 0x00009672,
+	0x000096a6, 0x000096ba, 0x000096d6, 0x000096f3,
+	0x0000970e, 0x00009735, 0x00009749, 0x00009765,
 	// Entry 460 - 47F
-	0x000094ce, 0x000094f5, 0x0000951e, 0x0000954c,
-	0x0000955c, 0x0000958b, 0x000095a0, 0x000095c8,
-	0x000095eb, 0x00009612, 0x00009620, 0x0000963c,
-	0x00009655, 0x00009667, 0x0000967c, 0x0000969b,
-	0x0000969e, 0x000096ba, 0x000096da, 0x00009700,
-	0x00009725, 0x00009737, 0x00009768, 0x0000977b,
-	0x00009799, 0x000097a9, 0x000097be, 0x000097da,
-	0x00009808, 0x0000983b, 0x00009859, 0x0000988a,
+	0x0000977d, 0x0000979a, 0x000097a6, 0x000097d3,
+	0x000097fe, 0x00009812, 0x0000982e, 0x00009850,
+	0x00009867, 0x00009881, 0x000098a1, 0x000098b7,
+	0x000098d5, 0x000098fa, 0x00009927, 0x00009940,
+	0x0000995b, 0x00009975, 0x00009994, 0x000099ab,
+	0x000099e7, 0x000099fb, 0x00009a19, 0x00009a35,
+	0x00009a4c, 0x00009a70, 0x00009a99, 0x00009ab0,
+	0x00009ad6, 0x00009aed, 0x00009b0a, 0x00009b35,
 	// Entry 480 - 49F
-	0x000098cc, 0x0000991e, 0x00009936, 0x0000995d,
-	0x00009975, 0x00009992, 0x000099ac, 0x000099ed,
-	0x00009a0b, 0x00009a26, 0x00009a42, 0x00009a6a,
-	0x00009a91, 0x00009aba, 0x00009ae3, 0x00009b2a,
-	0x00009b44, 0x00009b71, 0x00009ba0, 0x00009bb9,
-	0x00009bd0, 0x00009bf0, 0x00009c0e, 0x00009c42,
-	0x00009c56, 0x00009c72, 0x00009c8f, 0x00009caa,
-	0x00009cd1, 0x00009ce5, 0x00009d01, 0x00009d19,
+	0x00009b4c, 0x00009b68, 0x00009b82, 0x00009ba7,
+	0x00009bd2, 0x00009bf4, 0x00009c12, 0x00009c3a,
+	0x00009c63, 0x00009c8d, 0x00009cb1, 0x00009cde,
+	0x00009cef, 0x00009d0f, 0x00009d40, 0x00009d5e,
+	0x00009d6d, 0x00009dbd, 0x00009df0, 0x00009e1b,
+	0x00009e35, 0x00009e4c, 0x00009e62, 0x00009e84,
+	0x00009eb2, 0x00009ede, 0x00009ef8, 0x00009f1d,
+	0x00009f33, 0x00009f64, 0x00009f74, 0x00009f97,
 	// Entry 4A0 - 4BF
-	0x00009d36, 0x00009d42, 0x00009d6f, 0x00009d9a,
-	0x00009dae, 0x00009dca, 0x00009dec, 0x00009e03,
-	0x00009e1d, 0x00009e3d, 0x00009e53, 0x00009e71,
-	0x00009e96, 0x00009ec3, 0x00009edc, 0x00009ef7,
-	0x00009f11, 0x00009f30, 0x00009f47, 0x00009f83,
-	0x00009f97, 0x00009fb5, 0x00009fd1, 0x00009fe8,
-	0x0000a00c, 0x0000a035, 0x0000a04c, 0x0000a072,
-	0x0000a089, 0x0000a0a6, 0x0000a0d1, 0x0000a0e8,
+	0x00009fc5, 0x00009fd8, 0x00009ff0, 0x0000a021,
+	0x0000a045, 0x0000a066, 0x0000a08f, 0x0000a0b4,
+	0x0000a0e3, 0x0000a10f, 0x0000a12e, 0x0000a162,
+	0x0000a192, 0x0000a1ac, 0x0000a1bc, 0x0000a1e0,
+	0x0000a1fd, 0x0000a219, 0x0000a231, 0x0000a247,
+	0x0000a26c, 0x0000a284, 0x0000a2a2, 0x0000a2bb,
+	0x0000a2d3, 0x0000a2ea, 0x0000a308, 0x0000a31d,
+	0x0000a339, 0x0000a34b, 0x0000a361, 0x0000a37a,
 	// Entry 4C0 - 4DF
-	0x0000a104, 0x0000a11e, 0x0000a143, 0x0000a16e,
-	0x0000a190, 0x0000a1ae, 0x0000a1d6, 0x0000a1ff,
-	0x0000a229, 0x0000a24d, 0x0000a27a, 0x0000a28b,
-	0x0000a2ab, 0x0000a2dc, 0x0000a2fa, 0x0000a309,
-	0x0000a359, 0x0000a38c, 0x0000a3b7, 0x0000a3d1,
-	0x0000a3e8, 0x0000a3fe, 0x0000a420, 0x0000a44e,
-	0x0000a47a, 0x0000a494, 0x0000a4b9, 0x0000a4cf,
-	0x0000a500, 0x0000a510, 0x0000a533, 0x0000a561,
+	0x0000a38d, 0x0000a3b0, 0x0000a3cd, 0x0000a3d4,
+	0x0000a40c, 0x0000a41f, 0x0000a460, 0x0000a4a2,
+	0x0000a4cb, 0x0000a4f4, 0x0000a514, 0x0000a52c,
+	0x0000a557, 0x0000a572, 0x0000a5a1, 0x0000a5cb,
+	0x0000a602, 0x0000a618, 0x0000a643, 0x0000a665,
+	0x0000a69b, 0x0000a6bf, 0x0000a6d3, 0x0000a6f4,
+	0x0000a713, 0x0000a746, 0x0000a758, 0x0000a76c,
+	0x0000a781, 0x0000a798, 0x0000a7a7, 0x0000a7c6,
 	// Entry 4E0 - 4FF
-	0x0000a574, 0x0000a58c, 0x0000a5bd, 0x0000a5e1,
-	0x0000a602, 0x0000a62b, 0x0000a650, 0x0000a67f,
-	0x0000a6ab, 0x0000a6ca, 0x0000a6fe, 0x0000a72e,
-	0x0000a748, 0x0000a758, 0x0000a77c, 0x0000a799,
-	0x0000a7b5, 0x0000a7cd, 0x0000a7e3, 0x0000a808,
-	0x0000a820, 0x0000a83e, 0x0000a857, 0x0000a86f,
-	0x0000a886, 0x0000a8a4, 0x0000a8b9, 0x0000a8d5,
-	0x0000a8e7, 0x0000a8fd, 0x0000a916, 0x0000a929,
+	0x0000a7e1, 0x0000a819, 0x0000a85b, 0x0000a882,
+	0x0000a8b5, 0x0000a8d4, 0x0000a8e5, 0x0000a91c,
+	0x0000a947, 0x0000a972, 0x0000a9ac, 0x0000a9d5,
+	0x0000aa08, 0x0000aa26, 0x0000aa4f, 0x0000aa8d,
+	0x0000aaaf, 0x0000aaec, 0x0000ab30, 0x0000ab63,
+	0x0000ab83, 0x0000abb2, 0x0000abf7, 0x0000ac2a,
+	0x0000ac56, 0x0000aca1, 0x0000acd2, 0x0000acfe,
+	0x0000ad16, 0x0000ad2c, 0x0000ad6f, 0x0000adaf,
 	// Entry 500 - 51F
-	0x0000a94c, 0x0000a969, 0x0000a970, 0x0000a9a8,
-	0x0000a9bb, 0x0000a9fc, 0x0000aa3e, 0x0000aa67,
-	0x0000aa90, 0x0000aab0, 0x0000aac8, 0x0000aaf3,
-	0x0000ab0e, 0x0000ab3d, 0x0000ab67, 0x0000ab9e,
-	0x0000abb4, 0x0000abdf, 0x0000ac01, 0x0000ac37,
-	0x0000ac5b, 0x0000ac6f, 0x0000ac90, 0x0000acaf,
-	0x0000ace2, 0x0000acf4, 0x0000ad08, 0x0000ad1d,
-	0x0000ad34, 0x0000ad43, 0x0000ad62, 0x0000ad7d,
+	0x0000adce, 0x0000ae02, 0x0000ae78, 0x0000aeaa,
+	0x0000aee5, 0x0000af1c, 0x0000af79, 0x0000afad,
+	0x0000afed, 0x0000b02a, 0x0000b072, 0x0000b0cb,
+	0x0000b121, 0x0000b168, 0x0000b19b, 0x0000b1da,
+	0x0000b20b, 0x0000b231, 0x0000b25a, 0x0000b27a,
+	0x0000b294, 0x0000b2a9, 0x0000b2ca, 0x0000b2fe,
+	0x0000b341, 0x0000b35e, 0x0000b393, 0x0000b3cf,
+	0x0000b3fa, 0x0000b428, 0x0000b44f, 0x0000b471,
 	// Entry 520 - 53F
-	0x0000adb5, 0x0000adf7, 0x0000ae1e, 0x0000ae51,
-	0x0000ae70, 0x0000ae81, 0x0000aeb8, 0x0000aee3,
-	0x0000af0e, 0x0000af48, 0x0000af71, 0x0000afa4,
-	0x0000afc2, 0x0000afeb, 0x0000b029, 0x0000b04b,
-	0x0000b088, 0x0000b0cc, 0x0000b0ff, 0x0000b11f,
-	0x0000b14e, 0x0000b193, 0x0000b1c6, 0x0000b1f2,
-	0x0000b23d, 0x0000b26e, 0x0000b29a, 0x0000b2b2,
-	0x0000b2c8, 0x0000b30b, 0x0000b34b, 0x0000b36a,
+	0x0000b48e, 0x0000b4c6, 0x0000b506, 0x0000b541,
+	0x0000b571, 0x0000b5a7, 0x0000b5db, 0x0000b610,
+	0x0000b640, 0x0000b671, 0x0000b69b, 0x0000b6c9,
+	0x0000b6ff, 0x0000b732, 0x0000b75b, 0x0000b794,
+	0x0000b7ba, 0x0000b7e4, 0x0000b813, 0x0000b84a,
+	0x0000b874, 0x0000b8a7, 0x0000b8df, 0x0000b926,
+	0x0000b95f, 0x0000b99d, 0x0000b9ce, 0x0000b9f6,
+	0x0000ba1f, 0x0000ba4c, 0x0000ba89, 0x0000bac0,
 	// Entry 540 - 55F
-	0x0000b39e, 0x0000b414, 0x0000b446, 0x0000b481,
-	0x0000b4b8, 0x0000b515, 0x0000b549, 0x0000b589,
-	0x0000b5c6, 0x0000b60e, 0x0000b667, 0x0000b6bd,
-	0x0000b704, 0x0000b737, 0x0000b776, 0x0000b7a7,
-	0x0000b7cd, 0x0000b7f6, 0x0000b816, 0x0000b830,
-	0x0000b845, 0x0000b866, 0x0000b89a, 0x0000b8dd,
-	0x0000b8fa, 0x0000b92f, 0x0000b96b, 0x0000b996,
-	0x0000b9c4, 0x0000b9eb, 0x0000ba0d, 0x0000ba2a,
+	0x0000bad8, 0x0000bb13, 0x0000bb44, 0x0000bb6c,
+	0x0000bb9b, 0x0000bbd5, 0x0000bbe7, 0x0000bc05,
+	0x0000bc36, 0x0000bc48, 0x0000bc66, 0x0000bc83,
+	0x0000bc97, 0x0000bcb0, 0x0000bccf, 0x0000bcf6,
+	0x0000bd2f, 0x0000bd6d, 0x0000bd8f, 0x0000bdc8,
+	0x0000bdfd, 0x0000be2b, 0x0000be4f, 0x0000be68,
+	0x0000be85, 0x0000beac, 0x0000bed1, 0x0000bef1,
+	0x0000bf06, 0x0000bf38, 0x0000bf6a, 0x0000bf8b,
 	// Entry 560 - 57F
-	0x0000ba62, 0x0000baa2, 0x0000badd, 0x0000bb0d,
-	0x0000bb43, 0x0000bb77, 0x0000bbac, 0x0000bbdc,
-	0x0000bc0d, 0x0000bc37, 0x0000bc65, 0x0000bc9b,
-	0x0000bcce, 0x0000bcf7, 0x0000bd30, 0x0000bd56,
-	0x0000bd80, 0x0000bdaf, 0x0000bde6, 0x0000be10,
-	0x0000be43, 0x0000be7b, 0x0000bec2, 0x0000befb,
-	0x0000bf39, 0x0000bf6a, 0x0000bf92, 0x0000bfbb,
-	0x0000bfe8, 0x0000c025, 0x0000c05c, 0x0000c074,
+	0x0000bfac, 0x0000bfc2, 0x0000bfef, 0x0000c031,
+	0x0000c06e, 0x0000c084, 0x0000c0ab, 0x0000c0e3,
+	0x0000c119, 0x0000c13d, 0x0000c16a, 0x0000c1a7,
+	0x0000c1bc, 0x0000c1d8, 0x0000c1ed, 0x0000c208,
+	0x0000c224, 0x0000c25a, 0x0000c28d, 0x0000c2ac,
+	0x0000c2e2, 0x0000c30a, 0x0000c32c, 0x0000c358,
+	0x0000c382, 0x0000c38d, 0x0000c3a1, 0x0000c3b7,
+	0x0000c3c4, 0x0000c3d7, 0x0000c3ed, 0x0000c3ff,
 	// Entry 580 - 59F
-	0x0000c0af, 0x0000c0e0, 0x0000c108, 0x0000c137,
-	0x0000c171, 0x0000c183, 0x0000c1a1, 0x0000c1d2,
-	0x0000c1e4, 0x0000c202, 0x0000c21f, 0x0000c233,
-	0x0000c24c, 0x0000c26b, 0x0000c292, 0x0000c2cb,
-	0x0000c309, 0x0000c32b, 0x0000c364, 0x0000c399,
-	0x0000c3c7, 0x0000c3eb, 0x0000c404, 0x0000c421,
-	0x0000c448, 0x0000c46d, 0x0000c48d, 0x0000c4a2,
-	0x0000c4d4, 0x0000c506, 0x0000c527, 0x0000c548,
+	0x0000c413, 0x0000c427, 0x0000c439, 0x0000c44b,
+	0x0000c45e, 0x0000c472, 0x0000c484, 0x0000c49a,
+	0x0000c4b4, 0x0000c4c2, 0x0000c4d2, 0x0000c4dd,
+	0x0000c4e8, 0x0000c504, 0x0000c51c, 0x0000c52a,
+	0x0000c53a, 0x0000c54c, 0x0000c55e, 0x0000c575,
+	0x0000c584, 0x0000c597, 0x0000c5aa, 0x0000c5c1,
+	0x0000c5cf, 0x0000c5e1, 0x0000c5f5, 0x0000c60c,
+	0x0000c61b, 0x0000c62a, 0x0000c640, 0x0000c650,
 	// Entry 5A0 - 5BF
-	0x0000c55e, 0x0000c58b, 0x0000c5cd, 0x0000c60a,
-	0x0000c620, 0x0000c647, 0x0000c67f, 0x0000c6b5,
-	0x0000c6d9, 0x0000c706, 0x0000c743, 0x0000c758,
-	0x0000c774, 0x0000c789, 0x0000c7a4, 0x0000c7c0,
-	0x0000c7f6, 0x0000c829, 0x0000c848, 0x0000c87e,
-	0x0000c8a6, 0x0000c8c8, 0x0000c8f4, 0x0000c91e,
-	0x0000c929, 0x0000c93d, 0x0000c953, 0x0000c960,
-	0x0000c973, 0x0000c989, 0x0000c99b, 0x0000c9af,
+	0x0000c65c, 0x0000c66a, 0x0000c67e, 0x0000c694,
+	0x0000c6a7, 0x0000c6ff, 0x0000c714, 0x0000c729,
+	0x0000c73c, 0x0000c74b, 0x0000c754, 0x0000c75d,
+	0x0000c768, 0x0000c776, 0x0000c7b3, 0x0000c7c9,
+	0x0000c7f9, 0x0000c837, 0x0000c846, 0x0000c85f,
+	0x0000c878, 0x0000c889, 0x0000c8a6, 0x0000c8b8,
+	0x0000c8d1, 0x0000c8eb, 0x0000c907, 0x0000c920,
+	0x0000c93b, 0x0000c95e, 0x0000c967, 0x0000c983,
 	// Entry 5C0 - 5DF
-	0x0000c9c3, 0x0000c9d5, 0x0000c9e7, 0x0000c9fa,
-	0x0000ca0e, 0x0000ca20, 0x0000ca36, 0x0000ca50,
-	0x0000ca5e, 0x0000ca6e, 0x0000ca79, 0x0000ca84,
-	0x0000caa0, 0x0000cab8, 0x0000cac6, 0x0000cad6,
-	0x0000cae8, 0x0000cafa, 0x0000cb11, 0x0000cb20,
-	0x0000cb33, 0x0000cb46, 0x0000cb5d, 0x0000cb6b,
-	0x0000cb7d, 0x0000cb91, 0x0000cba8, 0x0000cbb7,
-	0x0000cbc6, 0x0000cbdc, 0x0000cbec, 0x0000cc00,
+	0x0000c998, 0x0000c9ac, 0x0000c9ca, 0x0000c9f1,
+	0x0000ca03, 0x0000ca32, 0x0000ca62, 0x0000ca85,
+	0x0000ca99, 0x0000caaa, 0x0000cab9, 0x0000cad1,
+	0x0000caea, 0x0000cb16, 0x0000cb30, 0x0000cb50,
+	0x0000cb74, 0x0000cb91, 0x0000cba4, 0x0000cbb8,
+	0x0000cbd3, 0x0000cbef, 0x0000cc0c, 0x0000cc29,
+	0x0000cc4d, 0x0000cc63, 0x0000cc7a, 0x0000cc9b,
+	0x0000ccb5, 0x0000cccc, 0x0000cce6, 0x0000cd00,
 	// Entry 5E0 - 5FF
-	0x0000cc16, 0x0000cc29, 0x0000cc81, 0x0000cc96,
-	0x0000cca9, 0x0000ccb8, 0x0000ccc1, 0x0000ccca,
-	0x0000ccd5, 0x0000cce3, 0x0000cd20, 0x0000cd36,
-	0x0000cd66, 0x0000cda4, 0x0000cdb3, 0x0000cdcc,
-	0x0000cde5, 0x0000cdf6, 0x0000ce13, 0x0000ce25,
-	0x0000ce3e, 0x0000ce58, 0x0000ce74, 0x0000ce8d,
-	0x0000cea8, 0x0000cecb, 0x0000ced4, 0x0000cef0,
-	0x0000cf05, 0x0000cf19, 0x0000cf37, 0x0000cf5e,
+	0x0000cd1f, 0x0000cd3f, 0x0000cd5c, 0x0000cd7c,
+	0x0000cda6, 0x0000cdd0, 0x0000cdeb, 0x0000cdfe,
+	0x0000ce1c, 0x0000ce3c, 0x0000ce51, 0x0000ce76,
+	0x0000ce97, 0x0000ceb1, 0x0000cedf, 0x0000cefb,
+	0x0000cf18, 0x0000cf29, 0x0000cf3a, 0x0000cf48,
+	0x0000cf56, 0x0000cf6b, 0x0000cf80, 0x0000cf8f,
+	0x0000cfa2, 0x0000cfb6, 0x0000cfcc, 0x0000cfdf,
+	0x0000cff5, 0x0000d005, 0x0000d021, 0x0000d034,
 	// Entry 600 - 61F
-	0x0000cf70, 0x0000cf9f, 0x0000cfcf, 0x0000cff2,
-	0x0000d006, 0x0000d017, 0x0000d026, 0x0000d03e,
-	0x0000d057, 0x0000d083, 0x0000d09d, 0x0000d0bd,
-	0x0000d0e1, 0x0000d0fe, 0x0000d111, 0x0000d125,
-	0x0000d140, 0x0000d15c, 0x0000d179, 0x0000d196,
-	0x0000d1ba, 0x0000d1d0, 0x0000d1e7, 0x0000d208,
-	0x0000d222, 0x0000d239, 0x0000d253, 0x0000d26d,
-	0x0000d28c, 0x0000d2ac, 0x0000d2c9, 0x0000d2e9,
+	0x0000d052, 0x0000d05f, 0x0000d06f, 0x0000d088,
+	0x0000d097, 0x0000d0a9, 0x0000d0b7, 0x0000d0c8,
+	0x0000d0df, 0x0000d0ec, 0x0000d0f9, 0x0000d10b,
+	0x0000d121, 0x0000d130, 0x0000d14b, 0x0000d15e,
+	0x0000d170, 0x0000d184, 0x0000d19d, 0x0000d1bc,
+	0x0000d1c8, 0x0000d1d5, 0x0000d1e9, 0x0000d1fd,
+	0x0000d209, 0x0000d21e, 0x0000d22f, 0x0000d24b,
+	0x0000d266, 0x0000d27c, 0x0000d289, 0x0000d299,
 	// Entry 620 - 63F
-	0x0000d313, 0x0000d33d, 0x0000d358, 0x0000d36b,
-	0x0000d389, 0x0000d3a9, 0x0000d3be, 0x0000d3db,
-	0x0000d3fc, 0x0000d416, 0x0000d444, 0x0000d460,
-	0x0000d47d, 0x0000d48e, 0x0000d49f, 0x0000d4ad,
-	0x0000d4bb, 0x0000d4d0, 0x0000d4e5, 0x0000d4f4,
-	0x0000d507, 0x0000d51b, 0x0000d531, 0x0000d544,
-	0x0000d55a, 0x0000d56a, 0x0000d586, 0x0000d599,
-	0x0000d5b7, 0x0000d5c4, 0x0000d5d4, 0x0000d5ed,
+	0x0000d2ac, 0x0000d2bc, 0x0000d2d0, 0x0000d2e1,
+	0x0000d2f7, 0x0000d314, 0x0000d339, 0x0000d372,
+	0x0000d395, 0x0000d3bc, 0x0000d3d7, 0x0000d3ef,
+	0x0000d40a, 0x0000d41c, 0x0000d435, 0x0000d44b,
+	0x0000d465, 0x0000d483, 0x0000d49c, 0x0000d4b6,
+	0x0000d4d6, 0x0000d4fc, 0x0000d515, 0x0000d52f,
+	0x0000d54b, 0x0000d566, 0x0000d589, 0x0000d5a7,
+	0x0000d5bc, 0x0000d5d0, 0x0000d5ed, 0x0000d615,
 	// Entry 640 - 65F
-	0x0000d5fc, 0x0000d60e, 0x0000d61c, 0x0000d62d,
-	0x0000d644, 0x0000d651, 0x0000d65e, 0x0000d670,
-	0x0000d686, 0x0000d695, 0x0000d6b0, 0x0000d6c3,
-	0x0000d6d5, 0x0000d6e9, 0x0000d702, 0x0000d721,
-	0x0000d72d, 0x0000d73a, 0x0000d74e, 0x0000d762,
-	0x0000d76e, 0x0000d783, 0x0000d794, 0x0000d7b0,
-	0x0000d7cb, 0x0000d7e1, 0x0000d7fb, 0x0000d808,
-	0x0000d818, 0x0000d82b, 0x0000d83b, 0x0000d84f,
-	// Entry 660 - 67F
-	0x0000d860, 0x0000d876, 0x0000d893, 0x0000d8b8,
-	0x0000d8f1, 0x0000d914, 0x0000d93b, 0x0000d956,
-	0x0000d96e, 0x0000d989, 0x0000d99b, 0x0000d9b4,
-	0x0000d9ca, 0x0000d9e4, 0x0000da02, 0x0000da1b,
-	0x0000da35, 0x0000da55, 0x0000da7b, 0x0000da94,
-	0x0000daae, 0x0000daca, 0x0000dae5, 0x0000db08,
-	0x0000db26, 0x0000db3b, 0x0000db4f, 0x0000db6c,
-	0x0000db94, 0x0000dbb5, 0x0000dbd9, 0x0000dbed,
-	// Entry 680 - 69F
-	0x0000dc01, 0x0000dc11, 0x0000dc2d, 0x0000dc4b,
-	0x0000dc63, 0x0000dc85, 0x0000dcb2, 0x0000dcda,
-	0x0000dcfb, 0x0000dd13, 0x0000dd2f, 0x0000dd48,
-	0x0000dd5b, 0x0000dd77, 0x0000dd9b, 0x0000ddb7,
-	0x0000ddd5, 0x0000ddf5, 0x0000de1b, 0x0000de3b,
-	0x0000de4d, 0x0000debb, 0x0000ded5, 0x0000dedc,
-	0x0000def4, 0x0000df0a, 0x0000df29, 0x0000df3e,
-} // Size: 6792 bytes
+	0x0000d636, 0x0000d65a, 0x0000d66e, 0x0000d682,
+	0x0000d692, 0x0000d6ae, 0x0000d6cc, 0x0000d6e4,
+	0x0000d706, 0x0000d733, 0x0000d75b, 0x0000d77c,
+	0x0000d794, 0x0000d7b0, 0x0000d7c9, 0x0000d7dc,
+	0x0000d7f8, 0x0000d81c, 0x0000d838, 0x0000d856,
+	0x0000d876, 0x0000d89c, 0x0000d8bc, 0x0000d8ce,
+	0x0000d93c, 0x0000d956, 0x0000d95d, 0x0000d975,
+	0x0000d98b, 0x0000d9aa, 0x0000d9bf,
+} // Size: 6548 bytes
 
-const en_USData string = "" + // Size: 57150 bytes
-	"\x02not found tenantId in body\x02failed to change project\x02get passwo" +
-	"rd in body\x02username or password is empty\x02missing credential\x02inv" +
-	"alid credential\x02fetch json for request: %v\x02request body is empty" +
-	"\x02missing id\x02fetchAuthInfo fail: %s\x02new password mismatch\x02not" +
-	" support reset user password\x02wrong password\x02invalid passcode\x02ge" +
-	"nerate totp qrcode failed\x02uid is empty\x02input parameter error\x02TO" +
-	"TP recovery questions do not exist\x02questions not found\x02%s answer i" +
-	"s incorrect\x02passcode is a 6-digits string\x02invalid passcode: %v\x02" +
-	"no revocery questions.\x02unmarshal questions: %v\x02get admin credentia" +
-	"l is nil\x02no usable regions, please contact admin\x02illegal region %s" +
-	", please contact admin\x02session expires, missing %s\x02parse query str" +
-	"ing error: %s\x02fetch form data error: %s\x02parse form data error: %s" +
-	"\x02invalid request\x02empty external user id\x02empty idp_id or idp_ent" +
-	"ity_id\x02invalid form\x02missing image name\x02missing image size\x02in" +
-	"valid image size\x02Parse query: %v\x02No token in header: %v\x02Missing" +
-	" parameter %s\x02Unsupported action %s\x02Wrong content type %s, want %s" +
-	"\x02can't open file\x02can't parse file\x02template file is invalid. ple" +
-	"ase check.\x02empty file content\x02row %d name is empty\x02row %d domai" +
-	"n is empty\x02row %d duplicate name %s\x02template_id\x02internal server" +
-	" error\x02template not found %s\x02request body is too large.\x02invalid" +
-	" multipart form\x02invalid content_length %s\x02No token in header\x02To" +
-	"ken in header invalid\x02Token expired\x02resource %s module not exists" +
-	"\x02No id list found\x02missing export keys\x02inconsistent export keys " +
-	"and texts\x02recv invalid data\x04\x00\x01 \x19\x02invalid CannedAction " +
-	"%s \x04\x00\x01 \x13\x02invalid Effect %s \x04\x00\x01 \x11\x02invalid i" +
-	"pv4 %s \x02invalid share_mode %s\x02mx_priority range limited to [1,50]" +
-	"\x02invalid domain %s for MX record\x02invalid ipv4 %s for A record\x02i" +
-	"nvalid ipv6 %s for AAAA record\x02invalid domain %s for CNAME record\x02" +
-	"duplicate route cidr %s\x02Internal server error: %s\x02Internal server " +
-	"error\x02Invalid handler %s\x02Handler not found\x02No request key: %s" +
-	"\x02Invalid request header: %v\x02request process timeout\x02Not allow e" +
-	"mpty records\x02Records limit exceeded.\x02%s method not found\x02%s met" +
-	"hod params length not match, expected %d, input %d\x02Invald ValidateCre" +
-	"ateData return value\x02Invald ListItemFilter return value count %d\x02I" +
-	"nvald OrderByExtraFields return value count %d\x02Invalid GetExtraDetail" +
-	"s return value count %d\x02Invalid FetchCustomizeColumns return value co" +
-	"unt %d\x02Invalid FetchCustomizeColumns return value type, not a slice!" +
-	"\x02Invalid FetchCustomizeColumns return value, inconsistent obj count: " +
-	"input %d != output %d\x02Invald ValidateUpdateData return value\x02Inval" +
-	"d CustomizeDelete return value\x02invalid joint resources %s\x02FetchCus" +
-	"tomizeColumns return incorrect number of results\x02No context manager" +
-	"\x02No such context %s(%s)\x02fail to get http response writer from cont" +
-	"ext\x02FetchCustomizeColumns returns incorrect results\x02reflect call %" +
-	"s fail %s\x02Invald %s return value\x02%s not allow to get property %s" +
-	"\x02No return value, so why query?\x02Not allow to get details\x02%s %s " +
-	"%s not found\x02%s not allow to get spec %s\x02Not allow to create item" +
-	"\x02body is not a json?\x02Missing name or generate_name\x02not allow to" +
-	" perform %s\x02%s allow %s %s not found\x02%s not allow to %s %s\x02Inva" +
-	"lid data JSONObject\x02Not allow to update item\x02%s(%s) not allow to d" +
-	"elete\x02Not allow to attach\x02Object %s %s has attached %s %s\x02proje" +
-	"ct in non-default domain is prohibited\x02missing new domain\x02check na" +
-	"me duplication error: %s\x02not enough privilege (require:%s,allow:%s,qu" +
-	"ery:%s)\x02Not support resource %s tag filter\x02Action %s not found\x02" +
-	"can't get string field\x02model has no field %s\x02Query database error " +
-	"%s\x02name starts with letter, and contains letter, number and - only" +
-	"\x02not allow to delete log\x02DIRECT setting cannot be changed\x02DIREC" +
-	"T setting cannot be deleted\x02get proxysetting refcount fail %s\x02prox" +
-	"ysetting %s is still referred to by %d %s\x02fail to decode body\x02Quot" +
-	"a %s not found\x02Default quota %s not allow to delete\x02not enough pri" +
-	"villeges\x02not allow to list domain quotas\x02out of privileges\x02not " +
-	"allow to list project quotas\x02query quotas %s\x02not enough privilege " +
-	"(require:%s,allow:%s:resource:%s)\x02not enough privilege (require:%s,al" +
-	"low:%s)\x02invalid scope %s\x02not allow create %s in scope %s\x02Not al" +
-	"low set scope to system\x02Not allow set scope to domain %s\x02Not allow" +
-	" set scope to project %s\x02sharing is limited to domains %s\x02Insert s" +
-	"hared resource failed %s\x02name starts with letter, and contains letter" +
-	", number and ._@- only\x02name longer than %d\x02not allow to set system" +
-	" key, please remove the underscore at the beginning\x02input key too lon" +
-	"g > %d\x02input value too long > %d\x02user %s not found\x02forbidden" +
-	"\x02non-admin user not allowed to create system object\x02Virtual resour" +
-	"ce freezed, can't do %s\x02virtual resource already freezed\x02virtual r" +
-	"esource not freezed\x02missing new project/tenant\x02InformerBackend not" +
-	" init\x02invalid format\x02operation not allowed\x02invalid input format" +
-	"\x02Missing key error: missing %q\x02General error: general error for %q" +
-	": %s\x02Invalid type error: expecting %s type for %q: %s\x02Invalid choi" +
-	"ce error: invalid %q, want %s, got %s\x02Invalid length error: %q too sh" +
-	"ort, got %d, min %d\x02Invalid length error: %q too long, got %d, max %d" +
-	"\x02Not in range error: invalid %q: %d, want [%d,%d]\x02Invalid value er" +
-	"ror: invalid %q: %s\x02Invalid value error: invalid %q: %v\x04\x00\x01 " +
-	"\x22\x02Invalid value error: invalid %q: \x02Model manager error: failed" +
-	" getting model manager for %q\x02Model not found error: cannot find %q w" +
-	"ith id/name %q\x02Model not found error: cannot find %q with id/name %q:" +
-	" %s\x02invalid cert pubkey algorithm: %s, want %s\x02no such provider" +
-	"\x02Not Implemented GetProvider\x02NotFoundError\x02DuplicateIdError\x02" +
-	"InvalidStatusError\x02TimeoutError\x02NotImplementedError\x02NotSupporte" +
-	"dError\x02InvalidProvider\x02NoBalancePermission\x02ErrAddressCountExcee" +
-	"d\x02cannot support more than 1 nic\x02The %s disk size must be in the r" +
-	"ange of %dGB ~ %dGB\x02%s requires that the eip bandwidth must be less t" +
-	"han 100Mbps\x02network %s associated route table has no internet gateway" +
-	" attached.\x02failed to find subformat vhd for image %s, please append '" +
-	"vhd' for glance options(target_image_formats)\x02Azure Mv2-series instan" +
-	"ce sku only support UEFI image\x02Azure UEFI image %s not support this i" +
-	"nstance sku\x02cannot support change azure instance name\x02Cannot chang" +
-	"e config for baremtal\x02Cannot resize disk for baremtal\x02Invalid raid" +
-	" config: %v\x02Host %s is not a baremetal\x02Baremetal %s is not ready" +
-	"\x02Baremetal %s is occupied\x02Cannot save image for baremtal\x02Not Im" +
-	"plement ValidateCreateEip\x02Not allow for hypervisor %s\x02Not supporte" +
-	"d, please use kubectl\x02Container not support %s\x02%s not support crea" +
-	"te eip\x02can't resize disk for guest with instance snapshots\x02esxi gu" +
-	"est migrate require prefer_host\x02can't rebuild root for a guest with i" +
-	"nstance snapshots\x02Unknown google storage type %s\x02System disk does " +
-	"not support %s disk\x02%s disk cannot exceed 8\x02%s for %s features are" +
-	" not compatible for creating instance\x02Host %s not found\x02Guest have" +
-	" backup, can't migrate\x02Cannot normal migrate guest in status %s, try " +
-	"rescue mode or server-live-migrate?\x02Rescue mode requires all disk sto" +
-	"re in shared storages\x02Cannot migrate with isolated devices\x02Cannot " +
-	"live migrate with cdrom\x02Cannot live migrate with isolated devices\x02" +
-	"Cannot do live migrate, too low qemu version\x02Guest %s can't hot remov" +
-	"e nic\x02%s not support cdrom params\x02%s not support create eip, it on" +
-	"ly support bind eip\x02%s not support create virtual machine with eip" +
-	"\x02data disk not support storage type %s\x02The %s disk size must be in" +
-	" the range of 10GB ~ 16000GB\x02The %s disk size must be in the range of" +
-	" 50GB ~ 16000GB\x02The %s disk size must be in the range of 100GB ~ 1600" +
-	"0GB\x02The %s disk size must be in the range of 20GB ~ 32000GB\x02storag" +
-	"e %s can not be data disk\x02Data disk size must be an integer multiple " +
-	"of 10G\x02failed to found system disk error: %v\x02failed to found stora" +
-	"ge for disk %s(%s)\x02The system disk is locally stored and does not sup" +
-	"port changing configuration\x02Not support create local storage disks" +
-	"\x02Please input new disk backend type\x02The disk is locally stored and" +
-	" does not support detach\x02Host %s is not online\x02GetGuestCount fail " +
-	"%s\x02host has been occupied\x02Aliyun reset disk required guest status " +
-	"is running or ready\x02Aws not support reset disk, you can create new di" +
-	"sk with snapshot\x02cannot support change azure disk name\x02Azure not s" +
-	"upport reset disk, you can create new disk with snapshot\x02not implemen" +
-	"t\x02Not Implement ValidateResetDisk\x02Not Implement ValidateAttachStor" +
-	"age\x02Not Implement RequestAttachStorage\x02Not Implement RequestDetach" +
-	"Storage\x02Disk must be dettached\x02%s reset disk required guest status" +
-	" is running or ready\x02Server %s must in status ready\x02Disk must be d" +
-	"etached\x02Unsupport attach %s storage for %s host\x02Attach rbd storage" +
-	" require host status is online\x02Query host storage error %s\x02Host %s" +
-	" already have mount point %s with other storage\x02Attach nfs storage re" +
-	"quire host status is online\x02%s is not mount point %s\x02Disk attach m" +
-	"uti guests\x02Disk attached guest status must be ready\x02Disk dosen't a" +
-	"ttach guest\x02OpenStack not support reset disk, you can create new disk" +
-	" with snapshot\x02Qcloud reset disk required guest status is running or " +
-	"read\x02Ucloud reset disk operation required disk not be attached\x02Ucl" +
-	"oud only support data disk reset operation\x02ZStack reset disk operatio" +
-	"n requried guest status is ready\x02Parse remote ip error %s\x02Network " +
-	"not found\x02Baremetal agent not found\x02Baremetal package not prepared" +
-	"\x02check agent uniqness fail %s\x02Conflict manager_uri %s\x02Duplicate" +
-	" manager_uri %s\x02missing duration/expire_time\x02expire time is before" +
-	" current expire at\x02invalid duration %s: %s\x02missing name\x02invalid" +
-	" bucket name %s: %s\x02invalid bucket name(%s): %s\x02no external bucket" +
-	"\x02fail to get objects: %s\x02missing key\x02fail to generate temp url:" +
-	" %s\x02empty directory name\x02invalid key %s: %s\x02GetIObject fail %s" +
-	"\x02object count limit exceeds\x02bucket.GetQuotaKeys %s\x02fail to mkdi" +
-	"r: %s\x02empty keys\x02object key should not ends with /\x02invalid obje" +
-	"ct key: %s\x02missing Content-Length\x02Illegal Content-Length %s\x02Con" +
-	"tent-Length negative %d\x02GetIObject error %s\x02object size limit exce" +
-	"eds\x02bucket.GetQuotaKeys fail %s\x02put object error %s\x02setAcl erro" +
-	"r %s\x02syncWithCloudBucket error %s\x02Bucket has %d task active, can't" +
-	" sync status\x02not an empty bucket\x02object %s not found\x02iBucket.Ge" +
-	"tIObjects error %s\x02iBucket.SetWebsite error %s\x02iBucket.DeleteWebSi" +
-	"teConf error %s\x02iBucket.GetWebsiteConf error %s\x02cloudprovider.SetB" +
-	"ucketCORS error %s\x02iBucket.DeleteCORS error %s\x02iBucket.GetCORSRule" +
-	"s error %s\x02iBucket.GetCdnDomains error %s\x02iBucket.SetRefer error %" +
-	"s\x02iBucket.GetRefer error %s\x02iBucket.GetPolicy error %s\x02iBucket." +
-	"SetPolicy error %s\x02iBucket.DeletePolicy error %s\x02unmarshal limit e" +
-	"rror %s\x02SetLimit error %s\x02Update error %s\x02missing manager?\x02i" +
-	"Bucket.GetIObject error %s\x02ValidateDeleteCondition error %s\x02The im" +
-	"age has been cached on storages\x02the image reference session has not b" +
-	"een expired!\x02failed to found storagecache %s\x02not allow to query sy" +
-	"stem capability\x02account %s not enable saml auth\x02account is enabled" +
-	"\x02account is not idle\x02provider %s: %v\x02Cannot enable deleting acc" +
-	"ount\x02%s not support saml auth\x02invalid proxy setting %s\x02invalid " +
-	"wire_level_for_vmware %q, accept %s\x02not support for cloudaccount with" +
-	" provider '%s'\x02Unsupported provider %s\x02Project %s(%s) not belong t" +
-	"o domain %s(%s)\x02Not support brand %s, only support %s\x02check uniqne" +
-	"ss fail %s\x02The account has been registered\x02no such provider %s\x02" +
-	"invalid cloud account info error: %s\x02check account_id duplication err" +
-	"or %s\x02the account has been registerd %s\x02Account disabled\x02Accoun" +
-	"t auto sync enabled\x02invalid input %s\x02failed to found provider fact" +
-	"ory error: %v\x02failed to unmarshal input params: %v\x02check uniquenes" +
-	"s fail %s\x02account %s conflict\x02inconsistent account_id, previous '%" +
-	"s' and now '%s'\x02project %s not found\x02cannot enable auto sync in st" +
-	"atus %s\x02provider is shared outside of domain\x02%s not support\x02%s " +
-	"not support create subscription\x02not allow to create\x02provider is en" +
-	"abled\x02provider is not idle\x02Directly creating cloudprovider is not " +
-	"supported, create cloudaccount instead\x02Region %s not found\x02Zone %s" +
-	" not found\x02Cloudprovider disabled\x02Cloudaccount disabled\x02not all" +
-	"ow to change project across domain\x02cannot change to a different domai" +
-	"n from a private cloud account\x02fail to get provider driver %s\x02stor" +
-	"age classes not supported\x02GetZoneCount fail %s\x02GetVpcCount fail %s" +
-	"\x02not empty cloud region\x02not allow to delete default cloud region" +
-	"\x02VPC %s not found\x02Cannot update external resource\x02not allow upd" +
-	"ate rds account name\x02failed to found dbinstance %s\x02DBInstance %s(%" +
-	"s) status is %s require status is %s\x02failed to found region for dbins" +
-	"tance %s(%s)\x02failed to found dbinstance %s(%s) database %s: %v\x02Fai" +
-	"led to found database %s for dbinstance %s(%s): %v\x02The account %s(%s)" +
-	" has permission %s to the database %s(%s)\x02Account status is not %s cu" +
-	"rrent status is %s\x02Instance status is not %s current status is %s\x02" +
-	"Database status is not %s current is %s\x02Account %s(%s) does not have " +
-	"database %s(%s) permissions\x02DBinstance has not valid cloudprovider" +
-	"\x02DBInstance backup has %d task active, can't sync status\x02not allow" +
-	" update rds database name\x02failed to found dbinstance %s(%s) account %" +
-	"s: %v\x02Not Implemented\x02invalid address: %s\x02Ip %s not in network " +
-	"%s(%s) range\x02cloudprovider %s(%s) is not available\x02invalid duratio" +
-	"n %s\x02unsupported duration %s\x02cloudregion %s not support create rds" +
-	"\x02cloudregion %s not support create %s rds\x02not match any dbinstance" +
-	" sku\x02%s rds not support secgroup\x02%s rds Support up to %d security " +
-	"groups\x02Cannot do recovery dbinstance in status %s required status %s" +
-	"\x02backup %s(%s) not contain database %s\x02conflict database %s for in" +
-	"stance %s(%s)\x02back and instance not in same cloudaccount\x02backup an" +
-	"d instance not in same cloudregion\x02can not recover data from diff rds" +
-	" engine\x02Cannot do reboot dbinstance in status %s\x02DBInstance has %d" +
-	" task active, can't sync status\x02Cannot do renew dbinstance in status " +
-	"%s required status %s\x02missong duration\x02The dbinstance status need " +
-	"be %s, current is %s\x02Only %s dbinstance support this operation\x02DBI" +
-	"nstance has opened the outer network connection\x02The extranet connecti" +
-	"on is not open\x02%s not support this operation\x02Cannot change config " +
-	"in status %s\x02Unmarshal input error: %v\x02failed to match any skus fo" +
-	"r change config\x02DBInstance is locked, cannot delete\x02dbinstance bil" +
-	"ling type is %s\x02dbinstance billing type %s not support cancel expire" +
-	"\x02this operation requires rds state to be %s\x02%s supported secgroup " +
-	"count is %d\x02guest %q not found\x02snapshotpolicy %s not found: %s\x02" +
-	"not support update disk_type %s\x02failed to find storage for disk %s" +
-	"\x02failed to find host for storage %s with disk %s\x02Storage %s not fo" +
-	"und\x02cloudprovider %s not available\x02storage %s(%s) need online and " +
-	"attach host for create disk\x02Cannot create disk with disabled storage[" +
-	"%s]\x02Cannot create disk with offline storage[%s]\x02Storage type[%s] n" +
-	"ot match backend %s\x02Storage[%s] must attach to a host\x02Not enough f" +
-	"ree space\x02Fetch snapshot count failed %s\x02Disk %s don't need conver" +
-	"t snapshots\x02Can not get disk snapshot\x02Get convert snapshot failed:" +
-	" %s\x02Snapshot %s dose not have convert snapshot\x02Cannot reset disk i" +
-	"n status %s\x02Cannot reset disk with snapshot in status %s\x02Cannot re" +
-	"set disk %s(%s),Snapshot is belong to disk %s\x02Resize disk when disk i" +
-	"s READY\x02Disk cannot be thrink\x02disk has no valid storage\x02disk.Ge" +
-	"tQuotaKeys fail %s\x02fail to find storage for disk %s\x02No zone for th" +
-	"is disk\x02Duplicate image name %s\x02Save disk when disk is READY\x02Ge" +
-	"tRuningGuestCount fail %s\x02Save disk when not being USED\x02Image name" +
-	" is required\x02cloud provider %s is not available\x02cloud account %s i" +
-	"s not available\x02storage of disk %s no valid host\x02GetGuestDiskCount" +
-	" for disk %s fail %s\x02Virtual disk %s(%s) used by virtual servers\x02n" +
-	"ot allow to delete prepaid disk in valid status\x02Diskinfo index %d: bo" +
-	"th imageID and size are absent\x02Snapshot %s not found\x02Snapshot %s s" +
-	"torage %s not found, is public cloud?\x02Image status is not active\x02D" +
-	"isk has %d task active, can't sync status\x02GetSnapshotCount fail %s" +
-	"\x02not allow to purge. Virtual disk must not have snapshots\x02not allo" +
-	"w to delete. Virtual disk must not have snapshots\x02not allow to delete" +
-	" %s disk with snapshots\x02no such snapshotpolicy %s\x02%s %s not suppor" +
-	"ted dns type %s\x02%s %s not supported policy type %s\x02%s %s %s not su" +
-	"pport %s\x02invalid record name %s\x02duplicated with CNAME dnsrecord na" +
-	"me not support\x02duplicated dnsrecord with existed dnsrecord can not di" +
-	"stinguish by %s policy\x02duplicated dnsrecord with existed dnsrecord no" +
-	"t support\x02%s not support policy type %s\x02%s %s not support policy v" +
-	"alue %s\x02Not support\x02invalid domain name %s\x02Not support %s for v" +
-	"pc %s, supported %s\x02Not support %s for account %s, supported %s\x02to" +
-	"p level public domain name %s not support\x02unknown zone type %s\x02can" +
-	" not sync record sets in %s\x02dns zone can not cache in status %s\x02On" +
-	"ly %s support cache for account\x02account %s has been cached\x02dns zon" +
-	"e can not uncache in status %s\x02vpc %s has already in this dns zone" +
-	"\x02vpc %s not in dns zone\x02SRV: insufficient param: %s\x02SRV: invali" +
-	"d port number: %s\x02SRV: invalid weight number: %s\x02SRV: weight numbe" +
-	"r %d not in range [0,65535]\x02SRV: invalid priority number: %s\x02SRV: " +
-	"priority number %d not in range [0,65535]\x02SRV cannot mix with other t" +
-	"ypes\x02CNAME cannot mix with other types\x02PTR cannot mix with other t" +
-	"ypes\x02%s: invalid domain name: %s\x02SRV: invalid srv record name: %s" +
-	"\x02PTR: invalid ptr record name: %s\x02%s: name cannot be ip address: %" +
-	"s\x02A: record value must be ipv4 address: %s\x02AAAA: record value must" +
-	" be ipv6 address: %s\x02%s: %s must be domain name: %s\x02%s: %s cannot " +
-	"be ip address: %s\x02%s: unknown record type\x02Empty record\x02invalid " +
-	"ttl: %s\x02invalid ttl: %d\x02Cannot mix different types of records, %s " +
-	"!= %s\x02invalid condition\x02schedtag %s not found\x02unmarshal Standal" +
-	"oneResourceCreateInput fail %s\x02Resource type %s not support\x02Virtua" +
-	"l resource type %s not support\x02%s %s not found\x02can't restore elast" +
-	"ic cache in status %s\x02unsupport delete %s backups\x02invalid billing_" +
-	"cycle %s\x02unmarshal VirtualResourceCreateInput fail %s\x02Cannot do re" +
-	"start elasticcache instance in status %s\x02Elastic cache is locked, can" +
-	"not delete\x02Elastic cache is not expired, cannot delete\x02provider mi" +
-	"smatch: %s instance can't use %s sku\x02region mismatch: instance region" +
-	" %s, sku region %s\x02zone mismatch: instance zone %s, sku zone %s\x02en" +
-	"gine version mismatch: instance version %s, sku version %s\x02can not ch" +
-	"ange specification in status %s\x02auth mode aready in status %s\x02no a" +
-	"dmin account found for elastic cache %s\x02maintain time has no change" +
-	"\x02public connection aready allocated\x02release public connection area" +
-	"dy released\x02invalid parameter format. json dict required\x02Elasticca" +
-	"che has %d task active, can't sync status\x02elasticcache billing type i" +
-	"s %s\x02elasticcache billing type %s not support cancel expire\x02Cannot" +
-	" add security groups in status %s\x02region\x02regiondriver\x02not suppo" +
-	"rted bind security group\x02beyond security group quantity limit, max it" +
-	"ems %d.\x02The secgroup name %s does not meet the requirements, please c" +
-	"hange the name\x02secgroups will be empty after update.\x02The elastic c" +
-	"ache status need be %s, current is %s\x02Only %s elastic cache support s" +
-	"et auto renew operation\x02elastic cache no related region found\x02Only" +
-	" %s elastic cache support renew operation\x02%s is not modifiable\x02res" +
-	"ource %s in vpc %s external access mode %s is not support accociate eip" +
-	"\x02server %s not found\x02Not support associate type %s, only support %" +
-	"s\x02charge type %s not supported\x02eip has been associated with instan" +
-	"ce\x02eip cannot associate in status %s\x02fixed eip cannot be associate" +
-	"d\x02Unsupported %s\x02cannot associate pending delete server\x02instanc" +
-	"e is already associated with eip\x02cannot associate server in status %s" +
-	"\x02cannot associate eip with same network\x02server region is not found" +
-	"???\x02eip region is not found???\x02eip and server are not in the same " +
-	"region\x02eip and server are not in the same zone\x02server host is not " +
-	"found???\x02server and eip are not managed by the same provider\x02eip c" +
-	"annot dissociate in status %s\x02fixed public eip cannot be dissociated" +
-	"\x02the associated natgateway has corresponding snat rules with eip %s, " +
-	"please delete them firstly\x02the associated natgateway has correspondin" +
-	"g dnat rules with eip %s, please delete them firstly\x02fixed eip cannot" +
-	" sync status\x02cannot change bandwidth in status %s\x02Invalid bandwidt" +
-	"h\x02Cannot purge elastic_ip on enabled cloud provider\x02account %s not" +
-	" share for domain %s\x02please retry after unbind all guests in group" +
-	"\x02can not bind guest from disabled guest\x02can not unbind guest from " +
-	"disabled guest\x02no such model %s\x02guest and instance group should be" +
-	"long to same project\x02Host missing\x02host status %s and enabled %v, c" +
-	"an't do server %s\x02Cannot send command in status %s\x02No host for ser" +
-	"ver\x02Cannot save image in status %s\x02No root image\x02Support only b" +
-	"y KVM Hypervisor\x02Cannot sync in status %s\x02Cannot live migrate in s" +
-	"tatus %s\x02Can't clone guest with backup guest\x02Guest hypervisor %s d" +
-	"oes not support clone\x02Cannot clone VM in status %s\x02Unmarshal input" +
-	" error %s\x02Cannot deploy in status %s\x02Disk %s and guest not belong " +
-	"to the same account\x02Disk %s and guest not belong to the same zone\x02" +
-	"isAttached check failed %s\x02Disk %s has been attached\x02Disk %s not b" +
-	"elong the guest's host\x02Disk in %s not able to attach\x02Guest %s not " +
-	"support attach disk in status %s\x02Disk %s not found\x02Cannot suspend " +
-	"VM in status %s\x02Cannot resume VM in status %s\x02host virtual memory " +
-	"not enough\x02Some disk not ready\x02Cannot do start server in status %s" +
-	"\x02CD-ROM not empty, please eject first\x02Insert ISO not allowed in st" +
-	"atus %s\x02No ISO to eject\x02Eject ISO not allowed in status %s\x02Cann" +
-	"ot add security groups for hypervisor %s\x02guest %s band to up to %d se" +
-	"curity groups\x02security group %s has already been assigned to guest %s" +
-	"\x02Cannot revoke security groups in status %s\x02security group %s not " +
-	"assigned to guest %s\x02Cannot assign security rules in status %s\x02Can" +
-	"not set security rules in status %s\x02Cannot set security group for thi" +
-	"s guest %s\x02Cannot purge server on enabled host\x02failed to find %s" +
-	"\x02invlid image\x02image size exceeds root disk size\x02Cannot switch O" +
-	"S between %s-%s\x02Can not rebuild root with with diff uefi image\x02No " +
-	"template for root disk, cannot rebuild root\x02%s not support rebuild ro" +
-	"ot with a different image\x02Cannot reset root in status %s\x02keypair %" +
-	"s not found\x02No Disk Info Provided\x02No valid host\x02No valid storag" +
-	"e on current host\x02Not eough storage space on current host\x02failed t" +
-	"o find disk %s\x02check isAttach2Disk fail %s\x02Cannot detach sys disk" +
-	"\x02Cannot keep detached disk\x02Server in %s not able to detach disk" +
-	"\x02Disk %s not attached\x02Only allowed to attach isolated device when " +
-	"guest is ready\x02Missing isolated device\x02Isolated device %s not foun" +
-	"d\x02Isolated device is not attached to this guest\x02guest attach gpu c" +
-	"ount must > 0\x02fetch gpu failed %s\x02guest %s host %s isolated device" +
-	" not enough\x02attach devices is not string array\x02detach devices is n" +
-	"ot string array\x02ip %s not found\x02mac %s not found\x02no either ip_a" +
-	"ddr or mac specified\x02Cannot change network ip_addr in status %s\x02ca" +
-	"nnot change mac when guest is running\x02check mac uniqueness fail %s" +
-	"\x02mac addr %s has been occupied\x02Cannot detach network in status %s" +
-	"\x02Cannot attach network in status %s\x02Cannot change bandwidth in sta" +
-	"tus %s\x02Bandwidth must be non-negative\x02Cannot change setting in sta" +
-	"tus %s\x02Not allow to change config\x02Guest have backup not allow to c" +
-	"hange config\x02Cannot change config in %s\x02Cannot change config with " +
-	"different instance family\x02Params vcpu_count parse error\x02Memory siz" +
-	"e must be number[+unit], like 256M, 1G or 256\x02Params vmem_size parse " +
-	"error\x02cannot change CPU/Memory spec in status %s\x02Unmarshal disks c" +
-	"onfigure error %s\x02Parse disk info error: %s\x02Cannot reduce disk siz" +
-	"e\x02Cannot reset VM in status %s\x02Guest has %d task active, can't syn" +
-	"c status\x02Cannot stop server in status %s\x02Cannot do restart server " +
-	"in status %s\x02Cannot send keys in status %s\x02cannot associate eip in" +
-	" status %s\x02already associate with eip\x02eip %s not found\x02eip has " +
-	"been associated\x02cannot associate eip and instance in different region" +
-	"\x02cannot associate eip and instance in different zone\x02cannot associ" +
-	"ate eip and instance in different provider\x02No eip to dissociate\x02Ou" +
-	"t of eip quota: %s\x02Cannot swith to backup when guest in status %s\x02" +
-	"Guest no backup host\x02Guest can't switch to backup, mirror job not rea" +
-	"dy\x02failed to found guest %s\x02input data not key value dict\x02Guest" +
-	" %s not found\x02Fetch guest error %s\x02Already have backup server\x02C" +
-	"annot create backup with shared storage\x02Backup only support hyperviso" +
-	"r kvm\x02Cannot create backup with isolated devices\x02GuestDisksHasSnap" +
-	"shot fail %s\x02Cannot create backup with snapshot\x02Guest without back" +
-	"up\x02Guest backup host not found\x02Backup host is offline\x02guest doe" +
-	"sn't need reconcile backup\x02guest billing type %s not support cancel e" +
-	"xpire\x02guest billing type is %s\x02guest %s unsupport postpaid expire" +
-	"\x02Invalid desc: %s\x02Server Id is empty\x02Server Name is empty\x02Se" +
-	"rver %s already exists\x02Empty import nics\x02ip %s or mac %s has been " +
-	"registered\x02Not found network by ip %s\x02Empty import disks\x02Unmars" +
-	"hal data error %s\x02Some host config missing xml_file_path\x02Some host" +
-	" config missing host ip\x02Invalid host ip %s\x02Invalid server mac addr" +
-	"ess %s\x02Invalid server ip address %s\x02NewTask error: %s\x02Hyperviso" +
-	"r %s can't generate libvirt xml\x02Generate xml failed: %s\x02not suppor" +
-	"t hypervisor %s\x02not support %s\x02guest has been converted\x02host %s" +
-	" is not kvm host\x02guest status must be ready\x02Check set pending quot" +
-	"a error %s\x02host not found???\x02empty ip list\x02Unreachable IP %s: %" +
-	"s\x02Unavailable IP %s: occupied\x02some disk missing!!!\x02disk %s not " +
-	"attached to server\x02Hypervisor %s can't do io throttle\x02Cannot do io" +
-	" throttle in status %s\x02bps must > 0\x02iops must > 0\x02guest %s hype" +
-	"rvisor %s can't migrate\x02guest %s has backup, can't migrate\x02guest %" +
-	"s has isolated device, can't migrate\x02can't rescue geust %s with local" +
-	" storage\x02guest %s status %s can't migrate\x02guest %s status %s has i" +
-	"solated device, can't do migrate\x02cannot migrate with cdrom\x02guest %" +
-	"s status %s can't migrate with local storage\x02missing guest id\x02Chec" +
-	"k input guests is exist\x02guest hypervisor %s can't create instance sna" +
-	"pshot\x02Can't do instance snapshot with backup guest\x02guest can't do " +
-	"snapshot in status %s\x02guests disk %d snapshot full, can't take anymor" +
-	"e\x02create instance snapshot failed: %s\x02start create snapshot task f" +
-	"ailed: %s\x02Instance sanpshot not ready\x02start snapshot reset failed " +
-	"%s\x02count must > 0\x02Generate snapshot name failed %s\x02not a bareme" +
-	"tal server\x02no valid host\x02host is not a baremetal\x02no such group " +
-	"%s\x02group and guest should belong to same project\x02can not bind or u" +
-	"nbind disabled instance group\x02The guest %s does not have any public I" +
-	"P\x02The guest status need be %s or %s, current is %s\x02The %s guest no" +
-	"t support public ip to eip operation\x02Only %s guest support this opera" +
-	"tion\x02guest has no vpc ip\x02no support for instance snapshot in guest" +
-	" template for now\x02there is no such secgroup %s descripted by guest te" +
-	"mplate\x02the %s in guest template is not a public resource\x02the %s %q" +
-	" in guest template is not a public resource\x02the %s in guest template " +
-	"is not a public resource in %s scope\x02the %s %q in guest template is n" +
-	"ot a public resource in %s scope\x02guest template %s used by service ca" +
-	"talog %s\x02guest template %s used by scalig group %s\x02check disk inde" +
-	"x uniqueness fail %s\x02DISK Index %d has been occupied\x02cannot alloca" +
-	"te ifname\x02checkout nic index uniqueness fail %s\x02NIC Index %d has b" +
-	"een occupied\x02host %s not found\x02secgroup %s not found\x02disk %s no" +
-	"t found\x02checkout guestdisk count fail %s\x02unknown server type %s" +
-	"\x02group %s not found\x02Virtual server is locked, cannot delete\x02not" +
-	" allow to delete prepaid server in valid status\x02Cannot delete server " +
-	"on disabled host\x02Cannot delete server on offline host\x02Cannot delet" +
-	"e server disk %s must not have snapshots.\x02Memory size must be 8MB ~ %" +
-	"d GB\x02CPU core count must be 1 ~ %d\x02Cannot modify Memory and CPU in" +
-	" status %s\x02Cannot modify memory for baremetal\x02name is too short" +
-	"\x02can't find instance snapshot %s\x02fetch instance snapshot error %s" +
-	"\x02Instance snapshot not ready\x02metdata must less then 20\x02login_ac" +
-	"count is longer than 32 chars\x02No disk information provided\x02Invalid" +
-	" root image: %s\x02System disk does not support iso image, please consid" +
-	"er using cdrom parameter\x02parse cdrom device info error %s\x02Miss ope" +
-	"rating system???\x02parse disk description error %s\x02Snapshot error: d" +
-	"isk index %d > 0 but disk type is %s\x02cannot create prepaid server on " +
-	"prepaid resource type\x02parse network description error %s\x02Cannot cr" +
-	"eate backup with isolated device\x02parse isolated device description er" +
-	"ror %s\x02Keypair %s not found\x02Secgroup %s not found\x02%s shall bind" +
-	" up to %d security groups\x02Invalid userdata: %v\x02invalid parameters " +
-	"for policy definition %s\x02policy definition %s require cloudregion in " +
-	"%s\x02policy definition %s require cloudregion not in %s\x02invalid poli" +
-	"cy definition %s(%s) condition %s\x02policy definition %s require must c" +
-	"ontains tag %s\x02policy definition %s require except tag %s\x02invalid " +
-	"category %s for policy definition %s(%s)\x02public ip not supported for " +
-	"%s\x02invalid public_ip_charge_type %s\x02eip not supported for %s\x02ei" +
-	"p %s status invalid %s\x02eip %s has been associated\x02cannot assoicate" +
-	" with eip %s: different cloudprovider\x02cannot assoicate with eip %s: d" +
-	"ifferent region\x02fetch disk size failed\x02image %s do not belong to g" +
-	"uest image %s\x02miss some subimage of guest image\x02Baremetal %s not e" +
-	"nabled\x02cannot run hypervisor %s on specified host with type %s\x02no " +
-	"valid storage on host\x02invalid aggregate_strategy: %s\x02Wire %s not f" +
-	"ound\x02Hypervisor %s not supported\x02cannot recycle in status %s\x02ca" +
-	"nnot undo recycle in status %s\x02host should be disabled\x02host is not" +
-	" a prepaid recycle host\x02cannot delete a recycle host without active i" +
-	"nstance\x02a recycle host shoud not allocate more than 1 guest\x02cannot" +
-	" undo a recycle host with pending_deleted guest\x02Not a prepaid recycle" +
-	" host\x02invalid any_mac address\x02Schedtag %s not found\x02not support" +
-	"ed hypervisor %s\x02Host is a converted baremetal, should be unconverted" +
-	" before delete\x02Host is not disabled\x02getGuestCount fail %s\x02Not a" +
-	"n empty host\x02GetDiskCount fail %s\x02Local host storage is not empty?" +
-	"??\x02Inconsistent: local storage is not empty???\x02No ipmi information" +
-	" was found for host %s\x02IPMI has no password information\x02check %s d" +
-	"uplication fail %s\x02duplicate %s %s\x02invalid macAddr %s\x02check acc" +
-	"ess_mac duplication fail %s\x02duplicate access_mac %s\x02%s is out of n" +
-	"etwork IP ranges\x02IPMI network has no zone???\x02IPMI address located " +
-	"in different zone than specified\x02Access ip %s has been used\x02Access" +
-	" network has no zone???\x02Access address located in different zone than" +
-	" specified\x02missing access_mac and uuid in no_probe mode\x02IPMI netwo" +
-	"rk has not zone???\x02New IPMI address located in another zone!\x02Canno" +
-	"t start a non-baremetal host\x02Cannot start baremetal with active guest" +
-	"\x02Cannot stop a non-baremetal host\x02Cannot stop baremetal with non-a" +
-	"ctive guest\x02Cannot stop baremetal with active guest\x02Cannot do main" +
-	"tenance in status %s\x02Cannot do maintenance while guest status %s\x02C" +
-	"annot do unmaintenance in status %s\x02Wrong guest status %s\x02not a ba" +
-	"remetal\x02need valid access_mac and uuid to do prepare\x02Cannot prepar" +
-	"e baremetal in status %s\x02Cannot prepare baremetal in server status %s" +
-	"\x02Cannot do Ipmi-probe in status %s\x02Cannot do initialization in sta" +
-	"tus %s\x02IPMI infomation not configured\x02Guest Insert error: %s\x02In" +
-	"vaild mac address\x02find Wire %s error: %s\x02invalid ipaddr %s\x02no n" +
-	"etworks on wire %s\x02IP %s not attach to wire %s\x02IP %s not attach to" +
-	" any wire\x02fail to fetch netif by mac %s: %s\x02fail to fetch hostwire" +
-	" by mac %s: %s\x02Interface %s not exist\x02Only ADMIN and IPMI nic can " +
-	"be enable\x02Interface %s not exists\x02Not a baremetal\x02Not being con" +
-	"vert to hypervisor\x02Not found baremetal server record\x02Not found gue" +
-	"st nic by mac %s\x02Guest nic ip addr %s not equal %s\x02Invalid mac add" +
-	"ress\x02Fetch netif error %s\x02Cannot sync status a non-baremetal host" +
-	"\x02Cannot reset baremetal in status %s\x02Cannot reset baremetal with a" +
-	"ctive guest\x02Cannot perform cache image in status %s\x02image %s not f" +
-	"ound\x02Cannot cache image with no checksum\x02host_type must be specifi" +
-	"ed\x02Must be a baremetal host\x02Baremetal host is aleady occupied\x02C" +
-	"onnot convert hypervisor in status %s\x02require system previleges to co" +
-	"nvert host in other domain\x02Unsupport driver type %s\x02isAlterNameUni" +
-	"que fail %s\x02Convert error: %s\x02Host should be disabled\x02Cannot un" +
-	"convert in status %s\x02Not an converted hypervisor\x02host status %s ca" +
-	"n't exit maintenance\x02host type %s can't do host maintenance\x02unsupp" +
-	"ort on host status %s\x02Host %s can't migrate guests %s in status %s" +
-	"\x02Cannot do insert-iso in status %s\x02Cannot do eject-iso in status %" +
-	"s\x02Cannot sync config a non-baremetal host\x02reserved cpu must >= 0" +
-	"\x02reserved memory must >= 0\x02reserved storage must >= 0\x02host %s c" +
-	"an't reserve %d cpu for each isolated device, not enough\x02host %s can'" +
-	"t reserve %dM memory for each isolated device, not enough\x02host %s can" +
-	"'t reserve %dM storage for each isolated device, not enough\x02Only syst" +
-	"em admin can assign host\x02StorageInUse\x02failed to find storage %s to" +
-	" attach host\x02failed to find host %s to attach storage\x02unmarshal Jo" +
-	"inResourceBaseCreateInput fail %s\x02GetGuestDiskCount fail %s\x02GetGue" +
-	"stnicsCount fail %s\x02guest on the host are using networks on this wire" +
-	"\x02can't delete instance snapshot with wrong status\x02vpc joint interV" +
-	"pcNetwork on different cloudprovider is not supported\x02vpc joint inter" +
-	"VpcNetwork on different cloudEnv is not supported\x02vpc %s already conn" +
-	"ected to a interVpcNetwork\x02vpc %s is not connected to this interVpcNe" +
-	"twork\x02Isolated device used by server\x02IsolatedDevice %s not found" +
-	"\x02Isolated device already attached to another guest: %s\x02Isolated de" +
-	"vice used by server: %s\x02Unsupported scheme %s\x02invalid public error" +
-	": %v\x02GetLinkedGuestsCount failed %s\x02Cannot delete keypair used by " +
-	"servers\x02find listener of listener rule %s(%s)\x02invalid addr %s\x02c" +
-	"omment too long (%d>=%d)\x02comment contains non-printable char: %v\x02a" +
-	"cl cidr duplicate %s\x02unmarshal SharableVirtualResourceCreateInput fai" +
-	"l %s\x02get acl count fail %s\x02acl %s is still referred to by %d %s" +
-	"\x02invalid vrrp interface %q\x02invalid vrrp authentication pass size: " +
-	"%d, want [1,8]\x02invalid vrrp priority %d: want [1,255]\x02invalid vrrp" +
-	" virtual_router_id %d: want [1,255]\x02invalid vrrp advert_int %d: want " +
-	"[1,255]\x02telegraf params: invalid influxdb url: %s\x02%s: bad base64 e" +
-	"ncoded string: %s\x02%s: bad template: %s\x02fetch lbagents of other clu" +
-	"sters: %v\x02conflict with lbagent %s(%s): %v\x02lbcluster %s(%s) alread" +
-	"y has virtual_router_id %d\x02%s: time error: %s\x02%s: new time is in t" +
-	"he future: %s > %s\x02peer lbagent %s(%s) already has vrrp priority %d" +
-	"\x02use yum requires valid repo_base_url\x02empty host name\x02find host" +
-	" %s: %v\x02lbagent cannot be deployed on managed host\x02find guest %s: " +
-	"%v\x02lbagent cannot be deployed on public guests\x02server is in %q sta" +
-	"te, want %q\x02unmarshal input: %v\x02host missing %s field\x02empty hos" +
-	"t %s field\x02authenticate error: %v\x02user must have system admin priv" +
-	"ileges\x02get %s service %s url: %v\x02No previous deployment info avail" +
-	"able\x02query backend group releated resource failed.\x02weight %d not s" +
-	"upport, only support range 0 ~ 256\x02port %d not support, only support " +
-	"range 1 ~ 65535\x02failed to find guest %s\x02only sysadmin can specify " +
-	"host as backend\x02failed to find host %s\x02unexpected backend type %s" +
-	"\x02region of backend %d does not match that of lb's\x02failed to find r" +
-	"egion for loadbalancer %s\x02get isDefault fail %s\x02backend group %s i" +
-	"s default backend group\x02get refCount fail %s\x02backend group %s is s" +
-	"till referred by %d %s\x02%s requires the virtual machine state to be %s" +
-	" before it can be added backendgroup, but current state of the virtual m" +
-	"achine is %s\x02guest %s(%s) vpc %s(%s) not same as loadbalancer vpc %s" +
-	"\x02failed getting guest %s\x02guest %s(%s) vpc %s(%s) not same as vpc %" +
-	"s(%s)\x02guest %s(%s) is already in the backendgroup %s(%s)\x02failed to" +
-	" found region for loadbalancer backend %s\x02failed to found backendgrou" +
-	"p for backend %s(%s)\x02the acl cache in region %s aready exists.\x02get" +
-	" certificate refcount fail %s\x02certificate %s is still referred to by " +
-	"%d %s\x02invalid local certificate, private key is empty.\x02invalid loc" +
-	"al certificate, certificate is empty.\x02the certificate cache in region" +
-	" %s aready exists.\x02not allowed update content of certificate\x02allow" +
-	" only internal zone, got %s(%s)\x02wire zone must match zone parameter, " +
-	"got %s, want %s(%s)\x02zone of wire must be %s, got %s\x02get lbcluster " +
-	"refcount fail %v\x02lbcluster %s(%s) is still referred to by %d %s\x04" +
-	"\x00\x01 A\x02lbclusters %s(%s) and %s(%s) has conflict virtual_router_i" +
-	"d: %d \x02invalid conditions format,required json\x02invalid conditions " +
-	"fromat,required json array\x02condition values limit (5 per rule). %d gi" +
-	"ven.\x02rule %s/%s already occupied by rule %s(%s)\x02failed to find reg" +
-	"ion for loadbalancer listener %s\x02failed to find region for loadbalanc" +
-	"er listener rule %s\x02%s listener port %d is already taken by listener " +
-	"%s(%s)\x02cannot find region info\x02backend group %s(%s) belongs to loa" +
-	"dbalancer %s, not %s\x04\x00\x01 0\x02cluster zone %s does not match net" +
-	"work zone %s \x02cluster wire affiliation does not match network's: %s !" +
-	"= %s\x02loadbalancer is locked, cannot delete\x02Unmarshal input failed " +
-	"%s\x02Port value error\x02invalid internal ip address: %s\x02eip has bee" +
-	"n binding to another instance\x02eip has been binding to snat rules\x02N" +
-	"o such eip\x02Nat gateway has %d task active, can't sync status\x02Only " +
-	"one of that sourceCIDR and netword_id is needed\x02cidr %s is not in ran" +
-	"ge vpc %s\x02eip has been binding to dnat rules\x02no such network\x02fe" +
-	"tch guest %s: %v\x02fetch guest nic: %v\x02cannot fetch network of guest" +
-	"network %d\x02batch create is not supported for external resources\x02un" +
-	"known parent object id spec\x02got unknown type %q, expect %s\x02got unk" +
-	"nown parent type %q, expect %s\x02allocate ip addr: %v\x02exceed address" +
-	" count limit: %v\x02GetAllocatedNicCount fail %s\x02not an empty network" +
-	" %s\x02address %s is not in the range of network %s(%s)\x02isAddressUsed" +
-	" fail %s\x02address %s is already occupied\x02getFreeAddressCount fail %" +
-	"s\x02network %s(%s) has no free addresses\x02candidate %s out of range" +
-	"\x02Out of IP address\x02no allow to access network %s\x02Network %s not" +
-	" found: %v\x02Address %s not in range\x02Only system admin allowed to us" +
-	"e reserved ip\x02Address %s not reserved\x02Address %s has been used\x02" +
-	"Bandwidth limit cannot exceed %dMbps\x02Duration %s invalid\x02not a val" +
-	"id ip address %s: %s\x02Address %s not in network\x02get reserved ip err" +
-	"or\x02found %d wires for zone %s and vpc %s\x02wire not found for zone %" +
-	"s and vpc %s\x02Invalid server_type: %s\x02valid vlan id\x02cannot deriv" +
-	"e valid ifname hint: %v\x02ip_prefix error: %s\x02subnet masklen should " +
-	"be smaller than 30\x02Invalid masklen %d\x02Invalid start ip: %s %s\x02i" +
-	"nvalid end ip: %s %s\x02start and end ip not in the same subnet\x02%s: I" +
-	"nvalid IP address %s\x02bad gateway ip: %v\x02gateway ip must be in the " +
-	"same subnet as start, end ip\x02zone and vpc info required when wire is " +
-	"absent\x02VPC not ready\x02eip network can only exist in default vpc, go" +
-	"t %s(%s)\x02start and end ip when masked are not in the same cidr subnet" +
-	"\x02Network not in range of VPC cidrblock %s\x02fail to GetNetworks of v" +
-	"pc: %v\x02Conflict address space with existing networks in vpc %q\x02que" +
-	"ry all networks fail\x02Conflict address space with existing networks" +
-	"\x02Address been assigned out of new range\x02start, end ip must be in t" +
-	"he same subnet\x02network server_type %s not support auto alloc\x02Parse" +
-	" Ip Failed\x02Cannot purge network on enabled cloud provider\x02Network " +
-	"%s not found\x02Invalid Target Network %s: inconsist %s\x02Incontinuity " +
-	"Network for %s and %s\x02only on premise support this operation\x02Inval" +
-	"id IP %s\x02Split IP %s is the start ip\x02Split IP %s out of range\x02D" +
-	"uplicate name %s\x02GenerateName fail %s\x02Generate ifname hint failed " +
-	"%s\x02ip\x02Only support server type %s\x02Only support on premise netwo" +
-	"rk\x02on-premise network cannot sync status\x02managed network cannot ch" +
-	"ange status\x02invalid status %s\x02BgpType attribute is only useful for" +
-	" eip network\x02not support create\x02not support create definition\x02i" +
-	"nvalid cidr %s\x02not enough privilege\x02not supported next hop type" +
-	"\x02Not support modify routetable for provider %s\x02Cannot purge route_" +
-	"table on enabled cloud provider\x02unmarshaling cidrs failed: %s\x02min_" +
-	"instance_number should not be smaller than 0\x02min_instance_number shou" +
-	"ld not be bigger than max_instance_number\x02desire_instance_number shou" +
-	"ld between min_instance_number and max_instance_number\x02no such cloud " +
-	"region %s\x02ScalingGroup should have some networks\x02some networks not" +
-	" exist\x02network '%s' not in vpc '%s'\x02no such guest template %s\x02t" +
-	"he guest template %s is not valid in cloudregion %s, reason: %s\x02unkow" +
-	"n expansion principle %s\x02unkown shrink principle %s\x02unkown health " +
-	"check mode %s\x02no such loadbalancer backend group '%s'\x02invalid load" +
-	"balancer backend port '%d'\x02invalid loadbalancer backend weight '%d'" +
-	"\x02Please disable this ScalingGroup firstly\x02There are some guests in" +
-	" this ScalingGroup, please delete them firstly\x02no such ScalingGroup '" +
-	"%s'\x02Guest '%s' don't belong to ScalingGroup '%s'\x02every scaling pol" +
-	"icy belong to a scaling group\x02no such scaling group %s\x02unkown trig" +
-	"ger type %s\x02unkown scaling policy action %s\x02unkown scaling policy " +
-	"unit %s\x02Can't trigger scaling policy without status 'ready'\x02mismat" +
-	"ched alarm id\x02unkown operator in alarm %s\x02unkown indicator in alar" +
-	"m %s\x02unkown wrapper in alarm %s\x02the min value of cycle in alarm is" +
-	" 300\x02invalid strategy %s\x02ResourceType %q not support\x02schedtag_i" +
-	"d not provide\x02Not support resource_type %s\x02Schedtag %s\x02Schedtag" +
-	" %s resource_type mismatch: %s != %s\x02unmarshal JointResourceCreateInp" +
-	"ut fail %s\x02Invalid schedtag %s\x02Invalid default stragegy %s\x02Cann" +
-	"ot set default strategy of %s\x02GetObjectCount fail %s\x02Tag is associ" +
-	"ated with %s\x02getDynamicSchedtagCount fail %s\x02tag has dynamic rules" +
-	"\x02getSchedPoliciesCount fail %s\x02tag is associate with sched policie" +
-	"s\x02Schedtag %s ResourceType is %s, not match %s\x02Resource %s %s not " +
-	"found\x02unkown scheduled type '%s'\x02unkown resource type '%s'\x02unko" +
-	"wn resource operation '%s'\x02unkown label type '%s'\x02This scheduled t" +
-	"ask is being executed now, please try later\x02need scheduled task\x02Fa" +
-	"iled to unmarshal input: %v\x02Failed fetching secgroup %s\x02rule %d is" +
-	" invalid: %s\x02vpc %s(%s) is not a managed resouce\x02Not support cache" +
-	" classic security group\x02invalid ip address: %s\x02secgroup %s rules n" +
-	"ot equals %s rules\x02GetGuestsCount fail %s\x02the security group is in" +
-	" use\x02not allow to delete default security group\x02no such guest temp" +
-	"late\x02fail to parse icon url '%s'\x02no such guest_template %s\x02reso" +
-	"urce %s is not support sync skus\x02input data contains invalid cloudreg" +
-	"ion id\x02no cloudregion found to sync skus\x02zone %s not in cloudregio" +
-	"n %s\x02cpu_core_count should be range of 1~256\x02memory_size_mb, shoud" +
-	" be range of 512~%d\x02instance_type_category shoud be one of %s\x02Not " +
-	"support create public cloud sku\x02checkout server sku name duplicate er" +
-	"ror: %v\x02Duplicate sku %s\x02instance specs list query error\x02can no" +
-	"t update instance_type for public cloud %s\x02Cannot change server sku n" +
-	"ame\x02check instance\x02now allow to delete inuse instance_type.please " +
-	"remove related servers first: %s\x02not allow to delete public cloud ins" +
-	"tance_type: %s\x02failed to find cloudregion for zone %s(%s)\x02duplicat" +
-	"e instanceType %s\x02query sku list failed.\x02delete sku %s failed.\x02" +
-	"Retention days must in 1~%d or -1\x02repeat_weekdays only contains %d da" +
-	"ys at most\x02time_points only contains %d points at most\x02Unmarshel i" +
-	"nput failed %s\x02Retention days must in 1~65535 or -1\x02Do not need to" +
-	" update\x02Couldn't delete snapshot policy binding to disks\x02no such d" +
-	"isk %s\x02snapshotpolicy disk has been exist\x02disk %s has too many sna" +
-	"pshot policy attached\x02guest %s not found\x02failed to found disk %s" +
-	"\x02failed to found region for disk's storage %s(%s)\x02Cannot delete sn" +
-	"apshot in status %s\x02Fetch instance snapshot error %s\x02snapshot refe" +
-	"renced by instance snapshot\x02Cannot delete snapshot on disk reset\x02S" +
-	"napshot has %d task active, can't sync status\x02Cannot Delete disk %s s" +
-	"napshots, disk exist\x02Disk %s dose not have snapshot\x02Can not delete" +
-	" disk snapshots, have manual snapshot\x02Cannot purge snapshot on enable" +
-	"d cloud provider\x02getReferenceCount fail %s\x02Image is in use\x02Acti" +
-	"ve download session not expired\x02Cannot delete the last cache\x02Canno" +
-	"t uncache in status %s\x02storage cache not empty\x02referered by storag" +
-	"es\x02cannot uncache non-customized images\x02storage not cache image" +
-	"\x02Fail to mark cache status: %s\x02missing image id or name\x02Invalid" +
-	" storage type %s\x02Invalid medium type %s\x02Not support create %s stor" +
-	"age\x02GetHostCount fail %s\x02storage has associate hosts\x02storage ha" +
-	"s disks\x02storage has snapshots\x02storage cache is missing\x02storage " +
-	"is enabled\x02can't detach host in status online\x02host %s storage %s n" +
-	"ot found\x02vpc_id\x02vpc on different cloudprovider peering is not supp" +
-	"orted\x02ipv4 range overlap\x02cloudprovider %s %s %s %s %s not supporte" +
-	"d CrossCloud vpcpeering\x02cloudprovider %s %s %s %s %s not supported Cr" +
-	"ossRegion vpcpeering\x02vpc %s and vpc %s have already connected\x02inva" +
-	"lid external_access_mode %q, want %s\x02not allow to delete default vpc" +
-	"\x02GetNetworkCount fail %s\x02VPC not empty, please delete network firs" +
-	"t\x02GetNatgatewayCount fail %v\x02VPC not empty, please delete nat gate" +
-	"way first\x02GetRequesterVpcPeeringConnections fail %v\x02VPC peering no" +
-	"t empty, please delete vpc peering first\x02invalid cidr_block %s\x02Can" +
-	"not purge vpc on enabled cloud provider\x02on-premise vpc cannot sync st" +
-	"atus\x02For default vpc, only system level sharing can be set\x02Prohibi" +
-	"t making default vpc private\x02mapped ip exhausted\x02bandwidth must be" +
-	" greater than 0\x02mtu must be range of 0~1000000\x02Currently only kvm " +
-	"platform supports creating wire\x02HostCount fail %s\x02wire contains ho" +
-	"sts\x02NetworkCount fail %s\x02wire contains networks\x02not empty zone" +
-	"\x02failed to found cloudregion %s\x02not support create %s zone\x02intr" +
-	"anet loadbalancer not support bandwidth charge type\x02Loadbalancer's ma" +
-	"nager (%s(%s)) does not match vpc's(%s(%s)) (%s)\x02Aliyun not allow to " +
-	"change certificate\x02master slave backendgorup must contain two backend" +
-	"\x02Unsupport backendgorup type %s\x02invalid guest %s\x02Aliyun instanc" +
-	"e weight must be in the range of 0 ~ 100\x02internal error: unexpected b" +
-	"ackend type %s\x02backendgroup %s not support this operation\x02region o" +
-	"f host %q (%s) != region of loadbalancer %q (%s))\x02%s backend group no" +
-	"t support change port\x02%s backend group not support change port or wei" +
-	"ght\x02Unknown backend group type %s\x02listener type must be http/https" +
-	", got %s\x02backend group %s(%s) belongs to loadbalancer %s instead of %" +
-	"s\x02backend group type must be normal\x02loadbalancerlistenerrule %s(%s" +
-	"): fetching listener %s failed\x02http or https listener only supportd d" +
-	"efault or normal backendgroup\x02health_check_domain must be in the rang" +
-	"e of 1 ~ 80\x02%s length must less 500 letters\x02sticky_session_cookie " +
-	"length must within 1~200\x02sticky_session_cookie can only contain lette" +
-	"rs, Numbers, '_' and '-'\x02Unknown sticky_session_type, only support %s" +
-	" or %s\x02failed to find loadbalancer's %s(%s) region\x02The specified S" +
-	"cheduler %s is invalid for performance sharing loadbalancer\x02failed to" +
-	" found loadbalancer for listener %s(%s)\x02cloudregion %s(%s) not suppor" +
-	"t %s scheduler\x02invalid %s,required int\x02%s cannot be set to 0\x02%s" +
-	" not support close tcp or udp loadbalancer listener health check\x02Snap" +
-	"shot for %s name can't start with auto, http:// or https://\x02Aliyun %s" +
-	" not support recovery\x02Aliyun %s only support recover from it self bac" +
-	"kups\x02Aliyun %s only 8.0 and 5.7 high_availability local_ssd or 5.6 hi" +
-	"gh_availability support recovery from it self backups\x02slave dbinstanc" +
-	"e not support prepaid billing type\x02failed to match any skus in the ne" +
-	"twork %s(%s) zone %s(%s)\x02Not support create readonly dbinstance for M" +
-	"ySQL %s %s\x02Not support create readonly dbinstance for MySQL %s %s wit" +
-	"h storage type %s, only support %s\x02Not support create readonly dbinst" +
-	"ance for MySQL %s\x02SQL Server only support create readonly dbinstance " +
-	"for 2017_ent\x02SQL Server cannot have more than seven read-only dbinsta" +
-	"nces\x02Not support create readonly dbinstance with master dbinstance en" +
-	"gine %s\x02Master dbinstance memory ≥64GB, up to 10 read-only instances " +
-	"are allowed to be created\x02Master dbinstance memory <64GB, up to 5 rea" +
-	"d-only instances are allowed to be created\x02At least two networks are " +
-	"required under vpc %s(%s) with aliyun %s(%s)\x02Description can not star" +
-	"t with http:// or https://\x02Aliyun DBInstance account name length shou" +
-	"d be 2~16 characters\x02%s is reserved for aliyun %s, please use another" +
-	"\x02invalid character %s for account name\x02account name can not start " +
-	"or end with _\x02%s only support aliyun %s or %s\x02%s only support aliy" +
-	"un %s\x02Unknown privilege %s\x02network %s related vpc not found\x02acc" +
-	"ount_privilege %s only support redis version 4.0\x02invalid cidr range %" +
-	"s, mask length should less than or equal to 24\x02required at least %d s" +
-	"ubnet.\x02required at least %d subnet with at least 8 free ip.\x02Loadba" +
-	"lancer's manager %s does not match vpc's(%s(%s)) (%s)\x02all networks sh" +
-	"ould in the same vpc. (%s).\x02already has one network in the zone %s. (" +
-	"%s).\x02invalid parameter loadbalancer_spec %s\x02invalid parameter back" +
-	"endgroup %s\x02invalid loadbalancer_spec %s\x02%s does not currently sup" +
-	"port creating loadbalancer acl\x02%s does not currently support creating" +
-	" loadbalancer certificate\x02loadbalancer listener %s related loadbalanc" +
-	"er %s not found\x02The backend %s is already registered on port %d\x02%s" +
-	" request the mask range should be between 16 and 28\x02%s does not curre" +
-	"ntly support creating loadbalancer\x02%s request the mask range should b" +
-	"e between 8 and 29\x02disk and snapshotpolicy should have same domain" +
-	"\x02disk and snapshotpolicy should have same project\x02%s does not supp" +
-	"ort creating loadbalancer\x02%s does not support creating loadbalancer a" +
-	"cl\x02%s does not support creating loadbalancer certificate\x02Google db" +
-	"instance not support prepaid billing type\x02disk size gb must in range " +
-	"10 ~ 30720 Gb\x02eip's manager (%s(%s)) does not match vpc's(%s(%s)) (%s" +
-	")\x02loadbalancer is using by %d listener.\x02loadbalancer is using by %" +
-	"d backendgroup.\x02Not support create read-only dbinstance for %s\x02Hua" +
-	"wei dbinstance name length shoud be 4~64 characters\x02%s require disk s" +
-	"ize must in 40 ~ 4000 GB\x02The disk_size_gb must be an integer multiple" +
-	" of 10\x02Not support create account for huawei cloud %s instance\x02Hua" +
-	"wei rds password cannot be in the same reverse order as the account\x02N" +
-	"ot support create database for huawei cloud %s instance\x02Huawei DBInst" +
-	"ance backup name length shoud be 4~64 characters\x02Huawei only supports" +
-	" specified databases with %s\x02Huawei DBInstance Disk cannot be thrink" +
-	"\x02Huawei DBInstance category cannot change\x02Huawei DBInstance storag" +
-	"e type cannot change\x02Huawei current not support reset dbinstance acco" +
-	"unt password\x02No need to grant or revoke privilege for admin account" +
-	"\x02%s not support recovery\x02Huawei %s rds not support recovery from i" +
-	"t self rds backup\x02Huawei only %s engine support databases recovery" +
-	"\x02New databases name can not be one of %s\x02zone mismatch, elastic ca" +
-	"che sku zone %s != %s\x02elastic cache sku zone (%s) and subnet zone (%s" +
-	") mismatch\x02sku %s is soldout\x02%s not support create account\x02huaw" +
-	"ei %s mode elastic not support create backup\x02zone info missing\x02vpc" +
-	" lb is not allowed for now\x02zone %s(%s) has no lbcluster\x02no viable " +
-	"lbcluster\x02host %s has no access ip\x02error getting host of guest %s" +
-	"\x02error loadbalancer of backend group %s\x02region of host %q (%s) != " +
-	"region of loadbalancer %q (%s)\x02redirect must have at least one of sch" +
-	"eme, host, path changed\x02backend_group argument is missing\x02non redi" +
-	"rect lblistener rule must have backend_group set\x02redirect can only be" +
-	" enabled for http/https listener\x02non http listener must have backend " +
-	"group set\x02%s only supports eip charge type %q\x02no available eip net" +
-	"work\x02bad network type %q, want %q\x02failed to found vpc for network " +
-	"%s(%s)\x02network %s(%s) does not belong to %s\x02Kvm snapshot missing s" +
-	"torage ??\x02failed to find %s %s\x02cannot change loadbalancer listener" +
-	" listener_type\x02cannot change loadbalancer listener listener_port\x02a" +
-	"ccount name '%s' is not allowed\x02can not make backup in status %s\x02i" +
-	"nvalid cidr range %s\x02loadbalancer listener %s is already updating\x02" +
-	"loadbalancer backendgroup aready associate with other %s listener\x02loa" +
-	"dbalancer aready associated with fourth layer listener %s\x02path can no" +
-	"t be emtpy\x02server %s with port %d already in used\x02server %s with p" +
-	"ort %d aready used by other %s listener\x02Qcloud Basic MySQL instance n" +
-	"ot support create backup\x02Not support create Qcloud databases\x02redis" +
-	" version 2.8 not support create account\x02%s request the mask range sho" +
-	"uld be less than or equal to 29\x02Empty spec query key\x02Parse spec ke" +
-	"y %s error: %v\x02Get object error: %v\x02empty project_id/tenant_id\x02" +
-	"tenant/project %s not found\x02Snapshot reference(by disk) count > 0, ca" +
-	"n not delete\x02disk need at least one of snapshot as backing file\x02Di" +
-	"sk %s dosen't attach guest ?\x02Disk attached Guest has backup, Can't cr" +
-	"eate snapshot\x02Cannot do snapshot when VM in status %s\x02check disk s" +
-	"napshot count fail %s\x02Disk %s snapshot full, cannot take any more\x02" +
-	"This RBD Storage[%s/%s] has already exist\x02BadGateway\x02InternalServe" +
-	"rError\x02ResourceNotReadyError\x02PaymentError\x02ImageNotFoundError" +
-	"\x02ResourceNotFoundError\x02SpecNotFoundError\x02ActionNotFoundError" +
-	"\x02TenantNotFoundError\x02UserNotFoundError\x02ServerStatusError\x02Inv" +
-	"alidFormatError\x02InputParameterError\x02WeakPasswordError\x02MissingPa" +
-	"rameterError\x02InsufficientResourceError\x02OutOfResource\x02OutOfQuota" +
-	"Error\x02OutOfRange\x02OutOfLimit\x02NotSufficientPrivilegeError\x02Unsu" +
-	"pportOperationError\x02NotEmptyError\x02BadRequestError\x02EmptyRequestE" +
-	"rror\x02UnauthorizedError\x02InvalidCredentialError\x02ForbiddenError" +
-	"\x02NotAcceptableError\x02DuplicateNameError\x02DuplicateResourceError" +
-	"\x02ConflictError\x02ResourceBusyError\x02RequireLicenseError\x02Protect" +
-	"edResourceError\x02NoProjectError\x02TooLargeEntity\x02TooManyFailedAtte" +
-	"mpts\x02TooManyRequests\x02UnsupportedProtocol\x02PolicyDefinitionError" +
-	"\x02Image %s not found\x02password must be 12 chars of at least one digi" +
-	"t, letter, uppercase letter and punctuate\x02Duplicate name %s %s\x02Dup" +
-	"licate ID %s %s\x02no such driver\x02empty DN\x02empty id\x02empty name" +
-	"\x02disabled user\x02join user into project of default domain or identic" +
-	"al domain\x02sysadmin is protected\x02cannot remove current user from cu" +
-	"rrent project\x02join group into project of default domain or identical " +
-	"domain\x02query error %s\x02missing input field type\x02missing input fi" +
-	"eld blob\x02encrypt error %s\x02cannot delete default domain\x02domain i" +
-	"s enabled\x02domain is in use by user\x02domain is in use by group\x02do" +
-	"main is in use by project\x02domain is in use by role\x02domain is in us" +
-	"e by policy\x02domain contains external resources\x02readonly\x02default" +
-	" domain is protected\x02field %s is readonly\x02endpoint is enabled\x02m" +
-	"issing input field interface\x02missing input field service/service_id" +
-	"\x02not found cert %s\x02get sensitive config requires admin priviliges" +
-	"\x02cannot update config when enabled and connected\x02cannot update con" +
-	"fig when not idle\x02saveConfigs fail %s\x02invalid template\x02missing " +
-	"driver\x02driver %s not supported\x02driver %s already exists\x02cannot " +
-	"delete default SQL identity provider\x02cannot delete enabled idp\x02ide" +
-	"ntity provider with projects\x02enabled domain %s cannot be deleted\x02c" +
-	"annot update in sync status\x02domain is disabled\x02resource is enabled" +
-	"\x02fail to decode policy data\x02cannot delete system policy\x02cannot " +
-	"delete enabled policy\x02cannot delete system project\x02project contain" +
-	"s external resources\x02project contains user\x02project contains group" +
-	"\x02cannot alter system project name\x02region contains endpoints\x02mis" +
-	"sing input field id\x02cannot alter name of role\x02cannot delete system" +
-	" role\x02role is being assigned to user\x02role is being assigned to gro" +
-	"up\x02not supported update context\x02not supported update context %s" +
-	"\x02inconsistent domain for project and roles\x02not supported secondary" +
-	" update context %s\x02service contains endpoints\x02service is enabled" +
-	"\x02update config version fail %s\x02cannot alter sysadmin user name\x02" +
-	"invalid password: %s\x02cannot delete non-local user\x02user contains ex" +
-	"ternal resources\x02cannot delete system user\x02cannot join user and gr" +
-	"oup in differnt domain\x02cannot join read-only group\x02cannot leave re" +
-	"ad-only group\x02version mismatch\x02project disabled\x02user disabled" +
-	"\x02expired token\x02invalid fernet token\x02invalid auth methods\x02use" +
-	"r not found\x02empty auth request\x02user not in project\x02invalid acce" +
-	"ss key id\x02expired access key\x02unrecognized input %s\x02unauthorized" +
-	" %s\x02fail to decode request body\x02duplicate username\x02user not fou" +
-	"nd or not enabled\x02invalid user\x02invalid project\x02internal server " +
-	"error %s\x02invalid domain\x02not allow to auth\x02invalid token\x02inva" +
-	"lid token %s\x02not allow to get usage\x02Unauthorized\x02InvalidToken" +
-	"\x02Name %s not found\x02No login secret found\x02no totp for %s\x02no r" +
-	"ecovery secrets for %s\x02totp secret exists\x02No password found\x02No " +
-	"ssh password: %s\x02invalid resources format\x02service %s not found err" +
-	"or: %v\x02missing uid\x02missing pids\x02missing pid in pids\x02missing " +
-	"rid in pids\x02missing rid\x02project is not found\x02No login key: %s" +
-	"\x02Not found kind in query: %v\x02Not found key in query: %v\x02unsuppo" +
-	"rted action %s\x02global-settings not found\x02url is empty\x02invalid u" +
-	"rl: %v\x02unsupport type: %s\x02app_id is empty\x02app_secret is empty" +
-	"\x02channel is empty\x02parameter %s is empty\x02unsupported no_data_sta" +
-	"te %s\x02unsupported execution_error_state %s\x02metric %s is invalid fo" +
-	"rmat, usage <measurement>.<field>\x02Cannot change state on pause alert" +
-	"\x02alert already attached to notification\x02Alert is already un-paused" +
-	"\x02Alert is already paused\x02Invalid refresh format: %s\x02not find al" +
-	"ert %s\x02not find notification %s\x02dashboard_id is empty\x02can not f" +
-	"ind dashboard:%s\x02the Comparator is illegal: %s\x02the reduce is illeg" +
-	"al %s\x02the reduce is illegal: %s\x02Alert resource driver not found" +
-	"\x02Alert resource driver duplicate match\x02Invalid level format: %s" +
-	"\x02Invalid period format: %s\x02the AlertType is illegal:%s\x02Cannot d" +
-	"elete system alert\x02threshold:%s should be number type\x02Default data" +
-	" source not found\x02not support database\x02not support type %q\x02unsu" +
-	"pported resource type %s\x02not found alert notification used by %s\x02u" +
-	"nsupported notification type %s\x02Alert notification used by %d alert" +
-	"\x02input not json dict\x02not found signature\x02signature error\x02Inv" +
-	"alid interval format: %s\x02Unsupported notification type\x02Influxdb in" +
-	"valid status\x02Not find executor for data source\x02Condition is missin" +
-	"g the threshold parameter\x02Condition is missing the type parameter\x02" +
-	"Invalid condition evaluator type\x02Unknown alert condition\x02Alert is " +
-	"missing conditions\x02input condition is empty\x02Unkown operator %s\x02" +
-	"select for nothing in query\x02query duration err: from: %s, to:%s\x02qu" +
-	"ery duration `to` err: %s\x02alert condition type is empty\x02Unkown ale" +
-	"rt condition type: %s\x02security group id should not be empty\x02failed" +
-	" to find SecurityGroup %s\x02no valid endpoint\x02require validated qclo" +
-	"ud cross region vpcPeering bandwidth values:[10, 20, 50, 100, 200, 500, " +
-	"1000],unit Mbps\x02failed parsing url %q: %v\x02bad ip\x02unmarshal inpu" +
-	"t fail %s\x02invalid characters %s\x02check name duplication fail %s\x02" +
-	"policy is referenced"
+const en_USData string = "" + // Size: 55743 bytes
+	"\x04\x00\x01 \x19\x02invalid CannedAction %s \x04\x00\x01 \x13\x02invali" +
+	"d Effect %s \x04\x00\x01 \x11\x02invalid ipv4 %s \x02invalid share_mode " +
+	"%s\x02mx_priority range limited to [1,50]\x02invalid domain %s for MX re" +
+	"cord\x02invalid ipv4 %s for A record\x02invalid ipv6 %s for AAAA record" +
+	"\x02invalid domain %s for CNAME record\x02duplicate route cidr %s\x02Int" +
+	"ernal server error: %s\x02Internal server error\x02Invalid handler %s" +
+	"\x02Handler not found\x02No request key: %s\x02Invalid request header: %" +
+	"v\x02request process timeout\x02Not allow empty records\x02Records limit" +
+	" exceeded.\x02%s method not found\x02%s method params length not match, " +
+	"expected %d, input %d\x02Invald ValidateCreateData return value\x02Inval" +
+	"d ListItemFilter return value count %d\x02Invald OrderByExtraFields retu" +
+	"rn value count %d\x02Invalid GetExtraDetails return value count %d\x02In" +
+	"valid FetchCustomizeColumns return value count %d\x02Invalid FetchCustom" +
+	"izeColumns return value type, not a slice!\x02Invalid FetchCustomizeColu" +
+	"mns return value, inconsistent obj count: input %d != output %d\x02Inval" +
+	"d ValidateUpdateData return value\x02Invald CustomizeDelete return value" +
+	"\x02invalid joint resources %s\x02FetchCustomizeColumns return incorrect" +
+	" number of results\x02No context manager\x02No such context %s(%s)\x02fa" +
+	"il to get http response writer from context\x02FetchCustomizeColumns ret" +
+	"urns incorrect results\x02reflect call %s fail %s\x02Invald %s return va" +
+	"lue\x02%s not allow to get property %s\x02No return value, so why query?" +
+	"\x02Not allow to get details\x02%s %s %s not found\x02%s not allow to ge" +
+	"t spec %s\x02Not allow to create item\x02body is not a json?\x02Missing " +
+	"name or generate_name\x02not allow to perform %s\x02%s allow %s %s not f" +
+	"ound\x02%s not allow to %s %s\x02Invalid data JSONObject\x02Not allow to" +
+	" update item\x02%s(%s) not allow to delete\x02Not allow to attach\x02Obj" +
+	"ect %s %s has attached %s %s\x02project in non-default domain is prohibi" +
+	"ted\x02missing new domain\x02check name duplication error: %s\x02not eno" +
+	"ugh privilege (require:%s,allow:%s,query:%s)\x02Not support resource %s " +
+	"tag filter\x02Action %s not found\x02can't get string field\x02model has" +
+	" no field %s\x02Query database error %s\x02name starts with letter, and " +
+	"contains letter, number and - only\x02not allow to delete log\x02DIRECT " +
+	"setting cannot be changed\x02DIRECT setting cannot be deleted\x02get pro" +
+	"xysetting refcount fail %s\x02proxysetting %s is still referred to by %d" +
+	" %s\x02fail to decode body\x02Quota %s not found\x02Default quota %s not" +
+	" allow to delete\x02not enough privilleges\x02not allow to list domain q" +
+	"uotas\x02out of privileges\x02not allow to list project quotas\x02query " +
+	"quotas %s\x02not enough privilege (require:%s,allow:%s:resource:%s)\x02n" +
+	"ot enough privilege (require:%s,allow:%s)\x02invalid scope %s\x02not all" +
+	"ow create %s in scope %s\x02Not allow set scope to system\x02Not allow s" +
+	"et scope to domain %s\x02Not allow set scope to project %s\x02sharing is" +
+	" limited to domains %s\x02Insert shared resource failed %s\x02name start" +
+	"s with letter, and contains letter, number and ._@- only\x02name longer " +
+	"than %d\x02not allow to set system key, please remove the underscore at " +
+	"the beginning\x02input key too long > %d\x02input value too long > %d" +
+	"\x02user %s not found\x02forbidden\x02non-admin user not allowed to crea" +
+	"te system object\x02Virtual resource freezed, can't do %s\x02virtual res" +
+	"ource already freezed\x02virtual resource not freezed\x02missing new pro" +
+	"ject/tenant\x02InformerBackend not init\x02invalid format\x02operation n" +
+	"ot allowed\x02invalid input format\x02Missing key error: missing %q\x02G" +
+	"eneral error: general error for %q: %s\x02Invalid type error: expecting " +
+	"%s type for %q: %s\x02Invalid choice error: invalid %q, want %s, got %s" +
+	"\x02Invalid length error: %q too short, got %d, min %d\x02Invalid length" +
+	" error: %q too long, got %d, max %d\x02Not in range error: invalid %q: %" +
+	"d, want [%d,%d]\x02Invalid value error: invalid %q: %s\x02Invalid value " +
+	"error: invalid %q: %v\x04\x00\x01 \x22\x02Invalid value error: invalid %" +
+	"q: \x02Model manager error: failed getting model manager for %q\x02Model" +
+	" not found error: cannot find %q with id/name %q\x02Model not found erro" +
+	"r: cannot find %q with id/name %q: %s\x02invalid cert pubkey algorithm: " +
+	"%s, want %s\x02no such provider\x02Not Implemented GetProvider\x02NotFou" +
+	"ndError\x02DuplicateIdError\x02InvalidStatusError\x02TimeoutError\x02Not" +
+	"ImplementedError\x02NotSupportedError\x02InvalidProvider\x02NoBalancePer" +
+	"mission\x02ErrAddressCountExceed\x02cannot support more than 1 nic\x02Th" +
+	"e %s disk size must be in the range of %dGB ~ %dGB\x02%s requires that t" +
+	"he eip bandwidth must be less than 100Mbps\x02network %s associated rout" +
+	"e table has no internet gateway attached.\x02failed to find subformat vh" +
+	"d for image %s, please append 'vhd' for glance options(target_image_form" +
+	"ats)\x02Azure Mv2-series instance sku only support UEFI image\x02Azure U" +
+	"EFI image %s not support this instance sku\x02cannot support change azur" +
+	"e instance name\x02Cannot change config for baremtal\x02Cannot resize di" +
+	"sk for baremtal\x02Invalid raid config: %v\x02Host %s is not a baremetal" +
+	"\x02Baremetal %s is not ready\x02Baremetal %s is occupied\x02Cannot save" +
+	" image for baremtal\x02Not Implement ValidateCreateEip\x02Not allow for " +
+	"hypervisor %s\x02Not supported, please use kubectl\x02Container not supp" +
+	"ort %s\x02%s not support create eip\x02can't resize disk for guest with " +
+	"instance snapshots\x02esxi guest migrate require prefer_host\x02can't re" +
+	"build root for a guest with instance snapshots\x02Unknown google storage" +
+	" type %s\x02System disk does not support %s disk\x02%s disk cannot excee" +
+	"d 8\x02%s for %s features are not compatible for creating instance\x02Ho" +
+	"st %s not found\x02Guest have backup, can't migrate\x02Cannot normal mig" +
+	"rate guest in status %s, try rescue mode or server-live-migrate?\x02Resc" +
+	"ue mode requires all disk store in shared storages\x02Cannot migrate wit" +
+	"h isolated devices\x02Cannot live migrate with cdrom\x02Cannot live migr" +
+	"ate with isolated devices\x02Cannot do live migrate, too low qemu versio" +
+	"n\x02Guest %s can't hot remove nic\x02%s not support cdrom params\x02%s " +
+	"not support create eip, it only support bind eip\x02%s not support creat" +
+	"e virtual machine with eip\x02data disk not support storage type %s\x02T" +
+	"he %s disk size must be in the range of 10GB ~ 16000GB\x02The %s disk si" +
+	"ze must be in the range of 50GB ~ 16000GB\x02The %s disk size must be in" +
+	" the range of 100GB ~ 16000GB\x02The %s disk size must be in the range o" +
+	"f 20GB ~ 32000GB\x02storage %s can not be data disk\x02Data disk size mu" +
+	"st be an integer multiple of 10G\x02failed to found system disk error: %" +
+	"v\x02failed to found storage for disk %s(%s)\x02The system disk is local" +
+	"ly stored and does not support changing configuration\x02Not support cre" +
+	"ate local storage disks\x02Please input new disk backend type\x02The dis" +
+	"k is locally stored and does not support detach\x02Host %s is not online" +
+	"\x02GetGuestCount fail %s\x02host has been occupied\x02Aliyun reset disk" +
+	" required guest status is running or ready\x02Aws not support reset disk" +
+	", you can create new disk with snapshot\x02cannot support change azure d" +
+	"isk name\x02Azure not support reset disk, you can create new disk with s" +
+	"napshot\x02not implement\x02Not Implement ValidateResetDisk\x02Not Imple" +
+	"ment ValidateAttachStorage\x02Not Implement RequestAttachStorage\x02Not " +
+	"Implement RequestDetachStorage\x02Disk must be dettached\x02%s reset dis" +
+	"k required guest status is running or ready\x02Server %s must in status " +
+	"ready\x02Disk must be detached\x02Unsupport attach %s storage for %s hos" +
+	"t\x02Attach rbd storage require host status is online\x02Query host stor" +
+	"age error %s\x02Host %s already have mount point %s with other storage" +
+	"\x02Attach nfs storage require host status is online\x02%s is not mount " +
+	"point %s\x02Disk attach muti guests\x02Disk attached guest status must b" +
+	"e ready\x02Disk dosen't attach guest\x02OpenStack not support reset disk" +
+	", you can create new disk with snapshot\x02Qcloud reset disk required gu" +
+	"est status is running or read\x02Ucloud reset disk operation required di" +
+	"sk not be attached\x02Ucloud only support data disk reset operation\x02Z" +
+	"Stack reset disk operation requried guest status is ready\x02Parse remot" +
+	"e ip error %s\x02Network not found\x02Baremetal agent not found\x02Barem" +
+	"etal package not prepared\x02check agent uniqness fail %s\x02Conflict ma" +
+	"nager_uri %s\x02Duplicate manager_uri %s\x02missing duration/expire_time" +
+	"\x02expire time is before current expire at\x02invalid duration %s: %s" +
+	"\x02missing name\x02invalid bucket name %s: %s\x02invalid bucket name(%s" +
+	"): %s\x02no external bucket\x02fail to get objects: %s\x02missing key" +
+	"\x02fail to generate temp url: %s\x02empty directory name\x02invalid key" +
+	" %s: %s\x02GetIObject fail %s\x02object count limit exceeds\x02bucket.Ge" +
+	"tQuotaKeys %s\x02fail to mkdir: %s\x02empty keys\x02object key should no" +
+	"t ends with /\x02invalid object key: %s\x02missing Content-Length\x02Ill" +
+	"egal Content-Length %s\x02Content-Length negative %d\x02GetIObject error" +
+	" %s\x02object size limit exceeds\x02bucket.GetQuotaKeys fail %s\x02put o" +
+	"bject error %s\x02setAcl error %s\x02syncWithCloudBucket error %s\x02Buc" +
+	"ket has %d task active, can't sync status\x02not an empty bucket\x02obje" +
+	"ct %s not found\x02iBucket.GetIObjects error %s\x02iBucket.SetWebsite er" +
+	"ror %s\x02iBucket.DeleteWebSiteConf error %s\x02iBucket.GetWebsiteConf e" +
+	"rror %s\x02cloudprovider.SetBucketCORS error %s\x02iBucket.DeleteCORS er" +
+	"ror %s\x02iBucket.GetCORSRules error %s\x02iBucket.GetCdnDomains error %" +
+	"s\x02iBucket.SetRefer error %s\x02iBucket.GetRefer error %s\x02iBucket.G" +
+	"etPolicy error %s\x02iBucket.SetPolicy error %s\x02iBucket.DeletePolicy " +
+	"error %s\x02unmarshal limit error %s\x02SetLimit error %s\x02Update erro" +
+	"r %s\x02missing manager?\x02iBucket.GetIObject error %s\x02ValidateDelet" +
+	"eCondition error %s\x02The image has been cached on storages\x02the imag" +
+	"e reference session has not been expired!\x02failed to found storagecach" +
+	"e %s\x02not allow to query system capability\x02account %s not enable sa" +
+	"ml auth\x02account is enabled\x02account is not idle\x02provider %s: %v" +
+	"\x02Cannot enable deleting account\x02%s not support saml auth\x02invali" +
+	"d proxy setting %s\x02invalid wire_level_for_vmware %q, accept %s\x02not" +
+	" support for cloudaccount with provider '%s'\x02Unsupported provider %s" +
+	"\x02Project %s(%s) not belong to domain %s(%s)\x02Not support brand %s, " +
+	"only support %s\x02check uniqness fail %s\x02The account has been regist" +
+	"ered\x02no such provider %s\x02invalid cloud account info error: %s\x02c" +
+	"heck account_id duplication error %s\x02the account has been registerd %" +
+	"s\x02Account disabled\x02Account auto sync enabled\x02invalid input %s" +
+	"\x02failed to found provider factory error: %v\x02failed to unmarshal in" +
+	"put params: %v\x02check uniqueness fail %s\x02account %s conflict\x02inc" +
+	"onsistent account_id, previous '%s' and now '%s'\x02project %s not found" +
+	"\x02cannot enable auto sync in status %s\x02provider is shared outside o" +
+	"f domain\x02%s not support\x02%s not support create subscription\x02not " +
+	"allow to create\x02provider is enabled\x02provider is not idle\x02Direct" +
+	"ly creating cloudprovider is not supported, create cloudaccount instead" +
+	"\x02Region %s not found\x02Zone %s not found\x02Cloudprovider disabled" +
+	"\x02Cloudaccount disabled\x02not allow to change project across domain" +
+	"\x02cannot change to a different domain from a private cloud account\x02" +
+	"fail to get provider driver %s\x02storage classes not supported\x02GetZo" +
+	"neCount fail %s\x02GetVpcCount fail %s\x02not empty cloud region\x02not " +
+	"allow to delete default cloud region\x02VPC %s not found\x02Cannot updat" +
+	"e external resource\x02not allow update rds account name\x02failed to fo" +
+	"und dbinstance %s\x02DBInstance %s(%s) status is %s require status is %s" +
+	"\x02failed to found region for dbinstance %s(%s)\x02failed to found dbin" +
+	"stance %s(%s) database %s: %v\x02Failed to found database %s for dbinsta" +
+	"nce %s(%s): %v\x02The account %s(%s) has permission %s to the database %" +
+	"s(%s)\x02Account status is not %s current status is %s\x02Instance statu" +
+	"s is not %s current status is %s\x02Database status is not %s current is" +
+	" %s\x02Account %s(%s) does not have database %s(%s) permissions\x02DBins" +
+	"tance has not valid cloudprovider\x02DBInstance backup has %d task activ" +
+	"e, can't sync status\x02not allow update rds database name\x02failed to " +
+	"found dbinstance %s(%s) account %s: %v\x02Not Implemented\x02invalid add" +
+	"ress: %s\x02Ip %s not in network %s(%s) range\x02cloudprovider %s(%s) is" +
+	" not available\x02invalid duration %s\x02unsupported duration %s\x02clou" +
+	"dregion %s not support create rds\x02cloudregion %s not support create %" +
+	"s rds\x02not match any dbinstance sku\x02%s rds not support secgroup\x02" +
+	"%s rds Support up to %d security groups\x02Cannot do recovery dbinstance" +
+	" in status %s required status %s\x02backup %s(%s) not contain database %" +
+	"s\x02conflict database %s for instance %s(%s)\x02back and instance not i" +
+	"n same cloudaccount\x02backup and instance not in same cloudregion\x02ca" +
+	"n not recover data from diff rds engine\x02Cannot do reboot dbinstance i" +
+	"n status %s\x02DBInstance has %d task active, can't sync status\x02Canno" +
+	"t do renew dbinstance in status %s required status %s\x02missong duratio" +
+	"n\x02The dbinstance status need be %s, current is %s\x02Only %s dbinstan" +
+	"ce support this operation\x02DBInstance has opened the outer network con" +
+	"nection\x02The extranet connection is not open\x02%s not support this op" +
+	"eration\x02Cannot change config in status %s\x02Unmarshal input error: %" +
+	"v\x02failed to match any skus for change config\x02DBInstance is locked," +
+	" cannot delete\x02dbinstance billing type is %s\x02dbinstance billing ty" +
+	"pe %s not support cancel expire\x02this operation requires rds state to " +
+	"be %s\x02%s supported secgroup count is %d\x02guest %q not found\x02snap" +
+	"shotpolicy %s not found: %s\x02not support update disk_type %s\x02failed" +
+	" to find storage for disk %s\x02failed to find host for storage %s with " +
+	"disk %s\x02Storage %s not found\x02cloudprovider %s not available\x02sto" +
+	"rage %s(%s) need online and attach host for create disk\x02Cannot create" +
+	" disk with disabled storage[%s]\x02Cannot create disk with offline stora" +
+	"ge[%s]\x02Storage type[%s] not match backend %s\x02Storage[%s] must atta" +
+	"ch to a host\x02Not enough free space\x02Fetch snapshot count failed %s" +
+	"\x02Disk %s don't need convert snapshots\x02Can not get disk snapshot" +
+	"\x02Get convert snapshot failed: %s\x02Snapshot %s dose not have convert" +
+	" snapshot\x02Cannot reset disk in status %s\x02Cannot reset disk with sn" +
+	"apshot in status %s\x02Cannot reset disk %s(%s),Snapshot is belong to di" +
+	"sk %s\x02Resize disk when disk is READY\x02Disk cannot be thrink\x02disk" +
+	" has no valid storage\x02disk.GetQuotaKeys fail %s\x02fail to find stora" +
+	"ge for disk %s\x02No zone for this disk\x02Duplicate image name %s\x02Sa" +
+	"ve disk when disk is READY\x02GetRuningGuestCount fail %s\x02Save disk w" +
+	"hen not being USED\x02Image name is required\x02cloud provider %s is not" +
+	" available\x02cloud account %s is not available\x02storage of disk %s no" +
+	" valid host\x02GetGuestDiskCount for disk %s fail %s\x02Virtual disk %s(" +
+	"%s) used by virtual servers\x02not allow to delete prepaid disk in valid" +
+	" status\x02Diskinfo index %d: both imageID and size are absent\x02Snapsh" +
+	"ot %s not found\x02Snapshot %s storage %s not found, is public cloud?" +
+	"\x02Image status is not active\x02Disk has %d task active, can't sync st" +
+	"atus\x02GetSnapshotCount fail %s\x02not allow to purge. Virtual disk mus" +
+	"t not have snapshots\x02not allow to delete. Virtual disk must not have " +
+	"snapshots\x02not allow to delete %s disk with snapshots\x02no such snaps" +
+	"hotpolicy %s\x02%s %s not supported dns type %s\x02%s %s not supported p" +
+	"olicy type %s\x02%s %s %s not support %s\x02invalid record name %s\x02du" +
+	"plicated with CNAME dnsrecord name not support\x02duplicated dnsrecord w" +
+	"ith existed dnsrecord can not distinguish by %s policy\x02duplicated dns" +
+	"record with existed dnsrecord not support\x02%s not support policy type " +
+	"%s\x02%s %s not support policy value %s\x02Not support\x02invalid domain" +
+	" name %s\x02Not support %s for vpc %s, supported %s\x02Not support %s fo" +
+	"r account %s, supported %s\x02top level public domain name %s not suppor" +
+	"t\x02unknown zone type %s\x02can not sync record sets in %s\x02dns zone " +
+	"can not cache in status %s\x02Only %s support cache for account\x02accou" +
+	"nt %s has been cached\x02dns zone can not uncache in status %s\x02vpc %s" +
+	" has already in this dns zone\x02vpc %s not in dns zone\x02SRV: insuffic" +
+	"ient param: %s\x02SRV: invalid port number: %s\x02SRV: invalid weight nu" +
+	"mber: %s\x02SRV: weight number %d not in range [0,65535]\x02SRV: invalid" +
+	" priority number: %s\x02SRV: priority number %d not in range [0,65535]" +
+	"\x02SRV cannot mix with other types\x02CNAME cannot mix with other types" +
+	"\x02PTR cannot mix with other types\x02%s: invalid domain name: %s\x02SR" +
+	"V: invalid srv record name: %s\x02PTR: invalid ptr record name: %s\x02%s" +
+	": name cannot be ip address: %s\x02A: record value must be ipv4 address:" +
+	" %s\x02AAAA: record value must be ipv6 address: %s\x02%s: %s must be dom" +
+	"ain name: %s\x02%s: %s cannot be ip address: %s\x02%s: unknown record ty" +
+	"pe\x02Empty record\x02invalid ttl: %s\x02invalid ttl: %d\x02Cannot mix d" +
+	"ifferent types of records, %s != %s\x02invalid condition\x02schedtag %s " +
+	"not found\x02unmarshal StandaloneResourceCreateInput fail %s\x02Resource" +
+	" type %s not support\x02Virtual resource type %s not support\x02%s %s no" +
+	"t found\x02can't restore elastic cache in status %s\x02unsupport delete " +
+	"%s backups\x02invalid billing_cycle %s\x02unmarshal VirtualResourceCreat" +
+	"eInput fail %s\x02Cannot do restart elasticcache instance in status %s" +
+	"\x02Elastic cache is locked, cannot delete\x02Elastic cache is not expir" +
+	"ed, cannot delete\x02provider mismatch: %s instance can't use %s sku\x02" +
+	"region mismatch: instance region %s, sku region %s\x02zone mismatch: ins" +
+	"tance zone %s, sku zone %s\x02engine version mismatch: instance version " +
+	"%s, sku version %s\x02can not change specification in status %s\x02auth " +
+	"mode aready in status %s\x02no admin account found for elastic cache %s" +
+	"\x02maintain time has no change\x02public connection aready allocated" +
+	"\x02release public connection aready released\x02invalid parameter forma" +
+	"t. json dict required\x02Elasticcache has %d task active, can't sync sta" +
+	"tus\x02elasticcache billing type is %s\x02elasticcache billing type %s n" +
+	"ot support cancel expire\x02Cannot add security groups in status %s\x02r" +
+	"egion\x02regiondriver\x02not supported bind security group\x02beyond sec" +
+	"urity group quantity limit, max items %d.\x02The secgroup name %s does n" +
+	"ot meet the requirements, please change the name\x02secgroups will be em" +
+	"pty after update.\x02The elastic cache status need be %s, current is %s" +
+	"\x02Only %s elastic cache support set auto renew operation\x02elastic ca" +
+	"che no related region found\x02Only %s elastic cache support renew opera" +
+	"tion\x02%s is not modifiable\x02resource %s in vpc %s external access mo" +
+	"de %s is not support accociate eip\x02server %s not found\x02Not support" +
+	" associate type %s, only support %s\x02charge type %s not supported\x02e" +
+	"ip has been associated with instance\x02eip cannot associate in status %" +
+	"s\x02fixed eip cannot be associated\x02Unsupported %s\x02cannot associat" +
+	"e pending delete server\x02instance is already associated with eip\x02ca" +
+	"nnot associate server in status %s\x02cannot associate eip with same net" +
+	"work\x02server region is not found???\x02eip region is not found???\x02e" +
+	"ip and server are not in the same region\x02eip and server are not in th" +
+	"e same zone\x02server host is not found???\x02server and eip are not man" +
+	"aged by the same provider\x02eip cannot dissociate in status %s\x02fixed" +
+	" public eip cannot be dissociated\x02the associated natgateway has corre" +
+	"sponding snat rules with eip %s, please delete them firstly\x02the assoc" +
+	"iated natgateway has corresponding dnat rules with eip %s, please delete" +
+	" them firstly\x02fixed eip cannot sync status\x02cannot change bandwidth" +
+	" in status %s\x02Invalid bandwidth\x02Cannot purge elastic_ip on enabled" +
+	" cloud provider\x02account %s not share for domain %s\x02please retry af" +
+	"ter unbind all guests in group\x02can not bind guest from disabled guest" +
+	"\x02can not unbind guest from disabled guest\x02no such model %s\x02gues" +
+	"t and instance group should belong to same project\x02Host missing\x02ho" +
+	"st status %s and enabled %v, can't do server %s\x02Cannot send command i" +
+	"n status %s\x02No host for server\x02Cannot save image in status %s\x02N" +
+	"o root image\x02Support only by KVM Hypervisor\x02Cannot sync in status " +
+	"%s\x02Cannot live migrate in status %s\x02Can't clone guest with backup " +
+	"guest\x02Guest hypervisor %s does not support clone\x02Cannot clone VM i" +
+	"n status %s\x02Unmarshal input error %s\x02Cannot deploy in status %s" +
+	"\x02Disk %s and guest not belong to the same account\x02Disk %s and gues" +
+	"t not belong to the same zone\x02isAttached check failed %s\x02Disk %s h" +
+	"as been attached\x02Disk %s not belong the guest's host\x02Disk in %s no" +
+	"t able to attach\x02Guest %s not support attach disk in status %s\x02Dis" +
+	"k %s not found\x02Cannot suspend VM in status %s\x02Cannot resume VM in " +
+	"status %s\x02host virtual memory not enough\x02Some disk not ready\x02Ca" +
+	"nnot do start server in status %s\x02CD-ROM not empty, please eject firs" +
+	"t\x02Insert ISO not allowed in status %s\x02No ISO to eject\x02Eject ISO" +
+	" not allowed in status %s\x02Cannot add security groups for hypervisor %" +
+	"s\x02guest %s band to up to %d security groups\x02security group %s has " +
+	"already been assigned to guest %s\x02Cannot revoke security groups in st" +
+	"atus %s\x02security group %s not assigned to guest %s\x02Cannot assign s" +
+	"ecurity rules in status %s\x02Cannot set security rules in status %s\x02" +
+	"Cannot set security group for this guest %s\x02Cannot purge server on en" +
+	"abled host\x02failed to find %s\x02invlid image\x02image size exceeds ro" +
+	"ot disk size\x02Cannot switch OS between %s-%s\x02Can not rebuild root w" +
+	"ith with diff uefi image\x02No template for root disk, cannot rebuild ro" +
+	"ot\x02%s not support rebuild root with a different image\x02Cannot reset" +
+	" root in status %s\x02keypair %s not found\x02No Disk Info Provided\x02N" +
+	"o valid host\x02No valid storage on current host\x02Not eough storage sp" +
+	"ace on current host\x02failed to find disk %s\x02check isAttach2Disk fai" +
+	"l %s\x02Cannot detach sys disk\x02Cannot keep detached disk\x02Server in" +
+	" %s not able to detach disk\x02Disk %s not attached\x02Only allowed to a" +
+	"ttach isolated device when guest is ready\x02Missing isolated device\x02" +
+	"Isolated device %s not found\x02Isolated device is not attached to this " +
+	"guest\x02guest attach gpu count must > 0\x02fetch gpu failed %s\x02guest" +
+	" %s host %s isolated device not enough\x02attach devices is not string a" +
+	"rray\x02detach devices is not string array\x02ip %s not found\x02mac %s " +
+	"not found\x02no either ip_addr or mac specified\x02Cannot change network" +
+	" ip_addr in status %s\x02cannot change mac when guest is running\x02chec" +
+	"k mac uniqueness fail %s\x02mac addr %s has been occupied\x02Cannot deta" +
+	"ch network in status %s\x02Cannot attach network in status %s\x02Cannot " +
+	"change bandwidth in status %s\x02Bandwidth must be non-negative\x02Canno" +
+	"t change setting in status %s\x02Not allow to change config\x02Guest hav" +
+	"e backup not allow to change config\x02Cannot change config in %s\x02Can" +
+	"not change config with different instance family\x02Params vcpu_count pa" +
+	"rse error\x02Memory size must be number[+unit], like 256M, 1G or 256\x02" +
+	"Params vmem_size parse error\x02cannot change CPU/Memory spec in status " +
+	"%s\x02Unmarshal disks configure error %s\x02Parse disk info error: %s" +
+	"\x02Cannot reduce disk size\x02Cannot reset VM in status %s\x02Guest has" +
+	" %d task active, can't sync status\x02Cannot stop server in status %s" +
+	"\x02Cannot do restart server in status %s\x02Cannot send keys in status " +
+	"%s\x02cannot associate eip in status %s\x02already associate with eip" +
+	"\x02eip %s not found\x02eip has been associated\x02cannot associate eip " +
+	"and instance in different region\x02cannot associate eip and instance in" +
+	" different zone\x02cannot associate eip and instance in different provid" +
+	"er\x02No eip to dissociate\x02Out of eip quota: %s\x02Cannot swith to ba" +
+	"ckup when guest in status %s\x02Guest no backup host\x02Guest can't swit" +
+	"ch to backup, mirror job not ready\x02failed to found guest %s\x02input " +
+	"data not key value dict\x02Guest %s not found\x02Fetch guest error %s" +
+	"\x02Already have backup server\x02Cannot create backup with shared stora" +
+	"ge\x02Backup only support hypervisor kvm\x02Cannot create backup with is" +
+	"olated devices\x02GuestDisksHasSnapshot fail %s\x02Cannot create backup " +
+	"with snapshot\x02Guest without backup\x02Guest backup host not found\x02" +
+	"Backup host is offline\x02guest doesn't need reconcile backup\x02guest b" +
+	"illing type %s not support cancel expire\x02guest billing type is %s\x02" +
+	"guest %s unsupport postpaid expire\x02Invalid desc: %s\x02Server Id is e" +
+	"mpty\x02Server Name is empty\x02Server %s already exists\x02Empty import" +
+	" nics\x02ip %s or mac %s has been registered\x02Not found network by ip " +
+	"%s\x02Empty import disks\x02Unmarshal data error %s\x02Some host config " +
+	"missing xml_file_path\x02Some host config missing host ip\x02Invalid hos" +
+	"t ip %s\x02Invalid server mac address %s\x02Invalid server ip address %s" +
+	"\x02NewTask error: %s\x02Hypervisor %s can't generate libvirt xml\x02Gen" +
+	"erate xml failed: %s\x02not support hypervisor %s\x02not support %s\x02g" +
+	"uest has been converted\x02host %s is not kvm host\x02guest status must " +
+	"be ready\x02Check set pending quota error %s\x02host not found???\x02emp" +
+	"ty ip list\x02Unreachable IP %s: %s\x02Unavailable IP %s: occupied\x02so" +
+	"me disk missing!!!\x02disk %s not attached to server\x02Hypervisor %s ca" +
+	"n't do io throttle\x02Cannot do io throttle in status %s\x02bps must > 0" +
+	"\x02iops must > 0\x02guest %s hypervisor %s can't migrate\x02guest %s ha" +
+	"s backup, can't migrate\x02guest %s has isolated device, can't migrate" +
+	"\x02can't rescue geust %s with local storage\x02guest %s status %s can't" +
+	" migrate\x02guest %s status %s has isolated device, can't do migrate\x02" +
+	"cannot migrate with cdrom\x02guest %s status %s can't migrate with local" +
+	" storage\x02missing guest id\x02Check input guests is exist\x02guest hyp" +
+	"ervisor %s can't create instance snapshot\x02Can't do instance snapshot " +
+	"with backup guest\x02guest can't do snapshot in status %s\x02guests disk" +
+	" %d snapshot full, can't take anymore\x02create instance snapshot failed" +
+	": %s\x02start create snapshot task failed: %s\x02Instance sanpshot not r" +
+	"eady\x02start snapshot reset failed %s\x02count must > 0\x02Generate sna" +
+	"pshot name failed %s\x02not a baremetal server\x02no valid host\x02host " +
+	"is not a baremetal\x02no such group %s\x02group and guest should belong " +
+	"to same project\x02can not bind or unbind disabled instance group\x02The" +
+	" guest %s does not have any public IP\x02The guest status need be %s or " +
+	"%s, current is %s\x02The %s guest not support public ip to eip operation" +
+	"\x02Only %s guest support this operation\x02guest has no vpc ip\x02no su" +
+	"pport for instance snapshot in guest template for now\x02there is no suc" +
+	"h secgroup %s descripted by guest template\x02the %s in guest template i" +
+	"s not a public resource\x02the %s %q in guest template is not a public r" +
+	"esource\x02the %s in guest template is not a public resource in %s scope" +
+	"\x02the %s %q in guest template is not a public resource in %s scope\x02" +
+	"guest template %s used by service catalog %s\x02guest template %s used b" +
+	"y scalig group %s\x02check disk index uniqueness fail %s\x02DISK Index %" +
+	"d has been occupied\x02cannot allocate ifname\x02checkout nic index uniq" +
+	"ueness fail %s\x02NIC Index %d has been occupied\x02host %s not found" +
+	"\x02secgroup %s not found\x02disk %s not found\x02checkout guestdisk cou" +
+	"nt fail %s\x02unknown server type %s\x02group %s not found\x02Virtual se" +
+	"rver is locked, cannot delete\x02not allow to delete prepaid server in v" +
+	"alid status\x02Cannot delete server on disabled host\x02Cannot delete se" +
+	"rver on offline host\x02Cannot delete server disk %s must not have snaps" +
+	"hots.\x02Memory size must be 8MB ~ %d GB\x02CPU core count must be 1 ~ %" +
+	"d\x02Cannot modify Memory and CPU in status %s\x02Cannot modify memory f" +
+	"or baremetal\x02name is too short\x02can't find instance snapshot %s\x02" +
+	"fetch instance snapshot error %s\x02Instance snapshot not ready\x02metda" +
+	"ta must less then 20\x02login_account is longer than 32 chars\x02No disk" +
+	" information provided\x02Invalid root image: %s\x02System disk does not " +
+	"support iso image, please consider using cdrom parameter\x02parse cdrom " +
+	"device info error %s\x02Miss operating system???\x02root disk image(%s) " +
+	"and sku(%s) architecture mismatch\x02parse disk description error %s\x02" +
+	"Snapshot error: disk index %d > 0 but disk type is %s\x02cannot create p" +
+	"repaid server on prepaid resource type\x02parse network description erro" +
+	"r %s\x02Cannot create backup with isolated device\x02parse isolated devi" +
+	"ce description error %s\x02Keypair %s not found\x02Secgroup %s not found" +
+	"\x02%s shall bind up to %d security groups\x02Invalid userdata: %v\x02in" +
+	"valid parameters for policy definition %s\x02policy definition %s requir" +
+	"e cloudregion in %s\x02policy definition %s require cloudregion not in %" +
+	"s\x02invalid policy definition %s(%s) condition %s\x02policy definition " +
+	"%s require must contains tag %s\x02policy definition %s require except t" +
+	"ag %s\x02invalid category %s for policy definition %s(%s)\x02public ip n" +
+	"ot supported for %s\x02invalid public_ip_charge_type %s\x02eip not suppo" +
+	"rted for %s\x02eip %s status invalid %s\x02eip %s has been associated" +
+	"\x02cannot assoicate with eip %s: different cloudprovider\x02cannot asso" +
+	"icate with eip %s: different region\x02fetch disk size failed\x02image %" +
+	"s do not belong to guest image %s\x02miss some subimage of guest image" +
+	"\x02Baremetal %s not enabled\x02cannot run hypervisor %s on specified ho" +
+	"st with type %s\x02no valid storage on host\x02invalid aggregate_strateg" +
+	"y: %s\x02Wire %s not found\x02Hypervisor %s not supported\x02cannot recy" +
+	"cle in status %s\x02cannot undo recycle in status %s\x02host should be d" +
+	"isabled\x02host is not a prepaid recycle host\x02cannot delete a recycle" +
+	" host without active instance\x02a recycle host shoud not allocate more " +
+	"than 1 guest\x02cannot undo a recycle host with pending_deleted guest" +
+	"\x02Not a prepaid recycle host\x02invalid any_mac address\x02Schedtag %s" +
+	" not found\x02not supported hypervisor %s\x02Host is a converted baremet" +
+	"al, should be unconverted before delete\x02Host is not disabled\x02getGu" +
+	"estCount fail %s\x02Not an empty host\x02GetDiskCount fail %s\x02Local h" +
+	"ost storage is not empty???\x02Inconsistent: local storage is not empty?" +
+	"??\x02No ipmi information was found for host %s\x02IPMI has no password " +
+	"information\x02check %s duplication fail %s\x02duplicate %s %s\x02invali" +
+	"d macAddr %s\x02check access_mac duplication fail %s\x02duplicate access" +
+	"_mac %s\x02%s is out of network IP ranges\x02IPMI network has no zone???" +
+	"\x02IPMI address located in different zone than specified\x02Access ip %" +
+	"s has been used\x02Access network has no zone???\x02Access address locat" +
+	"ed in different zone than specified\x02missing access_mac and uuid in no" +
+	"_probe mode\x02IPMI network has not zone???\x02New IPMI address located " +
+	"in another zone!\x02Cannot start a non-baremetal host\x02Cannot start ba" +
+	"remetal with active guest\x02Cannot stop a non-baremetal host\x02Cannot " +
+	"stop baremetal with non-active guest\x02Cannot stop baremetal with activ" +
+	"e guest\x02Cannot do maintenance in status %s\x02Cannot do maintenance w" +
+	"hile guest status %s\x02Cannot do unmaintenance in status %s\x02Wrong gu" +
+	"est status %s\x02not a baremetal\x02need valid access_mac and uuid to do" +
+	" prepare\x02Cannot prepare baremetal in status %s\x02Cannot prepare bare" +
+	"metal in server status %s\x02Cannot do Ipmi-probe in status %s\x02Cannot" +
+	" do initialization in status %s\x02IPMI infomation not configured\x02Gue" +
+	"st Insert error: %s\x02Invaild mac address\x02find Wire %s error: %s\x02" +
+	"invalid ipaddr %s\x02no networks on wire %s\x02IP %s not attach to wire " +
+	"%s\x02IP %s not attach to any wire\x02fail to fetch netif by mac %s: %s" +
+	"\x02fail to fetch hostwire by mac %s: %s\x02Interface %s not exist\x02On" +
+	"ly ADMIN and IPMI nic can be enable\x02Interface %s not exists\x02Not a " +
+	"baremetal\x02Not being convert to hypervisor\x02Not found baremetal serv" +
+	"er record\x02Not found guest nic by mac %s\x02Guest nic ip addr %s not e" +
+	"qual %s\x02Invalid mac address\x02Fetch netif error %s\x02Cannot sync st" +
+	"atus a non-baremetal host\x02Cannot reset baremetal in status %s\x02Cann" +
+	"ot reset baremetal with active guest\x02Cannot perform cache image in st" +
+	"atus %s\x02image %s not found\x02Cannot cache image with no checksum\x02" +
+	"host_type must be specified\x02Must be a baremetal host\x02Baremetal hos" +
+	"t is aleady occupied\x02Connot convert hypervisor in status %s\x02requir" +
+	"e system previleges to convert host in other domain\x02Unsupport driver " +
+	"type %s\x02isAlterNameUnique fail %s\x02Convert error: %s\x02Host should" +
+	" be disabled\x02Cannot unconvert in status %s\x02Not an converted hyperv" +
+	"isor\x02host status %s can't exit maintenance\x02host type %s can't do h" +
+	"ost maintenance\x02unsupport on host status %s\x02Host %s can't migrate " +
+	"guests %s in status %s\x02Cannot do insert-iso in status %s\x02Cannot do" +
+	" eject-iso in status %s\x02Cannot sync config a non-baremetal host\x02re" +
+	"served cpu must >= 0\x02reserved memory must >= 0\x02reserved storage mu" +
+	"st >= 0\x02host %s can't reserve %d cpu for each isolated device, not en" +
+	"ough\x02host %s can't reserve %dM memory for each isolated device, not e" +
+	"nough\x02host %s can't reserve %dM storage for each isolated device, not" +
+	" enough\x02Only system admin can assign host\x02StorageInUse\x02failed t" +
+	"o find storage %s to attach host\x02failed to find host %s to attach sto" +
+	"rage\x02unmarshal JoinResourceBaseCreateInput fail %s\x02GetGuestDiskCou" +
+	"nt fail %s\x02GetGuestnicsCount fail %s\x02guest on the host are using n" +
+	"etworks on this wire\x02can't delete instance snapshot with wrong status" +
+	"\x02vpc joint interVpcNetwork on different cloudprovider is not supporte" +
+	"d\x02vpc joint interVpcNetwork on different cloudEnv is not supported" +
+	"\x02vpc %s already connected to a interVpcNetwork\x02vpc %s is not conne" +
+	"cted to this interVpcNetwork\x02Isolated device used by server\x02Isolat" +
+	"edDevice %s not found\x02Isolated device already attached to another gue" +
+	"st: %s\x02Isolated device used by server: %s\x02Unsupported scheme %s" +
+	"\x02invalid public error: %v\x02GetLinkedGuestsCount failed %s\x02Cannot" +
+	" delete keypair used by servers\x02find listener of listener rule %s(%s)" +
+	"\x02invalid addr %s\x02comment too long (%d>=%d)\x02comment contains non" +
+	"-printable char: %v\x02acl cidr duplicate %s\x02unmarshal SharableVirtua" +
+	"lResourceCreateInput fail %s\x02get acl count fail %s\x02acl %s is still" +
+	" referred to by %d %s\x02invalid vrrp interface %q\x02invalid vrrp authe" +
+	"ntication pass size: %d, want [1,8]\x02invalid vrrp priority %d: want [1" +
+	",255]\x02invalid vrrp virtual_router_id %d: want [1,255]\x02invalid vrrp" +
+	" advert_int %d: want [1,255]\x02telegraf params: invalid influxdb url: %" +
+	"s\x02%s: bad base64 encoded string: %s\x02%s: bad template: %s\x02fetch " +
+	"lbagents of other clusters: %v\x02conflict with lbagent %s(%s): %v\x02lb" +
+	"cluster %s(%s) already has virtual_router_id %d\x02%s: time error: %s" +
+	"\x02%s: new time is in the future: %s > %s\x02peer lbagent %s(%s) alread" +
+	"y has vrrp priority %d\x02use yum requires valid repo_base_url\x02empty " +
+	"host name\x02find host %s: %v\x02lbagent cannot be deployed on managed h" +
+	"ost\x02find guest %s: %v\x02lbagent cannot be deployed on public guests" +
+	"\x02server is in %q state, want %q\x02unmarshal input: %v\x02host missin" +
+	"g %s field\x02empty host %s field\x02authenticate error: %v\x02user must" +
+	" have system admin privileges\x02get %s service %s url: %v\x02No previou" +
+	"s deployment info available\x02query backend group releated resource fai" +
+	"led.\x02weight %d not support, only support range 0 ~ 256\x02port %d not" +
+	" support, only support range 1 ~ 65535\x02failed to find guest %s\x02onl" +
+	"y sysadmin can specify host as backend\x02failed to find host %s\x02unex" +
+	"pected backend type %s\x02region of backend %d does not match that of lb" +
+	"'s\x02failed to find region for loadbalancer %s\x02get isDefault fail %s" +
+	"\x02backend group %s is default backend group\x02get refCount fail %s" +
+	"\x02backend group %s is still referred by %d %s\x02%s requires the virtu" +
+	"al machine state to be %s before it can be added backendgroup, but curre" +
+	"nt state of the virtual machine is %s\x02guest %s(%s) vpc %s(%s) not sam" +
+	"e as loadbalancer vpc %s\x02failed getting guest %s\x02guest %s(%s) vpc " +
+	"%s(%s) not same as vpc %s(%s)\x02guest %s(%s) is already in the backendg" +
+	"roup %s(%s)\x02failed to found region for loadbalancer backend %s\x02fai" +
+	"led to found backendgroup for backend %s(%s)\x02the acl cache in region " +
+	"%s aready exists.\x02get certificate refcount fail %s\x02certificate %s " +
+	"is still referred to by %d %s\x02invalid local certificate, private key " +
+	"is empty.\x02invalid local certificate, certificate is empty.\x02the cer" +
+	"tificate cache in region %s aready exists.\x02not allowed update content" +
+	" of certificate\x02allow only internal zone, got %s(%s)\x02wire zone mus" +
+	"t match zone parameter, got %s, want %s(%s)\x02zone of wire must be %s, " +
+	"got %s\x02get lbcluster refcount fail %v\x02lbcluster %s(%s) is still re" +
+	"ferred to by %d %s\x04\x00\x01 A\x02lbclusters %s(%s) and %s(%s) has con" +
+	"flict virtual_router_id: %d \x02invalid conditions format,required json" +
+	"\x02invalid conditions fromat,required json array\x02condition values li" +
+	"mit (5 per rule). %d given.\x02rule %s/%s already occupied by rule %s(%s" +
+	")\x02failed to find region for loadbalancer listener %s\x02failed to fin" +
+	"d region for loadbalancer listener rule %s\x02%s listener port %d is alr" +
+	"eady taken by listener %s(%s)\x02cannot find region info\x02backend grou" +
+	"p %s(%s) belongs to loadbalancer %s, not %s\x04\x00\x01 0\x02cluster zon" +
+	"e %s does not match network zone %s \x02cluster wire affiliation does no" +
+	"t match network's: %s != %s\x02loadbalancer is locked, cannot delete\x02" +
+	"Unmarshal input failed %s\x02Port value error\x02invalid internal ip add" +
+	"ress: %s\x02eip has been binding to another instance\x02eip has been bin" +
+	"ding to snat rules\x02No such eip\x02Nat gateway has %d task active, can" +
+	"'t sync status\x02Only one of that sourceCIDR and netword_id is needed" +
+	"\x02cidr %s is not in range vpc %s\x02eip has been binding to dnat rules" +
+	"\x02no such network\x02fetch guest %s: %v\x02fetch guest nic: %v\x02cann" +
+	"ot fetch network of guestnetwork %d\x02batch create is not supported for" +
+	" external resources\x02unknown parent object id spec\x02got unknown type" +
+	" %q, expect %s\x02got unknown parent type %q, expect %s\x02allocate ip a" +
+	"ddr: %v\x02exceed address count limit: %v\x02GetAllocatedNicCount fail %" +
+	"s\x02not an empty network %s\x02address %s is not in the range of networ" +
+	"k %s(%s)\x02isAddressUsed fail %s\x02address %s is already occupied\x02g" +
+	"etFreeAddressCount fail %s\x02network %s(%s) has no free addresses\x02ca" +
+	"ndidate %s out of range\x02Out of IP address\x02no allow to access netwo" +
+	"rk %s\x02Network %s not found: %v\x02Address %s not in range\x02Only sys" +
+	"tem admin allowed to use reserved ip\x02Address %s not reserved\x02Addre" +
+	"ss %s has been used\x02Bandwidth limit cannot exceed %dMbps\x02Duration " +
+	"%s invalid\x02not a valid ip address %s: %s\x02Address %s not in network" +
+	"\x02get reserved ip error\x02found %d wires for zone %s and vpc %s\x02wi" +
+	"re not found for zone %s and vpc %s\x02Invalid server_type: %s\x02valid " +
+	"vlan id\x02cannot derive valid ifname hint: %v\x02ip_prefix error: %s" +
+	"\x02subnet masklen should be smaller than 30\x02Invalid masklen %d\x02In" +
+	"valid start ip: %s %s\x02invalid end ip: %s %s\x02start and end ip not i" +
+	"n the same subnet\x02%s: Invalid IP address %s\x02bad gateway ip: %v\x02" +
+	"gateway ip must be in the same subnet as start, end ip\x02zone and vpc i" +
+	"nfo required when wire is absent\x02VPC not ready\x02eip network can onl" +
+	"y exist in default vpc, got %s(%s)\x02start and end ip when masked are n" +
+	"ot in the same cidr subnet\x02Network not in range of VPC cidrblock %s" +
+	"\x02fail to GetNetworks of vpc: %v\x02Conflict address space with existi" +
+	"ng networks in vpc %q\x02query all networks fail\x02Conflict address spa" +
+	"ce with existing networks\x02Address been assigned out of new range\x02s" +
+	"tart, end ip must be in the same subnet\x02network server_type %s not su" +
+	"pport auto alloc\x02Parse Ip Failed\x02Cannot purge network on enabled c" +
+	"loud provider\x02Network %s not found\x02Invalid Target Network %s: inco" +
+	"nsist %s\x02Incontinuity Network for %s and %s\x02only on premise suppor" +
+	"t this operation\x02Invalid IP %s\x02Split IP %s is the start ip\x02Spli" +
+	"t IP %s out of range\x02Duplicate name %s\x02GenerateName fail %s\x02Gen" +
+	"erate ifname hint failed %s\x02ip\x02Only support server type %s\x02Only" +
+	" support on premise network\x02on-premise network cannot sync status\x02" +
+	"managed network cannot change status\x02invalid status %s\x02BgpType att" +
+	"ribute is only useful for eip network\x02not support create\x02not suppo" +
+	"rt create definition\x02invalid cidr %s\x02not enough privilege\x02not s" +
+	"upported next hop type\x02Not support modify routetable for provider %s" +
+	"\x02Cannot purge route_table on enabled cloud provider\x02unmarshaling c" +
+	"idrs failed: %s\x02min_instance_number should not be smaller than 0\x02m" +
+	"in_instance_number should not be bigger than max_instance_number\x02desi" +
+	"re_instance_number should between min_instance_number and max_instance_n" +
+	"umber\x02no such cloud region %s\x02ScalingGroup should have some networ" +
+	"ks\x02some networks not exist\x02network '%s' not in vpc '%s'\x02no such" +
+	" guest template %s\x02the guest template %s is not valid in cloudregion " +
+	"%s, reason: %s\x02unkown expansion principle %s\x02unkown shrink princip" +
+	"le %s\x02unkown health check mode %s\x02no such loadbalancer backend gro" +
+	"up '%s'\x02invalid loadbalancer backend port '%d'\x02invalid loadbalance" +
+	"r backend weight '%d'\x02Please disable this ScalingGroup firstly\x02The" +
+	"re are some guests in this ScalingGroup, please delete them firstly\x02n" +
+	"o such ScalingGroup '%s'\x02Guest '%s' don't belong to ScalingGroup '%s'" +
+	"\x02every scaling policy belong to a scaling group\x02no such scaling gr" +
+	"oup %s\x02unkown trigger type %s\x02unkown scaling policy action %s\x02u" +
+	"nkown scaling policy unit %s\x02Can't trigger scaling policy without sta" +
+	"tus 'ready'\x02mismatched alarm id\x02unkown operator in alarm %s\x02unk" +
+	"own indicator in alarm %s\x02unkown wrapper in alarm %s\x02the min value" +
+	" of cycle in alarm is 300\x02invalid strategy %s\x02ResourceType %q not " +
+	"support\x02schedtag_id not provide\x02Not support resource_type %s\x02Sc" +
+	"hedtag %s\x02Schedtag %s resource_type mismatch: %s != %s\x02unmarshal J" +
+	"ointResourceCreateInput fail %s\x02Invalid schedtag %s\x02Invalid defaul" +
+	"t stragegy %s\x02Cannot set default strategy of %s\x02GetObjectCount fai" +
+	"l %s\x02Tag is associated with %s\x02getDynamicSchedtagCount fail %s\x02" +
+	"tag has dynamic rules\x02getSchedPoliciesCount fail %s\x02tag is associa" +
+	"te with sched policies\x02Schedtag %s ResourceType is %s, not match %s" +
+	"\x02Resource %s %s not found\x02unkown scheduled type '%s'\x02unkown res" +
+	"ource type '%s'\x02unkown resource operation '%s'\x02unkown label type '" +
+	"%s'\x02This scheduled task is being executed now, please try later\x02ne" +
+	"ed scheduled task\x02Failed to unmarshal input: %v\x02Failed fetching se" +
+	"cgroup %s\x02rule %d is invalid: %s\x02vpc %s(%s) is not a managed resou" +
+	"ce\x02Not support cache classic security group\x02invalid ip address: %s" +
+	"\x02secgroup %s rules not equals %s rules\x02GetGuestsCount fail %s\x02t" +
+	"he security group is in use\x02not allow to delete default security grou" +
+	"p\x02no such guest template\x02fail to parse icon url '%s'\x02no such gu" +
+	"est_template %s\x02resource %s is not support sync skus\x02input data co" +
+	"ntains invalid cloudregion id\x02no cloudregion found to sync skus\x02zo" +
+	"ne %s not in cloudregion %s\x02cpu_core_count should be range of 1~256" +
+	"\x02memory_size_mb, shoud be range of 512~%d\x02instance_type_category s" +
+	"houd be one of %s\x02Not support create public cloud sku\x02checkout ser" +
+	"ver sku name duplicate error: %v\x02Duplicate sku %s\x02instance specs l" +
+	"ist query error\x02can not update instance_type for public cloud %s\x02C" +
+	"annot change server sku name\x02check instance\x02now allow to delete in" +
+	"use instance_type.please remove related servers first: %s\x02not allow t" +
+	"o delete public cloud instance_type: %s\x02failed to find cloudregion fo" +
+	"r zone %s(%s)\x02duplicate instanceType %s\x02query sku list failed.\x02" +
+	"delete sku %s failed.\x02Retention days must in 1~%d or -1\x02repeat_wee" +
+	"kdays only contains %d days at most\x02time_points only contains %d poin" +
+	"ts at most\x02Unmarshel input failed %s\x02Retention days must in 1~6553" +
+	"5 or -1\x02Do not need to update\x02Couldn't delete snapshot policy bind" +
+	"ing to disks\x02no such disk %s\x02snapshotpolicy disk has been exist" +
+	"\x02disk %s has too many snapshot policy attached\x02guest %s not found" +
+	"\x02failed to found disk %s\x02failed to found region for disk's storage" +
+	" %s(%s)\x02Cannot delete snapshot in status %s\x02Fetch instance snapsho" +
+	"t error %s\x02snapshot referenced by instance snapshot\x02Cannot delete " +
+	"snapshot on disk reset\x02Snapshot has %d task active, can't sync status" +
+	"\x02Cannot Delete disk %s snapshots, disk exist\x02Disk %s dose not have" +
+	" snapshot\x02Can not delete disk snapshots, have manual snapshot\x02Cann" +
+	"ot purge snapshot on enabled cloud provider\x02getReferenceCount fail %s" +
+	"\x02Image is in use\x02Active download session not expired\x02Cannot del" +
+	"ete the last cache\x02Cannot uncache in status %s\x02storage cache not e" +
+	"mpty\x02referered by storages\x02cannot uncache non-customized images" +
+	"\x02storage not cache image\x02Fail to mark cache status: %s\x02missing " +
+	"image id or name\x02Invalid storage type %s\x02Invalid medium type %s" +
+	"\x02Not support create %s storage\x02GetHostCount fail %s\x02storage has" +
+	" associate hosts\x02storage has disks\x02storage has snapshots\x02storag" +
+	"e cache is missing\x02storage is enabled\x02can't detach host in status " +
+	"online\x02host %s storage %s not found\x02vpc_id\x02vpc on different clo" +
+	"udprovider peering is not supported\x02ipv4 range overlap\x02cloudprovid" +
+	"er %s %s %s %s %s not supported CrossCloud vpcpeering\x02cloudprovider %" +
+	"s %s %s %s %s not supported CrossRegion vpcpeering\x02vpc %s and vpc %s " +
+	"have already connected\x02invalid external_access_mode %q, want %s\x02no" +
+	"t allow to delete default vpc\x02GetNetworkCount fail %s\x02VPC not empt" +
+	"y, please delete network first\x02GetNatgatewayCount fail %v\x02VPC not " +
+	"empty, please delete nat gateway first\x02GetRequesterVpcPeeringConnecti" +
+	"ons fail %v\x02VPC peering not empty, please delete vpc peering first" +
+	"\x02invalid cidr_block %s\x02Cannot purge vpc on enabled cloud provider" +
+	"\x02on-premise vpc cannot sync status\x02For default vpc, only system le" +
+	"vel sharing can be set\x02Prohibit making default vpc private\x02mapped " +
+	"ip exhausted\x02bandwidth must be greater than 0\x02mtu must be range of" +
+	" 0~1000000\x02Currently only kvm platform supports creating wire\x02Host" +
+	"Count fail %s\x02wire contains hosts\x02NetworkCount fail %s\x02wire con" +
+	"tains networks\x02not empty zone\x02failed to found cloudregion %s\x02no" +
+	"t support create %s zone\x02intranet loadbalancer not support bandwidth " +
+	"charge type\x02Loadbalancer's manager (%s(%s)) does not match vpc's(%s(%" +
+	"s)) (%s)\x02Aliyun not allow to change certificate\x02master slave backe" +
+	"ndgorup must contain two backend\x02Unsupport backendgorup type %s\x02in" +
+	"valid guest %s\x02Aliyun instance weight must be in the range of 0 ~ 100" +
+	"\x02internal error: unexpected backend type %s\x02backendgroup %s not su" +
+	"pport this operation\x02region of host %q (%s) != region of loadbalancer" +
+	" %q (%s))\x02%s backend group not support change port\x02%s backend grou" +
+	"p not support change port or weight\x02Unknown backend group type %s\x02" +
+	"listener type must be http/https, got %s\x02backend group %s(%s) belongs" +
+	" to loadbalancer %s instead of %s\x02backend group type must be normal" +
+	"\x02loadbalancerlistenerrule %s(%s): fetching listener %s failed\x02http" +
+	" or https listener only supportd default or normal backendgroup\x02healt" +
+	"h_check_domain must be in the range of 1 ~ 80\x02%s length must less 500" +
+	" letters\x02sticky_session_cookie length must within 1~200\x02sticky_ses" +
+	"sion_cookie can only contain letters, Numbers, '_' and '-'\x02Unknown st" +
+	"icky_session_type, only support %s or %s\x02failed to find loadbalancer'" +
+	"s %s(%s) region\x02The specified Scheduler %s is invalid for performance" +
+	" sharing loadbalancer\x02failed to found loadbalancer for listener %s(%s" +
+	")\x02cloudregion %s(%s) not support %s scheduler\x02invalid %s,required " +
+	"int\x02%s cannot be set to 0\x02%s not support close tcp or udp loadbala" +
+	"ncer listener health check\x02Snapshot for %s name can't start with auto" +
+	", http:// or https://\x02Aliyun %s not support recovery\x02Aliyun %s onl" +
+	"y support recover from it self backups\x02Aliyun %s only 8.0 and 5.7 hig" +
+	"h_availability local_ssd or 5.6 high_availability support recovery from " +
+	"it self backups\x02slave dbinstance not support prepaid billing type\x02" +
+	"failed to match any skus in the network %s(%s) zone %s(%s)\x02Not suppor" +
+	"t create readonly dbinstance for MySQL %s %s\x02Not support create reado" +
+	"nly dbinstance for MySQL %s %s with storage type %s, only support %s\x02" +
+	"Not support create readonly dbinstance for MySQL %s\x02SQL Server only s" +
+	"upport create readonly dbinstance for 2017_ent\x02SQL Server cannot have" +
+	" more than seven read-only dbinstances\x02Not support create readonly db" +
+	"instance with master dbinstance engine %s\x02Master dbinstance memory ≥6" +
+	"4GB, up to 10 read-only instances are allowed to be created\x02Master db" +
+	"instance memory <64GB, up to 5 read-only instances are allowed to be cre" +
+	"ated\x02At least two networks are required under vpc %s(%s) with aliyun " +
+	"%s(%s)\x02Description can not start with http:// or https://\x02Aliyun D" +
+	"BInstance account name length shoud be 2~16 characters\x02%s is reserved" +
+	" for aliyun %s, please use another\x02invalid character %s for account n" +
+	"ame\x02account name can not start or end with _\x02%s only support aliyu" +
+	"n %s or %s\x02%s only support aliyun %s\x02Unknown privilege %s\x02netwo" +
+	"rk %s related vpc not found\x02account_privilege %s only support redis v" +
+	"ersion 4.0\x02invalid cidr range %s, mask length should less than or equ" +
+	"al to 24\x02required at least %d subnet.\x02required at least %d subnet " +
+	"with at least 8 free ip.\x02Loadbalancer's manager %s does not match vpc" +
+	"'s(%s(%s)) (%s)\x02all networks should in the same vpc. (%s).\x02already" +
+	" has one network in the zone %s. (%s).\x02invalid parameter loadbalancer" +
+	"_spec %s\x02invalid parameter backendgroup %s\x02invalid loadbalancer_sp" +
+	"ec %s\x02%s does not currently support creating loadbalancer acl\x02%s d" +
+	"oes not currently support creating loadbalancer certificate\x02loadbalan" +
+	"cer listener %s related loadbalancer %s not found\x02The backend %s is a" +
+	"lready registered on port %d\x02%s request the mask range should be betw" +
+	"een 16 and 28\x02%s does not currently support creating loadbalancer\x02" +
+	"%s request the mask range should be between 8 and 29\x02disk and snapsho" +
+	"tpolicy should have same domain\x02disk and snapshotpolicy should have s" +
+	"ame project\x02%s does not support creating loadbalancer\x02%s does not " +
+	"support creating loadbalancer acl\x02%s does not support creating loadba" +
+	"lancer certificate\x02Google dbinstance not support prepaid billing type" +
+	"\x02disk size gb must in range 10 ~ 30720 Gb\x02eip's manager (%s(%s)) d" +
+	"oes not match vpc's(%s(%s)) (%s)\x02loadbalancer is using by %d listener" +
+	".\x02loadbalancer is using by %d backendgroup.\x02Not support create rea" +
+	"d-only dbinstance for %s\x02Huawei dbinstance name length shoud be 4~64 " +
+	"characters\x02%s require disk size must in 40 ~ 4000 GB\x02The disk_size" +
+	"_gb must be an integer multiple of 10\x02Not support create account for " +
+	"huawei cloud %s instance\x02Huawei rds password cannot be in the same re" +
+	"verse order as the account\x02Not support create database for huawei clo" +
+	"ud %s instance\x02Huawei DBInstance backup name length shoud be 4~64 cha" +
+	"racters\x02Huawei only supports specified databases with %s\x02Huawei DB" +
+	"Instance Disk cannot be thrink\x02Huawei DBInstance category cannot chan" +
+	"ge\x02Huawei DBInstance storage type cannot change\x02Huawei current not" +
+	" support reset dbinstance account password\x02No need to grant or revoke" +
+	" privilege for admin account\x02%s not support recovery\x02Huawei %s rds" +
+	" not support recovery from it self rds backup\x02Huawei only %s engine s" +
+	"upport databases recovery\x02New databases name can not be one of %s\x02" +
+	"zone mismatch, elastic cache sku zone %s != %s\x02elastic cache sku zone" +
+	" (%s) and subnet zone (%s) mismatch\x02sku %s is soldout\x02%s not suppo" +
+	"rt create account\x02huawei %s mode elastic not support create backup" +
+	"\x02zone info missing\x02vpc lb is not allowed for now\x02zone %s(%s) ha" +
+	"s no lbcluster\x02no viable lbcluster\x02host %s has no access ip\x02err" +
+	"or getting host of guest %s\x02error loadbalancer of backend group %s" +
+	"\x02region of host %q (%s) != region of loadbalancer %q (%s)\x02redirect" +
+	" must have at least one of scheme, host, path changed\x02backend_group a" +
+	"rgument is missing\x02non redirect lblistener rule must have backend_gro" +
+	"up set\x02redirect can only be enabled for http/https listener\x02non ht" +
+	"tp listener must have backend group set\x02%s only supports eip charge t" +
+	"ype %q\x02no available eip network\x02bad network type %q, want %q\x02fa" +
+	"iled to found vpc for network %s(%s)\x02network %s(%s) does not belong t" +
+	"o %s\x02Kvm snapshot missing storage ??\x02failed to find %s %s\x02canno" +
+	"t change loadbalancer listener listener_type\x02cannot change loadbalanc" +
+	"er listener listener_port\x02account name '%s' is not allowed\x02can not" +
+	" make backup in status %s\x02invalid cidr range %s\x02loadbalancer liste" +
+	"ner %s is already updating\x02loadbalancer backendgroup aready associate" +
+	" with other %s listener\x02loadbalancer aready associated with fourth la" +
+	"yer listener %s\x02path can not be emtpy\x02server %s with port %d alrea" +
+	"dy in used\x02server %s with port %d aready used by other %s listener" +
+	"\x02Qcloud Basic MySQL instance not support create backup\x02Not support" +
+	" create Qcloud databases\x02redis version 2.8 not support create account" +
+	"\x02%s request the mask range should be less than or equal to 29\x02Empt" +
+	"y spec query key\x02Parse spec key %s error: %v\x02Get object error: %v" +
+	"\x02empty project_id/tenant_id\x02tenant/project %s not found\x02Snapsho" +
+	"t reference(by disk) count > 0, can not delete\x02disk need at least one" +
+	" of snapshot as backing file\x02Disk %s dosen't attach guest ?\x02Disk a" +
+	"ttached Guest has backup, Can't create snapshot\x02Cannot do snapshot wh" +
+	"en VM in status %s\x02check disk snapshot count fail %s\x02Disk %s snaps" +
+	"hot full, cannot take any more\x02This RBD Storage[%s/%s] has already ex" +
+	"ist\x02BadGateway\x02InternalServerError\x02ResourceNotReadyError\x02Pay" +
+	"mentError\x02ImageNotFoundError\x02ResourceNotFoundError\x02SpecNotFound" +
+	"Error\x02ActionNotFoundError\x02TenantNotFoundError\x02UserNotFoundError" +
+	"\x02ServerStatusError\x02InvalidFormatError\x02InputParameterError\x02We" +
+	"akPasswordError\x02MissingParameterError\x02InsufficientResourceError" +
+	"\x02OutOfResource\x02OutOfQuotaError\x02OutOfRange\x02OutOfLimit\x02NotS" +
+	"ufficientPrivilegeError\x02UnsupportOperationError\x02NotEmptyError\x02B" +
+	"adRequestError\x02EmptyRequestError\x02UnauthorizedError\x02InvalidCrede" +
+	"ntialError\x02ForbiddenError\x02NotAcceptableError\x02DuplicateNameError" +
+	"\x02DuplicateResourceError\x02ConflictError\x02ResourceBusyError\x02Requ" +
+	"ireLicenseError\x02ProtectedResourceError\x02NoProjectError\x02TooLargeE" +
+	"ntity\x02TooManyFailedAttempts\x02TooManyRequests\x02User Locked\x02User" +
+	" Disabled\x02UnsupportedProtocol\x02PolicyDefinitionError\x02Image %s no" +
+	"t found\x02password must be 12 chars of at least one digit, letter, uppe" +
+	"rcase letter and punctuate\x02Missing parameter %s\x02Duplicate name %s " +
+	"%s\x02Duplicate ID %s %s\x02no such driver\x02empty DN\x02empty id\x02em" +
+	"pty name\x02disabled user\x02join user into project of default domain or" +
+	" identical domain\x02sysadmin is protected\x02cannot remove current user" +
+	" from current project\x02join group into project of default domain or id" +
+	"entical domain\x02query error %s\x02missing input field type\x02missing " +
+	"input field blob\x02encrypt error %s\x02cannot delete default domain\x02" +
+	"domain is enabled\x02domain is in use by user\x02domain is in use by gro" +
+	"up\x02domain is in use by project\x02domain is in use by role\x02domain " +
+	"is in use by policy\x02domain contains external resources\x02readonly" +
+	"\x02default domain is protected\x02field %s is readonly\x02endpoint is e" +
+	"nabled\x02missing input field interface\x02missing input field service/s" +
+	"ervice_id\x02not found cert %s\x02get sensitive config requires admin pr" +
+	"iviliges\x02cannot update config when enabled and connected\x02cannot up" +
+	"date config when not idle\x02saveConfigs fail %s\x02invalid template\x02" +
+	"missing driver\x02driver %s not supported\x02driver %s already exists" +
+	"\x02cannot delete default SQL identity provider\x02cannot delete enabled" +
+	" idp\x02identity provider with projects\x02enabled domain %s cannot be d" +
+	"eleted\x02cannot update in sync status\x02domain is disabled\x02resource" +
+	" is enabled\x02fail to decode policy data\x02cannot delete system policy" +
+	"\x02cannot delete enabled policy\x02cannot delete system project\x02proj" +
+	"ect contains external resources\x02project contains user\x02project cont" +
+	"ains group\x02cannot alter system project name\x02region contains endpoi" +
+	"nts\x02missing input field id\x02cannot alter name of role\x02cannot del" +
+	"ete system role\x02role is being assigned to user\x02role is being assig" +
+	"ned to group\x02not supported update context\x02not supported update con" +
+	"text %s\x02inconsistent domain for project and roles\x02not supported se" +
+	"condary update context %s\x02service contains endpoints\x02service is en" +
+	"abled\x02update config version fail %s\x02cannot alter sysadmin user nam" +
+	"e\x02invalid password: %s\x02cannot delete non-local non-sso user\x02use" +
+	"r contains external resources\x02cannot delete system user\x02cannot joi" +
+	"n user and group in differnt domain\x02cannot join read-only group\x02ca" +
+	"nnot leave read-only group\x02version mismatch\x02project disabled\x02us" +
+	"er disabled\x02expired token\x02invalid fernet token\x02invalid auth met" +
+	"hods\x02user not found\x02empty auth request\x02user not in project\x02i" +
+	"nvalid access key id\x02expired access key\x02unrecognized input %s\x02u" +
+	"nauthorized %s\x02fail to decode request body\x02duplicate username\x02u" +
+	"ser not found or not enabled\x02invalid user\x02invalid project\x02inter" +
+	"nal server error %s\x02invalid domain\x02not allow to auth\x02invalid to" +
+	"ken\x02invalid token %s\x02not allow to get usage\x02Unauthorized\x02Inv" +
+	"alidToken\x02Name %s not found\x02No login secret found\x02no totp for %" +
+	"s\x02no recovery secrets for %s\x02totp secret exists\x02No password fou" +
+	"nd\x02No ssh password: %s\x02invalid resources format\x02service %s not " +
+	"found error: %v\x02missing uid\x02missing pids\x02missing pid in pids" +
+	"\x02missing rid in pids\x02missing rid\x02project is not found\x02No log" +
+	"in key: %s\x02Not found kind in query: %v\x02Not found key in query: %v" +
+	"\x02unsupported action %s\x02url is empty\x02invalid url: %v\x02unsuppor" +
+	"t type: %s\x02app_id is empty\x02app_secret is empty\x02channel is empty" +
+	"\x02parameter %s is empty\x02unsupported no_data_state %s\x02unsupported" +
+	" execution_error_state %s\x02metric %s is invalid format, usage <measure" +
+	"ment>.<field>\x02Cannot change state on pause alert\x02alert already att" +
+	"ached to notification\x02Alert is already un-paused\x02Alert is already " +
+	"paused\x02Invalid refresh format: %s\x02not find alert %s\x02not find no" +
+	"tification %s\x02dashboard_id is empty\x02can not find dashboard:%s\x02t" +
+	"he Comparator is illegal: %s\x02the reduce is illegal %s\x02the reduce i" +
+	"s illegal: %s\x02Alert resource driver not found\x02Alert resource drive" +
+	"r duplicate match\x02Invalid level format: %s\x02Invalid period format: " +
+	"%s\x02the AlertType is illegal:%s\x02Cannot delete system alert\x02thres" +
+	"hold:%s should be number type\x02Default data source not found\x02not su" +
+	"pport database\x02not support type %q\x02unsupported resource type %s" +
+	"\x02not found alert notification used by %s\x02unsupported notification " +
+	"type %s\x02Alert notification used by %d alert\x02input not json dict" +
+	"\x02not found signature\x02signature error\x02Invalid interval format: %" +
+	"s\x02Unsupported notification type\x02Influxdb invalid status\x02Not fin" +
+	"d executor for data source\x02Condition is missing the threshold paramet" +
+	"er\x02Condition is missing the type parameter\x02Invalid condition evalu" +
+	"ator type\x02Unknown alert condition\x02Alert is missing conditions\x02i" +
+	"nput condition is empty\x02Unkown operator %s\x02select for nothing in q" +
+	"uery\x02query duration err: from: %s, to:%s\x02query duration `to` err: " +
+	"%s\x02alert condition type is empty\x02Unkown alert condition type: %s" +
+	"\x02security group id should not be empty\x02failed to find SecurityGrou" +
+	"p %s\x02no valid endpoint\x02require validated qcloud cross region vpcPe" +
+	"ering bandwidth values:[10, 20, 50, 100, 200, 500, 1000],unit Mbps\x02fa" +
+	"iled parsing url %q: %v\x02bad ip\x02unmarshal input fail %s\x02invalid " +
+	"characters %s\x02check name duplication fail %s\x02policy is referenced"
 
-var zh_CNIndex = []uint32{ // 1692 elements
+var zh_CNIndex = []uint32{ // 1631 elements
 	// Entry 0 - 1F
-	0x00000000, 0x0000001b, 0x0000002e, 0x00000049,
-	0x00000062, 0x00000075, 0x0000008b, 0x000000b0,
-	0x000000c3, 0x000000d2, 0x000000f1, 0x0000010a,
-	0x00000126, 0x00000133, 0x00000146, 0x00000160,
-	0x0000016a, 0x0000017d, 0x000001a6, 0x000001c2,
-	0x000001d7, 0x000001f1, 0x00000206, 0x00000225,
-	0x00000243, 0x00000265, 0x00000290, 0x000002ba,
-	0x000002d2, 0x000002f0, 0x000002f0, 0x0000030e,
+	0x00000000, 0x0000001b, 0x00000038, 0x00000051,
+	0x00000069, 0x00000087, 0x000000ad, 0x000000d6,
+	0x00000102, 0x0000012b, 0x00000142, 0x0000015d,
+	0x00000173, 0x00000189, 0x0000019a, 0x000001b5,
+	0x000001d0, 0x000001e3, 0x000001ff, 0x00000215,
+	0x00000227, 0x0000025e, 0x00000283, 0x000002a9,
+	0x000002d3, 0x000002fa, 0x00000327, 0x00000360,
+	0x000003b3, 0x000003d5, 0x000003f4, 0x0000040c,
 	// Entry 20 - 3F
-	0x0000031e, 0x00000333, 0x00000350, 0x00000360,
-	0x00000379, 0x00000392, 0x000003ae, 0x000003c6,
-	0x000003e0, 0x000003f2, 0x00000404, 0x00000427,
-	0x0000043a, 0x0000044d, 0x0000046c, 0x0000047c,
-	0x00000497, 0x000004b2, 0x000004cf, 0x000004cf,
-	0x000004e2, 0x000004f7, 0x00000507, 0x00000520,
-	0x00000538, 0x0000054d, 0x00000565, 0x00000574,
-	0x00000595, 0x000005a7, 0x000005ba, 0x000005d9,
+	0x0000043d, 0x00000459, 0x00000472, 0x0000049e,
+	0x000004c6, 0x000004e0, 0x000004f2, 0x0000050c,
+	0x0000051c, 0x00000532, 0x00000544, 0x00000558,
+	0x0000056e, 0x0000058b, 0x000005ac, 0x000005be,
+	0x000005dc, 0x000005ed, 0x00000601, 0x00000617,
+	0x0000062d, 0x0000063d, 0x00000654, 0x0000067c,
+	0x0000068c, 0x000006ad, 0x000006de, 0x00000702,
+	0x00000714, 0x00000730, 0x00000745, 0x00000760,
 	// Entry 40 - 5F
-	0x000005ec, 0x00000607, 0x00000624, 0x0000063d,
-	0x00000655, 0x00000673, 0x00000699, 0x000006c2,
-	0x000006ee, 0x00000717, 0x0000072e, 0x00000749,
-	0x0000075f, 0x00000775, 0x00000786, 0x000007a1,
-	0x000007bc, 0x000007cf, 0x000007eb, 0x00000801,
-	0x00000813, 0x0000084a, 0x0000086f, 0x00000895,
-	0x000008bf, 0x000008e6, 0x00000913, 0x0000094c,
-	0x0000099f, 0x000009c1, 0x000009e0, 0x000009f8,
+	0x000007af, 0x000007c5, 0x000007e7, 0x00000803,
+	0x0000082d, 0x0000084f, 0x00000865, 0x00000877,
+	0x00000895, 0x000008a2, 0x000008bb, 0x000008c8,
+	0x000008e4, 0x000008f6, 0x00000930, 0x0000095c,
+	0x0000096b, 0x00000988, 0x000009ad, 0x000009d1,
+	0x000009f8, 0x00000a15, 0x00000a33, 0x00000a74,
+	0x00000a89, 0x00000acc, 0x00000ae7, 0x00000b02,
+	0x00000b14, 0x00000b1b, 0x00000b49, 0x00000b75,
 	// Entry 60 - 7F
-	0x00000a29, 0x00000a45, 0x00000a5e, 0x00000a8a,
-	0x00000ab2, 0x00000acc, 0x00000ade, 0x00000af8,
-	0x00000b08, 0x00000b1e, 0x00000b30, 0x00000b44,
-	0x00000b5a, 0x00000b77, 0x00000b98, 0x00000baa,
-	0x00000bc8, 0x00000bd9, 0x00000bed, 0x00000c03,
-	0x00000c19, 0x00000c29, 0x00000c40, 0x00000c68,
-	0x00000c78, 0x00000c99, 0x00000cca, 0x00000cee,
-	0x00000d00, 0x00000d1c, 0x00000d31, 0x00000d4c,
+	0x00000b8e, 0x00000ba4, 0x00000bb4, 0x00000bcf,
+	0x00000bdf, 0x00000bef, 0x00000c05, 0x00000c1d,
+	0x00000c34, 0x00000c6b, 0x00000c99, 0x00000cbb,
+	0x00000cdd, 0x00000d04, 0x00000d18, 0x00000d2f,
+	0x00000d46, 0x00000d6d, 0x00000d95, 0x00000dc2,
+	0x00000deb, 0x00000dfd, 0x00000e12, 0x00000e1c,
+	0x00000e25, 0x00000e35, 0x00000e3c, 0x00000e46,
+	0x00000e50, 0x00000e62, 0x00000e7e, 0x00000e9d,
 	// Entry 80 - 9F
-	0x00000d9b, 0x00000db1, 0x00000dd3, 0x00000def,
-	0x00000e19, 0x00000e3b, 0x00000e51, 0x00000e63,
-	0x00000e81, 0x00000e8e, 0x00000ea7, 0x00000eb4,
-	0x00000ed0, 0x00000ee2, 0x00000f1c, 0x00000f48,
-	0x00000f57, 0x00000f74, 0x00000f99, 0x00000fbd,
-	0x00000fe4, 0x00001001, 0x0000101f, 0x00001060,
-	0x00001075, 0x000010b8, 0x000010d3, 0x000010ee,
-	0x00001100, 0x00001107, 0x00001135, 0x00001161,
+	0x00000eb0, 0x00000edc, 0x00000f01, 0x00000f34,
+	0x00000f9d, 0x00000fc3, 0x00000fe5, 0x00001006,
+	0x00001025, 0x0000104a, 0x00001063, 0x0000108d,
+	0x000010b1, 0x000010d2, 0x000010fa, 0x00001115,
+	0x00001135, 0x0000115b, 0x0000116d, 0x00001182,
+	0x000011b9, 0x000011e1, 0x00001212, 0x0000122e,
+	0x00001249, 0x00001262, 0x0000128b, 0x000012a0,
+	0x000012b6, 0x00001311, 0x00001345, 0x0000136a,
 	// Entry A0 - BF
-	0x0000117a, 0x00001190, 0x000011a0, 0x000011bb,
-	0x000011cb, 0x000011db, 0x000011f1, 0x00001209,
-	0x00001220, 0x00001257, 0x00001285, 0x000012a7,
-	0x000012c9, 0x000012f0, 0x00001304, 0x0000131b,
-	0x00001332, 0x00001359, 0x00001381, 0x000013ae,
-	0x000013d7, 0x000013e9, 0x000013fe, 0x00001408,
-	0x00001411, 0x00001421, 0x00001428, 0x00001432,
-	0x0000143c, 0x0000144e, 0x0000146a, 0x00001489,
+	0x0000138b, 0x000013b3, 0x000013d9, 0x00001401,
+	0x0000141e, 0x0000144e, 0x00001478, 0x00001499,
+	0x000014c8, 0x000014f7, 0x00001527, 0x00001555,
+	0x00001573, 0x0000159c, 0x000015b4, 0x000015d9,
+	0x0000160a, 0x00001623, 0x0000163f, 0x00001667,
+	0x0000167c, 0x0000169b, 0x000016b1, 0x000016f1,
+	0x00001731, 0x00001752, 0x00001791, 0x0000179b,
+	0x000017b6, 0x000017d5, 0x000017f3, 0x00001811,
 	// Entry C0 - DF
-	0x0000149c, 0x000014c8, 0x000014ed, 0x00001520,
-	0x00001589, 0x000015af, 0x000015d1, 0x000015f2,
-	0x00001611, 0x00001636, 0x0000164f, 0x00001679,
-	0x0000169d, 0x000016be, 0x000016e6, 0x00001701,
-	0x00001721, 0x00001747, 0x00001759, 0x0000176e,
-	0x000017a5, 0x000017cd, 0x000017fe, 0x0000181a,
-	0x00001835, 0x0000184e, 0x00001877, 0x0000188c,
-	0x000018a2, 0x000018fd, 0x00001931, 0x00001956,
+	0x00001827, 0x00001869, 0x0000188a, 0x000018a0,
+	0x000018c6, 0x000018eb, 0x00001909, 0x00001932,
+	0x00001957, 0x00001974, 0x00001990, 0x000019bb,
+	0x000019d4, 0x00001a14, 0x00001a57, 0x00001a8b,
+	0x00001ab0, 0x00001ae1, 0x00001b01, 0x00001b11,
+	0x00001b32, 0x00001b58, 0x00001b78, 0x00001b8f,
+	0x00001ba6, 0x00001bc4, 0x00001be6, 0x00001bff,
+	0x00001c0f, 0x00001c26, 0x00001c3d, 0x00001c4d,
 	// Entry E0 - FF
-	0x00001977, 0x0000199f, 0x000019c5, 0x000019c5,
-	0x000019e2, 0x00001a12, 0x00001a3c, 0x00001a5d,
-	0x00001a8c, 0x00001abb, 0x00001aeb, 0x00001b19,
-	0x00001b37, 0x00001b60, 0x00001b78, 0x00001b9d,
-	0x00001bce, 0x00001be7, 0x00001c03, 0x00001c2b,
-	0x00001c40, 0x00001c5f, 0x00001c75, 0x00001cb5,
-	0x00001cf5, 0x00001d16, 0x00001d55, 0x00001d5f,
-	0x00001d7a, 0x00001d99, 0x00001db7, 0x00001dd5,
+	0x00001c65, 0x00001c72, 0x00001c8d, 0x00001c9d,
+	0x00001cb2, 0x00001cce, 0x00001ce7, 0x00001d0c,
+	0x00001d24, 0x00001d35, 0x00001d54, 0x00001d6c,
+	0x00001d84, 0x00001d9f, 0x00001db9, 0x00001dd5,
+	0x00001dee, 0x00001e13, 0x00001e2b, 0x00001e43,
+	0x00001e68, 0x00001eb0, 0x00001ebd, 0x00001ecf,
+	0x00001ef4, 0x00001f16, 0x00001f38, 0x00001f5a,
+	0x00001f70, 0x00001f8c, 0x00001fa8, 0x00001fc9,
 	// Entry 100 - 11F
-	0x00001deb, 0x00001e2d, 0x00001e4e, 0x00001e64,
-	0x00001e8a, 0x00001eaf, 0x00001ecd, 0x00001ef6,
-	0x00001f1b, 0x00001f38, 0x00001f54, 0x00001f7f,
-	0x00001f98, 0x00001fd8, 0x0000201b, 0x0000204f,
-	0x00002074, 0x000020a5, 0x000020c5, 0x000020d5,
-	0x000020f6, 0x0000211c, 0x0000213c, 0x00002153,
-	0x0000216a, 0x00002188, 0x000021aa, 0x000021c3,
-	0x000021d3, 0x000021ea, 0x00002201, 0x00002211,
+	0x00001fe2, 0x00001ffb, 0x00002019, 0x00002031,
+	0x0000204f, 0x00002070, 0x0000208a, 0x0000209c,
+	0x000020ad, 0x000020d1, 0x000020f4, 0x00002110,
+	0x0000212f, 0x00002147, 0x00002163, 0x00002182,
+	0x00002198, 0x000021a8, 0x000021b8, 0x000021dd,
+	0x000021f3, 0x0000220b, 0x00002238, 0x0000225b,
+	0x00002267, 0x00002286, 0x000022a6, 0x000022bc,
+	0x000022cf, 0x000022e4, 0x000022ff, 0x0000231c,
 	// Entry 120 - 13F
-	0x00002229, 0x00002236, 0x00002251, 0x00002261,
-	0x00002276, 0x00002292, 0x000022ab, 0x000022d0,
-	0x000022e8, 0x000022f9, 0x00002318, 0x00002330,
-	0x00002348, 0x00002363, 0x0000237d, 0x00002399,
-	0x000023b2, 0x000023d7, 0x000023ef, 0x00002407,
-	0x0000242c, 0x00002474, 0x00002481, 0x00002493,
-	0x000024b8, 0x000024b8, 0x000024b8, 0x000024b8,
-	0x000024b8, 0x000024b8, 0x000024b8, 0x000024b8,
+	0x00002331, 0x00002341, 0x0000235d, 0x00002372,
+	0x00002392, 0x000023b3, 0x000023ce, 0x000023e3,
+	0x00002413, 0x00002425, 0x0000244c, 0x00002464,
+	0x00002470, 0x00002488, 0x00002498, 0x000024b6,
+	0x000024d7, 0x00002512, 0x00002525, 0x00002536,
+	0x00002556, 0x00002572, 0x00002594, 0x000025bf,
+	0x000025df, 0x000025f5, 0x0000260e, 0x00002626,
+	0x0000263b, 0x0000265c, 0x0000266c, 0x00002688,
 	// Entry 140 - 15F
-	0x000024b8, 0x000024b8, 0x000024b8, 0x000024b8,
-	0x000024b8, 0x000024d9, 0x000024f3, 0x00002505,
-	0x00002516, 0x0000253a, 0x0000255d, 0x00002579,
-	0x00002598, 0x000025b0, 0x000025cc, 0x000025cc,
-	0x000025e2, 0x000025f2, 0x00002602, 0x00002627,
-	0x00002627, 0x0000263f, 0x0000263f, 0x00002662,
-	0x0000266e, 0x0000268d, 0x000026ad, 0x000026c3,
-	0x000026d6, 0x000026eb, 0x00002706, 0x00002723,
+	0x000026aa, 0x000026cb, 0x00002706, 0x00002734,
+	0x00002766, 0x000027a4, 0x000027d4, 0x000027fd,
+	0x00002826, 0x00002852, 0x0000287d, 0x000028a9,
+	0x00002906, 0x00002931, 0x00002960, 0x0000296a,
+	0x0000297c, 0x0000299d, 0x000029bb, 0x000029d3,
+	0x000029ee, 0x00002a0b, 0x00002a32, 0x00002a53,
+	0x00002a6c, 0x00002a95, 0x00002ad0, 0x00002af4,
+	0x00002b15, 0x00002b49, 0x00002b7c, 0x00002ba7,
 	// Entry 160 - 17F
-	0x00002738, 0x00002748, 0x00002764, 0x00002779,
-	0x00002799, 0x000027ba, 0x000027d5, 0x000027ea,
-	0x0000281a, 0x0000282c, 0x00002853, 0x0000286b,
-	0x00002877, 0x0000288f, 0x0000289f, 0x000028bd,
-	0x000028de, 0x00002919, 0x0000292c, 0x0000293d,
-	0x0000295d, 0x00002979, 0x0000299b, 0x000029c6,
-	0x000029e6, 0x000029fc, 0x00002a15, 0x00002a2d,
-	0x00002a42, 0x00002a63, 0x00002a73, 0x00002a8f,
+	0x00002bd1, 0x00002c16, 0x00002c63, 0x00002c78,
+	0x00002ca9, 0x00002cd2, 0x00002cf7, 0x00002d0d,
+	0x00002d22, 0x00002d4f, 0x00002d76, 0x00002d9b,
+	0x00002dc3, 0x00002de4, 0x00002e1d, 0x00002e48,
+	0x00002e6a, 0x00002e7c, 0x00002e99, 0x00002eba,
+	0x00002edb, 0x00002f13, 0x00002f25, 0x00002f3c,
+	0x00002f70, 0x00002f9d, 0x00002fc4, 0x00002fe7,
+	0x0000300e, 0x00003021, 0x0000303c, 0x0000305a,
 	// Entry 180 - 19F
-	0x00002ab1, 0x00002ad2, 0x00002b0d, 0x00002b3b,
-	0x00002b6d, 0x00002bab, 0x00002bdb, 0x00002c04,
-	0x00002c2d, 0x00002c59, 0x00002c84, 0x00002cb0,
-	0x00002d0d, 0x00002d38, 0x00002d67, 0x00002d71,
-	0x00002d83, 0x00002da4, 0x00002dc2, 0x00002dda,
-	0x00002df5, 0x00002e12, 0x00002e39, 0x00002e5a,
-	0x00002e73, 0x00002e9c, 0x00002ed7, 0x00002efb,
-	0x00002f1c, 0x00002f50, 0x00002f83, 0x00002fae,
+	0x00003073, 0x00003097, 0x000030b8, 0x000030d9,
+	0x00003100, 0x00003133, 0x00003160, 0x00003173,
+	0x0000319e, 0x000031bb, 0x000031df, 0x000031f9,
+	0x0000320e, 0x0000323e, 0x00003263, 0x00003294,
+	0x000032b0, 0x000032ca, 0x000032df, 0x0000330f,
+	0x0000333d, 0x0000335c, 0x00003387, 0x000033b8,
+	0x000033ca, 0x00003408, 0x00003421, 0x00003463,
+	0x0000347f, 0x000034b5, 0x000034ec, 0x0000351f,
 	// Entry 1A0 - 1BF
-	0x00002fd8, 0x0000301d, 0x0000306a, 0x0000307f,
-	0x0000307f, 0x0000307f, 0x000030a4, 0x000030ba,
-	0x000030cf, 0x000030fc, 0x00003123, 0x00003148,
-	0x00003170, 0x00003191, 0x000031ca, 0x000031ca,
-	0x000031ca, 0x000031dc, 0x000031f9, 0x0000321a,
-	0x0000323b, 0x00003273, 0x00003285, 0x0000329c,
-	0x000032d0, 0x000032fd, 0x00003324, 0x00003347,
-	0x0000336e, 0x00003381, 0x0000339c, 0x000033ba,
+	0x00003537, 0x00003551, 0x0000356e, 0x0000357f,
+	0x0000357f, 0x0000357f, 0x0000357f, 0x0000357f,
+	0x00003599, 0x000035b3, 0x000035bd, 0x000035cf,
+	0x000035ec, 0x0000360b, 0x00003631, 0x0000364a,
+	0x00003671, 0x00003698, 0x000036b3, 0x000036c5,
+	0x000036f2, 0x00003710, 0x00003728, 0x00003740,
+	0x0000375b, 0x00003776, 0x000037a3, 0x000037be,
+	0x000037e5, 0x00003816, 0x00003849, 0x0000387a,
 	// Entry 1C0 - 1DF
-	0x000033d3, 0x000033f7, 0x00003418, 0x00003439,
-	0x00003460, 0x00003493, 0x000034c0, 0x000034d3,
-	0x000034fe, 0x0000351b, 0x0000353f, 0x00003559,
-	0x0000356e, 0x0000359e, 0x000035c3, 0x000035f4,
-	0x00003610, 0x0000362a, 0x0000363f, 0x0000366f,
-	0x0000369d, 0x000036bc, 0x000036e7, 0x00003718,
-	0x0000372a, 0x00003768, 0x00003781, 0x000037c3,
-	0x000037df, 0x00003815, 0x0000384c, 0x0000387f,
+	0x00003894, 0x000038b5, 0x000038d6, 0x000038fb,
+	0x00003921, 0x0000394a, 0x00003966, 0x00003987,
+	0x000039a2, 0x000039ac, 0x000039c1, 0x000039d6,
+	0x00003a06, 0x00003a1c, 0x00003a34, 0x00003a67,
+	0x00003a7f, 0x00003a9d, 0x00003ab1, 0x00003ad8,
+	0x00003b02, 0x00003b1a, 0x00003b4a, 0x00003b77,
+	0x00003b9c, 0x00003bc1, 0x00003bf6, 0x00003c28,
+	0x00003c54, 0x00003c89, 0x00003cb9, 0x00003cd7,
 	// Entry 1E0 - 1FF
-	0x00003897, 0x000038b1, 0x000038ce, 0x000038df,
-	0x000038df, 0x000038df, 0x000038df, 0x000038df,
-	0x000038f9, 0x00003913, 0x0000391d, 0x0000392f,
-	0x0000394c, 0x0000396b, 0x00003991, 0x000039aa,
-	0x000039d1, 0x000039f8, 0x00003a13, 0x00003a25,
-	0x00003a52, 0x00003a70, 0x00003a88, 0x00003aa0,
-	0x00003abb, 0x00003ad6, 0x00003b03, 0x00003b1e,
-	0x00003b45, 0x00003b76, 0x00003ba9, 0x00003bda,
+	0x00003cfa, 0x00003d19, 0x00003d2f, 0x00003d45,
+	0x00003d6f, 0x00003db7, 0x00003dd8, 0x00003e11,
+	0x00003e41, 0x00003e48, 0x00003e55, 0x00003e6e,
+	0x00003ea6, 0x00003ec7, 0x00003ee6, 0x00003f14,
+	0x00003f49, 0x00003f6e, 0x00003f97, 0x00003fac,
+	0x00003ff0, 0x00004002, 0x00004028, 0x00004040,
+	0x0000405c, 0x00004077, 0x00004093, 0x0000409f,
+	0x000040ca, 0x000040e6, 0x00004110, 0x0000413b,
 	// Entry 200 - 21F
-	0x00003bf4, 0x00003c15, 0x00003c36, 0x00003c5b,
-	0x00003c81, 0x00003caa, 0x00003cc6, 0x00003ce7,
-	0x00003d02, 0x00003d0c, 0x00003d21, 0x00003d36,
-	0x00003d66, 0x00003d7c, 0x00003d94, 0x00003dc7,
-	0x00003ddf, 0x00003dfd, 0x00003e11, 0x00003e38,
-	0x00003e62, 0x00003e7a, 0x00003eaa, 0x00003ed7,
-	0x00003efc, 0x00003f21, 0x00003f56, 0x00003f88,
-	0x00003fb4, 0x00003fe9, 0x00004019, 0x00004037,
+	0x00004157, 0x00004170, 0x0000418f, 0x000041af,
+	0x000041ce, 0x000041f4, 0x0000421b, 0x00004239,
+	0x00004277, 0x000042b5, 0x000042e2, 0x00004303,
+	0x00004313, 0x00004353, 0x00004376, 0x0000439b,
+	0x000043ba, 0x000043d9, 0x000043eb, 0x00004413,
+	0x00004426, 0x0000446f, 0x00004490, 0x000044b2,
+	0x000044d3, 0x000044e6, 0x00004502, 0x0000452c,
+	0x00004550, 0x0000456f, 0x0000459d, 0x000045ca,
 	// Entry 220 - 23F
-	0x00004037, 0x00004056, 0x0000406c, 0x00004082,
-	0x000040ac, 0x000040f4, 0x00004115, 0x0000414e,
-	0x0000417e, 0x0000417e, 0x0000417e, 0x00004197,
-	0x000041cf, 0x000041f0, 0x000041f0, 0x000041f0,
-	0x000041f0, 0x000041f0, 0x000041f0, 0x00004205,
-	0x00004205, 0x00004217, 0x0000423d, 0x00004255,
-	0x00004271, 0x0000428c, 0x000042a8, 0x000042b4,
-	0x000042df, 0x000042fb, 0x00004325, 0x00004350,
+	0x000045eb, 0x00004618, 0x00004642, 0x0000466a,
+	0x00004686, 0x0000469b, 0x000046c2, 0x000046e3,
+	0x0000470c, 0x0000471e, 0x0000474b, 0x00004778,
+	0x00004797, 0x000047b0, 0x000047d1, 0x00004802,
+	0x0000482f, 0x00004842, 0x00004869, 0x0000488f,
+	0x000048b5, 0x000048d5, 0x000048fc, 0x0000491c,
+	0x00004943, 0x0000496a, 0x0000498b, 0x000049ca,
+	0x000049d6, 0x000049e6, 0x00004a08, 0x00004a29,
 	// Entry 240 - 25F
-	0x0000436c, 0x00004385, 0x000043a4, 0x000043c4,
-	0x000043e3, 0x00004409, 0x00004430, 0x0000444e,
-	0x0000448c, 0x000044ca, 0x000044f7, 0x00004518,
-	0x00004528, 0x00004568, 0x00004568, 0x0000458d,
-	0x000045ac, 0x000045cb, 0x000045dd, 0x00004605,
-	0x00004618, 0x00004661, 0x00004682, 0x000046a4,
-	0x000046c5, 0x000046d8, 0x000046f4, 0x0000471e,
-	0x00004742, 0x00004761, 0x0000478f, 0x000047bc,
+	0x00004a52, 0x00004a77, 0x00004aa5, 0x00004ac6,
+	0x00004adb, 0x00004aee, 0x00004b01, 0x00004b20,
+	0x00004b42, 0x00004b5a, 0x00004b73, 0x00004b89,
+	0x00004ba8, 0x00004bcc, 0x00004bde, 0x00004c15,
+	0x00004c2b, 0x00004c43, 0x00004c65, 0x00004c7c,
+	0x00004c91, 0x00004cbd, 0x00004cf1, 0x00004d25,
+	0x00004d34, 0x00004d44, 0x00004d5b, 0x00004d7b,
+	0x00004da0, 0x00004dbf, 0x00004dd7, 0x00004e04,
 	// Entry 260 - 27F
-	0x000047dd, 0x0000480a, 0x00004834, 0x0000485c,
-	0x00004878, 0x0000488d, 0x000048b4, 0x000048d5,
-	0x000048fe, 0x00004910, 0x0000493d, 0x0000496a,
-	0x0000496a, 0x00004983, 0x000049a4, 0x000049d5,
-	0x00004a02, 0x00004a15, 0x00004a3c, 0x00004a62,
-	0x00004a88, 0x00004aa8, 0x00004acf, 0x00004aef,
-	0x00004b16, 0x00004b3d, 0x00004b5e, 0x00004b9d,
-	0x00004ba9, 0x00004bb9, 0x00004bdb, 0x00004bfc,
+	0x00004e31, 0x00004e58, 0x00004e6e, 0x00004e8f,
+	0x00004ea5, 0x00004ec4, 0x00004ee8, 0x00004f01,
+	0x00004f1e, 0x00004f4f, 0x00004f6b, 0x00004f99,
+	0x00004fba, 0x00004fd8, 0x00004ff1, 0x00005015,
+	0x0000505d, 0x00005084, 0x000050ab, 0x000050d2,
+	0x000050f0, 0x00005103, 0x00005113, 0x00005123,
+	0x0000514e, 0x0000517d, 0x000051ad, 0x000051c6,
+	0x000051db, 0x00005205, 0x00005221, 0x00005258,
 	// Entry 280 - 29F
-	0x00004c25, 0x00004c4a, 0x00004c78, 0x00004c99,
-	0x00004cae, 0x00004cc1, 0x00004cd4, 0x00004cf3,
-	0x00004d15, 0x00004d2d, 0x00004d46, 0x00004d5c,
-	0x00004d7b, 0x00004d9f, 0x00004db1, 0x00004de8,
-	0x00004dfe, 0x00004e16, 0x00004e38, 0x00004e4f,
-	0x00004e64, 0x00004e90, 0x00004ec4, 0x00004ef8,
-	0x00004f07, 0x00004f17, 0x00004f2e, 0x00004f4e,
-	0x00004f73, 0x00004f92, 0x00004faa, 0x00004fd7,
+	0x0000526a, 0x00005289, 0x0000529b, 0x000052b3,
+	0x000052c9, 0x000052ee, 0x00005310, 0x00005335,
+	0x00005356, 0x00005372, 0x00005382, 0x000053a1,
+	0x000053bd, 0x000053df, 0x00005412, 0x0000542d,
+	0x00005454, 0x00005468, 0x00005477, 0x00005487,
+	0x00005499, 0x000054b2, 0x000054cd, 0x000054eb,
+	0x00005504, 0x0000551f, 0x00005548, 0x0000556a,
+	0x00005582, 0x0000559a, 0x000055b5, 0x000055cd,
 	// Entry 2A0 - 2BF
-	0x00005004, 0x0000502b, 0x00005041, 0x00005062,
-	0x00005078, 0x00005097, 0x000050bb, 0x000050d4,
-	0x000050f1, 0x00005122, 0x0000513e, 0x0000516c,
-	0x0000518d, 0x000051ab, 0x000051c4, 0x000051e8,
-	0x00005230, 0x00005257, 0x0000527e, 0x000052a5,
-	0x000052c3, 0x000052d6, 0x000052e6, 0x000052f6,
-	0x00005321, 0x00005350, 0x00005380, 0x00005399,
-	0x000053ae, 0x000053d8, 0x000053f4, 0x0000542b,
+	0x000055f2, 0x00005607, 0x0000561e, 0x0000562a,
+	0x00005640, 0x0000565b, 0x00005677, 0x000056a4,
+	0x000056b7, 0x000056c6, 0x000056da, 0x000056f8,
+	0x0000570e, 0x00005729, 0x0000574b, 0x0000576e,
+	0x0000577f, 0x00005791, 0x000057b7, 0x000057d8,
+	0x00005804, 0x00005834, 0x00005854, 0x00005889,
+	0x000058a4, 0x000058d6, 0x000058e8, 0x00005907,
+	0x00005933, 0x0000594f, 0x00005970, 0x000059a9,
 	// Entry 2C0 - 2DF
-	0x0000543d, 0x0000545c, 0x0000546e, 0x00005486,
-	0x0000549c, 0x000054c1, 0x000054e3, 0x00005508,
-	0x00005529, 0x00005545, 0x00005555, 0x00005574,
-	0x00005590, 0x000055b2, 0x000055e5, 0x00005600,
-	0x00005627, 0x0000563b, 0x0000564a, 0x0000565a,
-	0x0000566c, 0x00005685, 0x000056a0, 0x000056be,
-	0x000056d7, 0x000056f2, 0x0000571b, 0x0000573d,
-	0x00005755, 0x0000576d, 0x00005788, 0x000057a0,
+	0x000059c1, 0x000059df, 0x000059f2, 0x00005a0d,
+	0x00005a20, 0x00005a3e, 0x00005a57, 0x00005a6a,
+	0x00005a83, 0x00005a98, 0x00005ac3, 0x00005af1,
+	0x00005b06, 0x00005b37, 0x00005b5d, 0x00005b78,
+	0x00005b8e, 0x00005bb3, 0x00005bdd, 0x00005c04,
+	0x00005c2e, 0x00005c63, 0x00005c9b, 0x00005cc4,
+	0x00005cea, 0x00005d11, 0x00005d2c, 0x00005d42,
+	0x00005d69, 0x00005d84, 0x00005d99, 0x00005dae,
 	// Entry 2E0 - 2FF
-	0x000057c5, 0x000057da, 0x000057f1, 0x000057fd,
-	0x00005813, 0x0000582e, 0x0000584a, 0x00005877,
-	0x0000588a, 0x00005899, 0x000058ad, 0x000058cb,
-	0x000058e1, 0x000058fc, 0x0000591e, 0x00005941,
-	0x00005952, 0x00005964, 0x0000598a, 0x000059ab,
-	0x000059ab, 0x000059db, 0x000059fb, 0x00005a30,
-	0x00005a4b, 0x00005a7d, 0x00005a8f, 0x00005aae,
-	0x00005ada, 0x00005af6, 0x00005b17, 0x00005b50,
+	0x00005dc0, 0x00005de4, 0x00005e00, 0x00005e15,
+	0x00005e34, 0x00005e62, 0x00005e90, 0x00005eb8,
+	0x00005eec, 0x00005f15, 0x00005f37, 0x00005f67,
+	0x00005f8c, 0x00005f99, 0x00005fb1, 0x00005fcf,
+	0x00005fe8, 0x00006008, 0x0000602d, 0x00006043,
+	0x0000605d, 0x00006090, 0x000060b6, 0x000060d5,
+	0x0000611a, 0x0000613e, 0x00006171, 0x000061ae,
+	0x000061d2, 0x000061fd, 0x00006227, 0x0000623c,
 	// Entry 300 - 31F
-	0x00005b68, 0x00005b86, 0x00005b99, 0x00005bb4,
-	0x00005bc7, 0x00005be5, 0x00005bfe, 0x00005c11,
-	0x00005c2a, 0x00005c3f, 0x00005c6a, 0x00005c98,
-	0x00005cad, 0x00005cde, 0x00005d04, 0x00005d1f,
-	0x00005d1f, 0x00005d44, 0x00005d6e, 0x00005d95,
-	0x00005dbf, 0x00005df4, 0x00005e2c, 0x00005e55,
-	0x00005e7b, 0x00005ea2, 0x00005ebd, 0x00005ed3,
-	0x00005efa, 0x00005f15, 0x00005f2a, 0x00005f3f,
+	0x00006251, 0x00006271, 0x00006288, 0x000062ac,
+	0x000062da, 0x0000630b, 0x00006335, 0x0000635e,
+	0x00006384, 0x000063ab, 0x000063c6, 0x000063e7,
+	0x000063f6, 0x0000640b, 0x0000641e, 0x0000644d,
+	0x00006478, 0x00006491, 0x000064b1, 0x000064d9,
+	0x000064ee, 0x00006514, 0x00006533, 0x00006553,
+	0x0000656b, 0x00006582, 0x000065ac, 0x000065d6,
+	0x000065f5, 0x0000661d, 0x0000664e, 0x00006686,
 	// Entry 320 - 33F
-	0x00005f51, 0x00005f75, 0x00005f75, 0x00005f8a,
-	0x00005fa9, 0x00005fd7, 0x00006005, 0x0000602d,
-	0x00006061, 0x0000608a, 0x000060ac, 0x000060dc,
-	0x00006101, 0x0000610e, 0x00006126, 0x00006144,
-	0x0000615d, 0x0000617d, 0x000061a2, 0x000061b8,
-	0x000061d2, 0x00006205, 0x0000622b, 0x0000624a,
-	0x0000626e, 0x000062a1, 0x000062de, 0x00006302,
-	0x0000632d, 0x00006357, 0x0000636c, 0x00006381,
+	0x000066b7, 0x000066d9, 0x000066f0, 0x00006706,
+	0x0000671d, 0x00006772, 0x0000678b, 0x000067aa,
+	0x000067ba, 0x000067d8, 0x000067f7, 0x00006816,
+	0x00006838, 0x00006852, 0x0000686c, 0x00006878,
+	0x00006889, 0x000068ab, 0x000068c2, 0x000068d7,
+	0x000068f5, 0x00006916, 0x00006931, 0x0000695a,
+	0x00006979, 0x000069a5, 0x000069c0, 0x000069e4,
+	0x00006a0c, 0x00006a46, 0x00006a6e, 0x00006aab,
 	// Entry 340 - 35F
-	0x000063a1, 0x000063b8, 0x000063dc, 0x0000640a,
-	0x0000643b, 0x00006465, 0x0000648e, 0x000064b4,
-	0x000064db, 0x000064f6, 0x00006517, 0x00006526,
-	0x0000653b, 0x0000654e, 0x0000657d, 0x000065a8,
-	0x000065c1, 0x000065e1, 0x00006609, 0x0000661e,
-	0x00006644, 0x00006663, 0x00006683, 0x0000669b,
-	0x000066b2, 0x000066dc, 0x00006706, 0x00006725,
-	0x0000674d, 0x0000677e, 0x000067b6, 0x000067e7,
+	0x00006ae5, 0x00006b09, 0x00006b33, 0x00006b57,
+	0x00006b6f, 0x00006b8e, 0x00006bc7, 0x00006bf4,
+	0x00006c1e, 0x00006c46, 0x00006c6d, 0x00006c81,
+	0x00006c9f, 0x00006caf, 0x00006ccf, 0x00006ce0,
+	0x00006d04, 0x00006d21, 0x00006d42, 0x00006d6b,
+	0x00006d94, 0x00006da6, 0x00006dd0, 0x00006de2,
+	0x00006e01, 0x00006e1e, 0x00006e40, 0x00006e6c,
+	0x00006e97, 0x00006eaa, 0x00006ec2, 0x00006ef6,
 	// Entry 360 - 37F
-	0x00006809, 0x00006820, 0x00006836, 0x0000684d,
-	0x000068a2, 0x000068bb, 0x000068da, 0x000068ea,
-	0x00006908, 0x00006927, 0x00006946, 0x00006968,
-	0x00006982, 0x0000699c, 0x000069a8, 0x000069b9,
-	0x000069db, 0x000069f2, 0x00006a07, 0x00006a25,
-	0x00006a46, 0x00006a61, 0x00006a8a, 0x00006aa9,
-	0x00006ad5, 0x00006af0, 0x00006b14, 0x00006b3c,
-	0x00006b76, 0x00006b9e, 0x00006bdb, 0x00006c15,
+	0x00006f2c, 0x00006f72, 0x00006f9c, 0x00006fae,
+	0x00006fdc, 0x00006ff8, 0x0000701a, 0x00007039,
+	0x00007061, 0x0000708f, 0x000070a1, 0x000070c4,
+	0x000070d6, 0x000070f2, 0x00007116, 0x00007139,
+	0x00007163, 0x0000718d, 0x000071b4, 0x000071eb,
+	0x00007216, 0x00007240, 0x00007277, 0x00007299,
+	0x000072c1, 0x000072e3, 0x0000732a, 0x00007372,
+	0x000073ba, 0x000073df, 0x000073f2, 0x00007407,
 	// Entry 380 - 39F
-	0x00006c39, 0x00006c63, 0x00006c87, 0x00006c9f,
-	0x00006cbe, 0x00006cf7, 0x00006d24, 0x00006d4e,
-	0x00006d76, 0x00006d9d, 0x00006db1, 0x00006dcf,
-	0x00006ddf, 0x00006dff, 0x00006e10, 0x00006e34,
-	0x00006e51, 0x00006e72, 0x00006e9b, 0x00006ec4,
-	0x00006ed6, 0x00006f00, 0x00006f12, 0x00006f31,
-	0x00006f4e, 0x00006f4e, 0x00006f4e, 0x00006f4e,
-	0x00006f61, 0x00006f79, 0x00006fad, 0x00006fe3,
+	0x0000741f, 0x00007450, 0x0000746d, 0x00007490,
+	0x000074cd, 0x000074f8, 0x000074f8, 0x000074f8,
+	0x000074f8, 0x000074f8, 0x00007517, 0x0000752f,
+	0x0000755c, 0x0000757d, 0x0000758f, 0x000075a4,
+	0x000075c4, 0x000075ec, 0x00007617, 0x00007629,
+	0x00007648, 0x00007672, 0x00007695, 0x00007695,
+	0x000076b9, 0x000076db, 0x000076fa, 0x0000772d,
+	0x00007756, 0x00007789, 0x000077b5, 0x000077e1,
 	// Entry 3A0 - 3BF
-	0x00007029, 0x00007053, 0x00007065, 0x00007093,
-	0x000070af, 0x000070d1, 0x000070f0, 0x00007118,
-	0x00007146, 0x00007158, 0x0000717b, 0x0000718d,
-	0x000071a9, 0x000071cd, 0x000071f0, 0x0000721a,
-	0x00007244, 0x0000726b, 0x000072a2, 0x000072cd,
-	0x000072f7, 0x0000732e, 0x00007350, 0x00007378,
-	0x0000739a, 0x000073e1, 0x00007429, 0x00007471,
-	0x00007496, 0x000074a9, 0x000074be, 0x000074d6,
+	0x00007804, 0x0000781e, 0x0000784b, 0x0000786c,
+	0x0000789c, 0x000078b3, 0x000078db, 0x0000790c,
+	0x00007944, 0x00007954, 0x00007971, 0x000079a2,
+	0x000079bc, 0x000079ea, 0x00007a10, 0x00007a30,
+	0x00007a45, 0x00007a5a, 0x00007a6c, 0x00007a91,
+	0x00007ab1, 0x00007ad0, 0x00007af5, 0x00007b20,
+	0x00007b4b, 0x00007b5d, 0x00007b8e, 0x00007ba3,
+	0x00007bbe, 0x00007bf3, 0x00007c1d, 0x00007c38,
 	// Entry 3C0 - 3DF
-	0x00007507, 0x00007524, 0x00007547, 0x00007584,
-	0x00007584, 0x00007584, 0x00007584, 0x00007584,
-	0x00007584, 0x000075a3, 0x000075bb, 0x000075e8,
-	0x00007609, 0x0000761b, 0x00007630, 0x00007650,
-	0x00007678, 0x000076a3, 0x000076b5, 0x000076d4,
-	0x000076fe, 0x00007721, 0x00007721, 0x00007745,
-	0x00007767, 0x00007786, 0x000077b9, 0x000077e2,
-	0x00007815, 0x00007841, 0x0000786d, 0x00007890,
+	0x00007c59, 0x00007c73, 0x00007c92, 0x00007cde,
+	0x00007d1f, 0x00007d34, 0x00007d5d, 0x00007d85,
+	0x00007db2, 0x00007de0, 0x00007e08, 0x00007e29,
+	0x00007e45, 0x00007e6a, 0x00007e95, 0x00007eb7,
+	0x00007ed3, 0x00007f04, 0x00007f41, 0x00007f69,
+	0x00007f99, 0x00007fbf, 0x0000800e, 0x00008034,
+	0x00008063, 0x00008094, 0x000080b2, 0x000080e2,
+	0x0000810c, 0x00008132, 0x0000814b, 0x0000818c,
 	// Entry 3E0 - 3FF
-	0x000078aa, 0x000078d7, 0x000078f8, 0x00007928,
-	0x0000793f, 0x00007967, 0x00007998, 0x000079d0,
-	0x000079e0, 0x000079fd, 0x00007a2e, 0x00007a48,
-	0x00007a76, 0x00007a9c, 0x00007abc, 0x00007ad1,
-	0x00007ae6, 0x00007af8, 0x00007b1d, 0x00007b3d,
-	0x00007b5c, 0x00007b81, 0x00007bac, 0x00007bd7,
-	0x00007be9, 0x00007c1a, 0x00007c2f, 0x00007c4a,
-	0x00007c7f, 0x00007ca9, 0x00007cc4, 0x00007ce5,
+	0x000081ca, 0x0000820e, 0x00008239, 0x0000825a,
+	0x0000826a, 0x00008287, 0x000082a3, 0x000082bd,
+	0x000082ca, 0x00008315, 0x00008348, 0x0000836a,
+	0x00008384, 0x00008394, 0x00008394, 0x00008394,
+	0x00008394, 0x00008394, 0x00008394, 0x00008394,
+	0x00008394, 0x00008394, 0x00008394, 0x000083b4,
+	0x000083db, 0x000083ff, 0x0000841e, 0x00008433,
+	0x00008458, 0x0000847a, 0x00008495, 0x000084ad,
 	// Entry 400 - 41F
-	0x00007cff, 0x00007d1e, 0x00007d6a, 0x00007dab,
-	0x00007dc0, 0x00007de9, 0x00007e11, 0x00007e3e,
-	0x00007e6c, 0x00007e94, 0x00007eb5, 0x00007ed1,
-	0x00007ef6, 0x00007f21, 0x00007f43, 0x00007f5f,
-	0x00007f90, 0x00007fcd, 0x00007ff5, 0x00008025,
-	0x0000804b, 0x0000809a, 0x000080c0, 0x000080ef,
-	0x00008120, 0x0000813e, 0x0000816e, 0x00008198,
-	0x000081be, 0x000081d7, 0x00008218, 0x00008256,
+	0x000084c5, 0x000084df, 0x000084f7, 0x00008527,
+	0x0000853c, 0x00008551, 0x00008570, 0x00008588,
+	0x000085a1, 0x000085b9, 0x000085d2, 0x00008600,
+	0x00008624, 0x00008644, 0x00008654, 0x0000867e,
+	0x00008693, 0x000086b1, 0x000086c5, 0x000086df,
+	0x000086f9, 0x00008720, 0x00008738, 0x0000874f,
+	0x00008784, 0x000087b4, 0x000087c4, 0x00008801,
+	0x0000883e, 0x00008864, 0x00008885, 0x000088aa,
 	// Entry 420 - 43F
-	0x0000829a, 0x000082c5, 0x000082e6, 0x000082f6,
-	0x00008313, 0x0000832f, 0x00008349, 0x00008356,
-	0x000083a1, 0x000083d4, 0x000083f6, 0x00008410,
-	0x00008420, 0x00008420, 0x00008420, 0x00008420,
-	0x00008420, 0x00008420, 0x00008420, 0x00008420,
-	0x00008420, 0x00008420, 0x00008440, 0x00008467,
-	0x0000848b, 0x000084aa, 0x000084bf, 0x000084e4,
-	0x00008506, 0x00008521, 0x00008539, 0x00008551,
+	0x000088c6, 0x000088e2, 0x00008910, 0x00008937,
+	0x00008961, 0x00008976, 0x000089b9, 0x000089cb,
+	0x000089f5, 0x00008a12, 0x00008a2e, 0x00008a3d,
+	0x00008a5a, 0x00008a72, 0x00008a7f, 0x00008a9d,
+	0x00008abe, 0x00008ac1, 0x00008ad9, 0x00008af5,
+	0x00008b23, 0x00008b45, 0x00008b57, 0x00008b88,
+	0x00008b98, 0x00008bb4, 0x00008bb4, 0x00008bc1,
+	0x00008bc1, 0x00008bc1, 0x00008c07, 0x00008c27,
 	// Entry 440 - 45F
-	0x0000856b, 0x00008583, 0x000085b3, 0x000085c8,
-	0x000085dd, 0x000085fc, 0x00008614, 0x0000862d,
-	0x00008645, 0x0000865e, 0x0000868c, 0x000086b0,
-	0x000086d0, 0x000086e0, 0x0000870a, 0x0000871f,
-	0x0000873d, 0x00008751, 0x0000876b, 0x00008785,
-	0x000087ac, 0x000087c4, 0x000087db, 0x00008810,
-	0x00008840, 0x00008850, 0x0000888d, 0x000088ca,
-	0x000088f0, 0x00008911, 0x00008936, 0x00008952,
+	0x00008c48, 0x00008c7b, 0x00008cca, 0x00008ce2,
+	0x00008d04, 0x00008d1a, 0x00008d32, 0x00008d4a,
+	0x00008d81, 0x00008d9c, 0x00008db7, 0x00008dd5,
+	0x00008df6, 0x00008e1a, 0x00008e3e, 0x00008e57,
+	0x00008e8e, 0x00008ea6, 0x00008ec3, 0x00008ee8,
+	0x00008efd, 0x00008f15, 0x00008f33, 0x00008f57,
+	0x00008f8a, 0x00008f9c, 0x00008fc0, 0x00008fe4,
+	0x0000900b, 0x0000902a, 0x0000903c, 0x00009054,
 	// Entry 460 - 47F
-	0x0000896e, 0x0000899c, 0x000089c3, 0x000089ed,
-	0x00008a02, 0x00008a45, 0x00008a57, 0x00008a81,
-	0x00008a9e, 0x00008aba, 0x00008ac9, 0x00008ae6,
-	0x00008afe, 0x00008b0b, 0x00008b29, 0x00008b4a,
-	0x00008b4d, 0x00008b65, 0x00008b81, 0x00008baf,
-	0x00008bd1, 0x00008be3, 0x00008c14, 0x00008c24,
-	0x00008c40, 0x00008c40, 0x00008c4d, 0x00008c4d,
-	0x00008c4d, 0x00008c93, 0x00008cb3, 0x00008cd4,
+	0x0000906c, 0x00009084, 0x00009093, 0x000090c5,
+	0x000090f3, 0x0000910b, 0x00009123, 0x00009144,
+	0x00009164, 0x00009179, 0x000091a2, 0x000091bb,
+	0x000091e2, 0x00009201, 0x00009235, 0x00009235,
+	0x0000924d, 0x00009265, 0x00009277, 0x0000928f,
+	0x000092ba, 0x000092d3, 0x000092f4, 0x0000930c,
+	0x00009326, 0x00009349, 0x00009368, 0x0000937f,
+	0x000093a2, 0x000093c1, 0x000093d7, 0x000093f9,
 	// Entry 480 - 49F
-	0x00008d07, 0x00008d56, 0x00008d6e, 0x00008d90,
-	0x00008da6, 0x00008dbe, 0x00008dd6, 0x00008e0d,
-	0x00008e28, 0x00008e43, 0x00008e61, 0x00008e82,
-	0x00008ea6, 0x00008eca, 0x00008ee3, 0x00008f1a,
-	0x00008f32, 0x00008f4f, 0x00008f74, 0x00008f89,
-	0x00008fa1, 0x00008fbf, 0x00008fe3, 0x00009016,
-	0x00009028, 0x0000904c, 0x00009070, 0x00009097,
-	0x000090b6, 0x000090c8, 0x000090e0, 0x000090f8,
+	0x0000940f, 0x0000942a, 0x00009442, 0x00009442,
+	0x00009442, 0x00009442, 0x00009442, 0x00009467,
+	0x0000948b, 0x000094b6, 0x000094b6, 0x000094d4,
+	0x000094e4, 0x00009503, 0x0000952e, 0x00009544,
+	0x00009557, 0x000095a8, 0x000095d3, 0x000095ff,
+	0x00009614, 0x0000962a, 0x0000963d, 0x00009668,
+	0x0000968f, 0x000096bb, 0x000096dc, 0x00009712,
+	0x0000971f, 0x0000974d, 0x0000975f, 0x0000977b,
 	// Entry 4A0 - 4BF
-	0x00009110, 0x0000911f, 0x00009151, 0x0000917f,
-	0x00009197, 0x000091af, 0x000091d0, 0x000091f0,
-	0x00009205, 0x0000922e, 0x00009247, 0x0000926e,
-	0x0000928d, 0x000092c1, 0x000092c1, 0x000092d9,
-	0x000092f1, 0x00009303, 0x0000931b, 0x00009346,
-	0x0000935f, 0x00009380, 0x00009398, 0x000093b2,
-	0x000093d5, 0x000093f4, 0x0000940b, 0x0000942e,
-	0x0000944d, 0x00009463, 0x00009485, 0x0000949b,
+	0x000097a2, 0x000097b4, 0x000097c9, 0x000097ee,
+	0x0000980f, 0x0000982d, 0x0000984c, 0x0000986e,
+	0x000098b0, 0x000098dd, 0x000098f2, 0x00009923,
+	0x00009966, 0x00009989, 0x0000999c, 0x000099b5,
+	0x000099d1, 0x000099ef, 0x00009a02, 0x00009a15,
+	0x00009a3a, 0x00009a56, 0x00009a74, 0x00009a8f,
+	0x00009aa7, 0x00009abf, 0x00009ad7, 0x00009af5,
+	0x00009b0e, 0x00009b24, 0x00009b3a, 0x00009b50,
 	// Entry 4C0 - 4DF
-	0x000094b6, 0x000094ce, 0x000094ce, 0x000094ce,
-	0x000094ce, 0x000094ce, 0x000094f3, 0x00009517,
-	0x00009542, 0x00009542, 0x00009560, 0x00009570,
-	0x0000958f, 0x000095ba, 0x000095d0, 0x000095e3,
-	0x00009634, 0x0000965f, 0x0000968b, 0x000096a0,
-	0x000096b6, 0x000096c9, 0x000096f4, 0x0000971b,
-	0x00009747, 0x00009768, 0x0000979e, 0x000097ab,
-	0x000097d9, 0x000097eb, 0x00009807, 0x0000982e,
+	0x00009b69, 0x00009b8b, 0x00009ba8, 0x00009ba8,
+	0x00009ba8, 0x00009ba8, 0x00009ba8, 0x00009ba8,
+	0x00009ba8, 0x00009bd4, 0x00009bed, 0x00009c0e,
+	0x00009c39, 0x00009c5d, 0x00009c8b, 0x00009c8b,
+	0x00009c8b, 0x00009ca2, 0x00009ce2, 0x00009d0b,
+	0x00009d45, 0x00009d67, 0x00009d76, 0x00009d8d,
+	0x00009db1, 0x00009ddc, 0x00009df7, 0x00009e16,
+	0x00009e34, 0x00009e4d, 0x00009e5b, 0x00009e73,
 	// Entry 4E0 - 4FF
-	0x00009840, 0x00009855, 0x0000987a, 0x0000989b,
-	0x000098b9, 0x000098d8, 0x000098fa, 0x0000993c,
-	0x00009969, 0x0000997e, 0x000099af, 0x000099f2,
-	0x00009a15, 0x00009a28, 0x00009a41, 0x00009a5d,
-	0x00009a7b, 0x00009a8e, 0x00009aa1, 0x00009ac6,
-	0x00009ae2, 0x00009b00, 0x00009b1b, 0x00009b33,
-	0x00009b4b, 0x00009b63, 0x00009b81, 0x00009b9a,
-	0x00009bb0, 0x00009bc6, 0x00009bdc, 0x00009bf5,
+	0x00009e8c, 0x00009eba, 0x00009ef6, 0x00009f15,
+	0x00009f3d, 0x00009f58, 0x00009f6d, 0x00009f9c,
+	0x00009fc3, 0x00009fe1, 0x0000a022, 0x0000a043,
+	0x0000a06d, 0x0000a088, 0x0000a0b6, 0x0000a0e8,
+	0x0000a107, 0x0000a137, 0x0000a16b, 0x0000a19d,
+	0x0000a1c1, 0x0000a1f6, 0x0000a242, 0x0000a272,
+	0x0000a29d, 0x0000a2dc, 0x0000a30d, 0x0000a334,
+	0x0000a34f, 0x0000a362, 0x0000a392, 0x0000a3c9,
 	// Entry 500 - 51F
-	0x00009c17, 0x00009c34, 0x00009c34, 0x00009c34,
-	0x00009c34, 0x00009c34, 0x00009c34, 0x00009c34,
-	0x00009c60, 0x00009c79, 0x00009c9a, 0x00009cc5,
-	0x00009ce9, 0x00009d17, 0x00009d17, 0x00009d17,
-	0x00009d2e, 0x00009d6e, 0x00009d97, 0x00009dd1,
-	0x00009df3, 0x00009e02, 0x00009e19, 0x00009e3d,
-	0x00009e68, 0x00009e83, 0x00009ea2, 0x00009ec0,
-	0x00009ed9, 0x00009ee7, 0x00009eff, 0x00009f18,
+	0x0000a3e4, 0x0000a415, 0x0000a477, 0x0000a4a2,
+	0x0000a4dc, 0x0000a50b, 0x0000a55a, 0x0000a587,
+	0x0000a5c1, 0x0000a5f7, 0x0000a62a, 0x0000a66d,
+	0x0000a6a9, 0x0000a6e2, 0x0000a70a, 0x0000a744,
+	0x0000a764, 0x0000a78b, 0x0000a7b9, 0x0000a7d8,
+	0x0000a7f2, 0x0000a804, 0x0000a822, 0x0000a84e,
+	0x0000a84e, 0x0000a863, 0x0000a893, 0x0000a8d1,
+	0x0000a8f8, 0x0000a91e, 0x0000a944, 0x0000a965,
 	// Entry 520 - 53F
-	0x00009f46, 0x00009f82, 0x00009fa1, 0x00009fc9,
-	0x00009fe4, 0x00009ff9, 0x0000a028, 0x0000a04f,
-	0x0000a06d, 0x0000a0ae, 0x0000a0cf, 0x0000a0f9,
-	0x0000a114, 0x0000a142, 0x0000a174, 0x0000a193,
-	0x0000a1c3, 0x0000a1f7, 0x0000a229, 0x0000a24d,
-	0x0000a282, 0x0000a2ce, 0x0000a2fe, 0x0000a329,
-	0x0000a368, 0x0000a399, 0x0000a3c0, 0x0000a3db,
-	0x0000a3ee, 0x0000a41e, 0x0000a455, 0x0000a470,
+	0x0000a98b, 0x0000a9c1, 0x0000a9eb, 0x0000aa1a,
+	0x0000aa3a, 0x0000aa62, 0x0000aa8c, 0x0000aa8c,
+	0x0000aab4, 0x0000aadf, 0x0000ab03, 0x0000ab33,
+	0x0000ab57, 0x0000ab8b, 0x0000abb6, 0x0000abe9,
+	0x0000ac13, 0x0000ac40, 0x0000ac79, 0x0000acb6,
+	0x0000ace8, 0x0000ad0c, 0x0000ad36, 0x0000ad67,
+	0x0000ad97, 0x0000add7, 0x0000ae04, 0x0000ae32,
+	0x0000ae60, 0x0000ae94, 0x0000aed1, 0x0000aeff,
 	// Entry 540 - 55F
-	0x0000a4a1, 0x0000a503, 0x0000a52e, 0x0000a568,
-	0x0000a597, 0x0000a5e6, 0x0000a613, 0x0000a64d,
-	0x0000a683, 0x0000a6b6, 0x0000a6f9, 0x0000a735,
-	0x0000a76e, 0x0000a796, 0x0000a7d0, 0x0000a7f0,
-	0x0000a817, 0x0000a845, 0x0000a864, 0x0000a87e,
-	0x0000a890, 0x0000a8ae, 0x0000a8da, 0x0000a8da,
-	0x0000a8ef, 0x0000a91f, 0x0000a95d, 0x0000a984,
-	0x0000a9aa, 0x0000a9d0, 0x0000a9f1, 0x0000aa17,
+	0x0000af11, 0x0000af48, 0x0000af72, 0x0000af93,
+	0x0000afc3, 0x0000afc3, 0x0000afd3, 0x0000afeb,
+	0x0000b01e, 0x0000b032, 0x0000b054, 0x0000b084,
+	0x0000b0ac, 0x0000b0cc, 0x0000b0f0, 0x0000b123,
+	0x0000b16f, 0x0000b1a3, 0x0000b1c0, 0x0000b1f5,
+	0x0000b21e, 0x0000b241, 0x0000b241, 0x0000b241,
+	0x0000b264, 0x0000b28c, 0x0000b2a4, 0x0000b2c6,
+	0x0000b2c6, 0x0000b2f5, 0x0000b324, 0x0000b324,
 	// Entry 560 - 57F
-	0x0000aa4d, 0x0000aa77, 0x0000aaa6, 0x0000aac6,
-	0x0000aaee, 0x0000ab18, 0x0000ab18, 0x0000ab40,
-	0x0000ab6b, 0x0000ab8f, 0x0000abbf, 0x0000abe3,
-	0x0000ac17, 0x0000ac42, 0x0000ac75, 0x0000ac9f,
-	0x0000accc, 0x0000ad05, 0x0000ad42, 0x0000ad74,
-	0x0000ad98, 0x0000adc2, 0x0000adf3, 0x0000ae23,
-	0x0000ae63, 0x0000ae90, 0x0000aebe, 0x0000aeec,
-	0x0000af20, 0x0000af5d, 0x0000af8b, 0x0000af9d,
+	0x0000b345, 0x0000b345, 0x0000b369, 0x0000b393,
+	0x0000b3c0, 0x0000b3d3, 0x0000b3f0, 0x0000b418,
+	0x0000b44e, 0x0000b470, 0x0000b49e, 0x0000b49e,
+	0x0000b4ba, 0x0000b4da, 0x0000b4f2, 0x0000b50d,
+	0x0000b51f, 0x0000b547, 0x0000b576, 0x0000b594,
+	0x0000b5cb, 0x0000b5f2, 0x0000b616, 0x0000b63d,
+	0x0000b656, 0x0000b663, 0x0000b679, 0x0000b692,
+	0x0000b6a2, 0x0000b6b2, 0x0000b6c2, 0x0000b6d0,
 	// Entry 580 - 59F
-	0x0000afd4, 0x0000affe, 0x0000b01f, 0x0000b04f,
-	0x0000b04f, 0x0000b05f, 0x0000b077, 0x0000b0aa,
-	0x0000b0be, 0x0000b0e0, 0x0000b110, 0x0000b138,
-	0x0000b158, 0x0000b17c, 0x0000b1af, 0x0000b1fb,
-	0x0000b22f, 0x0000b24c, 0x0000b281, 0x0000b2aa,
-	0x0000b2cd, 0x0000b2cd, 0x0000b2cd, 0x0000b2f0,
-	0x0000b318, 0x0000b330, 0x0000b352, 0x0000b352,
-	0x0000b381, 0x0000b3b0, 0x0000b3b0, 0x0000b3d1,
+	0x0000b6e0, 0x0000b6f0, 0x0000b700, 0x0000b716,
+	0x0000b726, 0x0000b739, 0x0000b743, 0x0000b753,
+	0x0000b760, 0x0000b76d, 0x0000b77a, 0x0000b787,
+	0x0000b794, 0x0000b7a1, 0x0000b7b4, 0x0000b7c1,
+	0x0000b7d1, 0x0000b7de, 0x0000b7e8, 0x0000b7f8,
+	0x0000b7ff, 0x0000b80c, 0x0000b819, 0x0000b826,
+	0x0000b82d, 0x0000b837, 0x0000b845, 0x0000b858,
+	0x0000b865, 0x0000b872, 0x0000b88b, 0x0000b89b,
 	// Entry 5A0 - 5BF
-	0x0000b3d1, 0x0000b3f5, 0x0000b41f, 0x0000b44c,
-	0x0000b45f, 0x0000b47c, 0x0000b4a4, 0x0000b4da,
-	0x0000b4fc, 0x0000b52a, 0x0000b52a, 0x0000b546,
-	0x0000b566, 0x0000b57e, 0x0000b599, 0x0000b5ab,
-	0x0000b5d3, 0x0000b602, 0x0000b620, 0x0000b657,
-	0x0000b67e, 0x0000b6a2, 0x0000b6c9, 0x0000b6e2,
-	0x0000b6ef, 0x0000b705, 0x0000b71e, 0x0000b72e,
-	0x0000b73e, 0x0000b74e, 0x0000b75c, 0x0000b76c,
+	0x0000b8ab, 0x0000b8bb, 0x0000b8ce, 0x0000b8e1,
+	0x0000b8f3, 0x0000b941, 0x0000b953, 0x0000b967,
+	0x0000b97d, 0x0000b98d, 0x0000b996, 0x0000b99f,
+	0x0000b9ac, 0x0000b9bc, 0x0000b9ed, 0x0000ba02,
+	0x0000ba30, 0x0000ba5e, 0x0000ba70, 0x0000ba90,
+	0x0000baad, 0x0000babf, 0x0000bad5, 0x0000baeb,
+	0x0000bafe, 0x0000bb0e, 0x0000bb21, 0x0000bb34,
+	0x0000bb4d, 0x0000bb66, 0x0000bb6d, 0x0000bb83,
 	// Entry 5C0 - 5DF
-	0x0000b77c, 0x0000b78c, 0x0000b7a2, 0x0000b7b2,
-	0x0000b7c5, 0x0000b7cf, 0x0000b7df, 0x0000b7ec,
-	0x0000b7f9, 0x0000b806, 0x0000b813, 0x0000b820,
-	0x0000b82d, 0x0000b840, 0x0000b84d, 0x0000b85d,
-	0x0000b86a, 0x0000b874, 0x0000b884, 0x0000b88b,
-	0x0000b898, 0x0000b8a5, 0x0000b8b2, 0x0000b8b9,
-	0x0000b8c3, 0x0000b8d1, 0x0000b8e4, 0x0000b8f1,
-	0x0000b8fe, 0x0000b917, 0x0000b927, 0x0000b93a,
+	0x0000bb95, 0x0000bbad, 0x0000bbc9, 0x0000bbee,
+	0x0000bc00, 0x0000bc28, 0x0000bc56, 0x0000bc7e,
+	0x0000bc9b, 0x0000bcab, 0x0000bcb8, 0x0000bccb,
+	0x0000bcde, 0x0000bd00, 0x0000bd22, 0x0000bd3b,
+	0x0000bd59, 0x0000bd75, 0x0000bd82, 0x0000bd92,
+	0x0000bdab, 0x0000bdca, 0x0000bdec, 0x0000be05,
+	0x0000be21, 0x0000be37, 0x0000be4a, 0x0000be66,
+	0x0000be7e, 0x0000be93, 0x0000beaf, 0x0000bec8,
 	// Entry 5E0 - 5FF
-	0x0000b94d, 0x0000b95f, 0x0000b95f, 0x0000b973,
-	0x0000b989, 0x0000b999, 0x0000b9a2, 0x0000b9ab,
-	0x0000b9b8, 0x0000b9c8, 0x0000b9f9, 0x0000ba0e,
-	0x0000ba3c, 0x0000ba6a, 0x0000ba7c, 0x0000ba9c,
-	0x0000bab9, 0x0000bacb, 0x0000bae1, 0x0000baf7,
-	0x0000bb0a, 0x0000bb1a, 0x0000bb2d, 0x0000bb40,
-	0x0000bb59, 0x0000bb72, 0x0000bb79, 0x0000bb8f,
-	0x0000bba1, 0x0000bbb9, 0x0000bbd5, 0x0000bbfa,
+	0x0000bee4, 0x0000befd, 0x0000bf2e, 0x0000bf64,
+	0x0000bf86, 0x0000bfc6, 0x0000bfe1, 0x0000bff1,
+	0x0000c00f, 0x0000c030, 0x0000c045, 0x0000c06a,
+	0x0000c083, 0x0000c09c, 0x0000c0c1, 0x0000c0d7,
+	0x0000c0ed, 0x0000c0fd, 0x0000c10d, 0x0000c11d,
+	0x0000c12c, 0x0000c142, 0x0000c158, 0x0000c168,
+	0x0000c17b, 0x0000c191, 0x0000c1a5, 0x0000c1b9,
+	0x0000c1d1, 0x0000c1e0, 0x0000c1f6, 0x0000c206,
 	// Entry 600 - 61F
-	0x0000bc0c, 0x0000bc34, 0x0000bc62, 0x0000bc8a,
-	0x0000bca7, 0x0000bcb7, 0x0000bcc4, 0x0000bcd7,
-	0x0000bcea, 0x0000bd0c, 0x0000bd2e, 0x0000bd47,
-	0x0000bd65, 0x0000bd81, 0x0000bd8e, 0x0000bd9e,
-	0x0000bdb7, 0x0000bdd6, 0x0000bdf8, 0x0000be11,
-	0x0000be2d, 0x0000be43, 0x0000be56, 0x0000be72,
-	0x0000be8a, 0x0000be9f, 0x0000bebb, 0x0000bed4,
-	0x0000bef0, 0x0000bf09, 0x0000bf3a, 0x0000bf70,
+	0x0000c22b, 0x0000c23b, 0x0000c24b, 0x0000c263,
+	0x0000c270, 0x0000c280, 0x0000c28f, 0x0000c2a3,
+	0x0000c2bc, 0x0000c2c6, 0x0000c2d5, 0x0000c2e7,
+	0x0000c303, 0x0000c31c, 0x0000c33d, 0x0000c351,
+	0x0000c361, 0x0000c379, 0x0000c38f, 0x0000c3a6,
+	0x0000c3b3, 0x0000c3c1, 0x0000c3d5, 0x0000c3e9,
+	0x0000c3f6, 0x0000c406, 0x0000c41f, 0x0000c43b,
+	0x0000c456, 0x0000c46b, 0x0000c46b, 0x0000c46b,
 	// Entry 620 - 63F
-	0x0000bf92, 0x0000bfd2, 0x0000bfed, 0x0000bffd,
-	0x0000c01b, 0x0000c03c, 0x0000c051, 0x0000c076,
-	0x0000c08f, 0x0000c0a8, 0x0000c0cd, 0x0000c0e3,
-	0x0000c0f9, 0x0000c109, 0x0000c119, 0x0000c129,
-	0x0000c138, 0x0000c14e, 0x0000c164, 0x0000c174,
-	0x0000c187, 0x0000c19d, 0x0000c1b1, 0x0000c1c5,
-	0x0000c1dd, 0x0000c1ec, 0x0000c202, 0x0000c212,
-	0x0000c237, 0x0000c247, 0x0000c257, 0x0000c26f,
+	0x0000c46b, 0x0000c46b, 0x0000c46b, 0x0000c46b,
+	0x0000c46b, 0x0000c46b, 0x0000c46b, 0x0000c46b,
+	0x0000c46b, 0x0000c46b, 0x0000c46b, 0x0000c46b,
+	0x0000c46b, 0x0000c46b, 0x0000c46b, 0x0000c46b,
+	0x0000c46b, 0x0000c46b, 0x0000c46b, 0x0000c46b,
+	0x0000c46b, 0x0000c46b, 0x0000c46b, 0x0000c46b,
+	0x0000c46b, 0x0000c46b, 0x0000c46b, 0x0000c46b,
+	0x0000c46b, 0x0000c46b, 0x0000c46b, 0x0000c46b,
 	// Entry 640 - 65F
-	0x0000c27c, 0x0000c28c, 0x0000c29b, 0x0000c2af,
-	0x0000c2c8, 0x0000c2d2, 0x0000c2e1, 0x0000c2f3,
-	0x0000c30f, 0x0000c328, 0x0000c349, 0x0000c35d,
-	0x0000c36d, 0x0000c385, 0x0000c39b, 0x0000c3b2,
-	0x0000c3bf, 0x0000c3cd, 0x0000c3e1, 0x0000c3f5,
-	0x0000c402, 0x0000c412, 0x0000c42b, 0x0000c447,
-	0x0000c462, 0x0000c477, 0x0000c490, 0x0000c490,
-	0x0000c490, 0x0000c490, 0x0000c490, 0x0000c490,
-	// Entry 660 - 67F
+	0x0000c46b, 0x0000c46b, 0x0000c46b, 0x0000c46b,
+	0x0000c46b, 0x0000c46b, 0x0000c46b, 0x0000c46b,
 	0x0000c490, 0x0000c490, 0x0000c490, 0x0000c490,
 	0x0000c490, 0x0000c490, 0x0000c490, 0x0000c490,
 	0x0000c490, 0x0000c490, 0x0000c490, 0x0000c490,
-	0x0000c490, 0x0000c490, 0x0000c490, 0x0000c490,
-	0x0000c490, 0x0000c490, 0x0000c490, 0x0000c490,
-	0x0000c490, 0x0000c490, 0x0000c490, 0x0000c490,
-	0x0000c490, 0x0000c490, 0x0000c490, 0x0000c490,
-	0x0000c490, 0x0000c490, 0x0000c490, 0x0000c490,
-	// Entry 680 - 69F
-	0x0000c490, 0x0000c490, 0x0000c490, 0x0000c490,
-	0x0000c490, 0x0000c4b5, 0x0000c4b5, 0x0000c4b5,
-	0x0000c4b5, 0x0000c4b5, 0x0000c4b5, 0x0000c4b5,
-	0x0000c4b5, 0x0000c4b5, 0x0000c4b5, 0x0000c4b5,
-	0x0000c4b5, 0x0000c4b5, 0x0000c4cd, 0x0000c4e2,
-	0x0000c4f5, 0x0000c4f5, 0x0000c50d, 0x0000c50d,
-	0x0000c50d, 0x0000c523, 0x0000c541, 0x0000c55a,
-} // Size: 6792 bytes
+	0x0000c490, 0x0000c4a8, 0x0000c4bd, 0x0000c4d0,
+	0x0000c4d0, 0x0000c4e8, 0x0000c4e8, 0x0000c4e8,
+	0x0000c4fe, 0x0000c51c, 0x0000c535,
+} // Size: 6548 bytes
 
-const zh_CNData string = "" + // Size: 50522 bytes
-	"\x02获取tenantId参数失败\x02切换项目失败\x02获取password参数失败\x02用户名或密码为空\x02缺少认证信息\x02" +
-	"无效的认证信息\x02获取请求的JSON内容失败：%v\x02请求内容为空\x02缺少id参数\x02fetchAuthInfo调用失败：%" +
-	"s\x02新密码相互不匹配\x02不支持重置用户密码\x02密码错误\x02无效的验证码\x02生成TOTP二维码失败\x02uid为空\x02" +
-	"输入参数错误\x02未设置TOTP找回密码的提示问题\x02未找到密码提示问题\x02%s：答案不正确\x02验证码应为6个数字\x02验证" +
-	"码无效：%v\x02没有密码找到提示问题\x02解析提示问题失败：%v\x02获取管理员鉴权信息失败\x02没有可用的region，请联系管" +
-	"理员\x02无效的可用区%s，请联系管理员\x02会话过期，缺少%s\x02解析请求参数出错：%s\x02获取表单数据出错：%s\x02无效" +
-	"的请求\x02外部用户ID为空\x02idp_id或idp_entity_id为空\x02无效的表单\x02缺少镜像名称参数\x02缺少镜像" +
-	"大小参数\x02无效的镜像大小参数\x02解析查询失败：%v\x02头部中没有token：%v\x02找不到参数%s\x02不支持动作%s" +
-	"\x02Content-Type错误，%s，应为%s\x02打开文件出错\x02解析文件出错\x02模板文件无效，请检查\x02文件内容空" +
-	"\x02第%d行，用户名为空\x02第%d行，域名称为空\x02第%d行，名称重复：%s\x02内部服务错误\x02找不到模板：%s\x02请求" +
-	"体太大\x02无效的multipart表单\x02无效的content_length\x02头部中没有token\x02头部中的token无" +
-	"效\x02token已过期\x02找不到资源%s对应的module\x02找不到id列表\x02缺少导出键名\x02导出键名与文本不一致" +
-	"\x02收到无效数据\x04\x00\x01 \x16\x02无效的预置操作\x04\x00\x01 \x18\x02无效的权限(Effect)" +
-	"\x04\x00\x01 \x14\x02无效的IPv4地址\x02无效的shared_mode %s\x02mx_priority应在[1,5" +
-	"0]范围\x02无效的MX记录：无效的域名%s\x02无效的A记录：无效的IPv4地址%s\x02无效的AAAA记录：无效的IPv6地址%s" +
-	"\x02无效的CNAME记录：无效的域名%s\x02无效的路由CIDR %s\x02服务器内部错误：%s\x02服务器内部错误\x02无效的ha" +
-	"ndler：%s\x02未找到handler\x02找不到请求的键：%s\x02无效的请求头部：%v\x02请求处理超时\x02不允许记录列表为" +
-	"空\x02记录条目数过多\x02找不到%s方法\x02%s方法参数长度不匹配，期望数%d，实际%d\x02无效的ValidateCreate" +
-	"Data返回值\x02ListItemFilter返回无效的计数%d\x02OrderByExtraFields返回无效的计数%d\x02Get" +
-	"ExtraDetails返回无效的计数%d\x02FetchCustomizeColumns返回无效的计数%d\x02FetchCustomiz" +
-	"eColumns返回类型无数（不是slice）\x02FetchCustomizeColumns返回值无效，对象数目不匹配，输入%d，输出%d" +
-	"\x02ValidateUpdateData返回值无效\x02CustomizeDelete返回值无效\x02无效的联合资源%s\x02Fetc" +
-	"hCustomizeColumns返回的结果数不正确\x02找不到上下文管理器\x02没有此上下文%s(%s)\x02从上下文中获取HTTP响应" +
-	"Writer失败\x02FetchCustomizeColumns返回值不正确\x02反射调用%s出错：%s\x02%s返回值无效\x02%s不" +
-	"允许获取%s属性\x02没有返回值\x02不允许获取详情\x02%s %s %s找不到\x02%s不允许获取%s\x02不允许创建对象" +
-	"\x02请求体不是JSON对象？\x02未指定name或者generate_name\x02不允许执行%s\x02找不到%s Allow %s " +
-	"%s方法\x02%s不允许%s %s\x02无效的JSON对象\x02不允许更新对象\x02不允许删除%s(%s)\x02不允许绑定\x02%s" +
-	" %s已与%s %s绑定\x02非默认域中的项目是被禁止的\x02新域未指定\x02检查名称重复时出错：%s\x02权限不足（要求%s，允许%s" +
-	"，实际%s）\x02不支持%s资源使用标签过滤\x02找不到动作%s\x02无法获取字符串字段\x02模型没有%s字段\x02数据库查询出错" +
-	"：%s\x02名称必须以字母开头，内容仅包含字母、数字或英语破折号\x02不允许删除日志\x02不允许变更直连模式配置\x02不允许删除直连" +
-	"模式\x02获取代理设置的使用数出错：%s\x02代理设置%s仍被%d个%s使用\x02请求体解析失败\x02找不到%s配额\x02%s默认" +
-	"配额不允许删除\x02权限不足\x02不允许列出域配额\x02权限不足\x02不允许列出项目配额\x02查询配额：%s\x02权限不足（要求" +
-	"：%s，允许：%s：资源：%s）\x02权限不足（要求：%s，允许：%s）\x02无效范围%s\x02不允许创建%s，范围%s\x02不允许" +
-	"设置范围为整个系统\x02不允许设置范围为整个%s域\x02不允许设置范围为整个%s项目\x02只能共享给指定域: %s\x02插入共享资源" +
-	"出错：%s\x02名称需以字母开头，包含字母、数字，或“._@-”\x02名字长度超过%d\x02不允许使用系统保留键，请移除键名起始的下划" +
-	"线\x02输入键名长度超过%d\x02输入键值长度超过%d\x02找不到用户%s\x02禁止\x02非管理员不允许创建系统级别资源\x02该" +
-	"资源被锁定，无法执行 %s 操作\x02该资源已经被锁定\x02该资源未被锁定\x02未指定项目\x02Informer后端未初始化\x02" +
-	"无效的格式\x02操作不允许\x02无效的输入格式\x02缺少输入参数：%q\x02%q：常规错误：%s\x02类型错误：期望类型%s，%q" +
-	"的实际类型为%s\x02%q：错误的枚举值：期望%s，实际%s\x02%q：长度%d太短，最小为%d\x02%q：长度%d太长，最长为%d" +
-	"\x02%q：%d不在范围内，应为[%d,%d]\x02%q：无效的值%s\x02%q：无效的值：%v\x04\x00\x01 \x12\x02" +
-	"%q：无效的值\x02无法找到%q对应的模型管理器\x02无法通过名称或ID找到%q（%q）\x02无法通过名称或ID找到%q（%q）：%s" +
-	"\x02无效的证书算法：%s，要求为%s\x02找不到provider\x02未实现GetProvider\x02未找到\x02Id重复\x02" +
-	"无效的状态\x02超时\x02未实现\x02不支持\x02无效的Provider\x02没有查询余额的权限\x02地址分配数量达到上线" +
-	"\x02不支持多网卡\x02%s磁盘大小必须在%dGB到%dGB范围内\x02%s要求EIP带宽必须小于100Mbps\x02与路由表关联的网络" +
-	"%s没有因特网网关\x02无法找到镜像%s的subformats中找到vhd，请尝试为glance target_image_formats选项" +
-	"添加'vhd'\x02Azure Mv2系列SKU仅支持UEFI镜像\x02Azure UEFI镜像%s不支持此SKU\x02不支持变更Az" +
-	"ure实例名称\x02不能变更裸金属的配置\x02不能变更裸金属的磁盘大小\x02无效的RAID配置：%v\x02宿主机%s不是一个裸金属服务器" +
-	"\x02裸金属服务器%s没有准备好\x02裸金属服务器%s已被占用\x02无法为裸金属服务器保存镜像\x02未实现ValidateCreateE" +
-	"ip\x02hypervisor %s不允许此操作\x02不支持此操作，请使用kubectl\x02容器不支持%s\x02%s不支持创建EIP" +
-	"\x02无法为有主机快照的虚拟机调整磁盘大小\x02ESXi虚机迁移需要指定prefer_host\x02无法为有主机快照的虚拟机重装系统" +
-	"\x02未知的Google存储类型\x02系统盘不支持%s磁盘\x02%s磁盘数量超过8个\x02%s和%s特性创建实例时互不兼容\x02找不到" +
-	"宿主机%s\x02主备机不可迁移\x02无法为状态为%s的虚机执行迁移操作，尝试救援模式或server-live-migrate\x02救援" +
-	"模式要求所有磁盘都使用共享存储\x02使用透传设备时不支持迁移\x02使用cdrom时无法在线迁移\x02使用透传设备时无法在线迁移\x02" +
-	"QEMU版本太低，无法在线迁移\x02%s不支持指定CDROM参数\x02%s不支持创建EIP，仅支持绑定已有EIP\x02%s不支持创建虚机时" +
-	"同时创建EIP\x02数据盘不支持存储类型%s\x02%s盘的大小必须在10GB到16000GB范围内\x02%s盘的大小必须在50GB到1" +
-	"6000GB范围内\x02%s盘的大小必须在100GB到16000GB范围内\x02磁盘 %s 的大小必须介于20GB ~ 32000GB" +
-	"\x02%s存储不能作为数据盘\x02数据盘大小必须是10GB的整数倍\x02找不到系统盘：%v\x02找不到磁盘%s(%s)所属的存储\x02" +
-	"系统盘存储在本地，不支持变更配置\x02不支持创建本地盘\x02请指定新的磁盘类型\x02磁盘存储在本地，不支持解绑\x02宿主机%s不在线" +
-	"\x02GetGuestCount调用出错：%s\x02宿主机已被占用\x02阿里支重置磁盘要求虚机状态为运行中或已关机\x02AWS不支持重置" +
-	"磁盘，您可以使用快照来创建新盘\x02不支持变更Azure磁盘名称\x02Azure不支持重置磁盘，您可以使用快照创建新盘\x02未实现" +
-	"\x02ValidateResetDisk未实现\x02ValidateAttachStorage未实现\x02RequestAttachSto" +
-	"rage未实现\x02RequestDetachStorage未实现\x02磁盘必须已解绑\x02%s重置磁盘时要求虚机状态必须是运行中或已关机" +
-	"\x02主机%s必须处于关机状态\x02磁盘必须已解绑\x02不支持挂载%s存储到%s宿主机\x02挂载rbd存储要求宿主机在线\x02查询主机" +
-	"磁盘出错：%s\x02宿主机%s挂载点%s已有其它存储\x02挂载NFS存储要求宿主机在线\x02%s不是一个挂解点：%s\x02磁盘挂载到" +
-	"多个虚机\x02磁盘所在虚机必须是已关机状态\x02磁盘未挂载到虚机\x02OpenStack不支持重置磁盘，您可以从快照创建新盘\x02Q" +
-	"cloud重置磁盘要求虚机状态必须是运行中或已关机\x02Ucloud重置磁盘要求磁盘处于未挂载状态\x02Ucloud仅支持数据盘重置操作" +
-	"\x02ZStack重置磁盘要求虚机处于关机状态\x02解析远端IP地址出错：%s\x02子网未找到\x02裸金属服务器Agent未找到\x02" +
-	"裸金属服务器package未准备好\x02检查agent唯一性失败：%s\x02manager_url冲突：%s\x02manager_ur" +
-	"l重复：%s\x02未指定duration/expire_time\x02新的过期时间先于当前值\x02无效的duration %s: %s" +
-	"\x02找不到名称\x02无效的桶名%s：%s\x02无效的桶名%s：%s\x02没有外部桶\x02获取对象出错：%s\x02未指定key" +
-	"\x02生成临时URL出错：%s\x02空的目录名\x02无效的key %s：%s\x02GetIObject调用出错：%s\x02对象数量超出" +
-	"限制\x02bucket.GetQuotaKeys调用出错：%s\x02创建目录失败：%s\x02keys列表为空\x02对象key不应以斜" +
-	"线结尾\x02无效的对象key：%s\x02找不到Content-Length\x02无效的Content-Length %s\x02Con" +
-	"tent-Length为负值%d\x02GetIObject调用出错：%s\x02对象大小超出限制\x02bucket.GetQuotaKeys" +
-	"调用出错：%s\x02更新对象出错：%s\x02setAcl调用出错：%s\x02syncWithCloudBucket调用出错：%s" +
+const zh_CNData string = "" + // Size: 50485 bytes
+	"\x04\x00\x01 \x16\x02无效的预置操作\x04\x00\x01 \x18\x02无效的权限(Effect)\x04\x00" +
+	"\x01 \x14\x02无效的IPv4地址\x02无效的shared_mode %s\x02mx_priority应在[1,50]范围\x02" +
+	"无效的MX记录：无效的域名%s\x02无效的A记录：无效的IPv4地址%s\x02无效的AAAA记录：无效的IPv6地址%s\x02无效的C" +
+	"NAME记录：无效的域名%s\x02无效的路由CIDR %s\x02服务器内部错误：%s\x02服务器内部错误\x02无效的handler：%s" +
+	"\x02未找到handler\x02找不到请求的键：%s\x02无效的请求头部：%v\x02请求处理超时\x02不允许记录列表为空\x02记录条" +
+	"目数过多\x02找不到%s方法\x02%s方法参数长度不匹配，期望数%d，实际%d\x02无效的ValidateCreateData返回值" +
+	"\x02ListItemFilter返回无效的计数%d\x02OrderByExtraFields返回无效的计数%d\x02GetExtraDe" +
+	"tails返回无效的计数%d\x02FetchCustomizeColumns返回无效的计数%d\x02FetchCustomizeColumn" +
+	"s返回类型无数（不是slice）\x02FetchCustomizeColumns返回值无效，对象数目不匹配，输入%d，输出%d\x02Vali" +
+	"dateUpdateData返回值无效\x02CustomizeDelete返回值无效\x02无效的联合资源%s\x02FetchCustomi" +
+	"zeColumns返回的结果数不正确\x02找不到上下文管理器\x02没有此上下文%s(%s)\x02从上下文中获取HTTP响应Writer失败" +
+	"\x02FetchCustomizeColumns返回值不正确\x02反射调用%s出错：%s\x02%s返回值无效\x02%s不允许获取%s属性" +
+	"\x02没有返回值\x02不允许获取详情\x02%s %s %s找不到\x02%s不允许获取%s\x02不允许创建对象\x02请求体不是JSON" +
+	"对象？\x02未指定name或者generate_name\x02不允许执行%s\x02找不到%s Allow %s %s方法\x02%s不" +
+	"允许%s %s\x02无效的JSON对象\x02不允许更新对象\x02不允许删除%s(%s)\x02不允许绑定\x02%s %s已与%s %" +
+	"s绑定\x02非默认域中的项目是被禁止的\x02新域未指定\x02检查名称重复时出错：%s\x02权限不足（要求%s，允许%s，实际%s）" +
+	"\x02不支持%s资源使用标签过滤\x02找不到动作%s\x02无法获取字符串字段\x02模型没有%s字段\x02数据库查询出错：%s\x02名" +
+	"称必须以字母开头，内容仅包含字母、数字或英语破折号\x02不允许删除日志\x02不允许变更直连模式配置\x02不允许删除直连模式\x02获取" +
+	"代理设置的使用数出错：%s\x02代理设置%s仍被%d个%s使用\x02请求体解析失败\x02找不到%s配额\x02%s默认配额不允许删除" +
+	"\x02权限不足\x02不允许列出域配额\x02权限不足\x02不允许列出项目配额\x02查询配额：%s\x02权限不足（要求：%s，允许：%s" +
+	"：资源：%s）\x02权限不足（要求：%s，允许：%s）\x02无效范围%s\x02不允许创建%s，范围%s\x02不允许设置范围为整个系统" +
+	"\x02不允许设置范围为整个%s域\x02不允许设置范围为整个%s项目\x02只能共享给指定域: %s\x02插入共享资源出错：%s\x02名称" +
+	"需以字母开头，包含字母、数字，或“._@-”\x02名字长度超过%d\x02不允许使用系统保留键，请移除键名起始的下划线\x02输入键名长度" +
+	"超过%d\x02输入键值长度超过%d\x02找不到用户%s\x02禁止\x02非管理员不允许创建系统级别资源\x02该资源被锁定，无法执行 " +
+	"%s 操作\x02该资源已经被锁定\x02该资源未被锁定\x02未指定项目\x02Informer后端未初始化\x02无效的格式\x02操作不允" +
+	"许\x02无效的输入格式\x02缺少输入参数：%q\x02%q：常规错误：%s\x02类型错误：期望类型%s，%q的实际类型为%s\x02%" +
+	"q：错误的枚举值：期望%s，实际%s\x02%q：长度%d太短，最小为%d\x02%q：长度%d太长，最长为%d\x02%q：%d不在范围内，应" +
+	"为[%d,%d]\x02%q：无效的值%s\x02%q：无效的值：%v\x04\x00\x01 \x12\x02%q：无效的值\x02无法找" +
+	"到%q对应的模型管理器\x02无法通过名称或ID找到%q（%q）\x02无法通过名称或ID找到%q（%q）：%s\x02无效的证书算法：%s" +
+	"，要求为%s\x02找不到provider\x02未实现GetProvider\x02未找到\x02Id重复\x02无效的状态\x02超时" +
+	"\x02未实现\x02不支持\x02无效的Provider\x02没有查询余额的权限\x02地址分配数量达到上线\x02不支持多网卡\x02%s" +
+	"磁盘大小必须在%dGB到%dGB范围内\x02%s要求EIP带宽必须小于100Mbps\x02与路由表关联的网络%s没有因特网网关\x02无" +
+	"法找到镜像%s的subformats中找到vhd，请尝试为glance target_image_formats选项添加'vhd'\x02A" +
+	"zure Mv2系列SKU仅支持UEFI镜像\x02Azure UEFI镜像%s不支持此SKU\x02不支持变更Azure实例名称\x02不能变" +
+	"更裸金属的配置\x02不能变更裸金属的磁盘大小\x02无效的RAID配置：%v\x02宿主机%s不是一个裸金属服务器\x02裸金属服务器%s" +
+	"没有准备好\x02裸金属服务器%s已被占用\x02无法为裸金属服务器保存镜像\x02未实现ValidateCreateEip\x02hype" +
+	"rvisor %s不允许此操作\x02不支持此操作，请使用kubectl\x02容器不支持%s\x02%s不支持创建EIP\x02无法为有主机快" +
+	"照的虚拟机调整磁盘大小\x02ESXi虚机迁移需要指定prefer_host\x02无法为有主机快照的虚拟机重装系统\x02未知的Googl" +
+	"e存储类型\x02系统盘不支持%s磁盘\x02%s磁盘数量超过8个\x02%s和%s特性创建实例时互不兼容\x02找不到宿主机%s\x02主备机" +
+	"不可迁移\x02无法为状态为%s的虚机执行迁移操作，尝试救援模式或server-live-migrate\x02救援模式要求所有磁盘都使用共" +
+	"享存储\x02使用透传设备时不支持迁移\x02使用cdrom时无法在线迁移\x02使用透传设备时无法在线迁移\x02QEMU版本太低，无法在" +
+	"线迁移\x02无法在运行时移除虚拟机网卡\x02%s不支持指定CDROM参数\x02%s不支持创建EIP，仅支持绑定已有EIP\x02%s不" +
+	"支持创建虚机时同时创建EIP\x02数据盘不支持存储类型%s\x02%s盘的大小必须在10GB到16000GB范围内\x02%s盘的大小必须" +
+	"在50GB到16000GB范围内\x02%s盘的大小必须在100GB到16000GB范围内\x02磁盘 %s 的大小必须介于20GB ~ 3" +
+	"2000GB\x02%s存储不能作为数据盘\x02数据盘大小必须是10GB的整数倍\x02找不到系统盘：%v\x02找不到磁盘%s(%s)所属的" +
+	"存储\x02系统盘存储在本地，不支持变更配置\x02不支持创建本地盘\x02请指定新的磁盘类型\x02磁盘存储在本地，不支持解绑\x02宿主" +
+	"机%s不在线\x02GetGuestCount调用出错：%s\x02宿主机已被占用\x02阿里支重置磁盘要求虚机状态为运行中或已关机\x02" +
+	"AWS不支持重置磁盘，您可以使用快照来创建新盘\x02不支持变更Azure磁盘名称\x02Azure不支持重置磁盘，您可以使用快照创建新盘" +
+	"\x02未实现\x02ValidateResetDisk未实现\x02ValidateAttachStorage未实现\x02RequestAt" +
+	"tachStorage未实现\x02RequestDetachStorage未实现\x02磁盘必须已解绑\x02%s重置磁盘时要求虚机状态必须是" +
+	"运行中或已关机\x02主机%s必须处于关机状态\x02磁盘必须已解绑\x02不支持挂载%s存储到%s宿主机\x02挂载rbd存储要求宿主机在" +
+	"线\x02查询主机磁盘出错：%s\x02宿主机%s挂载点%s已有其它存储\x02挂载NFS存储要求宿主机在线\x02%s不是一个挂解点：%s" +
+	"\x02磁盘挂载到多个虚机\x02磁盘所在虚机必须是已关机状态\x02磁盘未挂载到虚机\x02OpenStack不支持重置磁盘，您可以从快照创建" +
+	"新盘\x02Qcloud重置磁盘要求虚机状态必须是运行中或已关机\x02Ucloud重置磁盘要求磁盘处于未挂载状态\x02Ucloud仅支持" +
+	"数据盘重置操作\x02ZStack重置磁盘要求虚机处于关机状态\x02解析远端IP地址出错：%s\x02子网未找到\x02裸金属服务器Age" +
+	"nt未找到\x02裸金属服务器package未准备好\x02检查agent唯一性失败：%s\x02manager_url冲突：%s\x02man" +
+	"ager_url重复：%s\x02未指定duration/expire_time\x02新的过期时间先于当前值\x02无效的duration %" +
+	"s: %s\x02找不到名称\x02无效的桶名%s：%s\x02无效的桶名%s：%s\x02没有外部桶\x02获取对象出错：%s\x02未指定k" +
+	"ey\x02生成临时URL出错：%s\x02空的目录名\x02无效的key %s：%s\x02GetIObject调用出错：%s\x02对象数量" +
+	"超出限制\x02bucket.GetQuotaKeys调用出错：%s\x02创建目录失败：%s\x02keys列表为空\x02对象key不应" +
+	"以斜线结尾\x02无效的对象key：%s\x02找不到Content-Length\x02无效的Content-Length %s\x02C" +
+	"ontent-Length为负值%d\x02GetIObject调用出错：%s\x02对象大小超出限制\x02bucket.GetQuotaKe" +
+	"ys调用出错：%s\x02更新对象出错：%s\x02setAcl调用出错：%s\x02syncWithCloudBucket调用出错：%s" +
 	"\x02桶当前有%d个活跃任务在执行，无法执行同步状态操作\x02桶不为空\x02找不到对象%s\x02iBucket.GetIObjects调" +
-	"用出错：%s\x02unmarshal limit参数出错：%s\x02SetLimit调用出错：%s\x02更新出错：%s\x02找不到m" +
-	"anager\x02iBucket.GetIObject调用出错：%s\x02ValidateDeleteCondition出错：%s\x02镜" +
-	"像已被缓存到磁盘\x02镜像引用会话还未过期\x02找不到存储缓存%s\x02不允许查询系统能力\x02账号为启用状态\x02账号不空闲" +
-	"\x02%s provider: %v\x02无法启用正在删除中的账号\x02无效的代理设备%s\x02不支持provider为%s的云账号" +
-	"\x02不支持%s\x02项目%s(%s)不属于域%s(%s)\x02不支持品牌%s，仅支持%s\x02唯一性检查失败\x02账户已被注册" +
-	"\x02找不到provider %s\x02无效的账号信息：%s\x02检查重复account_id出错\x02账号%s已被注册\x02账号已禁" +
-	"用\x02账号自动同步已启用\x02无效的输入：%s\x02无法找到provider工厂：%v\x02unmarshal输入参数出错：%v" +
-	"\x02检查唯一性出错：%s\x02账号%s出现冲突\x02account_id不一致，之前为%q，现在为%q\x02找不到项目%s\x02状态" +
-	"为%s时无法启用自动同步\x02provider在域间共享\x02不支持%s\x02%s不支持创建订阅\x02不允许创建\x02provid" +
-	"er当前是启用状态\x02provider当前不是空闲状态\x02不支持直接创建cloudprovider，请先创建云账号\x02找不到regi" +
-	"on %s\x02找不到zone %s\x02cloudprovider是已禁用状态\x02云账号是已禁用状态\x02不允许跨域变更项目属性" +
-	"\x02不允许变更为私有云另外一个域\x02获取provider驱动失败：%s\x02不支持存储类型\x02GetZoneCount调用失败" +
-	"\x02GetVpcCount调用失败\x02cloudregion不为空\x02不允许删除默认cloudregion\x02找不到VPC %s" +
-	"\x02不允许更新外部资源\x02禁止允许更改RDS账号名称\x02查找数据库实例出错：%s\x02数据库实例%s(%s)当前状态为%s，要求状" +
-	"态为%s\x02找不到数据库实例%s(%s)所属的region\x02在数据库实例%s(%s)中查找%s库失败：%v\x02查找数据库%s失" +
-	"败，在实例%s(%s)中查找出错：%v\x02账号%s(%s)已有权限%s访问数据库%s(%s)\x02账号状态不是%s，当前状态为%s" +
-	"\x02实例状态不是%s，当前状态为%s\x02数据库状态不是%s，当前状态为%s\x02账号%s(%s)没有数据库%s(%s)的权限\x02数" +
-	"据库实例没有有效的cloudprovider\x02数据库实例的备份当前有%d个活跃任务执行中，无法执行同步状态操作\x02禁止不允许更改R" +
-	"DS的数据据名称\x02找不到数据库实例%s(%s)的账号%s：%v\x02未实现\x02无效地址：%s\x02%s不在子网%s(%s)的范围中" +
-	"\x02云订阅 %s(%s) 无法使用\x02无效的时间长度%s\x02不支持的时间长度%s\x02区域 %s 不支持创建RDS\x02区域 %" +
-	"s 不支持创建 %s 类型RDS\x02找不到匹配的dbinstance sku\x02%s RDS不支持安全组\x02%s RDS支持绑定最多" +
-	" %d 个安全组\x02不可在%s状态做恢复操作，要求状态必须为%s\x02备份%s(%s)中不包含数据库%s\x02数据库%s与实例%s(%s" +
-	")冲突\x02备份与数据库实例不属于同一个云账号\x02备份与数据库实例不在同一个cloudregion\x02无法从不同的rds引擎中恢复数据" +
-	"\x02无法重启状态为%s的数据库实例\x02数据库实例已有%d个活跃任务在执行，无法同步状态\x02无法为状态为%s的数据库实例执行刷新操作，" +
-	"要求状态为%s\x02缺少duration参数\x02数据库实例已开启外网访问\x02外网连接未开放\x02%s不支持此操作\x02处于状态" +
-	"%s无法执行变更配置操作\x02Unmarshal输入参数产生错误：%v\x02执行变更操作时无法找到sku\x02数据库实例已锁定，无法删除" +
-	"\x02数据库实例计费类型为%s\x02数据库实例计费类型%s不支持取消过期时间\x02找不到虚机%q\x02快照策略%s未找到：%s\x02不" +
-	"支持变更磁盘类型为%s\x02找不到磁盘%s对应的存储\x02无法为存储%s和磁盘%s找不到对应的宿主机\x02找不到存储%s\x02云订阅" +
-	" %s 不可用\x02存储%s(%s)需挂载到宿主机达到在线状态\x02无法使用已禁用的存储%s创建磁盘\x02无法使用离线存储%s创建磁盘" +
-	"\x02存储类型%s与后端%s不匹配\x02存储%s必须绑定到一个宿主机\x02空闲空间不够\x02获取快照数失败：%s\x02磁盘%s不需要转" +
-	"换快照\x02无法获得磁盘快照\x02获取转换快照对象失败：%s\x02快照%s没有转换快照对象\x02无法重置状态为%s的磁盘\x02无法" +
-	"重置快照状态为%s的磁盘\x02无法重置磁盘%s(%s)，因快照属于磁盘%s\x02磁盘状态为READY时方可调整其大小\x02磁盘不可缩容" +
-	"\x02无法找到磁盘所归属的存储资源\x02disk.GetQuotaKeys失败：%s\x02无法找到磁盘%s所属的存储\x02该磁盘没有zo" +
-	"ne信息\x02重复的镜像名%s\x02磁盘状态为READY时方可执行保存操作\x02GetRuningGuestCount调用失败：%s" +
-	"\x02当磁盘未被使用时才可执行保存操作\x02镜像名称是必选参数\x02cloudprovider %s不可用\x02云账号%s不可用\x02" +
-	"磁盘%s所在的存储资源找不到宿主机\x02磁盘%s调用GetGuestDiskCount时出错：%s\x02磁盘%s(%s)正被虚机使用" +
-	"\x02无法删除状态正常的预付费磁盘\x02Diskinfo下标%d：镜像id和尺寸都未指定\x02未找到快照%s\x02快照%s归属的存储%s" +
-	"未找到，它是公有云资源吗\x02镜像不在活跃状态\x02磁盘有%d个任务正在执行，无法执行同步状态操作\x02GetSnapshotCoun" +
-	"t失败：%s\x02无法执行purge操作，磁盘必须不能有快照\x02无法执行删除操作，磁盘必须不能有快照\x02存储类型为%s的磁盘若有快照不" +
-	"可删除\x02找不到快照策略%s\x02%s %s不支持DNS类型%s\x02%s %s不支持策略类型%s\x02%s %s不支持%s" +
-	"\x02%s不支持策略类型%s\x02%s %s不支持策略值%s\x02不支持\x02无效的域名%s\x02不支持%s，vpc %s支持%s" +
-	"\x02不支持%s，账号%s支持%s\x02不支持配置顶级公共域名 %s \x02不识别的zone类型%s\x02当前状态%s无法执行同步操作" +
-	"\x02当前状态%s无法执行缓存操作\x02仅%s支持为账号缓存\x02账号%s已缓存\x02当前状态%s无法执行解除缓存操作\x02vpc %" +
-	"s已经在这个DNS zone\x02vpc %s不在此DNS zone\x02SRV：参数不够：%s\x02SRV：无效端口号：%s\x02SR" +
-	"V：无效权重值：%s\x02SRV：权限值%d不在范围[0,65535]范围\x02SRV：无效优先组：%s\x02SRV：优先级%d不在[0," +
-	"65535]范围\x02SRV记录不可与其它类型记录同时存在\x02CNAME记录不可与其它类型记录同时存在\x02PTR记录不可与其它类型记录" +
-	"同时存在\x02%s：无效的域名：%s\x02SRV：无效的srv记录名：%s\x02PTR：无效的ptr记录名：%s\x02%s：名字不可" +
-	"以是IP地址：%s\x02A：记录值必须是IPv4地址：%s\x02AAAA：记录值必须是IPv6地址：%s\x02%s：%s必须是域名：%" +
-	"s\x02%s：%s不可以是IP地址：%s\x02%s：未知的记录类型\x02空记录\x02无效的TTL值：%s\x02无效的TTL值：%d" +
-	"\x02不可以混合不同类型的记录：%s != %s\x02条件表达式无效\x02找不到调度标签%s\x02unmarshal Standalon" +
-	"eResourceCreateInput失败：%s\x02不支持资源类型%s\x02不支持虚拟资源类型%s\x02找不到%s资源%s\x02无法" +
-	"恢复状态为%s的弹性缓存\x02不支持删除%s弹性弹性缓存备份\x02无效的计费周期%s\x02unmarshal VirtualResou" +
-	"rceCreateInput失败：%s\x02无法重启状态为%s的弹性缓存实例\x02弹性缓存已锁定，不可删除\x02弹性缓存未过期，不可删除" +
-	"\x02provider不匹配：%s缓存实例不可使用%s sku\x02region不匹配：实例region %s，sku region %s" +
-	"\x02zone不匹配：实例zone %s，sku zone %s\x02引擎版本不匹配：实例版本%s，sku版本%s\x02无法为状态为%s的" +
-	"缓存实例变更配置\x02认证模式的状态已为%s\x02运维时间参数没有变化\x02公网连接已分配\x02公网连接已释放\x02无效参数格式：" +
-	"必须为JSON Object\x02弹性缓存已有%d个任务在执行，无法执行同步状态操作\x02弹性缓存的计费类型为%s\x02弹性缓存的计费" +
-	"类型%s不支持取消过期时间\x02虚机状态%s不可执行添加安全组操作\x02不支持绑定安全组\x02超过可绑定的安全组数量限制，最多 %d " +
-	"个\x02安全组名称%s不符合要求\x02参数%s不可变更\x02找不到虚机%s\x02不支持绑定类型%s，仅支持%s\x02不支持付费类型" +
-	"%s\x02EIP已绑定到其它实例\x02EIP状态为%s无法绑定\x02固定EIP不可再被关联\x02不支持%s\x02无法与正在删除的虚机进" +
-	"行绑定\x02实例已与其它EIP绑定\x02虚机状态%s无法进行EIP绑定操作\x02虚机与EIP在同一子网下不可关联\x02找不到虚机所属" +
-	"region\x02找不到EIP所属region\x02EIP的虚机不在同一region\x02EIP和虚机不在同一个zone\x02虚机所在宿" +
-	"主机找不到\x02虚机和EIP分属不同cloudprovider\x02EIP状态为%s无法执行解绑操作\x02固定的公网IP无法解绑" +
-	"\x02EIP %s正被NAT网关的SNAT规则使用，请先删除它们\x02EIP %s正被NAT网关的DNAT规则使用，请先删除它们\x02固定" +
-	"公网IP无法执行同步状态操作\x02EIP状态为%s无法变更带宽\x02无效的带宽\x02EIP所属cloudprovider为启用状态，无" +
-	"法执行purge操作\x02请解绑组中所有虚机后再试\x02无法绑定已禁用的虚机\x02无法解绑已禁用的虚机\x02找不到实例%s\x02虚" +
-	"机和实例组应属于同一项目\x02找不到宿主机\x02宿主机状态为%s，启用状态为%s，无法对虚机执行%s操作\x02状态为%s时无法发送命令" +
-	"\x02无法找到虚机所在宿主机\x02状态为%s时不可保持镜像\x02找不到根镜像\x02仅KVM虚机支持此操作\x02状态为%s无法执行同步状" +
-	"态操作\x02状态为%s无法执行在线迁移\x02主备机不支持克隆操作\x02hypervisor为%s的虚机不支持克隆操作\x02状态为%s" +
-	"的虚机不可执行克隆操作\x02unmarshal输入参数错误：%s\x02状态为%s的虚机无法执行部署操作\x02磁盘%s和虚机不属于同一个" +
-	"账号\x02磁盘%s和虚机不属于同一个zone\x02isAttached检查失败：%s\x02磁盘%s已被占用\x02磁盘%s和虚机不在同" +
-	"一宿主机\x02磁盘状态为%s，无法挂载\x02虚机%s的状态%s不支持挂载磁盘\x02找不到磁盘%s\x02状态为%s的虚机无法执行挂起操" +
-	"作\x02状态为%s的虚机无法执行恢复操作\x02部分磁盘未准备好\x02不可启动状态为%s的虚机\x02CD-ROM当前使用中，请先执行弹" +
-	"出操作\x02虚机状态%s不允许执行插入ISO操作\x02没有ISO可弹出\x02虚机状态%s不允许弹出ISO操作\x02无法为hyperv" +
-	"isor %s添加安全组\x02虚机%s最多可关联%d个安全组\x02安全组%s已被虚机%s使用\x02虚机状态为%s无法解除安全组\x02安全" +
-	"组%s未与虚机%s关联\x02虚机状态为%s无法关联安全组\x02虚机状态为%s无法设定安全组\x02无法为虚机%s设定安全组\x02虚机所" +
-	"在宿主机为启用状态，不可执行purge操作\x02找不到%s\x02无效的镜像\x02镜像大小超过系统盘大小\x02无法切换操作系统：%s-" +
-	"%s\x02镜像uefi状态不同重装操作系统\x02找不到模板，无法重装系统\x02不支持使用另外一个镜像重装系统\x02状态为%s不支持重装系" +
-	"统\x02找不到密钥对%s\x02未提供Disk Info\x02找不到宿主机\x02所在宿主机无可用存储\x02所在宿主机存储空间不足" +
-	"\x02查找磁盘错误：%s\x02isAttach2Disk失败：%s\x02不可解绑系统盘\x02无法保留已解绑的磁盘\x02虚机状态%s不支" +
-	"持解绑磁盘\x02磁盘%s未挂载\x02仅当虚机为关机状态时才可挂载透传设备\x02未指定透传设备\x02找不到透传设备%s\x02透传设备" +
-	"未挂载到此虚机\x02GPU数量必须大于1\x02获取GPU失败：%s\x02虚机%s所在宿主机%s透传设备不足\x02挂载设备列表参数类型" +
-	"不是字符串数组\x02卸载设备列表参数类型不是字符串数组\x02找不到IP %s\x02找不到MAC %s\x02未指定ip_addr或ma" +
-	"c\x02状态为%s无法变更IP地址\x02虚机运行中无法变更MAC地址\x02MAC地址唯一性检查失败\x02MAC地址%s已被占用\x02虚" +
-	"机状态%s无法执行解绑网络操作\x02虚机状态%s无法执行绑定网络操作\x02虚机状态%s无法变更带宽大小\x02带宽值必须非负\x02虚机" +
-	"状态%s不可变更配置\x02不允许变更配置\x02主备机不允许变更配置\x02虚机状态为%s不可变更配置\x02不可变更套餐类型\x02参数" +
-	"vcpu_count解析出错\x02内存大小参数错误，如256M，1G，或256\x02参数vmem_size解析出错\x02虚机状态为%s无法" +
-	"变更CPU/内存配置\x02Unmarshal磁盘配置出错：%s\x02解析磁盘信息出错：%s\x02不可缩小磁盘大小\x02虚机状态为%s" +
-	"无法重装系统\x02虚机已有%d个活跃任务执行中，无法执行同步状态操作\x02虚机状态%s无法执行关机操作\x02虚机状态%s无法执行重启操" +
-	"作\x02虚机状态%s无法发送键盘指令\x02虚机状态%s无法关联EIP\x02虚机已关联EIP\x02找不到EIP %s\x02EIP已被" +
-	"关联\x02虚机与EIP不在同一region无法关联\x02虚机与EIP不在同一个zone下无法关联\x02虚机与EIP不属于同一provi" +
-	"der无法关联\x02没有可解关联的EIP\x02EIP配额不足：%s\x02虚机状态为%s时无法切换到备机\x02虚机没有备用宿主机\x02虚" +
-	"机无法切换到备机，因镜像任务未结束\x02找不到虚机%s\x02输入数据不是键值字典\x02找不到虚机%s\x02查找虚机失败：%s\x02" +
-	"虚机已有备用机\x02使用共享存储不可创建备机\x02仅KVM虚机支持创建主备机\x02使用透传设备无法创建备机\x02GuestDisks" +
-	"HasSnapshot失败：%s\x02无法从快照创建备机\x02虚机无备机\x02备机所在宿主机找不到\x02备机所在宿主机离线\x02虚机不" +
-	"需要做reconcile操作\x02虚机的计费类型%s不支持取消过期时间\x02虚机的计费类型为%s\x02虚机%s不支持后付费自动过期" +
-	"\x02无效的desc内容\x02虚机Id为空\x02虚机名为空\x02虚机%s已存在\x02导入网卡列表为空\x02IP %s或MAC %s已" +
-	"被注册\x02无法通过IP %s找到网络\x02导入磁盘列表为空\x02Unmarshal数据失败：%s\x02部分宿主机配置缺少xml_f" +
-	"ile_path\x02部分宿主机缺少HostIp字段\x02无效的宿主机IP %s\x02无效虚机MAC地址%s\x02无效的虚机IP地址 %" +
-	"s\x02创建任务失败：%s\x02Hypervisor %s无法创建libvirt XML\x02生成XML失败：%s\x02不支持hyper" +
-	"visor %s\x02不支持%s\x02虚机已被转换过\x02宿主机%s不是KVM类型\x02虚机必须为关机状态\x02检查并设置待使用配置时" +
-	"出错：%s\x02找不到宿主机\x02空的IP列表\x02IP %s不可达：%s\x02IP %s不可用：已被占用\x02部分磁盘找不到" +
-	"\x02磁盘%s未挂载到虚机\x02Hypervisor %s无法实现io限速\x02虚机状态%s无法设定io限速\x02bps必须大于0" +
-	"\x02iops必须大于0\x02虚机%s hypervisor %s不支持迁移\x02虚机%s有备机，不可迁移\x02虚机%s使用本地存储不支" +
-	"持救援模式\x02虚机%s状态为%s不可迁移\x02虚机%s状态为%s，有透传设备，无法迁移\x02虚机有cdrom不可迁移\x02虚机%s" +
-	"状态%s因使用本地存储无法迁移\x02未指定虚机Id\x02部分指定的虚机不存在\x02虚机hypervisor %s无法创建实例快照" +
-	"\x02备份机无法创建快照\x02虚机状态为%s无法做快照\x02虚机%d号磁盘快照数达到上限，不可再创建\x02创建快照失败：%s\x02创建" +
-	"快照任务失败：%s\x02快照未准备好\x02从快照恢复失败：%s\x02count必须大于0\x02生成快照名称失败：%s\x02不是裸金" +
-	"属服务器\x02找不到宿主机\x02宿主机不是裸金属\x02找不到主机组%s\x02主机组与虚机应属于同一个项目\x02无法关联或解关联已禁" +
-	"用的主机组\x02虚机没有公网IP\x02虚机状态要求为%s或%s，当前状态为%s\x02%s虚机不支持转发公网IP为EIP\x02仅%s虚" +
-	"机支持此操作\x02虚机模板暂不支持实例快照\x02找不到虚机模板指定的安全组%s\x02虚机模板中的%s不是共享资源\x02虚机模板中的%" +
-	"s %q不是共享资源\x02虚机模板中的%s在范围%s内不是共享资源\x02虚机模板中的%s %q在范围%s内不是共享资源\x02虚机模板%s正" +
-	"被服务目录%s使用\x02虚机模板%s正被伸缩组%s使用\x02检查磁盘序号唯一性失败：%s\x02磁盘序号%d已被占用\x02无法分配网卡" +
-	"名\x02检查网卡序号唯一性失败：%s\x02网卡序号%d已被占用\x02找不到宿主机%s\x02找不到安全组%s\x02找不到磁盘%s" +
-	"\x02检查虚机磁盘数量失败：%s\x02找不到主机组%s\x02虚机已锁定，无法删除\x02不允许删除有效状态的预付费虚机\x02不允许删除已" +
-	"禁用宿主机上的虚机\x02无法删除离线宿主机上的虚机\x02虚机磁盘存在快照，无法执行删除操作\x02内存大小必须在8MB〜%dGB范围内" +
-	"\x02CPU核数必须在范围1〜%d内\x02虚机状态为%s无法变更内存和CPU配置\x02无法为裸金属变更内存配置\x02名称太短\x02找不" +
-	"到实例快照%s\x02获取实例快照出错：%s\x02实例快照未准备好\x02metadata条目数不可超过20\x02login_accou" +
-	"nt长度已超过32字节\x02未提供磁盘信息\x02无效的系统镜像: %s\x02系统盘不支持ISO镜像，请使用cdrom参数\x02解析cdr" +
-	"om设备信息出错误：%s\x02未指定操作系统镜像？\x02解析磁盘描述信息出错：%s\x02快照错误：序号%d大于0的磁盘类型为%s\x02无" +
-	"法在预付费的资源类型上创建预付费的虚机\x02解析网络描述信息出错：%s\x02无法创建带有透传设备的主备机\x02解析透传设备描述信息出错" +
-	"：%s\x02找不到密钥对%s\x02找不到安全组%s\x02%s最多可关联%d个安全组\x02无效的userdata：%v\x02策略定义" +
-	"中有无效参数：%s\x02策略定义%s要求cloudregion在%s范围中\x02策略定义%s要求cloudregion不在%s范围中" +
-	"\x02策略定义%s(%s)包含无效的条件%s\x02策略定义%s要求必须包含%s标签\x02策略定义%s要求不可有%s标签\x02类别%s在策" +
-	"略定义%s(%s)中无效\x02%s 不支持静态公网IP\x02无效的静态公网IP类型 %s\x02%s不支持EIP\x02EIP %s状态" +
-	"无效%s\x02EIP %s已被占用\x02EIP %s属于不同cloudprovider，无法绑定\x02EIP %s属于不同的regio" +
-	"n，无法绑定\x02获取磁盘大小失败\x02镜像%s不在虚机镜像%s中\x02部分虚机镜像的子镜像未指定\x02裸金属%s未启用\x02无法运行" +
-	"%s，宿主机类型为%s\x02宿主机上没有可用存储\x02无效的aggregate_strategy: %s\x02找不到二层网络%s\x02不" +
-	"支持hypervisor %s\x02虚机状态为%s无法执行回收操作\x02虚机状态为%s无法从回收站恢复\x02宿主机应为已禁用状态" +
-	"\x02宿主机不是预付费资源池类型\x02预付费资源池宿主机没有可用的虚机\x02预付费资源池宿主机不可拥有超过1个虚机\x02无法从资源池中恢" +
-	"复已伪删除的虚机\x02不是预付费资源池宿主机\x02无效的any_mac参数\x02找不到调度标签\x02不支持hypervisor %s" +
-	"\x02宿主机是一个裸金属，请先恢复到转换之前状态再执行删除操作\x02宿主机还未被禁用\x02getGuestCount调用失败：%s\x02" +
-	"宿主机非空\x02调用GetDiskCount失败：%s\x02宿主机本地存储非空？\x02不一致：本地存储非空\x02找不到宿主机%s的I" +
-	"PMI信息\x02IPMI信息中缺少密码\x02检查重复%s出错：%s\x02%s %s重复\x02无效的macAddr\x02检查重复acce" +
-	"ss_mac出错：%s\x02重复的access_mac %s\x02%s不在子网范围\x02IPMI子网没有zone信息？\x02IPMI地址" +
-	"不在所指定的zone\x02宿主机IP %s已被注册\x02宿主机所属子网没有zone信息？\x02宿主机IP不在指定的zone\x02no" +
-	"_probe模式缺少access_mac和uuid信息\x02IPMI子网没有zone信息\x02新的IPMI地址在另外一个zone\x02不能" +
-	"启动一个非裸金属服务器\x02因裸金属服务器还有活跃的虚机，不可启动\x02不可停止一个非裸金属服务器\x02因裸金属服务器还有非活跃的虚机" +
-	"，不可停止\x02因裸金属服务器还有活跃的虚机，不可停止\x02状态为%s无法进入维护模式\x02虚机状态为%s无法进入维护模式\x02状态" +
-	"为%s无法解除维护模式\x02错误的虚机状态%s\x02不是一个裸金属服务器\x02执行准备操作需要有效的access_mac和uuid参数" +
-	"\x02裸金属状态为%s无法执行准备操作\x02虚机状态为%s无法执行准备操作\x02状态为%s无法执行IPMI探测操作\x02状态为%s无法执" +
-	"行初始化操作\x02IPMI信息未配置\x02虚机插入操作出错：%s\x02无效MAC地址\x02查找二层网络%s出错：%s\x02无效IP" +
-	"地址%s\x02二层网络%s中没有可用子网\x02IP %s不在二层网络%s中\x02IP %s不属于任何二层网络\x02无法通过MAC地址" +
-	"%s找到网卡：%s\x02无法通过MAC地址找到hostwire：%s\x02网卡%s不存在\x02仅admin, ipmi类型网卡可以被启用" +
-	"\x02网卡%s不存在\x02不是一个裸金属服务器\x02没有在转换为hypervisor\x02无效的MAC地址\x02获取网卡出错：%s" +
-	"\x02非裸金属服务器无法执行同步状态操作\x02裸金属服务器状态为%s无法执行重启操作\x02裸金属服务器上存在活跃的虚机，无法执行重启操作" +
-	"\x02状态为%s无法执行镜像缓存操作\x02找不到镜像%s\x02镜像没有校验值无法执行缓存操作\x02必须指定host_type参数\x02" +
-	"要求必须为裸金属服务器\x02裸金属服务器已被占用\x02hypervisor状态为%s无法执行转换\x02转换其它域的宿主机需要系统权限" +
-	"\x02不支持驱动%s\x02isAlterNameUnique调用失败：%s\x02转换出错：%s\x02宿主机应为禁用状态\x02当前状态为" +
-	"%s无法取消转换\x02不是一个转换后的hypervisor\x02宿主机状态%s无法退出维护模式\x02宿主机类型%s无法进入维护模式\x02" +
-	"宿主机状态为%s不支持此操作\x02宿主机%s无法迁移虚机%s，因虚机状态为%s\x02因状态为%s无法执行insert-iso指令\x02" +
-	"因状态为%s无法执行eject-iso指令\x02非裸金属服务器中无法执行同步配置操作\x02预留CPU数必须为非负整数\x02预留内存大小" +
-	"必须为非负整数\x02预留存储必须为非负整数\x02宿主机%s无法为每个透传设备预留%d个CPU，因资源不够\x02宿主机%s无法为每个透传" +
-	"设备预留%dM内存，因资源不够\x02宿主机%s无法为每个透传设备预留%dM存储，因资源不够\x02仅系统管理员可指定宿主机\x02存储正使" +
-	"用中\x02查找存储%s失败\x02查找宿主机%s失败\x02unmarshal JoinResourceBaseCreateInput出错" +
-	"：%s\x02GetGuestDiskCount失败：%s\x02GetGuestnicsCount调用出错：%s\x02宿主机上的虚机正在" +
-	"使用此二层网络中的子网\x02透传设备正被虚机使用\x02找不到透传设备%s\x02透传设备已被另外一台虚机%s使用\x02透传设备已被虚机" +
-	"%s使用\x02不支持格式%s\x02无效的公钥：%v\x02GetLinkedGuestsCount失败：%s\x02密钥对正被虚机使用无法删" +
-	"除\x02找不到转发策略%s(%s)所属的监听\x02无效的地址%s\x02描述文本过长（%d>=%d）\x02描述文本包含不可打印字符：%" +
-	"v\x02访问控制包含重复的CIDR %s\x02获取访问控制数量失败：%s\x02访问控制%s仍被%d个%s使用\x02无效的VRRP网络接口" +
-	"名%q\x02无效的VRRP认证密钥长度：%d，要求[1,8]\x02无效的VRRP优先级%d，要求[1,255]\x02无效的VRRP v" +
-	"irtual_router_id %d：要求[1,255]\x02无效的VRRP advert_int %d：要求[1,255]\x02tele" +
-	"graf参数：无效的influxdb URL：%s\x02%s：无效的base64编码串：%s\x02%s：无效的模板：%s\x02获取其它集群" +
-	"的转发节点失败：%v\x02与转发节点%s(%s)冲突：%v\x02转发集群%s(%s)已占用virtual_router_id %d" +
-	"\x02%s：时间错误：%s\x02%s：新指定时间在未来：%s > %s\x02集群中已有节点%s(%s)使用VRRP优先级%d\x02使用y" +
-	"um模式需要提供有效的repo_base_url参数\x02主机名为空\x02查找宿主机%s出错：%v\x02转发节点不能部署到纳管的宿主机上" +
-	"\x02查找虚机%s出错：%v\x02转发节点不能部署到公有云虚机上\x02虚机当前状态为%q，要求为%q\x02unmarshal输入参数出错" +
-	": %v\x02主机缺少%s字段\x02主机缺少%s字段\x02认证出错：%v\x02用户必须有系统管理员权限\x02获取%s %s服务URL出" +
-	"错：%v\x02上次部署的信息不可用\x02查找后端组相关的资源出错\x02无效的权重%d，要求在0～256范围\x02无效的端口%d，要求" +
-	"在1~65535范围\x02找不到虚机%s\x02仅系统管理员可指定宿主机作为后端\x02找不到宿主机%s\x02未识别的后端类型%s" +
-	"\x02第%d个后端所属的region与lb的region不匹配\x02查找负载均衡所属region失败：%s\x02调用isDefault出错" +
-	"：%s\x02后端服务器组%s是默认组\x02调用refCount出错：%s\x02后端组%s仍被%d个%s使用\x02%s要求添加到后端组" +
-	"中的虚机状态为%s，当前虚机状态为%s\x02虚机%s(%s)所处VPC %s(%s)和负载均衡所处VPC %s不一致\x02获取虚机%s出" +
-	"错\x02虚机%s(%s)所属VPC %s(%s)不是%s(%s)\x02虚机%s(%s)已存在于后端组%s(%s)\x02查找负载均衡后端" +
-	"%s的region时出错\x02查找后端%s(%s)所属的后端组时出错\x02访问控制缓存已在region %s存在\x02获取证书使用数失败：" +
-	"%s\x02证书%s仍被%d个%s使用\x02无效的本地证书：私钥为空\x02无效的本地证书：证书内容为空\x02证书缓存已在region %s" +
-	"存在\x02不允许变更证书内容\x02zone %s(%s)不合法：仅允许本地IDC的zone\x02二层网络所属zone %s与参数中的z" +
-	"one %s(%s)冲突，\x02wire所属zone必须为%s，实际为%s\x02获取负载均衡集群引用次数失败：%v\x02负载均衡集群仍被%" +
-	"d个%s使用\x04\x00\x01 J\x02负载均衡集群%s(%s)和%s(%s)两者virtual_router_id参数冲突：%d" +
-	"\x02无效的条件格式，要求为JSON\x02无效的表达式格式，要求为JSON数组\x02触及条件数目上限（5），已指定%d个\x02规则%s/" +
-	"%s已被%s(%s)使用\x02查找负载均衡监听所属region失败：%s\x02查找负载均衡转发策略失败：%s\x02%s监听的端口%d已被%" +
-	"s(%s)占用\x02无法找到region信息\x02后端服务器组%s(%s)属于负载均衡实例%s，而不是%s\x04\x00\x01 9" +
-	"\x02负载均衡集群所属zone %s与子网zone %s不匹配\x02负载均衡集群所属wire与子网所属wire不匹配：%s != %s" +
-	"\x02负载均衡已经被锁定，无法删除\x02Unmarshal输入参数失败：%s\x02端口值错误\x02无效的内网IP地址：%s\x02EIP" +
-	"已绑定到其它实例\x02EIP已绑定到SNAT规则\x02找不到EIP\x02NAT网关已有%d个活跃任务在执行，无法执行同步状态操作" +
-	"\x02sourceCIDR和network_id仅允许指定其中一个\x02CIDR %s不在VPC允许范围%s内\x02EIP已绑定到DNAT" +
-	"规则\x02找不到子网\x02GetAllocatedNicCount失败：%s\x02IP子网 %s 包含已分配的IP地址\x02地址%s" +
-	"不在子网%s(%s)范围内\x02isAddressUsed调用失败：%s\x02地址%s已被占用\x02getFreeAddressCou" +
+	"用出错：%s\x02设置静态网站配置错误 %s\x02删除静态网站配置错误 %s\x02获取静态网站配置错误 %s\x02设置CORS错误：" +
+	"%s\x02删除CORS设置错误：%s\x02获取CORS规则错误：%s\x02获取CDN加速域名错误：%s\x02设置Referer错误：%s" +
+	"\x02获取Referer错误：%s\x02获取权限设置错误：%s\x02设置权限错误：%s\x02删除权限设置错误：%s\x02unmarsh" +
+	"al limit参数出错：%s\x02SetLimit调用出错：%s\x02更新出错：%s\x02找不到manager\x02iBucket.G" +
+	"etIObject调用出错：%s\x02ValidateDeleteCondition出错：%s\x02镜像已被缓存到磁盘\x02镜像引用会话还" +
+	"未过期\x02找不到存储缓存%s\x02不允许查询系统能力\x02云账号%s为启用SAML认证\x02账号为启用状态\x02账号不空闲" +
+	"\x02%s provider: %v\x02无法启用正在删除中的账号\x02%s不支持SAML认证\x02无效的代理设备%s\x02无效的wi" +
+	"re_level_for_vmware %q, 允许 %s\x02不支持provider为%s的云账号\x02不支持%s\x02项目%s(%s)" +
+	"不属于域%s(%s)\x02不支持品牌%s，仅支持%s\x02唯一性检查失败\x02账户已被注册\x02找不到provider %s\x02" +
+	"无效的账号信息：%s\x02检查重复account_id出错\x02账号%s已被注册\x02账号已禁用\x02账号自动同步已启用\x02无效" +
+	"的输入：%s\x02无法找到provider工厂：%v\x02unmarshal输入参数出错：%v\x02检查唯一性出错：%s\x02账号%" +
+	"s出现冲突\x02account_id不一致，之前为%q，现在为%q\x02找不到项目%s\x02状态为%s时无法启用自动同步\x02provi" +
+	"der在域间共享\x02不支持%s\x02%s不支持创建订阅\x02不允许创建\x02provider当前是启用状态\x02provider当前" +
+	"不是空闲状态\x02不支持直接创建cloudprovider，请先创建云账号\x02找不到region %s\x02找不到zone %s" +
+	"\x02cloudprovider是已禁用状态\x02云账号是已禁用状态\x02不允许跨域变更项目属性\x02不允许变更为私有云另外一个域" +
+	"\x02获取provider驱动失败：%s\x02不支持存储类型\x02GetZoneCount调用失败\x02GetVpcCount调用失败" +
+	"\x02cloudregion不为空\x02不允许删除默认cloudregion\x02找不到VPC %s\x02不允许更新外部资源\x02禁止" +
+	"允许更改RDS账号名称\x02查找数据库实例出错：%s\x02数据库实例%s(%s)当前状态为%s，要求状态为%s\x02找不到数据库实例%" +
+	"s(%s)所属的region\x02在数据库实例%s(%s)中查找%s库失败：%v\x02查找数据库%s失败，在实例%s(%s)中查找出错：%v" +
+	"\x02账号%s(%s)已有权限%s访问数据库%s(%s)\x02账号状态不是%s，当前状态为%s\x02实例状态不是%s，当前状态为%s" +
+	"\x02数据库状态不是%s，当前状态为%s\x02账号%s(%s)没有数据库%s(%s)的权限\x02数据库实例没有有效的cloudprovid" +
+	"er\x02数据库实例的备份当前有%d个活跃任务执行中，无法执行同步状态操作\x02禁止不允许更改RDS的数据据名称\x02找不到数据库实例%s" +
+	"(%s)的账号%s：%v\x02未实现\x02无效地址：%s\x02%s不在子网%s(%s)的范围中\x02云订阅 %s(%s) 无法使用" +
+	"\x02无效的时间长度%s\x02不支持的时间长度%s\x02区域 %s 不支持创建RDS\x02区域 %s 不支持创建 %s 类型RDS" +
+	"\x02找不到匹配的dbinstance sku\x02%s RDS不支持安全组\x02%s RDS支持绑定最多 %d 个安全组\x02不可在%" +
+	"s状态做恢复操作，要求状态必须为%s\x02备份%s(%s)中不包含数据库%s\x02数据库%s与实例%s(%s)冲突\x02备份与数据库实例不" +
+	"属于同一个云账号\x02备份与数据库实例不在同一个cloudregion\x02无法从不同的rds引擎中恢复数据\x02无法重启状态为%s的" +
+	"数据库实例\x02数据库实例已有%d个活跃任务在执行，无法同步状态\x02无法为状态为%s的数据库实例执行刷新操作，要求状态为%s\x02缺" +
+	"少duration参数\x02数据库实例状态需要是 %s，目前是 %s\x02只有 %s 数据库实例支持该操作\x02数据库实例已开启外网访" +
+	"问\x02外网连接未开放\x02%s不支持此操作\x02处于状态%s无法执行变更配置操作\x02Unmarshal输入参数产生错误：%v" +
+	"\x02执行变更操作时无法找到sku\x02数据库实例已锁定，无法删除\x02数据库实例计费类型为%s\x02数据库实例计费类型%s不支持取消过" +
+	"期时间\x02该操作要求数据库实例状态为 %s\x02%s 允许的安全组数量为 %d\x02找不到虚机%q\x02快照策略%s未找到：%s" +
+	"\x02不支持变更磁盘类型为%s\x02找不到磁盘%s对应的存储\x02无法为存储%s和磁盘%s找不到对应的宿主机\x02找不到存储%s\x02" +
+	"云订阅 %s 不可用\x02存储%s(%s)需挂载到宿主机达到在线状态\x02无法使用已禁用的存储%s创建磁盘\x02无法使用离线存储%s创" +
+	"建磁盘\x02存储类型%s与后端%s不匹配\x02存储%s必须绑定到一个宿主机\x02空闲空间不够\x02获取快照数失败：%s\x02磁盘%" +
+	"s不需要转换快照\x02无法获得磁盘快照\x02获取转换快照对象失败：%s\x02快照%s没有转换快照对象\x02无法重置状态为%s的磁盘" +
+	"\x02无法重置快照状态为%s的磁盘\x02无法重置磁盘%s(%s)，因快照属于磁盘%s\x02磁盘状态为READY时方可调整其大小\x02磁盘" +
+	"不可缩容\x02无法找到磁盘所归属的存储资源\x02disk.GetQuotaKeys失败：%s\x02无法找到磁盘%s所属的存储\x02该" +
+	"磁盘没有zone信息\x02重复的镜像名%s\x02磁盘状态为READY时方可执行保存操作\x02GetRuningGuestCount调用" +
+	"失败：%s\x02当磁盘未被使用时才可执行保存操作\x02镜像名称是必选参数\x02cloudprovider %s不可用\x02云账号%s" +
+	"不可用\x02磁盘%s所在的存储资源找不到宿主机\x02磁盘%s调用GetGuestDiskCount时出错：%s\x02磁盘%s(%s)正" +
+	"被虚机使用\x02无法删除状态正常的预付费磁盘\x02Diskinfo下标%d：镜像id和尺寸都未指定\x02未找到快照%s\x02快照%s" +
+	"归属的存储%s未找到，它是公有云资源吗\x02镜像不在活跃状态\x02磁盘有%d个任务正在执行，无法执行同步状态操作\x02GetSnaps" +
+	"hotCount失败：%s\x02无法执行purge操作，磁盘必须不能有快照\x02无法执行删除操作，磁盘必须不能有快照\x02存储类型为%s的" +
+	"磁盘若有快照不可删除\x02找不到快照策略%s\x02%s %s不支持DNS类型%s\x02%s %s不支持策略类型%s\x02%s %s不" +
+	"支持%s\x02%s不支持策略类型%s\x02%s %s不支持策略值%s\x02不支持\x02无效的域名%s\x02不支持%s，vpc %s" +
+	"支持%s\x02不支持%s，账号%s支持%s\x02不支持配置顶级公共域名 %s \x02不识别的zone类型%s\x02当前状态%s无法执" +
+	"行同步操作\x02当前状态%s无法执行缓存操作\x02仅%s支持为账号缓存\x02账号%s已缓存\x02当前状态%s无法执行解除缓存操作" +
+	"\x02vpc %s已经在这个DNS zone\x02vpc %s不在此DNS zone\x02SRV：参数不够：%s\x02SRV：无效端口号" +
+	"：%s\x02SRV：无效权重值：%s\x02SRV：权限值%d不在范围[0,65535]范围\x02SRV：无效优先组：%s\x02SRV" +
+	"：优先级%d不在[0,65535]范围\x02SRV记录不可与其它类型记录同时存在\x02CNAME记录不可与其它类型记录同时存在\x02P" +
+	"TR记录不可与其它类型记录同时存在\x02%s：无效的域名：%s\x02SRV：无效的srv记录名：%s\x02PTR：无效的ptr记录名：%s" +
+	"\x02%s：名字不可以是IP地址：%s\x02A：记录值必须是IPv4地址：%s\x02AAAA：记录值必须是IPv6地址：%s\x02%s：" +
+	"%s必须是域名：%s\x02%s：%s不可以是IP地址：%s\x02%s：未知的记录类型\x02空记录\x02无效的TTL值：%s\x02无效的" +
+	"TTL值：%d\x02不可以混合不同类型的记录：%s != %s\x02条件表达式无效\x02找不到调度标签%s\x02unmarshal St" +
+	"andaloneResourceCreateInput失败：%s\x02不支持资源类型%s\x02不支持虚拟资源类型%s\x02找不到%s资源%" +
+	"s\x02无法恢复状态为%s的弹性缓存\x02不支持删除%s弹性弹性缓存备份\x02无效的计费周期%s\x02unmarshal Virtual" +
+	"ResourceCreateInput失败：%s\x02无法重启状态为%s的弹性缓存实例\x02弹性缓存已锁定，不可删除\x02弹性缓存未过期，" +
+	"不可删除\x02provider不匹配：%s缓存实例不可使用%s sku\x02region不匹配：实例region %s，sku regi" +
+	"on %s\x02zone不匹配：实例zone %s，sku zone %s\x02引擎版本不匹配：实例版本%s，sku版本%s\x02无法为状" +
+	"态为%s的缓存实例变更配置\x02认证模式的状态已为%s\x02弹性缓存 %s 没有管理账号\x02运维时间参数没有变化\x02公网连接已分" +
+	"配\x02公网连接已释放\x02无效参数格式：必须为JSON Object\x02弹性缓存已有%d个任务在执行，无法执行同步状态操作\x02" +
+	"弹性缓存的计费类型为%s\x02弹性缓存的计费类型%s不支持取消过期时间\x02虚机状态%s不可执行添加安全组操作\x02区域\x02区域类" +
+	"型\x02不支持绑定安全组\x02超过可绑定的安全组数量限制，最多 %d 个\x02安全组名称%s不符合要求\x02安全组在更新后会置空" +
+	"\x02弹性缓存状态应该是 %s，目前是 %s\x02只有 %s 弹性缓存支持设置自动更新操作\x02弹性缓存找不到关联的区域\x02只有 %s" +
+	" 弹性缓存支持续期操作\x02参数%s不可变更\x02资源 %s（归属VPC %s 外部访问模式 %s）不支持关联EIP\x02找不到虚机%s" +
+	"\x02不支持绑定类型%s，仅支持%s\x02不支持付费类型%s\x02EIP已绑定到其它实例\x02EIP状态为%s无法绑定\x02固定EIP" +
+	"不可再被关联\x02不支持%s\x02无法与正在删除的虚机进行绑定\x02实例已与其它EIP绑定\x02虚机状态%s无法进行EIP绑定操作" +
+	"\x02虚机与EIP在同一子网下不可关联\x02找不到虚机所属region\x02找不到EIP所属region\x02EIP的虚机不在同一reg" +
+	"ion\x02EIP和虚机不在同一个zone\x02虚机所在宿主机找不到\x02虚机和EIP分属不同cloudprovider\x02EIP状态" +
+	"为%s无法执行解绑操作\x02固定的公网IP无法解绑\x02EIP %s正被NAT网关的SNAT规则使用，请先删除它们\x02EIP %s正" +
+	"被NAT网关的DNAT规则使用，请先删除它们\x02固定公网IP无法执行同步状态操作\x02EIP状态为%s无法变更带宽\x02无效的带宽" +
+	"\x02EIP所属cloudprovider为启用状态，无法执行purge操作\x02云账号 %s 并未共享到域 %s\x02请解绑组中所有虚机" +
+	"后再试\x02无法绑定已禁用的虚机\x02无法解绑已禁用的虚机\x02找不到实例%s\x02虚机和实例组应属于同一项目\x02找不到宿主机" +
+	"\x02宿主机状态为%s，启用状态为%s，无法对虚机执行%s操作\x02状态为%s时无法发送命令\x02无法找到虚机所在宿主机\x02状态为%s" +
+	"时不可保持镜像\x02找不到根镜像\x02仅KVM虚机支持此操作\x02状态为%s无法执行同步状态操作\x02状态为%s无法执行在线迁移" +
+	"\x02主备机不支持克隆操作\x02hypervisor为%s的虚机不支持克隆操作\x02状态为%s的虚机不可执行克隆操作\x02unmarsh" +
+	"al输入参数错误：%s\x02状态为%s的虚机无法执行部署操作\x02磁盘%s和虚机不属于同一个账号\x02磁盘%s和虚机不属于同一个zone" +
+	"\x02isAttached检查失败：%s\x02磁盘%s已被占用\x02磁盘%s和虚机不在同一宿主机\x02磁盘状态为%s，无法挂载\x02虚" +
+	"机%s的状态%s不支持挂载磁盘\x02找不到磁盘%s\x02状态为%s的虚机无法执行挂起操作\x02状态为%s的虚机无法执行恢复操作\x02" +
+	"宿主机虚拟机内存不足\x02部分磁盘未准备好\x02不可启动状态为%s的虚机\x02CD-ROM当前使用中，请先执行弹出操作\x02虚机状态" +
+	"%s不允许执行插入ISO操作\x02没有ISO可弹出\x02虚机状态%s不允许弹出ISO操作\x02无法为hypervisor %s添加安全组" +
+	"\x02虚机%s最多可关联%d个安全组\x02安全组%s已被虚机%s使用\x02虚机状态为%s无法解除安全组\x02安全组%s未与虚机%s关联" +
+	"\x02虚机状态为%s无法关联安全组\x02虚机状态为%s无法设定安全组\x02无法为虚机%s设定安全组\x02虚机所在宿主机为启用状态，不可执" +
+	"行purge操作\x02找不到%s\x02无效的镜像\x02镜像大小超过系统盘大小\x02无法切换操作系统：%s-%s\x02镜像uefi状" +
+	"态不同重装操作系统\x02找不到模板，无法重装系统\x02不支持使用另外一个镜像重装系统\x02状态为%s不支持重装系统\x02找不到密钥对" +
+	"%s\x02未提供Disk Info\x02找不到宿主机\x02所在宿主机无可用存储\x02所在宿主机存储空间不足\x02查找磁盘错误：%s" +
+	"\x02isAttach2Disk失败：%s\x02不可解绑系统盘\x02无法保留已解绑的磁盘\x02虚机状态%s不支持解绑磁盘\x02磁盘%s" +
+	"未挂载\x02仅当虚机为关机状态时才可挂载透传设备\x02未指定透传设备\x02找不到透传设备%s\x02透传设备未挂载到此虚机\x02GP" +
+	"U数量必须大于1\x02获取GPU失败：%s\x02虚机%s所在宿主机%s透传设备不足\x02挂载设备列表参数类型不是字符串数组\x02卸载设备" +
+	"列表参数类型不是字符串数组\x02找不到IP %s\x02找不到MAC %s\x02未指定ip_addr或mac\x02状态为%s无法变更I" +
+	"P地址\x02虚机运行中无法变更MAC地址\x02MAC地址唯一性检查失败\x02MAC地址%s已被占用\x02虚机状态%s无法执行解绑网络操作" +
+	"\x02虚机状态%s无法执行绑定网络操作\x02虚机状态%s无法变更带宽大小\x02带宽值必须非负\x02虚机状态%s不可变更配置\x02不允许" +
+	"变更配置\x02主备机不允许变更配置\x02虚机状态为%s不可变更配置\x02不可变更套餐类型\x02参数vcpu_count解析出错" +
+	"\x02内存大小参数错误，如256M，1G，或256\x02参数vmem_size解析出错\x02虚机状态为%s无法变更CPU/内存配置\x02" +
+	"Unmarshal磁盘配置出错：%s\x02解析磁盘信息出错：%s\x02不可缩小磁盘大小\x02虚机状态为%s无法重装系统\x02虚机已有%d" +
+	"个活跃任务执行中，无法执行同步状态操作\x02虚机状态%s无法执行关机操作\x02虚机状态%s无法执行重启操作\x02虚机状态%s无法发送键" +
+	"盘指令\x02虚机状态%s无法关联EIP\x02虚机已关联EIP\x02找不到EIP %s\x02EIP已被关联\x02虚机与EIP不在同一" +
+	"region无法关联\x02虚机与EIP不在同一个zone下无法关联\x02虚机与EIP不属于同一provider无法关联\x02没有可解关联的" +
+	"EIP\x02EIP配额不足：%s\x02虚机状态为%s时无法切换到备机\x02虚机没有备用宿主机\x02虚机无法切换到备机，因镜像任务未结束" +
+	"\x02找不到虚机%s\x02输入数据不是键值字典\x02找不到虚机%s\x02查找虚机失败：%s\x02虚机已有备用机\x02使用共享存储不可" +
+	"创建备机\x02仅KVM虚机支持创建主备机\x02使用透传设备无法创建备机\x02GuestDisksHasSnapshot失败：%s" +
+	"\x02无法从快照创建备机\x02虚机无备机\x02备机所在宿主机找不到\x02备机所在宿主机离线\x02虚机不需要做reconcile操作" +
+	"\x02虚机的计费类型%s不支持取消过期时间\x02虚机的计费类型为%s\x02虚机%s不支持后付费自动过期\x02无效的desc内容\x02虚" +
+	"机Id为空\x02虚机名为空\x02虚机%s已存在\x02导入网卡列表为空\x02IP %s或MAC %s已被注册\x02无法通过IP %s" +
+	"找到网络\x02导入磁盘列表为空\x02Unmarshal数据失败：%s\x02部分宿主机配置缺少xml_file_path\x02部分宿主" +
+	"机缺少HostIp字段\x02无效的宿主机IP %s\x02无效虚机MAC地址%s\x02无效的虚机IP地址 %s\x02创建任务失败：%s" +
+	"\x02Hypervisor %s无法创建libvirt XML\x02生成XML失败：%s\x02不支持hypervisor %s\x02不支" +
+	"持%s\x02虚机已被转换过\x02宿主机%s不是KVM类型\x02虚机必须为关机状态\x02检查并设置待使用配置时出错：%s\x02找不到" +
+	"宿主机\x02空的IP列表\x02IP %s不可达：%s\x02IP %s不可用：已被占用\x02部分磁盘找不到\x02磁盘%s未挂载到虚机" +
+	"\x02Hypervisor %s无法实现io限速\x02虚机状态%s无法设定io限速\x02bps必须大于0\x02iops必须大于0\x02" +
+	"虚机%s hypervisor %s不支持迁移\x02虚机%s有备机，不可迁移\x02虚拟机 %s 有直通设备，无法迁移\x02虚机%s使用" +
+	"本地存储不支持救援模式\x02虚机%s状态为%s不可迁移\x02虚机%s状态为%s，有透传设备，无法迁移\x02虚机有cdrom不可迁移" +
+	"\x02虚机%s状态%s因使用本地存储无法迁移\x02未指定虚机Id\x02部分指定的虚机不存在\x02虚机hypervisor %s无法创建实" +
+	"例快照\x02备份机无法创建快照\x02虚机状态为%s无法做快照\x02虚机%d号磁盘快照数达到上限，不可再创建\x02创建快照失败：%s" +
+	"\x02创建快照任务失败：%s\x02快照未准备好\x02从快照恢复失败：%s\x02count必须大于0\x02生成快照名称失败：%s\x02" +
+	"不是裸金属服务器\x02找不到宿主机\x02宿主机不是裸金属\x02找不到主机组%s\x02主机组与虚机应属于同一个项目\x02无法关联或解" +
+	"关联已禁用的主机组\x02虚机没有公网IP\x02虚机状态要求为%s或%s，当前状态为%s\x02%s虚机不支持转发公网IP为EIP\x02" +
+	"仅%s虚机支持此操作\x02虚拟机没有VPC IP\x02虚机模板暂不支持实例快照\x02找不到虚机模板指定的安全组%s\x02虚机模板中的" +
+	"%s不是共享资源\x02虚机模板中的%s %q不是共享资源\x02虚机模板中的%s在范围%s内不是共享资源\x02虚机模板中的%s %q在范围%" +
+	"s内不是共享资源\x02虚机模板%s正被服务目录%s使用\x02虚机模板%s正被伸缩组%s使用\x02检查磁盘序号唯一性失败：%s\x02磁盘序" +
+	"号%d已被占用\x02无法分配网卡名\x02检查网卡序号唯一性失败：%s\x02网卡序号%d已被占用\x02找不到宿主机%s\x02找不到安" +
+	"全组%s\x02找不到磁盘%s\x02检查虚机磁盘数量失败：%s\x02未知的虚拟机类型 %s\x02找不到主机组%s\x02虚机已锁定，无" +
+	"法删除\x02不允许删除有效状态的预付费虚机\x02不允许删除已禁用宿主机上的虚机\x02无法删除离线宿主机上的虚机\x02虚机磁盘存在快照" +
+	"，无法执行删除操作\x02内存大小必须在8MB〜%dGB范围内\x02CPU核数必须在范围1〜%d内\x02虚机状态为%s无法变更内存和CP" +
+	"U配置\x02无法为裸金属变更内存配置\x02名称太短\x02找不到实例快照%s\x02获取实例快照出错：%s\x02实例快照未准备好\x02m" +
+	"etadata条目数不可超过20\x02login_account长度已超过32字节\x02未提供磁盘信息\x02无效的系统镜像: %s\x02" +
+	"系统盘不支持ISO镜像，请使用cdrom参数\x02解析cdrom设备信息出错误：%s\x02未指定操作系统镜像？\x02系统盘的镜像(%s" +
+	")和虚拟机规格SKU(%s)的CPU架构不匹配\x02解析磁盘描述信息出错：%s\x02快照错误：序号%d大于0的磁盘类型为%s\x02无法在预" +
+	"付费的资源类型上创建预付费的虚机\x02解析网络描述信息出错：%s\x02无法创建带有透传设备的主备机\x02解析透传设备描述信息出错：%s" +
+	"\x02找不到密钥对%s\x02找不到安全组%s\x02%s最多可关联%d个安全组\x02无效的userdata：%v\x02策略定义中有无效参" +
+	"数：%s\x02策略定义%s要求cloudregion在%s范围中\x02策略定义%s要求cloudregion不在%s范围中\x02策略定" +
+	"义%s(%s)包含无效的条件%s\x02策略定义%s要求必须包含%s标签\x02策略定义%s要求不可有%s标签\x02类别%s在策略定义%s" +
+	"(%s)中无效\x02%s 不支持静态公网IP\x02无效的静态公网IP类型 %s\x02%s不支持EIP\x02EIP %s状态无效%s" +
+	"\x02EIP %s已被占用\x02EIP %s属于不同cloudprovider，无法绑定\x02EIP %s属于不同的region，无法绑定" +
+	"\x02获取磁盘大小失败\x02镜像%s不在虚机镜像%s中\x02部分虚机镜像的子镜像未指定\x02裸金属%s未启用\x02无法运行%s，宿主机" +
+	"类型为%s\x02宿主机上没有可用存储\x02无效的aggregate_strategy: %s\x02找不到二层网络%s\x02不支持hy" +
+	"pervisor %s\x02虚机状态为%s无法执行回收操作\x02虚机状态为%s无法从回收站恢复\x02宿主机应为已禁用状态\x02宿主机不是" +
+	"预付费资源池类型\x02预付费资源池宿主机没有可用的虚机\x02预付费资源池宿主机不可拥有超过1个虚机\x02无法从资源池中恢复已伪删除的虚" +
+	"机\x02不是预付费资源池宿主机\x02无效的any_mac参数\x02找不到调度标签\x02不支持hypervisor %s\x02宿主机" +
+	"是一个裸金属，请先恢复到转换之前状态再执行删除操作\x02宿主机还未被禁用\x02getGuestCount调用失败：%s\x02宿主机非空" +
+	"\x02调用GetDiskCount失败：%s\x02宿主机本地存储非空？\x02不一致：本地存储非空\x02找不到宿主机%s的IPMI信息" +
+	"\x02IPMI信息中缺少密码\x02检查重复%s出错：%s\x02%s %s重复\x02无效的macAddr\x02检查重复access_ma" +
+	"c出错：%s\x02重复的access_mac %s\x02%s不在子网范围\x02IPMI子网没有zone信息？\x02IPMI地址不在所指定" +
+	"的zone\x02宿主机IP %s已被注册\x02宿主机所属子网没有zone信息？\x02宿主机IP不在指定的zone\x02no_prob" +
+	"e模式缺少access_mac和uuid信息\x02IPMI子网没有zone信息\x02新的IPMI地址在另外一个zone\x02不能启动一个非" +
+	"裸金属服务器\x02因裸金属服务器还有活跃的虚机，不可启动\x02不可停止一个非裸金属服务器\x02因裸金属服务器还有非活跃的虚机，不可停止" +
+	"\x02因裸金属服务器还有活跃的虚机，不可停止\x02状态为%s无法进入维护模式\x02虚机状态为%s无法进入维护模式\x02状态为%s无法解除" +
+	"维护模式\x02错误的虚机状态%s\x02不是一个裸金属服务器\x02执行准备操作需要有效的access_mac和uuid参数\x02裸金属" +
+	"状态为%s无法执行准备操作\x02虚机状态为%s无法执行准备操作\x02状态为%s无法执行IPMI探测操作\x02状态为%s无法执行初始化操" +
+	"作\x02IPMI信息未配置\x02虚机插入操作出错：%s\x02无效MAC地址\x02查找二层网络%s出错：%s\x02无效IP地址%s" +
+	"\x02二层网络%s中没有可用子网\x02IP %s不在二层网络%s中\x02IP %s不属于任何二层网络\x02无法通过MAC地址%s找到网卡" +
+	"：%s\x02无法通过MAC地址找到hostwire：%s\x02网卡%s不存在\x02仅admin, ipmi类型网卡可以被启用\x02网" +
+	"卡%s不存在\x02不是一个裸金属服务器\x02没有在转换为hypervisor\x02未找到裸金属服务器记录\x02未找到MAC地址为 %" +
+	"s 的虚拟机磁盘\x02虚拟机的网卡IP地址为 %s 不是 %s\x02无效的MAC地址\x02获取网卡出错：%s\x02非裸金属服务器无法执行" +
+	"同步状态操作\x02裸金属服务器状态为%s无法执行重启操作\x02裸金属服务器上存在活跃的虚机，无法执行重启操作\x02状态为%s无法执行镜" +
+	"像缓存操作\x02找不到镜像%s\x02镜像没有校验值无法执行缓存操作\x02必须指定host_type参数\x02要求必须为裸金属服务器" +
+	"\x02裸金属服务器已被占用\x02hypervisor状态为%s无法执行转换\x02转换其它域的宿主机需要系统权限\x02不支持驱动%s" +
+	"\x02isAlterNameUnique调用失败：%s\x02转换出错：%s\x02宿主机应为禁用状态\x02当前状态为%s无法取消转换" +
+	"\x02不是一个转换后的hypervisor\x02宿主机状态%s无法退出维护模式\x02宿主机类型%s无法进入维护模式\x02宿主机状态为%s" +
+	"不支持此操作\x02宿主机%s无法迁移虚机%s，因虚机状态为%s\x02因状态为%s无法执行insert-iso指令\x02因状态为%s无法" +
+	"执行eject-iso指令\x02非裸金属服务器中无法执行同步配置操作\x02预留CPU数必须为非负整数\x02预留内存大小必须为非负整数" +
+	"\x02预留存储必须为非负整数\x02宿主机%s无法为每个透传设备预留%d个CPU，因资源不够\x02宿主机%s无法为每个透传设备预留%dM内存" +
+	"，因资源不够\x02宿主机%s无法为每个透传设备预留%dM存储，因资源不够\x02仅系统管理员可指定宿主机\x02存储正使用中\x02查找存" +
+	"储%s失败\x02查找宿主机%s失败\x02unmarshal JoinResourceBaseCreateInput出错：%s\x02Ge" +
+	"tGuestDiskCount失败：%s\x02GetGuestnicsCount调用出错：%s\x02宿主机上的虚机正在使用此二层网络中的子网" +
+	"\x02无法删除错误状态的虚拟机快照\x02透传设备正被虚机使用\x02找不到透传设备%s\x02透传设备已被另外一台虚机%s使用\x02透传设" +
+	"备已被虚机%s使用\x02不支持格式%s\x02无效的公钥：%v\x02GetLinkedGuestsCount失败：%s\x02密钥对正被" +
+	"虚机使用无法删除\x02找不到转发策略%s(%s)所属的监听\x02无效的地址%s\x02描述文本过长（%d>=%d）\x02描述文本包含不" +
+	"可打印字符：%v\x02访问控制包含重复的CIDR %s\x02获取访问控制数量失败：%s\x02访问控制%s仍被%d个%s使用\x02无效" +
+	"的VRRP网络接口名%q\x02无效的VRRP认证密钥长度：%d，要求[1,8]\x02无效的VRRP优先级%d，要求[1,255]\x02" +
+	"无效的VRRP virtual_router_id %d：要求[1,255]\x02无效的VRRP advert_int %d：要求[1,2" +
+	"55]\x02telegraf参数：无效的influxdb URL：%s\x02%s：无效的base64编码串：%s\x02%s：无效的模板：%" +
+	"s\x02获取其它集群的转发节点失败：%v\x02与转发节点%s(%s)冲突：%v\x02转发集群%s(%s)已占用virtual_router" +
+	"_id %d\x02%s：时间错误：%s\x02%s：新指定时间在未来：%s > %s\x02集群中已有节点%s(%s)使用VRRP优先级%d" +
+	"\x02使用yum模式需要提供有效的repo_base_url参数\x02主机名为空\x02查找宿主机%s出错：%v\x02转发节点不能部署到纳" +
+	"管的宿主机上\x02查找虚机%s出错：%v\x02转发节点不能部署到公有云虚机上\x02虚机当前状态为%q，要求为%q\x02unmarsh" +
+	"al输入参数出错: %v\x02主机缺少%s字段\x02主机缺少%s字段\x02认证出错：%v\x02用户必须有系统管理员权限\x02获取%s " +
+	"%s服务URL出错：%v\x02上次部署的信息不可用\x02查找后端组相关的资源出错\x02无效的权重%d，要求在0～256范围\x02无效的端" +
+	"口%d，要求在1~65535范围\x02找不到虚机%s\x02仅系统管理员可指定宿主机作为后端\x02找不到宿主机%s\x02未识别的后端类" +
+	"型%s\x02第%d个后端所属的region与lb的region不匹配\x02查找负载均衡所属region失败：%s\x02调用isDefa" +
+	"ult出错：%s\x02后端服务器组%s是默认组\x02调用refCount出错：%s\x02后端组%s仍被%d个%s使用\x02%s要求添加到" +
+	"后端组中的虚机状态为%s，当前虚机状态为%s\x02虚机%s(%s)所处VPC %s(%s)和负载均衡所处VPC %s不一致\x02获取虚机" +
+	"%s出错\x02虚机%s(%s)所属VPC %s(%s)不是%s(%s)\x02虚机%s(%s)已存在于后端组%s(%s)\x02查找负载均衡后" +
+	"端%s的region时出错\x02查找后端%s(%s)所属的后端组时出错\x02访问控制缓存已在region %s存在\x02获取证书使用数" +
+	"失败：%s\x02证书%s仍被%d个%s使用\x02无效的本地证书：私钥为空\x02无效的本地证书：证书内容为空\x02证书缓存已在regi" +
+	"on %s存在\x02不允许变更证书内容\x02zone %s(%s)不合法：仅允许本地IDC的zone\x02二层网络所属zone %s与参数" +
+	"中的zone %s(%s)冲突，\x02wire所属zone必须为%s，实际为%s\x02获取负载均衡集群引用次数失败：%v\x02负载均衡" +
+	"集群仍被%d个%s使用\x04\x00\x01 J\x02负载均衡集群%s(%s)和%s(%s)两者virtual_router_id参数冲" +
+	"突：%d\x02无效的条件格式，要求为JSON\x02无效的表达式格式，要求为JSON数组\x02触及条件数目上限（5），已指定%d个" +
+	"\x02规则%s/%s已被%s(%s)使用\x02查找负载均衡监听所属region失败：%s\x02查找负载均衡转发策略失败：%s\x02%s监" +
+	"听的端口%d已被%s(%s)占用\x02无法找到region信息\x02后端服务器组%s(%s)属于负载均衡实例%s，而不是%s\x04" +
+	"\x00\x01 9\x02负载均衡集群所属zone %s与子网zone %s不匹配\x02负载均衡集群所属wire与子网所属wire不匹配：%" +
+	"s != %s\x02负载均衡已经被锁定，无法删除\x02Unmarshal输入参数失败：%s\x02端口值错误\x02无效的内网IP地址：%s" +
+	"\x02EIP已绑定到其它实例\x02EIP已绑定到SNAT规则\x02找不到EIP\x02NAT网关已有%d个活跃任务在执行，无法执行同步状态" +
+	"操作\x02sourceCIDR和network_id仅允许指定其中一个\x02CIDR %s不在VPC允许范围%s内\x02EIP已绑定到" +
+	"DNAT规则\x02找不到子网\x02GetAllocatedNicCount失败：%s\x02IP子网 %s 包含已分配的IP地址\x02地址" +
+	"%s不在子网%s(%s)范围内\x02isAddressUsed调用失败：%s\x02地址%s已被占用\x02getFreeAddressCou" +
 	"nt调用失败：%s\x02子网%s(%s)已没有可用地址\x02候选IP %s不在范围内\x02找不到可用IP地址\x02不允许使用网络%s" +
 	"\x02查找网络%s失败：%v\x02地址%s不在范围内\x02仅系统管理员允许使用预留的IP地址\x02地址%s未被预留\x02地址%s已被使" +
 	"用\x02带宽限速不可超过%dMbps\x02无效的时间长度%s\x02无效的IP地址%s：%s\x02地址%s不在子网中\x02获取预留地" +
@@ -3933,31 +3813,31 @@ const zh_CNData string = "" + // Size: 50522 bytes
 	"误\x02无效的格式\x02输入参数错误\x02弱密码\x02参数不存在\x02资源不足\x02资源不足\x02配置不足\x02超出范围" +
 	"\x02超出上限\x02权限不足\x02不支持的操作\x02内容非空\x02无效的请求\x02空的请求\x02未授权\x02无效的凭证\x02禁" +
 	"止\x02不可接受\x02名称重复\x02资源重复\x02冲突\x02资源忙\x02需要License\x02被保护的资源\x02没有项目" +
-	"\x02实体太大\x02尝试失败次数过多\x02请求数过多\x02不支持的协议\x02策略定义错误\x02找不到镜像%s\x02%s资源重名：%" +
-	"s\x02%s资源id重复：%s\x02没有此driver\x02DN为空\x02id为空\x02名称为空\x02用户已禁用\x02仅允许加入默" +
-	"认域或当前域下的项目\x02sysadmin受到保护\x02无法将当前用户从当前项目中移除\x02仅允许加入默认域或当前域下的组\x02查询" +
-	"出错：%s\x02输入参数未指定type字段\x02输入参数缺少blob字段\x02加密出错：%s\x02不可删除默认域\x02域仍为启用状" +
-	"态\x02域中仍有用户\x02域中仍有组\x02域中仍有项目\x02域中仍有角色\x02域中仍有权限定义\x02域中包含外部资源\x02只读" +
-	"\x02默认域受到保护\x02字段%s为只读\x02endpoint为启用状态\x02缺少输入字段interface\x02缺少输入字段serv" +
-	"ice/service_id\x02找不到证书%s\x02获取敏感配置需要管理员权限\x02状态为启用、已连接无法更新配置\x02状态不为空闲时" +
-	"无法更新配置\x02saveConfigs调用失败：%s\x02无效的模板\x02缺少driver\x02不支持driver %s\x02d" +
-	"river %s已存在\x02不可删除默认的SQL认证源\x02不可删除已启用的认证源\x02认证源中仍有项目\x02已启用的域%s不可删除" +
-	"\x02同步状态中不可更新\x02域已禁用\x02资源已启用\x02解析权限定义失败\x02不可删除系统权限定义\x02不可删除已启用权限定义" +
-	"\x02不可删除system项目\x02项目中包含外部资源\x02项目中包含用户\x02项目中包含组\x02不可变更system项目名\x02区" +
-	"域中包含endpoint\x02缺少输入删除id\x02不可变更角色的名称\x02不可删除系统角色\x02角色已被赋予给用户\x02角色已被" +
-	"赋予给组\x02不支持在指定上下文中执行更新操作\x02不支持在指定上下文中执行更新操作：%s\x02项目和角色不在同一个域\x02不支持在" +
-	"指定的第2个上下文中执行更新操作：%s\x02服务还有endpoint定义\x02服务已启用\x02更新配置版本失败：%s\x02不可变更s" +
-	"ysadmin的用户名\x02无效的密码：%s\x02不可删除来源非本地的用户\x02用户仍有外部资源\x02不可删除系统用户\x02用户和组的" +
-	"域归属必须相同\x02不可加入只读组\x02不可离开只读组\x02版本不匹配\x02项目已禁用\x02用户已禁用\x02token已过期" +
-	"\x02无效的fernet token\x02无效的认证方法\x02找不到用户\x02空的认证请求\x02用户不在项目中\x02无效的acces" +
-	"s key\x02过期的access key\x02输入无法识别：%s\x02未鉴权：%s\x02解析请求体失败\x02用户名重复\x02找不到" +
-	"用户，或用户未启用\x02无效的用户\x02无效的项目\x02内部服务错误：%s\x02无效的域\x02不允许认证\x02无效的token" +
-	"\x02无效的token：%s\x02不允许获取使用量\x02未授权\x02无效的Token\x02找不到名字%s\x02找不到登录密文信息" +
-	"\x02找不到%s的TOTP信息\x02找不到%s的密文恢复信息\x02TOTP密文已存在\x02找不到密码\x02找不到SSH密码：%s" +
-	"\x02无效的资源格式\x02服务%s找不到：%v\x02未指定uid\x02未指定pids\x02pids中未指定pid\x02pids中未指" +
-	"定rid\x02未指定rid\x02找不到项目\x02找不到登录login_key\x02查询中找不到kind：%v\x02查询中找不到ke" +
-	"y：%v\x02不支持的动作%s\x02找不到global-settings\x02找不到数据源对应的执行器\x02安全组id不应为空\x02找" +
-	"不到安全组%s\x02无效的服务点\x02解析URL %q出错：%v\x02不支持的字符 %s\x02检查重复名称失败：%s\x02权限定义" +
-	"正被使用"
+	"\x02实体太大\x02尝试失败次数过多\x02请求数过多\x02用户被锁住\x02用户被禁用\x02不支持的协议\x02策略定义错误\x02找" +
+	"不到镜像%s\x02密码必须12位长度，包含至少一个数字，大小写字母和符号\x02找不到参数%s\x02%s资源重名：%s\x02%s资源i" +
+	"d重复：%s\x02没有此driver\x02DN为空\x02id为空\x02名称为空\x02用户已禁用\x02仅允许加入默认域或当前域下的项目" +
+	"\x02sysadmin受到保护\x02无法将当前用户从当前项目中移除\x02仅允许加入默认域或当前域下的组\x02查询出错：%s\x02输入参" +
+	"数未指定type字段\x02输入参数缺少blob字段\x02加密出错：%s\x02不可删除默认域\x02域仍为启用状态\x02域中仍有用户" +
+	"\x02域中仍有组\x02域中仍有项目\x02域中仍有角色\x02域中仍有权限定义\x02域中包含外部资源\x02只读\x02默认域受到保护" +
+	"\x02字段%s为只读\x02endpoint为启用状态\x02缺少输入字段interface\x02缺少输入字段service/service" +
+	"_id\x02找不到证书%s\x02获取敏感配置需要管理员权限\x02状态为启用、已连接无法更新配置\x02状态不为空闲时无法更新配置\x02s" +
+	"aveConfigs调用失败：%s\x02无效的模板\x02缺少driver\x02不支持driver %s\x02driver %s已存在" +
+	"\x02不可删除默认的SQL认证源\x02不可删除已启用的认证源\x02认证源中仍有项目\x02已启用的域%s不可删除\x02同步状态中不可更新" +
+	"\x02域已禁用\x02资源已启用\x02解析权限定义失败\x02不可删除系统权限定义\x02不可删除已启用权限定义\x02不可删除system" +
+	"项目\x02项目中包含外部资源\x02项目中包含用户\x02项目中包含组\x02不可变更system项目名\x02区域中包含endpoint" +
+	"\x02缺少输入删除id\x02不可变更角色的名称\x02不可删除系统角色\x02角色已被赋予给用户\x02角色已被赋予给组\x02不支持在指定" +
+	"上下文中执行更新操作\x02不支持在指定上下文中执行更新操作：%s\x02项目和角色不在同一个域\x02不支持在指定的第2个上下文中执行更新" +
+	"操作：%s\x02服务还有endpoint定义\x02服务已启用\x02更新配置版本失败：%s\x02不可变更sysadmin的用户名" +
+	"\x02无效的密码：%s\x02无法删除非本地的非SSO用户\x02用户仍有外部资源\x02不可删除系统用户\x02用户和组的域归属必须相同" +
+	"\x02不可加入只读组\x02不可离开只读组\x02版本不匹配\x02项目已禁用\x02用户已禁用\x02token已过期\x02无效的fern" +
+	"et token\x02无效的认证方法\x02找不到用户\x02空的认证请求\x02用户不在项目中\x02无效的access key\x02过期" +
+	"的access key\x02输入无法识别：%s\x02未鉴权：%s\x02解析请求体失败\x02用户名重复\x02找不到用户，或用户未启用" +
+	"\x02无效的用户\x02无效的项目\x02内部服务错误：%s\x02无效的域\x02不允许认证\x02无效的token\x02无效的token" +
+	"：%s\x02不允许获取使用量\x02未授权\x02无效的Token\x02找不到名字%s\x02找不到登录密文信息\x02找不到%s的TO" +
+	"TP信息\x02找不到%s的密文恢复信息\x02TOTP密文已存在\x02找不到密码\x02找不到SSH密码：%s\x02无效的资源格式\x02" +
+	"服务%s找不到：%v\x02未指定uid\x02未指定pids\x02pids中未指定pid\x02pids中未指定rid\x02未指定ri" +
+	"d\x02找不到项目\x02找不到登录login_key\x02查询中找不到kind：%v\x02查询中找不到key：%v\x02不支持的动作%" +
+	"s\x02找不到数据源对应的执行器\x02安全组id不应为空\x02找不到安全组%s\x02无效的服务点\x02解析URL %q出错：%v" +
+	"\x02不支持的字符 %s\x02检查重复名称失败：%s\x02权限定义正被使用"
 
-	// Total table size 121256 bytes (118KiB); checksum: 2A26FCDD
+	// Total table size 119324 bytes (116KiB); checksum: C7F5363F

--- a/locales/zh-CN/messages.gotext.json
+++ b/locales/zh-CN/messages.gotext.json
@@ -2,390 +2,6 @@
     "language": "zh-CN",
     "messages": [
         {
-            "id": "not found tenantId in body",
-            "message": "not found tenantId in body",
-            "translation": "获取tenantId参数失败",
-            "position": "pkg/apigateway/handler/auth.go:233:53"
-        },
-        {
-            "id": "failed to change project",
-            "message": "failed to change project",
-            "translation": "切换项目失败",
-            "position": "pkg/apigateway/handler/auth.go:245:56"
-        },
-        {
-            "id": "get password in body",
-            "message": "get password in body",
-            "translation": "获取password参数失败",
-            "position": "pkg/apigateway/handler/auth.go:287:49"
-        },
-        {
-            "id": "username or password is empty",
-            "message": "username or password is empty",
-            "translation": "用户名或密码为空",
-            "position": "pkg/apigateway/handler/auth.go:294:49"
-        },
-        {
-            "id": "missing credential",
-            "message": "missing credential",
-            "translation": "缺少认证信息",
-            "position": "pkg/apigateway/handler/auth.go:307:48"
-        },
-        {
-            "id": "invalid credential",
-            "message": "invalid credential",
-            "translation": "无效的认证信息",
-            "position": "pkg/apigateway/handler/auth.go:316:51"
-        },
-        {
-            "id": "fetch json for request: %v",
-            "message": "fetch json for request: %v",
-            "translation": "获取请求的JSON内容失败：%v",
-            "position": "pkg/apigateway/handler/auth.go:484:31"
-        },
-        {
-            "id": "request body is empty",
-            "message": "request body is empty",
-            "translation": "请求内容为空",
-            "position": "pkg/apigateway/handler/auth.go:999:31"
-        },
-        {
-            "id": "missing id",
-            "message": "missing id",
-            "translation": "缺少id参数",
-            "position": "pkg/apigateway/handler/auth.go:1076:31"
-        },
-        {
-            "id": "fetchAuthInfo fail: %s",
-            "message": "fetchAuthInfo fail: %s",
-            "translation": "fetchAuthInfo调用失败：%s",
-            "position": "pkg/apigateway/handler/auth.go:1111:36"
-        },
-        {
-            "id": "new password mismatch",
-            "message": "new password mismatch",
-            "translation": "新密码相互不匹配",
-            "position": "pkg/apigateway/handler/auth.go:1133:33"
-        },
-        {
-            "id": "not support reset user password",
-            "message": "not support reset user password",
-            "translation": "不支持重置用户密码",
-            "position": "pkg/apigateway/handler/auth.go:1139:28"
-        },
-        {
-            "id": "wrong password",
-            "message": "wrong password",
-            "translation": "密码错误",
-            "position": "pkg/apigateway/handler/auth.go:1153:33"
-        },
-        {
-            "id": "invalid passcode",
-            "message": "invalid passcode",
-            "translation": "无效的验证码",
-            "position": "pkg/apigateway/handler/auth.go:1162:34"
-        },
-        {
-            "id": "generate totp qrcode failed",
-            "message": "generate totp qrcode failed",
-            "translation": "生成TOTP二维码失败",
-            "position": "pkg/apigateway/handler/auth_totp.go:57:47"
-        },
-        {
-            "id": "uid is empty",
-            "message": "uid is empty",
-            "translation": "uid为空",
-            "position": "pkg/apigateway/handler/auth_totp.go:95:41"
-        },
-        {
-            "id": "input parameter error",
-            "message": "input parameter error",
-            "translation": "输入参数错误",
-            "position": "pkg/apigateway/handler/auth_totp.go:174:43"
-        },
-        {
-            "id": "TOTP recovery questions do not exist",
-            "message": "TOTP recovery questions do not exist",
-            "translation": "未设置TOTP找回密码的提示问题",
-            "position": "pkg/apigateway/handler/auth_totp.go:188:37"
-        },
-        {
-            "id": "questions not found",
-            "message": "questions not found",
-            "translation": "未找到密码提示问题",
-            "position": "pkg/apigateway/handler/auth_totp.go:193:44"
-        },
-        {
-            "id": "%s answer is incorrect",
-            "message": "%s answer is incorrect",
-            "translation": "%s：答案不正确",
-            "position": "pkg/apigateway/handler/auth_totp.go:196:45"
-        },
-        {
-            "id": "passcode is a 6-digits string",
-            "message": "passcode is a 6-digits string",
-            "translation": "验证码应为6个数字",
-            "position": "pkg/apigateway/handler/auth_totp.go:253:33"
-        },
-        {
-            "id": "invalid passcode: %v",
-            "message": "invalid passcode: %v",
-            "translation": "验证码无效：%v",
-            "position": "pkg/apigateway/handler/auth_totp.go:263:36"
-        },
-        {
-            "id": "no revocery questions.",
-            "message": "no revocery questions.",
-            "translation": "没有密码找到提示问题",
-            "position": "pkg/apigateway/handler/auth_totp.go:321:27"
-        },
-        {
-            "id": "unmarshal questions: %v",
-            "message": "unmarshal questions: %v",
-            "translation": "解析提示问题失败：%v",
-            "position": "pkg/apigateway/handler/auth_totp.go:352:31"
-        },
-        {
-            "id": "get admin credential is nil",
-            "message": "get admin credential is nil",
-            "translation": "获取管理员鉴权信息失败",
-            "position": "pkg/apigateway/handler/csrfexempt.go:50:27"
-        },
-        {
-            "id": "no usable regions, please contact admin",
-            "message": "no usable regions, please contact admin",
-            "translation": "没有可用的region，请联系管理员",
-            "position": "pkg/apigateway/handler/csrfexempt.go:56:27"
-        },
-        {
-            "id": "illegal region %s, please contact admin",
-            "message": "illegal region %s, please contact admin",
-            "translation": "无效的可用区%s，请联系管理员",
-            "position": "pkg/apigateway/handler/csrfexempt.go:61:27"
-        },
-        {
-            "id": "session expires, missing %s",
-            "message": "session expires, missing %s",
-            "translation": "会话过期，缺少%s",
-            "position": "pkg/apigateway/handler/idp.go:153:26"
-        },
-        {
-            "id": "parse query string error: %s",
-            "message": "parse query string error: %s",
-            "translation": "解析请求参数出错：%s",
-            "position": "pkg/apigateway/handler/idp.go:167:34"
-        },
-        {
-            "id": "fetch form data error: %s",
-            "message": "fetch form data error: %s",
-            "translation": "",
-            "position": "pkg/apigateway/handler/idp.go:173:34"
-        },
-        {
-            "id": "parse form data error: %s",
-            "message": "parse form data error: %s",
-            "translation": "获取表单数据出错：%s",
-            "position": "pkg/apigateway/handler/idp.go:177:34"
-        },
-        {
-            "id": "invalid request",
-            "message": "invalid request",
-            "translation": "无效的请求",
-            "position": "pkg/apigateway/handler/idp.go:181:33"
-        },
-        {
-            "id": "empty external user id",
-            "message": "empty external user id",
-            "translation": "外部用户ID为空",
-            "position": "pkg/apigateway/handler/idp.go:204:40"
-        },
-        {
-            "id": "empty idp_id or idp_entity_id",
-            "message": "empty idp_id or idp_entity_id",
-            "translation": "idp_id或idp_entity_id为空",
-            "position": "pkg/apigateway/handler/idp.go:367:33"
-        },
-        {
-            "id": "invalid form",
-            "message": "invalid form",
-            "translation": "无效的表单",
-            "position": "pkg/apigateway/handler/imageutils.go:73:31"
-        },
-        {
-            "id": "missing image name",
-            "message": "missing image name",
-            "translation": "缺少镜像名称参数",
-            "position": "pkg/apigateway/handler/imageutils.go:87:31"
-        },
-        {
-            "id": "missing image size",
-            "message": "missing image size",
-            "translation": "缺少镜像大小参数",
-            "position": "pkg/apigateway/handler/imageutils.go:94:31"
-        },
-        {
-            "id": "invalid image size",
-            "message": "invalid image size",
-            "translation": "无效的镜像大小参数",
-            "position": "pkg/apigateway/handler/imageutils.go:99:31"
-        },
-        {
-            "id": "Parse query: %v",
-            "message": "Parse query: %v",
-            "translation": "解析查询失败：%v",
-            "position": "pkg/apigateway/handler/k8s.go:74:48"
-        },
-        {
-            "id": "No token in header: %v",
-            "message": "No token in header: %v",
-            "translation": "头部中没有token：%v",
-            "position": "pkg/apigateway/handler/middleware.go:132:37"
-        },
-        {
-            "id": "Missing parameter %s",
-            "message": "Missing parameter %s",
-            "translation": "找不到参数%s",
-            "position": "pkg/apigateway/handler/misc.go:126:43"
-        },
-        {
-            "id": "Unsupported action %s",
-            "message": "Unsupported action %s",
-            "translation": "不支持动作%s",
-            "position": "pkg/apigateway/handler/misc.go:141:43"
-        },
-        {
-            "id": "Wrong content type %s, want %s",
-            "message": "Wrong content type %s, want %s",
-            "translation": "Content-Type错误，%s，应为%s",
-            "position": "pkg/apigateway/handler/misc.go:160:41"
-        },
-        {
-            "id": "can't open file",
-            "message": "can't open file",
-            "translation": "打开文件出错",
-            "position": "pkg/apigateway/handler/misc.go:169:41"
-        },
-        {
-            "id": "can't parse file",
-            "message": "can't parse file",
-            "translation": "解析文件出错",
-            "position": "pkg/apigateway/handler/misc.go:177:41"
-        },
-        {
-            "id": "template file is invalid. please check.",
-            "message": "template file is invalid. please check.",
-            "translation": "模板文件无效，请检查",
-            "position": "pkg/apigateway/handler/misc.go:204:33"
-        },
-        {
-            "id": "empty file content",
-            "message": "empty file content",
-            "translation": "文件内容空",
-            "position": "pkg/apigateway/handler/misc.go:228:42"
-        },
-        {
-            "id": "row %d name is empty",
-            "message": "row %d name is empty",
-            "translation": "第%d行，用户名为空",
-            "position": "pkg/apigateway/handler/misc.go:359:34"
-        },
-        {
-            "id": "row %d domain is empty",
-            "message": "row %d domain is empty",
-            "translation": "第%d行，域名称为空",
-            "position": "pkg/apigateway/handler/misc.go:367:35"
-        },
-        {
-            "id": "row %d duplicate name %s",
-            "message": "row %d duplicate name %s",
-            "translation": "第%d行，名称重复：%s",
-            "position": "pkg/apigateway/handler/misc.go:383:34"
-        },
-        {
-            "id": "template_id",
-            "message": "template_id",
-            "translation": "",
-            "position": "pkg/apigateway/handler/misc.go:436:31"
-        },
-        {
-            "id": "internal server error",
-            "message": "internal server error",
-            "translation": "内部服务错误",
-            "position": "pkg/apigateway/handler/misc.go:447:34"
-        },
-        {
-            "id": "template not found %s",
-            "message": "template not found %s",
-            "translation": "找不到模板：%s",
-            "position": "pkg/apigateway/handler/misc.go:486:33"
-        },
-        {
-            "id": "request body is too large.",
-            "message": "request body is too large.",
-            "translation": "请求体太大",
-            "position": "pkg/apigateway/handler/misc.go:500:31"
-        },
-        {
-            "id": "invalid multipart form",
-            "message": "invalid multipart form",
-            "translation": "无效的multipart表单",
-            "position": "pkg/apigateway/handler/misc.go:505:31"
-        },
-        {
-            "id": "invalid content_length %s",
-            "message": "invalid content_length %s",
-            "translation": "无效的content_length",
-            "position": "pkg/apigateway/handler/misc.go:557:31"
-        },
-        {
-            "id": "No token in header",
-            "message": "No token in header",
-            "translation": "头部中没有token",
-            "position": "pkg/apigateway/handler/oidc.go:390:36"
-        },
-        {
-            "id": "Token in header invalid",
-            "message": "Token in header invalid",
-            "translation": "头部中的token无效",
-            "position": "pkg/apigateway/handler/oidc.go:396:36"
-        },
-        {
-            "id": "Token expired",
-            "message": "Token expired",
-            "translation": "token已过期",
-            "position": "pkg/apigateway/handler/oidc.go:400:36"
-        },
-        {
-            "id": "resource %s module not exists",
-            "message": "resource %s module not exists",
-            "translation": "找不到资源%s对应的module",
-            "position": "pkg/apigateway/handler/request.go:149:42"
-        },
-        {
-            "id": "No id list found",
-            "message": "No id list found",
-            "translation": "找不到id列表",
-            "position": "pkg/apigateway/handler/resource.go:149:31"
-        },
-        {
-            "id": "missing export keys",
-            "message": "missing export keys",
-            "translation": "缺少导出键名",
-            "position": "pkg/apigateway/handler/resource.go:204:32"
-        },
-        {
-            "id": "inconsistent export keys and texts",
-            "message": "inconsistent export keys and texts",
-            "translation": "导出键名与文本不一致",
-            "position": "pkg/apigateway/handler/resource.go:210:33"
-        },
-        {
-            "id": "recv invalid data",
-            "message": "recv invalid data",
-            "translation": "收到无效数据",
-            "position": "pkg/apigateway/handler/rpc.go:130:29"
-        },
-        {
             "id": "invalid CannedAction %s ",
             "message": "invalid CannedAction %s ",
             "translation": "无效的预置操作",
@@ -737,7 +353,7 @@
             "id": "Not support resource %s tag filter",
             "message": "Not support resource %s tag filter",
             "translation": "不支持%s资源使用标签过滤",
-            "position": "pkg/cloudcommon/db/metadata.go:335:49"
+            "position": "pkg/cloudcommon/db/metadata.go:336:49"
         },
         {
             "id": "Action %s not found",
@@ -773,7 +389,7 @@
             "id": "not allow to delete log",
             "message": "not allow to delete log",
             "translation": "不允许删除日志",
-            "position": "pkg/cloudcommon/db/opslog.go:357:37"
+            "position": "pkg/cloudcommon/db/opslog.go:358:37"
         },
         {
             "id": "DIRECT setting cannot be changed",
@@ -1360,14 +976,14 @@
         {
             "id": "Guest %s can't hot remove nic",
             "message": "Guest %s can't hot remove nic",
-            "translation": "",
+            "translation": "无法在运行时移除虚拟机网卡",
             "position": "pkg/compute/guestdrivers/kvm.go:762:39"
         },
         {
             "id": "%s not support cdrom params",
             "message": "%s not support cdrom params",
             "translation": "%s不支持指定CDROM参数",
-            "position": "pkg/compute/guestdrivers/managedvirtual.go:203:48"
+            "position": "pkg/compute/guestdrivers/managedvirtual.go:204:48"
         },
         {
             "id": "%s not support create eip, it only support bind eip",
@@ -1876,73 +1492,73 @@
         {
             "id": "iBucket.SetWebsite error %s",
             "message": "iBucket.SetWebsite error %s",
-            "translation": "",
+            "translation": "设置静态网站配置错误 %s",
             "position": "pkg/compute/models/buckets.go:1283:48"
         },
         {
             "id": "iBucket.DeleteWebSiteConf error %s",
             "message": "iBucket.DeleteWebSiteConf error %s",
-            "translation": "",
+            "translation": "删除静态网站配置错误 %s",
             "position": "pkg/compute/models/buckets.go:1310:48"
         },
         {
             "id": "iBucket.GetWebsiteConf error %s",
             "message": "iBucket.GetWebsiteConf error %s",
-            "translation": "",
+            "translation": "获取静态网站配置错误 %s",
             "position": "pkg/compute/models/buckets.go:1337:56"
         },
         {
             "id": "cloudprovider.SetBucketCORS error %s",
             "message": "cloudprovider.SetBucketCORS error %s",
-            "translation": "",
+            "translation": "设置CORS错误：%s",
             "position": "pkg/compute/models/buckets.go:1393:48"
         },
         {
             "id": "iBucket.DeleteCORS error %s",
             "message": "iBucket.DeleteCORS error %s",
-            "translation": "",
+            "translation": "删除CORS设置错误：%s",
             "position": "pkg/compute/models/buckets.go:1420:48"
         },
         {
             "id": "iBucket.GetCORSRules error %s",
             "message": "iBucket.GetCORSRules error %s",
-            "translation": "",
+            "translation": "获取CORS规则错误：%s",
             "position": "pkg/compute/models/buckets.go:1447:50"
         },
         {
             "id": "iBucket.GetCdnDomains error %s",
             "message": "iBucket.GetCdnDomains error %s",
-            "translation": "",
+            "translation": "获取CDN加速域名错误：%s",
             "position": "pkg/compute/models/buckets.go:1484:52"
         },
         {
             "id": "iBucket.SetRefer error %s",
             "message": "iBucket.SetRefer error %s",
-            "translation": "",
+            "translation": "设置Referer错误：%s",
             "position": "pkg/compute/models/buckets.go:1528:48"
         },
         {
             "id": "iBucket.GetRefer error %s",
             "message": "iBucket.GetRefer error %s",
-            "translation": "",
+            "translation": "获取Referer错误：%s",
             "position": "pkg/compute/models/buckets.go:1555:49"
         },
         {
             "id": "iBucket.GetPolicy error %s",
             "message": "iBucket.GetPolicy error %s",
-            "translation": "",
+            "translation": "获取权限设置错误：%s",
             "position": "pkg/compute/models/buckets.go:1584:51"
         },
         {
             "id": "iBucket.SetPolicy error %s",
             "message": "iBucket.SetPolicy error %s",
-            "translation": "",
+            "translation": "设置权限错误：%s",
             "position": "pkg/compute/models/buckets.go:1636:48"
         },
         {
             "id": "iBucket.DeletePolicy error %s",
             "message": "iBucket.DeletePolicy error %s",
-            "translation": "",
+            "translation": "删除权限设置错误：%s",
             "position": "pkg/compute/models/buckets.go:1663:48"
         },
         {
@@ -2008,7 +1624,7 @@
         {
             "id": "account %s not enable saml auth",
             "message": "account %s not enable saml auth",
-            "translation": "",
+            "translation": "云账号%s为启用SAML认证",
             "position": "pkg/compute/models/cloudaccount_saml.go:42:49"
         },
         {
@@ -2038,7 +1654,7 @@
         {
             "id": "%s not support saml auth",
             "message": "%s not support saml auth",
-            "translation": "",
+            "translation": "%s不支持SAML认证",
             "position": "pkg/compute/models/cloudaccounts.go:312:48"
         },
         {
@@ -2050,7 +1666,7 @@
         {
             "id": "invalid wire_level_for_vmware %q, accept %s",
             "message": "invalid wire_level_for_vmware %q, accept %s",
-            "translation": "",
+            "translation": "无效的wire_level_for_vmware %q, 允许 %s",
             "position": "pkg/compute/models/cloudaccounts.go:420:48"
         },
         {
@@ -2267,37 +1883,37 @@
             "id": "GetZoneCount fail %s",
             "message": "GetZoneCount fail %s",
             "translation": "GetZoneCount调用失败",
-            "position": "pkg/compute/models/cloudregions.go:108:43"
+            "position": "pkg/compute/models/cloudregions.go:109:43"
         },
         {
             "id": "GetVpcCount fail %s",
             "message": "GetVpcCount fail %s",
             "translation": "GetVpcCount调用失败",
-            "position": "pkg/compute/models/cloudregions.go:112:43"
+            "position": "pkg/compute/models/cloudregions.go:113:43"
         },
         {
             "id": "not empty cloud region",
             "message": "not empty cloud region",
             "translation": "cloudregion不为空",
-            "position": "pkg/compute/models/cloudregions.go:115:37"
+            "position": "pkg/compute/models/cloudregions.go:116:37"
         },
         {
             "id": "not allow to delete default cloud region",
             "message": "not allow to delete default cloud region",
             "translation": "不允许删除默认cloudregion",
-            "position": "pkg/compute/models/cloudregions.go:118:46"
+            "position": "pkg/compute/models/cloudregions.go:119:46"
         },
         {
             "id": "VPC %s not found",
             "message": "VPC %s not found",
             "translation": "找不到VPC %s",
-            "position": "pkg/compute/models/cloudregions.go:575:50"
+            "position": "pkg/compute/models/cloudregions.go:576:50"
         },
         {
             "id": "Cannot update external resource",
             "message": "Cannot update external resource",
             "translation": "不允许更新外部资源",
-            "position": "pkg/compute/models/cloudregions.go:914:37"
+            "position": "pkg/compute/models/cloudregions.go:915:37"
         },
         {
             "id": "not allow update rds account name",
@@ -2518,13 +2134,13 @@
         {
             "id": "The dbinstance status need be %s, current is %s",
             "message": "The dbinstance status need be %s, current is %s",
-            "translation": "",
+            "translation": "数据库实例状态需要是 %s，目前是 %s",
             "position": "pkg/compute/models/dbinstances.go:983:52"
         },
         {
             "id": "Only %s dbinstance support this operation",
             "message": "Only %s dbinstance support this operation",
-            "translation": "",
+            "translation": "只有 %s 数据库实例支持该操作",
             "position": "pkg/compute/models/dbinstances.go:987:52"
         },
         {
@@ -2584,14 +2200,14 @@
         {
             "id": "this operation requires rds state to be %s",
             "message": "this operation requires rds state to be %s",
-            "translation": "",
-            "position": "pkg/compute/models/dbinstances.go:2067:47"
+            "translation": "该操作要求数据库实例状态为 %s",
+            "position": "pkg/compute/models/dbinstances.go:2068:47"
         },
         {
             "id": "%s supported secgroup count is %d",
             "message": "%s supported secgroup count is %d",
-            "translation": "",
-            "position": "pkg/compute/models/dbinstances.go:2084:52"
+            "translation": "%s 允许的安全组数量为 %d",
+            "position": "pkg/compute/models/dbinstances.go:2085:52"
         },
         {
             "id": "guest %q not found",
@@ -3262,7 +2878,7 @@
         {
             "id": "no admin account found for elastic cache %s",
             "message": "no admin account found for elastic cache %s",
-            "translation": "",
+            "translation": "弹性缓存 %s 没有管理账号",
             "position": "pkg/compute/models/elasticcache_instances.go:1348:41"
         },
         {
@@ -3311,67 +2927,67 @@
             "id": "Cannot add security groups in status %s",
             "message": "Cannot add security groups in status %s",
             "translation": "虚机状态%s不可执行添加安全组操作",
-            "position": "pkg/compute/models/elasticcache_instances.go:1955:43"
+            "position": "pkg/compute/models/elasticcache_instances.go:1956:43"
         },
         {
             "id": "region",
             "message": "region",
-            "translation": "",
-            "position": "pkg/compute/models/elasticcache_instances.go:1960:37"
+            "translation": "区域",
+            "position": "pkg/compute/models/elasticcache_instances.go:1961:37"
         },
         {
             "id": "regiondriver",
             "message": "regiondriver",
-            "translation": "",
-            "position": "pkg/compute/models/elasticcache_instances.go:1965:37"
+            "translation": "区域类型",
+            "position": "pkg/compute/models/elasticcache_instances.go:1966:37"
         },
         {
             "id": "not supported bind security group",
             "message": "not supported bind security group",
             "translation": "不支持绑定安全组",
-            "position": "pkg/compute/models/elasticcache_instances.go:1970:41"
+            "position": "pkg/compute/models/elasticcache_instances.go:1971:41"
         },
         {
             "id": "beyond security group quantity limit, max items %d.",
             "message": "beyond security group quantity limit, max items %d.",
             "translation": "超过可绑定的安全组数量限制，最多 %d 个",
-            "position": "pkg/compute/models/elasticcache_instances.go:1974:39"
+            "position": "pkg/compute/models/elasticcache_instances.go:1975:39"
         },
         {
             "id": "The secgroup name %s does not meet the requirements, please change the name",
             "message": "The secgroup name %s does not meet the requirements, please change the name",
             "translation": "安全组名称%s不符合要求",
-            "position": "pkg/compute/models/elasticcache_instances.go:1993:49"
+            "position": "pkg/compute/models/elasticcache_instances.go:1994:49"
         },
         {
             "id": "secgroups will be empty after update.",
             "message": "secgroups will be empty after update.",
-            "translation": "",
-            "position": "pkg/compute/models/elasticcache_instances.go:2136:48"
+            "translation": "安全组在更新后会置空",
+            "position": "pkg/compute/models/elasticcache_instances.go:2137:48"
         },
         {
             "id": "The elastic cache status need be %s, current is %s",
             "message": "The elastic cache status need be %s, current is %s",
-            "translation": "",
-            "position": "pkg/compute/models/elasticcache_instances.go:2253:52"
+            "translation": "弹性缓存状态应该是 %s，目前是 %s",
+            "position": "pkg/compute/models/elasticcache_instances.go:2254:52"
         },
         {
             "id": "Only %s elastic cache support set auto renew operation",
             "message": "Only %s elastic cache support set auto renew operation",
-            "translation": "",
-            "position": "pkg/compute/models/elasticcache_instances.go:2257:52"
+            "translation": "只有 %s 弹性缓存支持设置自动更新操作",
+            "position": "pkg/compute/models/elasticcache_instances.go:2258:52"
         },
         {
             "id": "elastic cache no related region found",
             "message": "elastic cache no related region found",
-            "translation": "",
-            "position": "pkg/compute/models/elasticcache_instances.go:2266:50"
+            "translation": "弹性缓存找不到关联的区域",
+            "position": "pkg/compute/models/elasticcache_instances.go:2267:50"
         },
         {
             "id": "Only %s elastic cache support renew operation",
             "message": "Only %s elastic cache support renew operation",
-            "translation": "",
-            "position": "pkg/compute/models/elasticcache_instances.go:2301:52"
+            "translation": "只有 %s 弹性缓存支持续期操作",
+            "position": "pkg/compute/models/elasticcache_instances.go:2302:52"
         },
         {
             "id": "%s is not modifiable",
@@ -3382,7 +2998,7 @@
         {
             "id": "resource %s in vpc %s external access mode %s is not support accociate eip",
             "message": "resource %s in vpc %s external access mode %s is not support accociate eip",
-            "translation": "",
+            "translation": "资源 %s（归属VPC %s 外部访问模式 %s）不支持关联EIP",
             "position": "pkg/compute/models/elasticipresource.go:18:42"
         },
         {
@@ -3538,7 +3154,7 @@
         {
             "id": "account %s not share for domain %s",
             "message": "account %s not share for domain %s",
-            "translation": "",
+            "translation": "云账号 %s 并未共享到域 %s",
             "position": "pkg/compute/models/external_projects.go:334:43"
         },
         {
@@ -3718,7 +3334,7 @@
         {
             "id": "host virtual memory not enough",
             "message": "host virtual memory not enough",
-            "translation": "",
+            "translation": "宿主机虚拟机内存不足",
             "position": "pkg/compute/models/guest_actions.go:816:56"
         },
         {
@@ -4534,7 +4150,7 @@
         {
             "id": "guest %s has isolated device, can't migrate",
             "message": "guest %s has isolated device, can't migrate",
-            "translation": "",
+            "translation": "虚拟机 %s 有直通设备，无法迁移",
             "position": "pkg/compute/models/guest_actions.go:4461:46"
         },
         {
@@ -4702,7 +4318,7 @@
         {
             "id": "guest has no vpc ip",
             "message": "guest has no vpc ip",
-            "translation": "",
+            "translation": "虚拟机没有VPC IP",
             "position": "pkg/compute/models/guest_actions.go:5134:48"
         },
         {
@@ -4787,319 +4403,325 @@
             "id": "host %s not found",
             "message": "host %s not found",
             "translation": "找不到宿主机%s",
-            "position": "pkg/compute/models/guests.go:259:51"
+            "position": "pkg/compute/models/guests.go:258:51"
         },
         {
             "id": "secgroup %s not found",
             "message": "secgroup %s not found",
             "translation": "找不到安全组%s",
-            "position": "pkg/compute/models/guests.go:281:51"
+            "position": "pkg/compute/models/guests.go:280:51"
         },
         {
             "id": "disk %s not found",
             "message": "disk %s not found",
             "translation": "找不到磁盘%s",
-            "position": "pkg/compute/models/guests.go:380:51"
+            "position": "pkg/compute/models/guests.go:379:51"
         },
         {
             "id": "checkout guestdisk count fail %s",
             "message": "checkout guestdisk count fail %s",
             "translation": "检查虚机磁盘数量失败：%s",
-            "position": "pkg/compute/models/guests.go:386:49"
+            "position": "pkg/compute/models/guests.go:385:49"
         },
         {
             "id": "unknown server type %s",
             "message": "unknown server type %s",
-            "translation": "",
-            "position": "pkg/compute/models/guests.go:446:49"
+            "translation": "未知的虚拟机类型 %s",
+            "position": "pkg/compute/models/guests.go:445:49"
         },
         {
             "id": "group %s not found",
             "message": "group %s not found",
             "translation": "找不到主机组%s",
-            "position": "pkg/compute/models/guests.go:475:43"
+            "position": "pkg/compute/models/guests.go:474:43"
         },
         {
             "id": "Virtual server is locked, cannot delete",
             "message": "Virtual server is locked, cannot delete",
             "translation": "虚机已锁定，无法删除",
-            "position": "pkg/compute/models/guests.go:671:42"
+            "position": "pkg/compute/models/guests.go:670:42"
         },
         {
             "id": "not allow to delete prepaid server in valid status",
             "message": "not allow to delete prepaid server in valid status",
             "translation": "不允许删除有效状态的预付费虚机",
-            "position": "pkg/compute/models/guests.go:674:38"
+            "position": "pkg/compute/models/guests.go:673:38"
         },
         {
             "id": "Cannot delete server on disabled host",
             "message": "Cannot delete server on disabled host",
             "translation": "不允许删除已禁用宿主机上的虚机",
-            "position": "pkg/compute/models/guests.go:687:44"
+            "position": "pkg/compute/models/guests.go:686:44"
         },
         {
             "id": "Cannot delete server on offline host",
             "message": "Cannot delete server on offline host",
             "translation": "无法删除离线宿主机上的虚机",
-            "position": "pkg/compute/models/guests.go:690:44"
+            "position": "pkg/compute/models/guests.go:689:44"
         },
         {
             "id": "Cannot delete server disk %s must not have snapshots.",
             "message": "Cannot delete server disk %s must not have snapshots.",
             "translation": "虚机磁盘存在快照，无法执行删除操作",
-            "position": "pkg/compute/models/guests.go:698:43"
+            "position": "pkg/compute/models/guests.go:697:43"
         },
         {
             "id": "Memory size must be 8MB ~ %d GB",
             "message": "Memory size must be 8MB ~ %d GB",
             "translation": "内存大小必须在8MB〜%dGB范围内",
-            "position": "pkg/compute/models/guests.go:934:47"
+            "position": "pkg/compute/models/guests.go:933:47"
         },
         {
             "id": "CPU core count must be 1 ~ %d",
             "message": "CPU core count must be 1 ~ %d",
             "translation": "CPU核数必须在范围1〜%d内",
-            "position": "pkg/compute/models/guests.go:943:46"
+            "position": "pkg/compute/models/guests.go:942:46"
         },
         {
             "id": "Cannot modify Memory and CPU in status %s",
             "message": "Cannot modify Memory and CPU in status %s",
             "translation": "虚机状态为%s无法变更内存和CPU配置",
-            "position": "pkg/compute/models/guests.go:989:48"
+            "position": "pkg/compute/models/guests.go:988:48"
         },
         {
             "id": "Cannot modify memory for baremetal",
             "message": "Cannot modify memory for baremetal",
             "translation": "无法为裸金属变更内存配置",
-            "position": "pkg/compute/models/guests.go:992:49"
+            "position": "pkg/compute/models/guests.go:991:49"
         },
         {
             "id": "name is too short",
             "message": "name is too short",
             "translation": "名称太短",
-            "position": "pkg/compute/models/guests.go:1020:49"
+            "position": "pkg/compute/models/guests.go:1019:49"
         },
         {
             "id": "can't find instance snapshot %s",
             "message": "can't find instance snapshot %s",
             "translation": "找不到实例快照%s",
-            "position": "pkg/compute/models/guests.go:1088:44"
+            "position": "pkg/compute/models/guests.go:1087:44"
         },
         {
             "id": "fetch instance snapshot error %s",
             "message": "fetch instance snapshot error %s",
             "translation": "获取实例快照出错：%s",
-            "position": "pkg/compute/models/guests.go:1091:48"
+            "position": "pkg/compute/models/guests.go:1090:48"
         },
         {
             "id": "Instance snapshot not ready",
             "message": "Instance snapshot not ready",
             "translation": "实例快照未准备好",
-            "position": "pkg/compute/models/guests.go:1095:44"
+            "position": "pkg/compute/models/guests.go:1094:44"
         },
         {
             "id": "metdata must less then 20",
             "message": "metdata must less then 20",
             "translation": "metadata条目数不可超过20",
-            "position": "pkg/compute/models/guests.go:1110:48"
+            "position": "pkg/compute/models/guests.go:1109:48"
         },
         {
             "id": "login_account is longer than 32 chars",
             "message": "login_account is longer than 32 chars",
             "translation": "login_account长度已超过32字节",
-            "position": "pkg/compute/models/guests.go:1148:49"
+            "position": "pkg/compute/models/guests.go:1147:49"
         },
         {
             "id": "No disk information provided",
             "message": "No disk information provided",
             "translation": "未提供磁盘信息",
-            "position": "pkg/compute/models/guests.go:1181:49"
+            "position": "pkg/compute/models/guests.go:1180:49"
         },
         {
             "id": "Invalid root image: %s",
             "message": "Invalid root image: %s",
             "translation": "无效的系统镜像: %s",
-            "position": "pkg/compute/models/guests.go:1186:49"
+            "position": "pkg/compute/models/guests.go:1185:49"
         },
         {
             "id": "System disk does not support iso image, please consider using cdrom parameter",
             "message": "System disk does not support iso image, please consider using cdrom parameter",
             "translation": "系统盘不支持ISO镜像，请使用cdrom参数",
-            "position": "pkg/compute/models/guests.go:1204:49"
+            "position": "pkg/compute/models/guests.go:1203:49"
         },
         {
             "id": "parse cdrom device info error %s",
             "message": "parse cdrom device info error %s",
             "translation": "解析cdrom设备信息出错误：%s",
-            "position": "pkg/compute/models/guests.go:1211:50"
+            "position": "pkg/compute/models/guests.go:1210:50"
         },
         {
             "id": "Miss operating system???",
             "message": "Miss operating system???",
             "translation": "未指定操作系统镜像？",
-            "position": "pkg/compute/models/guests.go:1253:44"
+            "position": "pkg/compute/models/guests.go:1252:44"
+        },
+        {
+            "id": "root disk image(%s) and sku(%s) architecture mismatch",
+            "message": "root disk image(%s) and sku(%s) architecture mismatch",
+            "translation": "系统盘的镜像(%s)和虚拟机规格SKU(%s)的CPU架构不匹配",
+            "position": "pkg/compute/models/guests.go:1329:45"
         },
         {
             "id": "parse disk description error %s",
             "message": "parse disk description error %s",
             "translation": "解析磁盘描述信息出错：%s",
-            "position": "pkg/compute/models/guests.go:1332:50"
+            "position": "pkg/compute/models/guests.go:1338:50"
         },
         {
             "id": "Snapshot error: disk index %d \u003e 0 but disk type is %s",
             "message": "Snapshot error: disk index %d \u003e 0 but disk type is %s",
             "translation": "快照错误：序号%d大于0的磁盘类型为%s",
-            "position": "pkg/compute/models/guests.go:1335:46"
+            "position": "pkg/compute/models/guests.go:1341:46"
         },
         {
             "id": "cannot create prepaid server on prepaid resource type",
             "message": "cannot create prepaid server on prepaid resource type",
             "translation": "无法在预付费的资源类型上创建预付费的虚机",
-            "position": "pkg/compute/models/guests.go:1353:44"
+            "position": "pkg/compute/models/guests.go:1359:44"
         },
         {
             "id": "parse network description error %s",
             "message": "parse network description error %s",
             "translation": "解析网络描述信息出错：%s",
-            "position": "pkg/compute/models/guests.go:1390:49"
+            "position": "pkg/compute/models/guests.go:1396:49"
         },
         {
             "id": "Cannot create backup with isolated device",
             "message": "Cannot create backup with isolated device",
             "translation": "无法创建带有透传设备的主备机",
-            "position": "pkg/compute/models/guests.go:1407:45"
+            "position": "pkg/compute/models/guests.go:1413:45"
         },
         {
             "id": "parse isolated device description error %s",
             "message": "parse isolated device description error %s",
             "translation": "解析透传设备描述信息出错：%s",
-            "position": "pkg/compute/models/guests.go:1411:49"
+            "position": "pkg/compute/models/guests.go:1417:49"
         },
         {
             "id": "Keypair %s not found",
             "message": "Keypair %s not found",
             "translation": "找不到密钥对%s",
-            "position": "pkg/compute/models/guests.go:1424:51"
+            "position": "pkg/compute/models/guests.go:1430:51"
         },
         {
             "id": "Secgroup %s not found",
             "message": "Secgroup %s not found",
             "translation": "找不到安全组%s",
-            "position": "pkg/compute/models/guests.go:1433:51"
+            "position": "pkg/compute/models/guests.go:1439:51"
         },
         {
             "id": "%s shall bind up to %d security groups",
             "message": "%s shall bind up to %d security groups",
             "translation": "%s最多可关联%d个安全组",
-            "position": "pkg/compute/models/guests.go:1458:48"
+            "position": "pkg/compute/models/guests.go:1464:48"
         },
         {
             "id": "Invalid userdata: %v",
             "message": "Invalid userdata: %v",
             "translation": "无效的userdata：%v",
-            "position": "pkg/compute/models/guests.go:1486:48"
+            "position": "pkg/compute/models/guests.go:1492:48"
         },
         {
             "id": "invalid parameters for policy definition %s",
             "message": "invalid parameters for policy definition %s",
             "translation": "策略定义中有无效参数：%s",
-            "position": "pkg/compute/models/guests.go:1511:47"
+            "position": "pkg/compute/models/guests.go:1517:47"
         },
         {
             "id": "policy definition %s require cloudregion in %s",
             "message": "policy definition %s require cloudregion in %s",
             "translation": "策略定义%s要求cloudregion在%s范围中",
-            "position": "pkg/compute/models/guests.go:1524:48"
+            "position": "pkg/compute/models/guests.go:1530:48"
         },
         {
             "id": "policy definition %s require cloudregion not in %s",
             "message": "policy definition %s require cloudregion not in %s",
             "translation": "策略定义%s要求cloudregion不在%s范围中",
-            "position": "pkg/compute/models/guests.go:1528:48"
+            "position": "pkg/compute/models/guests.go:1534:48"
         },
         {
             "id": "invalid policy definition %s(%s) condition %s",
             "message": "invalid policy definition %s(%s) condition %s",
             "translation": "策略定义%s(%s)包含无效的条件%s",
-            "position": "pkg/compute/models/guests.go:1531:47"
+            "position": "pkg/compute/models/guests.go:1537:47"
         },
         {
             "id": "policy definition %s require must contains tag %s",
             "message": "policy definition %s require must contains tag %s",
             "translation": "策略定义%s要求必须包含%s标签",
-            "position": "pkg/compute/models/guests.go:1548:49"
+            "position": "pkg/compute/models/guests.go:1554:49"
         },
         {
             "id": "policy definition %s require except tag %s",
             "message": "policy definition %s require except tag %s",
             "translation": "策略定义%s要求不可有%s标签",
-            "position": "pkg/compute/models/guests.go:1552:49"
+            "position": "pkg/compute/models/guests.go:1558:49"
         },
         {
             "id": "invalid category %s for policy definition %s(%s)",
             "message": "invalid category %s for policy definition %s(%s)",
             "translation": "类别%s在策略定义%s(%s)中无效",
-            "position": "pkg/compute/models/guests.go:1559:46"
+            "position": "pkg/compute/models/guests.go:1565:46"
         },
         {
             "id": "public ip not supported for %s",
             "message": "public ip not supported for %s",
             "translation": "%s 不支持静态公网IP",
-            "position": "pkg/compute/models/guests.go:1593:44"
+            "position": "pkg/compute/models/guests.go:1599:44"
         },
         {
             "id": "invalid public_ip_charge_type %s",
             "message": "invalid public_ip_charge_type %s",
             "translation": "无效的静态公网IP类型 %s",
-            "position": "pkg/compute/models/guests.go:1602:44"
+            "position": "pkg/compute/models/guests.go:1608:44"
         },
         {
             "id": "eip not supported for %s",
             "message": "eip not supported for %s",
             "translation": "%s不支持EIP",
-            "position": "pkg/compute/models/guests.go:1610:44"
+            "position": "pkg/compute/models/guests.go:1616:44"
         },
         {
             "id": "eip %s status invalid %s",
             "message": "eip %s status invalid %s",
             "translation": "EIP %s状态无效%s",
-            "position": "pkg/compute/models/guests.go:1624:44"
+            "position": "pkg/compute/models/guests.go:1630:44"
         },
         {
             "id": "eip %s has been associated",
             "message": "eip %s has been associated",
             "translation": "EIP %s已被占用",
-            "position": "pkg/compute/models/guests.go:1627:43"
+            "position": "pkg/compute/models/guests.go:1633:43"
         },
         {
             "id": "cannot assoicate with eip %s: different cloudprovider",
             "message": "cannot assoicate with eip %s: different cloudprovider",
             "translation": "EIP %s属于不同cloudprovider，无法绑定",
-            "position": "pkg/compute/models/guests.go:1633:39"
+            "position": "pkg/compute/models/guests.go:1639:39"
         },
         {
             "id": "cannot assoicate with eip %s: different region",
             "message": "cannot assoicate with eip %s: different region",
             "translation": "EIP %s属于不同的region，无法绑定",
-            "position": "pkg/compute/models/guests.go:1640:39"
+            "position": "pkg/compute/models/guests.go:1646:39"
         },
         {
             "id": "fetch disk size failed",
             "message": "fetch disk size failed",
             "translation": "获取磁盘大小失败",
-            "position": "pkg/compute/models/guests.go:5519:63"
+            "position": "pkg/compute/models/guests.go:5491:63"
         },
         {
             "id": "image %s do not belong to guest image %s",
             "message": "image %s do not belong to guest image %s",
             "translation": "镜像%s不在虚机镜像%s中",
-            "position": "pkg/compute/models/guests.go:5585:41"
+            "position": "pkg/compute/models/guests.go:5557:41"
         },
         {
             "id": "miss some subimage of guest image",
             "message": "miss some subimage of guest image",
             "translation": "部分虚机镜像的子镜像未指定",
-            "position": "pkg/compute/models/guests.go:5591:39"
+            "position": "pkg/compute/models/guests.go:5563:39"
         },
         {
             "id": "Baremetal %s not enabled",
@@ -5524,19 +5146,19 @@
         {
             "id": "Not found baremetal server record",
             "message": "Not found baremetal server record",
-            "translation": "",
+            "translation": "未找到裸金属服务器记录",
             "position": "pkg/compute/models/hosts.go:4439:42"
         },
         {
             "id": "Not found guest nic by mac %s",
             "message": "Not found guest nic by mac %s",
-            "translation": "",
+            "translation": "未找到MAC地址为 %s 的虚拟机磁盘",
             "position": "pkg/compute/models/hosts.go:4455:37"
         },
         {
             "id": "Guest nic ip addr %s not equal %s",
             "message": "Guest nic ip addr %s not equal %s",
-            "translation": "",
+            "translation": "虚拟机的网卡IP地址为 %s 不是 %s",
             "position": "pkg/compute/models/hosts.go:4459:42"
         },
         {
@@ -5782,8 +5404,8 @@
         {
             "id": "can't delete instance snapshot with wrong status",
             "message": "can't delete instance snapshot with wrong status",
-            "translation": "",
-            "position": "pkg/compute/models/instance_snapshots.go:509:38"
+            "translation": "无法删除错误状态的虚拟机快照",
+            "position": "pkg/compute/models/instance_snapshots.go:510:38"
         },
         {
             "id": "vpc joint interVpcNetwork on different cloudprovider is not supported",
@@ -6341,7 +5963,7 @@
             "id": "loadbalancer is locked, cannot delete",
             "message": "loadbalancer is locked, cannot delete",
             "translation": "负载均衡已经被锁定，无法删除",
-            "position": "pkg/compute/models/loadbalancers.go:727:42"
+            "position": "pkg/compute/models/loadbalancers.go:725:42"
         },
         {
             "id": "Unmarshal input failed %s",
@@ -7241,49 +6863,49 @@
             "id": "rule %d is invalid: %s",
             "message": "rule %d is invalid: %s",
             "translation": "第%d条规则无效：%s",
-            "position": "pkg/compute/models/secgroups.go:483:51"
+            "position": "pkg/compute/models/secgroups.go:493:51"
         },
         {
             "id": "vpc %s(%s) is not a managed resouce",
             "message": "vpc %s(%s) is not a managed resouce",
             "translation": "vpc %s(%s)不是一个纳管资源",
-            "position": "pkg/compute/models/secgroups.go:631:48"
+            "position": "pkg/compute/models/secgroups.go:639:48"
         },
         {
             "id": "Not support cache classic security group",
             "message": "Not support cache classic security group",
             "translation": "不支持缓存经典安全组",
-            "position": "pkg/compute/models/secgroups.go:640:48"
+            "position": "pkg/compute/models/secgroups.go:648:48"
         },
         {
             "id": "invalid ip address: %s",
             "message": "invalid ip address: %s",
             "translation": "无效的IP地址：%s",
-            "position": "pkg/compute/models/secgroups.go:671:49"
+            "position": "pkg/compute/models/secgroups.go:679:49"
         },
         {
             "id": "secgroup %s rules not equals %s rules",
             "message": "secgroup %s rules not equals %s rules",
             "translation": "安全组%s的规则与%s不相等",
-            "position": "pkg/compute/models/secgroups.go:790:53"
+            "position": "pkg/compute/models/secgroups.go:798:53"
         },
         {
             "id": "GetGuestsCount fail %s",
             "message": "GetGuestsCount fail %s",
             "translation": "GetGuestCount调用出错：%s",
-            "position": "pkg/compute/models/secgroups.go:1143:43"
+            "position": "pkg/compute/models/secgroups.go:1167:43"
         },
         {
             "id": "the security group is in use",
             "message": "the security group is in use",
             "translation": "安全组正使用中",
-            "position": "pkg/compute/models/secgroups.go:1146:37"
+            "position": "pkg/compute/models/secgroups.go:1170:37"
         },
         {
             "id": "not allow to delete default security group",
             "message": "not allow to delete default security group",
             "translation": "不允许删除默认的安全组",
-            "position": "pkg/compute/models/secgroups.go:1149:46"
+            "position": "pkg/compute/models/secgroups.go:1173:46"
         },
         {
             "id": "no such guest template",
@@ -7325,103 +6947,103 @@
             "id": "zone %s not in cloudregion %s",
             "message": "zone %s not in cloudregion %s",
             "translation": "",
-            "position": "pkg/compute/models/skus.go:312:45"
+            "position": "pkg/compute/models/skus.go:313:45"
         },
         {
             "id": "cpu_core_count should be range of 1~256",
             "message": "cpu_core_count should be range of 1~256",
             "translation": "cpu_core_count应在1～256范围内",
-            "position": "pkg/compute/models/skus.go:318:46"
+            "position": "pkg/compute/models/skus.go:319:46"
         },
         {
             "id": "memory_size_mb, shoud be range of 512~%d",
             "message": "memory_size_mb, shoud be range of 512~%d",
             "translation": "memory_size_mb应在512~%d范围内",
-            "position": "pkg/compute/models/skus.go:322:46"
+            "position": "pkg/compute/models/skus.go:323:46"
         },
         {
             "id": "instance_type_category shoud be one of %s",
             "message": "instance_type_category shoud be one of %s",
             "translation": "instance_type_category应是%s其中之一",
-            "position": "pkg/compute/models/skus.go:330:50"
+            "position": "pkg/compute/models/skus.go:331:50"
         },
         {
             "id": "Not support create public cloud sku",
             "message": "Not support create public cloud sku",
             "translation": "",
-            "position": "pkg/compute/models/skus.go:347:54"
+            "position": "pkg/compute/models/skus.go:348:54"
         },
         {
             "id": "checkout server sku name duplicate error: %v",
             "message": "checkout server sku name duplicate error: %v",
             "translation": "检查SKU重名时出错：%v",
-            "position": "pkg/compute/models/skus.go:366:51"
+            "position": "pkg/compute/models/skus.go:367:51"
         },
         {
             "id": "Duplicate sku %s",
             "message": "Duplicate sku %s",
             "translation": "重复的SKU %s",
-            "position": "pkg/compute/models/skus.go:369:54"
+            "position": "pkg/compute/models/skus.go:370:54"
         },
         {
             "id": "instance specs list query error",
             "message": "instance specs list query error",
             "translation": "实例规格列表查询出错",
-            "position": "pkg/compute/models/skus.go:583:44"
+            "position": "pkg/compute/models/skus.go:584:44"
         },
         {
             "id": "can not update instance_type for public cloud %s",
             "message": "can not update instance_type for public cloud %s",
             "translation": "无法变更公有云%s SKU的实例类型",
-            "position": "pkg/compute/models/skus.go:633:45"
+            "position": "pkg/compute/models/skus.go:634:45"
         },
         {
             "id": "Cannot change server sku name",
             "message": "Cannot change server sku name",
             "translation": "无法变更SKU名称",
-            "position": "pkg/compute/models/skus.go:637:54"
+            "position": "pkg/compute/models/skus.go:638:54"
         },
         {
             "id": "check instance",
             "message": "check instance",
             "translation": "检查实例出错",
-            "position": "pkg/compute/models/skus.go:683:43"
+            "position": "pkg/compute/models/skus.go:684:43"
         },
         {
             "id": "now allow to delete inuse instance_type.please remove related servers first: %s",
             "message": "now allow to delete inuse instance_type.please remove related servers first: %s",
             "translation": "不允许删除正在使用中的实例类型，请先移除相关的虚机：%s",
-            "position": "pkg/compute/models/skus.go:686:37"
+            "position": "pkg/compute/models/skus.go:687:37"
         },
         {
             "id": "not allow to delete public cloud instance_type: %s",
             "message": "not allow to delete public cloud instance_type: %s",
             "translation": "不允许删除公有云instance_type：%s",
-            "position": "pkg/compute/models/skus.go:690:38"
+            "position": "pkg/compute/models/skus.go:691:38"
         },
         {
             "id": "failed to find cloudregion for zone %s(%s)",
             "message": "failed to find cloudregion for zone %s(%s)",
             "translation": "查找zone %s(%s)所属的cloudregion失败",
-            "position": "pkg/compute/models/skus.go:807:51"
+            "position": "pkg/compute/models/skus.go:808:51"
         },
         {
             "id": "duplicate instanceType %s",
             "message": "duplicate instanceType %s",
             "translation": "实例类型%s重复",
-            "position": "pkg/compute/models/skus.go:941:53"
+            "position": "pkg/compute/models/skus.go:942:53"
         },
         {
             "id": "query sku list failed.",
             "message": "query sku list failed.",
             "translation": "查询SKU列表出错",
-            "position": "pkg/compute/models/skus.go:1015:43"
+            "position": "pkg/compute/models/skus.go:1016:43"
         },
         {
             "id": "delete sku %s failed.",
             "message": "delete sku %s failed.",
             "translation": "删除SKU %s失败",
-            "position": "pkg/compute/models/skus.go:1026:44"
+            "position": "pkg/compute/models/skus.go:1027:44"
         },
         {
             "id": "Retention days must in 1~%d or -1",
@@ -7787,19 +7409,19 @@
             "id": "on-premise vpc cannot sync status",
             "message": "on-premise vpc cannot sync status",
             "translation": "本地IDC VPC不支持同步状态操作",
-            "position": "pkg/compute/models/vpcs.go:1268:51"
+            "position": "pkg/compute/models/vpcs.go:1305:51"
         },
         {
             "id": "For default vpc, only system level sharing can be set",
             "message": "For default vpc, only system level sharing can be set",
             "translation": "对于经典网络，仅可设置为系统级别的共享",
-            "position": "pkg/compute/models/vpcs.go:1440:43"
+            "position": "pkg/compute/models/vpcs.go:1477:43"
         },
         {
             "id": "Prohibit making default vpc private",
             "message": "Prohibit making default vpc private",
             "translation": "禁止将经典网络设为私有",
-            "position": "pkg/compute/models/vpcs.go:1461:43"
+            "position": "pkg/compute/models/vpcs.go:1498:43"
         },
         {
             "id": "mapped ip exhausted",
@@ -9014,16 +8636,28 @@
             "position": "pkg/httperrors/consts.go:85:2"
         },
         {
+            "id": "User Locked",
+            "message": "User Locked",
+            "translation": "用户被锁住",
+            "position": "pkg/httperrors/consts.go:87:2"
+        },
+        {
+            "id": "User Disabled",
+            "message": "User Disabled",
+            "translation": "用户被禁用",
+            "position": "pkg/httperrors/consts.go:88:2"
+        },
+        {
             "id": "UnsupportedProtocol",
             "message": "UnsupportedProtocol",
             "translation": "不支持的协议",
-            "position": "pkg/httperrors/consts.go:87:2"
+            "position": "pkg/httperrors/consts.go:90:2"
         },
         {
             "id": "PolicyDefinitionError",
             "message": "PolicyDefinitionError",
             "translation": "策略定义错误",
-            "position": "pkg/httperrors/consts.go:89:2"
+            "position": "pkg/httperrors/consts.go:92:2"
         },
         {
             "id": "Image %s not found",
@@ -9034,8 +8668,14 @@
         {
             "id": "password must be 12 chars of at least one digit, letter, uppercase letter and punctuate",
             "message": "password must be 12 chars of at least one digit, letter, uppercase letter and punctuate",
-            "translation": "",
+            "translation": "密码必须12位长度，包含至少一个数字，大小写字母和符号",
             "position": "pkg/httperrors/errors.go:89:37"
+        },
+        {
+            "id": "Missing parameter %s",
+            "message": "Missing parameter %s",
+            "translation": "找不到参数%s",
+            "position": "pkg/httperrors/errors.go:94:37"
         },
         {
             "id": "Duplicate name %s %s",
@@ -9107,7 +8747,7 @@
             "id": "query error %s",
             "message": "query error %s",
             "translation": "查询出错：%s",
-            "position": "pkg/keystone/models/assignments.go:702:52"
+            "position": "pkg/keystone/models/assignments.go:709:52"
         },
         {
             "id": "missing input field type",
@@ -9437,49 +9077,49 @@
             "id": "cannot alter sysadmin user name",
             "message": "cannot alter sysadmin user name",
             "translation": "不可变更sysadmin的用户名",
-            "position": "pkg/keystone/models/users.go:513:46"
+            "position": "pkg/keystone/models/users.go:514:46"
         },
         {
             "id": "invalid password: %s",
             "message": "invalid password: %s",
             "translation": "无效的密码：%s",
-            "position": "pkg/keystone/models/users.go:545:51"
+            "position": "pkg/keystone/models/users.go:546:51"
         },
         {
-            "id": "cannot delete non-local user",
-            "message": "cannot delete non-local user",
-            "translation": "不可删除来源非本地的用户",
-            "position": "pkg/keystone/models/users.go:746:38"
+            "id": "cannot delete non-local non-sso user",
+            "message": "cannot delete non-local non-sso user",
+            "translation": "无法删除非本地的非SSO用户",
+            "position": "pkg/keystone/models/users.go:766:40"
         },
         {
             "id": "user contains external resources",
             "message": "user contains external resources",
             "translation": "用户仍有外部资源",
-            "position": "pkg/keystone/models/users.go:758:37"
+            "position": "pkg/keystone/models/users.go:780:37"
         },
         {
             "id": "cannot delete system user",
             "message": "cannot delete system user",
             "translation": "不可删除系统用户",
-            "position": "pkg/keystone/models/users.go:761:38"
+            "position": "pkg/keystone/models/users.go:783:38"
         },
         {
             "id": "cannot join user and group in differnt domain",
             "message": "cannot join user and group in differnt domain",
             "translation": "用户和组的域归属必须相同",
-            "position": "pkg/keystone/models/users.go:810:48"
+            "position": "pkg/keystone/models/users.go:832:48"
         },
         {
             "id": "cannot join read-only group",
             "message": "cannot join read-only group",
             "translation": "不可加入只读组",
-            "position": "pkg/keystone/models/users.go:813:43"
+            "position": "pkg/keystone/models/users.go:835:43"
         },
         {
             "id": "cannot leave read-only group",
             "message": "cannot leave read-only group",
             "translation": "不可离开只读组",
-            "position": "pkg/keystone/models/users.go:827:43"
+            "position": "pkg/keystone/models/users.go:849:43"
         },
         {
             "id": "version mismatch",
@@ -9752,12 +9392,6 @@
             "position": "pkg/mcclient/modules/mod_users.go:139:48"
         },
         {
-            "id": "global-settings not found",
-            "message": "global-settings not found",
-            "translation": "找不到global-settings",
-            "position": "pkg/mcclient/modules/yunionconf/mod_parameters.go:56:42"
-        },
-        {
             "id": "url is empty",
             "message": "url is empty",
             "translation": "",
@@ -9917,19 +9551,19 @@
             "id": "the AlertType is illegal:%s",
             "message": "the AlertType is illegal:%s",
             "translation": "",
-            "position": "pkg/monitor/models/commonalert.go:142:50"
+            "position": "pkg/monitor/models/commonalert.go:145:50"
         },
         {
             "id": "Cannot delete system alert",
             "message": "Cannot delete system alert",
             "translation": "",
-            "position": "pkg/monitor/models/commonalert.go:432:42"
+            "position": "pkg/monitor/models/commonalert.go:437:42"
         },
         {
             "id": "threshold:%s should be number type",
             "message": "threshold:%s should be number type",
             "translation": "",
-            "position": "pkg/monitor/models/commonalert.go:1014:50"
+            "position": "pkg/monitor/models/commonalert.go:1023:50"
         },
         {
             "id": "Default data source not found",
@@ -9995,7 +9629,7 @@
             "id": "Invalid interval format: %s",
             "message": "Invalid interval format: %s",
             "translation": "",
-            "position": "pkg/monitor/models/unifiedmonitor.go:293:43"
+            "position": "pkg/monitor/models/unifiedmonitor.go:302:43"
         },
         {
             "id": "Unsupported notification type",


### PR DESCRIPTION
allow delete SSO imported non-local users

**这个 PR 实现什么功能/修复什么问题**:
修正：允许删除SSO导入的非本地用户


<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area keystone
/cc @zexi