### PR TITLE
fix(apigateway): ignore fetch IDP errors in getRegions

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -171,13 +171,12 @@ func (h *AuthHandlers) GetRegionsResponse(ctx context.Context, w http.ResponseWr
 		filters.Add(jsonutils.JSONFalse, "auto_create_user")
 	}
 	idps, err := modules.IdentityProviders.List(s, filters)
-	if err != nil {
-		return nil, errors.Wrap(err, "list idp")
-	}
 	retIdps := make([]jsonutils.JSONObject, 0)
-	for i := range idps.Data {
-		retIdp := idps.Data[i].(*jsonutils.JSONDict).CopyIncludes("id", "name", "driver", "template", "icon_uri", "is_default")
-		retIdps = append(retIdps, retIdp)
+	if err == nil {
+		for i := range idps.Data {
+			retIdp := idps.Data[i].(*jsonutils.JSONDict).CopyIncludes("id", "name", "driver", "template", "icon_uri", "is_default")
+			retIdps = append(retIdps, retIdp)
+		}
 	}
 
 	resp.Add(jsonutils.NewArray(retIdps...), "idps")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：获取region信息时忽略获取IDP列表的错误

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area apigateway