### PR TITLE
fix(keystone): hide system scope policies in domain scope view

### DIFF
--- a/pkg/keystone/models/policies.go
+++ b/pkg/keystone/models/policies.go
@@ -547,7 +547,14 @@ func (policy *SPolicy) GetUsages() []db.IUsage {
 }
 
 func (manager *SPolicyManager) FilterByOwner(q *sqlchemy.SQuery, owner mcclient.IIdentityProvider, scope rbacutils.TRbacScope) *sqlchemy.SQuery {
-	return db.SharableManagerFilterByOwner(manager, q, owner, scope)
+	q = db.SharableManagerFilterByOwner(manager, q, owner, scope)
+	switch scope {
+	case rbacutils.ScopeProject:
+		q = q.Equals("scope", rbacutils.ScopeProject)
+	case rbacutils.ScopeDomain:
+		q = q.NotEquals("scope", rbacutils.ScopeSystem)
+	}
+	return q
 }
 
 func (policy *SPolicy) GetSharableTargetDomainIds() []string {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：在域视图隐藏系统级别的权限

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area keystone