### PR TITLE
Automated cherry pick of #10402: fix(region): cloud provider filter by domain_id ignore private case

### DIFF
--- a/pkg/compute/models/cloudproviders.go
+++ b/pkg/compute/models/cloudproviders.go
@@ -1517,6 +1517,10 @@ func (manager *SCloudproviderManager) filterByDomainId(q *sqlchemy.SQuery, domai
 			sqlchemy.Equals(cloudaccounts.Field("share_mode"), api.CLOUD_ACCOUNT_SHARE_MODE_SYSTEM),
 			sqlchemy.OR(
 				sqlchemy.AND(
+					sqlchemy.Equals(cloudaccounts.Field("public_scope"), rbacutils.ScopeNone),
+					sqlchemy.Equals(cloudaccounts.Field("domain_id"), domainId),
+				),
+				sqlchemy.AND(
 					sqlchemy.Equals(cloudaccounts.Field("public_scope"), rbacutils.ScopeDomain),
 					sqlchemy.OR(
 						sqlchemy.Equals(cloudaccounts.Field("domain_id"), domainId),


### PR DESCRIPTION
Cherry pick of #10402 on release/3.7.

#10402: fix(region): cloud provider filter by domain_id ignore private case