### PR TITLE
fix(monitor): fix 报警静默期和未恢复告警策略的兼容

### DIFF
--- a/pkg/monitor/alerting/conditions/query.go
+++ b/pkg/monitor/alerting/conditions/query.go
@@ -268,6 +268,9 @@ type meterFetchImp struct {
 func (m *meterFetchImp) FetchCustomizeEvalMatch(context *alerting.EvalContext, evalMatch *monitor.EvalMatch,
 	alertDetails *monitor.CommonAlertMetricDetails) error {
 	meterCustomizeConfig := new(monitor.MeterCustomizeConfig)
+	if context.Rule.CustomizeConfig == nil {
+		return nil
+	}
 	err := context.Rule.CustomizeConfig.Unmarshal(meterCustomizeConfig)
 	if err != nil {
 		return err
@@ -348,7 +351,7 @@ func (c *QueryCondition) executeQuery(context *alerting.EvalContext, timeRange *
 		})
 	}
 
-	resp, err := c.HandleRequest(context.Ctx, ds.ToTSDBDataSource(""), req)
+	resp, err := c.HandleRequest(context.Ctx, ds.ToTSDBDataSource(c.Query.Model.Database), req)
 	if err != nil {
 		if err == gocontext.DeadlineExceeded {
 			return nil, errors.Error("Alert execution exceeded the timeout")


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1.处于告警静默期内的报警策略仍可以在未恢复告警策略中进行查询


**是否需要 backport 到之前的 release 分支**:
- release/3.7

/cc @swordqiu 
/area monitor

 
