### PR TITLE
Automated cherry pick of #10073: fix(host-deployer): remove escape character on windows passwd

### DIFF
--- a/pkg/hostman/guestfs/fsdriver/windows.go
+++ b/pkg/hostman/guestfs/fsdriver/windows.go
@@ -356,6 +356,8 @@ func (w *SWindowsRootFs) ChangeUserPasswd(part IDiskPartition, account, gid, pub
 	tool.CheckPath()
 	success := false
 
+	// symbol ^ is escape character is batch file.
+	password = strings.ReplaceAll(password, "^", "")
 	if rinfo != nil && version.GE(rinfo.Version, "6.1") {
 		success = w.deployPublicKeyByGuest(account, password)
 	} else {
@@ -408,8 +410,6 @@ func (w *SWindowsRootFs) deployPublicKeyByGuest(uname, passwd string) bool {
 	logPath := w.guestDebugLogPath
 	chksum := stringutils2.GetMD5Hash(passwd + logPath[(len(logPath)-10):])
 
-	// symbol ^ is escape character is batch file.
-	passwd = strings.ReplaceAll(passwd, "^", "^^")
 	chgpwdScript := strings.Join([]string{
 		w.MakeGuestDebugCmd("change password step 1"),
 		strings.Join([]string{


### PR DESCRIPTION
Cherry pick of #10073 on release/3.7.

#10073: fix(host-deployer): remove escape character on windows passwd