### PR TITLE
fix(telegraf): megactl raid  add rebuild status

### DIFF
--- a/pkg/baremetal/utils/raid/megactl/megactl.go
+++ b/pkg/baremetal/utils/raid/megactl/megactl.go
@@ -115,6 +115,8 @@ func (dev *MegaRaidPhyDev) parseLine(line string) bool {
 			dev.Status = "jbod"
 		} else if strings.Contains(strings.ToLower(val), "online") {
 			dev.Status = "online"
+		} else if val == "Rebuild" {
+			dev.Status = "rebuild"
 		} else {
 			dev.Status = "offline"
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
raid 卡status 增加 rebuild 状态

**是否需要 backport 到之前的 release 分支**:
- release/3.6
- release/3.7

/cc @zexi 
/area monitor
