### PR TITLE
fix(cloudid): saml navigation template support i18n

### DIFF
--- a/pkg/cloudid/saml/initidp.go
+++ b/pkg/cloudid/saml/initidp.go
@@ -28,6 +28,7 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudid/models"
 	"yunion.io/x/onecloud/pkg/cloudid/options"
 	"yunion.io/x/onecloud/pkg/httperrors"
+	"yunion.io/x/onecloud/pkg/i18n"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/util/httputils"
 	"yunion.io/x/onecloud/pkg/util/samlutils"
@@ -111,8 +112,7 @@ func initSAMLIdp(app *appsrv.Application, prefix string) error {
 	}
 
 	idpInst.AddHandlers(app, prefix, auth.Authenticate)
-	idpInst.SetHtmlTemplate("zh-CN", `<!DOCTYPE html><html lang="zh"><head><meta charset="utf-8"><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><h1>正在跳转到云控制台，请等待。。。</h1>$FORM$</body></html>`)
-	idpInst.SetHtmlTemplate("en", `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><h1>Jumping to the console, please wait。。。</h1>$FORM$</body></html>`)
+	idpInst.SetHtmlTemplate(i18n.NewTableEntry().CN(`<!DOCTYPE html><html lang="zh"><head><meta charset="utf-8"><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><h1>正在跳转到云控制台，请等待。。。</h1>$FORM$</body></html>`).EN(`<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><h1>Login into to the cloud console, please wait。。。</h1>$FORM$</body></html>`))
 
 	idpInstance = idpInst
 

--- a/pkg/util/samlutils/demo/service.go
+++ b/pkg/util/samlutils/demo/service.go
@@ -29,6 +29,7 @@ import (
 
 	"yunion.io/x/onecloud/pkg/appsrv"
 	"yunion.io/x/onecloud/pkg/httperrors"
+	"yunion.io/x/onecloud/pkg/i18n"
 	"yunion.io/x/onecloud/pkg/util/fileutils2"
 	"yunion.io/x/onecloud/pkg/util/httputils"
 	"yunion.io/x/onecloud/pkg/util/samlutils"
@@ -371,7 +372,7 @@ func prepareServer() error {
 		}
 	}
 	idpInst.AddHandlers(app, "SAML/idp", nil)
-	idpInst.SetHtmlTemplate("zh-CN", `<!DOCTYPE html><html lang="zh_CN"><head><meta charset="utf-8"><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><h1>正在跳转到云控制台，请等待。。。</h1>$FORM$</body></html>`)
+	idpInst.SetHtmlTemplate(i18n.NewTableEntry().CN(`<!DOCTYPE html><html lang="zh_CN"><head><meta charset="utf-8"><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><h1>正在跳转到云控制台，请等待。。。</h1>$FORM$</body></html>`))
 
 	app.AddHandler("GET", "SAML/idp", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		idpInitUrl := httputils.JoinPath(options.Entity, "SAML/idp/sso")


### PR DESCRIPTION
saml navigation template support i18n

**这个 PR 实现什么功能/修复什么问题**:
修正：SAML跳转文字支持i18n


<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7


<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @yousong 
/area cloudid
