### PR TITLE
fix(baremetal): try channel 8 for default profile

### DIFF
--- a/pkg/baremetal/profiles/profiles.go
+++ b/pkg/baremetal/profiles/profiles.go
@@ -27,7 +27,7 @@ type IPMIProfile struct {
 
 func DefaultProfile() IPMIProfile {
 	return IPMIProfile{
-		LanChannel: []int{1},
+		LanChannel: []int{1, 2, 8},
 		RootName:   "root",
 		RootId:     2,
 	}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：缺省baremetal profile会尝试channel 1, 2, 8

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area baremetal
/cc @zexi 