### PR TITLE
Automated cherry pick of #10202: feature(compute): allow live migration without checking Host CPU modes

### DIFF
--- a/pkg/apis/compute/guests.go
+++ b/pkg/apis/compute/guests.go
@@ -372,7 +372,10 @@ type GuestMigrateInput struct {
 }
 
 type GuestLiveMigrateInput struct {
+	// 指定期望的迁移目标宿主机
 	PreferHost string `json:"prefer_host"`
+	// 是否跳过CPU检查，默认要做CPU检查
+	SkipCpuCheck *bool `json:"skip_cpu_check"`
 }
 
 type GuestSetSecgroupInput struct {

--- a/pkg/apis/scheduler/api.go
+++ b/pkg/apis/scheduler/api.go
@@ -82,6 +82,8 @@ type ScheduleInput struct {
 	CpuMode      string `json:"cpu_mode"`
 	OsArch       string `json:"os_arch"`
 
+	SkipCpuCheck *bool `json:"skip_cpu_check"`
+
 	// In the migrate and create backup cases
 	// we don't need reallocate network
 	ReuseNetwork bool `json:"reuse_network"`

--- a/pkg/compute/models/guest_actions.go
+++ b/pkg/compute/models/guest_actions.go
@@ -432,17 +432,20 @@ func (self *SGuest) PerformLiveMigrate(ctx context.Context, userCred mcclient.To
 			host := iHost.(*SHost)
 			preferHostId = host.Id
 		}
-		err := self.StartGuestLiveMigrateTask(ctx, userCred, self.Status, preferHostId, "")
+		err := self.StartGuestLiveMigrateTask(ctx, userCred, self.Status, preferHostId, input.SkipCpuCheck, "")
 		return nil, err
 	}
 	return nil, httperrors.NewBadRequestError("Cannot live migrate in status %s", self.Status)
 }
 
-func (self *SGuest) StartGuestLiveMigrateTask(ctx context.Context, userCred mcclient.TokenCredential, guestStatus, preferHostId, parentTaskId string) error {
+func (self *SGuest) StartGuestLiveMigrateTask(ctx context.Context, userCred mcclient.TokenCredential, guestStatus, preferHostId string, skipCpuCheck *bool, parentTaskId string) error {
 	self.SetStatus(userCred, api.VM_START_MIGRATE, "")
 	data := jsonutils.NewDict()
 	if len(preferHostId) > 0 {
 		data.Set("prefer_host_id", jsonutils.NewString(preferHostId))
+	}
+	if skipCpuCheck != nil {
+		data.Set("skip_cpu_check", jsonutils.NewBool(*skipCpuCheck))
 	}
 	data.Set("guest_status", jsonutils.NewString(guestStatus))
 	dedicateMigrateTask := "GuestLiveMigrateTask"

--- a/pkg/compute/tasks/guest_live_migrate_task.go
+++ b/pkg/compute/tasks/guest_live_migrate_task.go
@@ -76,6 +76,8 @@ func (self *GuestMigrateTask) GetSchedParams() (*schedapi.ScheduleInput, error) 
 		} else {
 			schedDesc.CpuMode = api.CPU_MODE_QEMU
 		}
+		skipCpuCheck := jsonutils.QueryBoolean(self.Params, "skip_cpu_check", false)
+		schedDesc.SkipCpuCheck = &skipCpuCheck
 	}
 	schedDesc.ReuseNetwork = true
 	return schedDesc, nil

--- a/pkg/compute/tasks/host_guests_migrate_task.go
+++ b/pkg/compute/tasks/host_guests_migrate_task.go
@@ -49,7 +49,7 @@ func (self *HostGuestsMigrateTask) OnInit(ctx context.Context, obj db.IStandalon
 		guest := models.GuestManager.FetchGuestById(guests[i].Id)
 		if guests[i].LiveMigrate {
 			err := guest.StartGuestLiveMigrateTask(
-				ctx, self.UserCred, guests[i].OldStatus, preferHostId, self.Id)
+				ctx, self.UserCred, guests[i].OldStatus, preferHostId, nil, self.Id)
 			if err != nil {
 				log.Errorln(err)
 				continue

--- a/pkg/mcclient/options/servers.go
+++ b/pkg/mcclient/options/servers.go
@@ -888,8 +888,9 @@ func (o *ServerMigrateOptions) Params() (jsonutils.JSONObject, error) {
 }
 
 type ServerLiveMigrateOptions struct {
-	ID         string `help:"ID of server" json:"-"`
-	PreferHost string `help:"Server migration prefer host id or name" json:"prefer_host"`
+	ID           string `help:"ID of server" json:"-"`
+	PreferHost   string `help:"Server migration prefer host id or name" json:"prefer_host"`
+	SkipCpuCheck *bool  `help:"Skip check CPU mode of the target host" json:"skip_cpu_check"`
 }
 
 func (o *ServerLiveMigrateOptions) GetId() string {

--- a/pkg/scheduler/algorithm/predicates/guest/migrate_predicate.go
+++ b/pkg/scheduler/algorithm/predicates/guest/migrate_predicate.go
@@ -46,7 +46,7 @@ func (p *MigratePredicate) Execute(u *core.Unit, c core.Candidater) (bool, []cor
 		return h.GetResult()
 	}
 
-	if schedData.LiveMigrate && schedData.CpuMode != compute.CPU_MODE_QEMU {
+	if schedData.LiveMigrate && schedData.CpuMode != compute.CPU_MODE_QEMU && (schedData.SkipCpuCheck == nil || *schedData.SkipCpuCheck == false) {
 		host := c.Getter().Host()
 		if schedData.CpuDesc != host.CpuDesc {
 			h.Exclude(predicates.ErrHostCpuModelIsNotMatchForLiveMigrate)


### PR DESCRIPTION
Cherry pick of #10202 on release/3.6.

#10202: feature(compute): allow live migration with checking Host CPU modes