### PR TITLE
Automated cherry pick of #10327: fix(cloudcommon): add default domain of common options

### DIFF
--- a/pkg/cloudcommon/options/options.go
+++ b/pkg/cloudcommon/options/options.go
@@ -112,10 +112,10 @@ const (
 type CommonOptions struct {
 	AuthURL            string `help:"Keystone auth URL" alias:"auth-uri"`
 	AdminUser          string `help:"Admin username"`
-	AdminDomain        string `help:"Admin user domain"`
+	AdminDomain        string `help:"Admin user domain" default:"default"`
 	AdminPassword      string `help:"Admin password" alias:"admin-passwd"`
 	AdminProject       string `help:"Admin project" default:"system" alias:"admin-tenant-name"`
-	AdminProjectDomain string `help:"Domain of Admin project"`
+	AdminProjectDomain string `help:"Domain of Admin project" default:"default"`
 	AuthTokenCacheSize uint32 `help:"Auth token Cache Size" default:"2048"`
 
 	TenantCacheExpireSeconds int `help:"expire seconds of cached tenant/domain info. defailt 15 minutes" default:"900"`


### PR DESCRIPTION
Cherry pick of #10327 on release/3.7.

#10327: fix(cloudcommon): add default domain of common options