### PR TITLE
fix(keystone): idp filter by sso_domain returns domain's idp only

### DIFF
--- a/pkg/keystone/models/identity_provider.go
+++ b/pkg/keystone/models/identity_provider.go
@@ -1169,14 +1169,7 @@ func (manager *SIdentityProviderManager) ListItemFilter(
 					return nil, errors.Wrap(err, "FetchDomainByIdOrName")
 				}
 			}
-			q = q.Filter(sqlchemy.OR(
-				sqlchemy.IsNullOrEmpty(q.Field("domain_id")),
-				sqlchemy.Equals(q.Field("domain_id"), ssoDomain.Id),
-			))
-			q = q.Filter(sqlchemy.OR(
-				sqlchemy.IsNullOrEmpty(q.Field("target_domain_id")),
-				sqlchemy.Equals(q.Field("target_domain_id"), ssoDomain.Id),
-			))
+			q = q.Equals("domain_id", ssoDomain.Id)
 		}
 	}
 	if query.AutoCreateProject != nil {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：IDP列表通过sso_domain过滤时只返回改域所属的idp

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @yousong 
/area keystone