### PR TITLE
fix(host-deployer): mount may fail to lock /etc/mtab, add retrier

### DIFF
--- a/pkg/hostman/guestfs/kvmpart/kvmpart.go
+++ b/pkg/hostman/guestfs/kvmpart/kvmpart.go
@@ -15,7 +15,9 @@
 package kvmpart
 
 import (
+	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"time"
@@ -173,8 +175,22 @@ func (p *SKVMGuestDiskPartition) mount(readonly bool) error {
 			}()
 		}
 	}
-	output, err := procutils.NewCommand(cmds[0], cmds[1:]...).Output()
-	return errors.Wrapf(err, "mount failed: %s", output)
+
+	retrier := func(utils.FibonacciRetrier) (bool, error) {
+		output, err := procutils.NewCommand(cmds[0], cmds[1:]...).Output()
+		if err == nil {
+			return true, nil
+		} else {
+			log.Errorf("mount fail: %s %s", err, output)
+			time.Sleep(time.Millisecond * time.Duration(100+rand.Intn(400)))
+			return false, errors.Wrap(err, "")
+		}
+	}
+	_, err = utils.NewFibonacciRetrierMaxTries(3, retrier).Start(context.Background())
+	if err != nil {
+		return errors.Wrap(err, "mount failed")
+	}
+	return nil // errors.Wrapf(err, "mount failed: %s", output)
 }
 
 func (p *SKVMGuestDiskPartition) fsck() error {


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：mount时候可能因为锁/etc/mtab冲突失败，增加retrier

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area host-deployer