### PR TITLE
Automated cherry pick of #10240: fix(region): set redis reboot timeout to 30 mins

### DIFF
--- a/pkg/compute/regiondrivers/managedvirtual.go
+++ b/pkg/compute/regiondrivers/managedvirtual.go
@@ -2043,7 +2043,7 @@ func (self *SManagedVirtualizationRegionDriver) RequestRestartElasticcache(ctx c
 		return errors.Wrap(err, "managedVirtualizationRegionDriver.RequestRestartElasticcache.Restart")
 	}
 
-	err = cloudprovider.WaitStatusWithDelay(iec, api.ELASTIC_CACHE_STATUS_RUNNING, 10*time.Second, 10*time.Second, 300*time.Second)
+	err = cloudprovider.WaitStatusWithDelay(iec, api.ELASTIC_CACHE_STATUS_RUNNING, 10*time.Second, 10*time.Second, 1800*time.Second)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Cherry pick of #10240 on release/3.6.

#10240: fix(region): set redis reboot timeout to 30 mins