### PR TITLE
fix(keystone): add alertrecords to default dashboard permission

### DIFF
--- a/pkg/keystone/locale/predefined_policies.go
+++ b/pkg/keystone/locale/predefined_policies.go
@@ -95,6 +95,9 @@ var (
 					},
 				},
 				"monitor": {
+					"alertrecords": {
+						"list",
+					},
 					"alertresources": {
 						"list",
 					},


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：给缺省的dashboard权限增加alertrecords的list权限

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area keystone