### PR TITLE
fix(keystone): user create without password can login with any password

### DIFF
--- a/pkg/keystone/models/users.go
+++ b/pkg/keystone/models/users.go
@@ -299,10 +299,10 @@ func VerifyPassword(user *api.SUserExtended, passwd string) error {
 func localUserVerifyPassword(user *api.SUserExtended, passwd string) error {
 	passes, err := PasswordManager.fetchByLocaluserId(user.LocalId)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "fetchPassword")
 	}
 	if len(passes) == 0 {
-		return nil
+		return errors.Error("no valid password")
 	}
 	// password expiration check skip system account
 	if passes[0].IsExpired() && !user.IsSystemAccount {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：未设置初始密码的用户可以用任意密码登录

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.4
- release/3.5
- release/3.6
- release/3.7

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area keystone