### PR TITLE
Automated cherry pick of #9993: fix(apigateway): getRegions return value of api_server

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -182,6 +182,8 @@ func (h *AuthHandlers) GetRegionsResponse(ctx context.Context, w http.ResponseWr
 
 	resp.Add(jsonutils.NewArray(retIdps...), "idps")
 
+	resp.Add(jsonutils.NewString(options.Options.ApiServer), "api_server")
+
 	return resp, nil
 }
 


### PR DESCRIPTION
Cherry pick of #9993 on release/3.7.

#9993: fix(apigateway): getRegions return value of api_server