### PR TITLE
Automated cherry pick of #10160: fix(keystone): add alertrecords to default dashboard permission

### DIFF
--- a/pkg/keystone/locale/predefined_policies.go
+++ b/pkg/keystone/locale/predefined_policies.go
@@ -95,6 +95,9 @@ var (
 					},
 				},
 				"monitor": {
+					"alertrecords": {
+						"list",
+					},
 					"alertresources": {
 						"list",
 					},


### PR DESCRIPTION
Cherry pick of #10160 on release/3.7.

#10160: fix(keystone): add alertrecords to default dashboard permission