### PR TITLE
Automated cherry pick of #10143: fix(baremetal): try channel 8 for default profile

### DIFF
--- a/pkg/baremetal/profiles/profiles.go
+++ b/pkg/baremetal/profiles/profiles.go
@@ -27,7 +27,7 @@ type IPMIProfile struct {
 
 func DefaultProfile() IPMIProfile {
 	return IPMIProfile{
-		LanChannel: []int{1},
+		LanChannel: []int{1, 2, 8},
 		RootName:   "root",
 		RootId:     2,
 	}


### PR DESCRIPTION
Cherry pick of #10143 on release/3.6.

#10143: fix(baremetal): try channel 8 for default profile