### PR TITLE
fix(scheduler): storage medium type should not exact match

### DIFF
--- a/pkg/apis/compute/storage_const.go
+++ b/pkg/apis/compute/storage_const.go
@@ -148,6 +148,25 @@ var (
 	SHARED_STORAGE = []string{STORAGE_NFS, STORAGE_GPFS, STORAGE_RBD}
 )
 
+func IsDiskTypeMatch(t1, t2 string) bool {
+	switch t1 {
+	case DISK_TYPE_ROTATE:
+		if t2 == DISK_TYPE_SSD {
+			return false
+		} else {
+			return true
+		}
+	case DISK_TYPE_SSD:
+		if t2 == DISK_TYPE_ROTATE {
+			return false
+		} else {
+			return true
+		}
+	default:
+		return true
+	}
+}
+
 type StorageResourceInput struct {
 	// 存储（ID或Name）
 	StorageId string `json:"storage_id"`

--- a/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/disk_schedtag_predicate.go
@@ -121,7 +121,7 @@ func (p *DiskSchedtagPredicate) IsResourceFitInput(u *core.Unit, c core.Candidat
 		}
 	}
 	if len(d.Medium) != 0 {
-		if storage.MediumType != d.Medium {
+		if !computeapi.IsDiskTypeMatch(storage.MediumType, d.Medium) {
 			return &FailReason{
 				fmt.Sprintf("Storage %s medium %s != %s", storage.Name, storage.MediumType, d.Medium),
 				StorageMedium,


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：调度器storage比较medium type时候需要考虑hybrid类型为无类型

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6
- release/3.5

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @rainzm 
/area scheduler