### PR TITLE
fix(region): including domain info in project-role results

### DIFF
--- a/pkg/mcclient/modules/mod_roleassignments.go
+++ b/pkg/mcclient/modules/mod_roleassignments.go
@@ -31,35 +31,59 @@ type RoleAssignmentManagerV3 struct {
 }
 
 type role struct {
-	id   string
-	name string
+	id     string
+	name   string
+	domain struct {
+		id   string
+		name string
+	}
 }
 
 type projectRoles struct {
-	id    string
-	name  string
+	id     string
+	name   string
+	domain struct {
+		id   string
+		name string
+	}
 	typ   string
 	roles []role
 }
 
-func newProjectRoles(projectId, projectName, roleId, roleName, typ string) *projectRoles {
-	return &projectRoles{id: projectId, name: projectName, typ: typ, roles: []role{{id: roleId, name: roleName}}}
+func newProjectRoles(projectId, projectName, projectDomainId, projectDomainName, roleId, roleName, roleDomainId, roleDomainName, typ string) *projectRoles {
+	r := role{
+		id:   roleId,
+		name: roleName,
+	}
+	r.domain.id = roleDomainId
+	r.domain.name = roleDomainName
+	pr := &projectRoles{id: projectId, name: projectName, typ: typ, roles: []role{r}}
+	pr.domain.id = projectDomainId
+	pr.domain.name = projectDomainName
+	return pr
 }
 
-func (this *projectRoles) add(roleId, roleName string) {
-	this.roles = append(this.roles, role{id: roleId, name: roleName})
+func (this *projectRoles) add(roleId, roleName, roleDomainId, roleDomainName string) {
+	r := role{id: roleId, name: roleName}
+	r.domain.id = roleDomainId
+	r.domain.name = roleDomainName
+	this.roles = append(this.roles, r)
 }
 
 func (this *projectRoles) json() jsonutils.JSONObject {
 	obj := jsonutils.NewDict()
 	obj.Add(jsonutils.NewString(this.id), "id")
 	obj.Add(jsonutils.NewString(this.name), "name")
+	obj.Add(jsonutils.NewString(this.domain.id), "domain", "id")
+	obj.Add(jsonutils.NewString(this.domain.name), "domain", "name")
 	obj.Add(jsonutils.NewString(this.typ), "type")
 	roles := jsonutils.NewArray()
 	for _, r := range this.roles {
 		role := jsonutils.NewDict()
 		role.Add(jsonutils.NewString(r.id), "id")
 		role.Add(jsonutils.NewString(r.name), "name")
+		role.Add(jsonutils.NewString(r.domain.id), "domain", "id")
+		role.Add(jsonutils.NewString(r.domain.name), "domain", "name")
 		roles.Add(role)
 	}
 	obj.Add(roles, "roles")
@@ -67,13 +91,21 @@ func (this *projectRoles) json() jsonutils.JSONObject {
 }
 
 type sRole struct {
-	Id   string `json:"id"`
-	Name string `json:"name"`
+	Id     string `json:"id"`
+	Name   string `json:"name"`
+	Domain struct {
+		Id   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"domain"`
 }
 
 type sGroupRole struct {
-	Id       string  `json:"id"`
-	Name     string  `json:"name"`
+	Id     string `json:"id"`
+	Name   string `json:"name"`
+	Domain struct {
+		Id   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"domain"`
 	Roles    []sRole `json:"roles"`
 	Policies struct {
 		Project []string `json:"project"`
@@ -83,12 +115,16 @@ type sGroupRole struct {
 }
 
 type sProjectGroupRole struct {
-	Id     string       `json:"id"`
-	Name   string       `json:"name"`
+	Id     string `json:"id"`
+	Name   string `json:"name"`
+	Domain struct {
+		Id   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"domain"`
 	Groups []sGroupRole `json:"groups"`
 }
 
-func (pgr *sProjectGroupRole) add(groupId, groupName, roleId, roleName string, projectPolicies, domainPolicies, systemPolicies []string) {
+func (pgr *sProjectGroupRole) add(groupId, groupName, groupDomainId, groupDomainName, roleId, roleName, roleDomainId, roleDomainName string, projectPolicies, domainPolicies, systemPolicies []string) {
 	groupIdx := -1
 	for i := range pgr.Groups {
 		if pgr.Groups[i].Id == groupId {
@@ -98,19 +134,25 @@ func (pgr *sProjectGroupRole) add(groupId, groupName, roleId, roleName string, p
 	}
 	if groupIdx < 0 {
 		groupIdx = len(pgr.Groups)
-		pgr.Groups = append(pgr.Groups, sGroupRole{
+		gr := sGroupRole{
 			Id:   groupId,
 			Name: groupName,
-		})
+		}
+		gr.Domain.Id = groupDomainId
+		gr.Domain.Name = groupDomainName
+		pgr.Groups = append(pgr.Groups, gr)
 	}
-	pgr.Groups[groupIdx].add(roleId, roleName, projectPolicies, domainPolicies, systemPolicies)
+	pgr.Groups[groupIdx].add(roleId, roleName, roleDomainId, roleDomainName, projectPolicies, domainPolicies, systemPolicies)
 }
 
-func (gr *sGroupRole) add(roleId, roleName string, projectPolicies, domainPolicies, systemPolicies []string) {
-	gr.Roles = append(gr.Roles, sRole{
+func (gr *sGroupRole) add(roleId, roleName, roleDomainId, roleDomainName string, projectPolicies, domainPolicies, systemPolicies []string) {
+	sr := sRole{
 		Id:   roleId,
 		Name: roleName,
-	})
+	}
+	sr.Domain.Id = roleDomainId
+	sr.Domain.Name = roleDomainName
+	gr.Roles = append(gr.Roles, sr)
 	for _, p := range projectPolicies {
 		if !utils.IsInStringArray(p, gr.Policies.Project) {
 			gr.Policies.Project = append(gr.Policies.Project, p)
@@ -189,21 +231,27 @@ func (this *RoleAssignmentManagerV3) GetProjectUsers(s *mcclient.ClientSession, 
 
 		roleId, _ := roleAssign.GetString("role", "id")
 		roleName, _ := roleAssign.GetString("role", "name")
+		roleDomainId, _ := roleAssign.GetString("role", "domain", "id")
+		roleDomainName, _ := roleAssign.GetString("role", "domain", "name")
 		userId, _ := roleAssign.GetString("user", "id")
 		userName, _ := roleAssign.GetString("user", "name")
+		userDomainId, _ := roleAssign.GetString("user", "domain", "id")
+		userDomainName, _ := roleAssign.GetString("user", "domain", "name")
 
 		if len(userName) == 0 {
 			typ = "group"
 			userName, _ = roleAssign.GetString("group", "name")
 			userId, _ = roleAssign.GetString("group", "id")
+			userDomainId, _ = roleAssign.GetString("group", "domain", "id")
+			userDomainName, _ = roleAssign.GetString("group", "domain", "name")
 		}
 
 		_, ok := projects[userId]
 
 		if ok {
-			projects[userId].add(roleId, roleName)
+			projects[userId].add(roleId, roleName, roleDomainId, roleDomainName)
 		} else {
-			projects[userId] = newProjectRoles(userId, userName, roleId, roleName, typ)
+			projects[userId] = newProjectRoles(userId, userName, userDomainId, userDomainName, roleId, roleName, roleDomainId, roleDomainName, typ)
 		}
 	}
 
@@ -291,20 +339,27 @@ func (this *RoleAssignmentManagerV3) GetProjectRole(s *mcclient.ClientSession, i
 	for _, roleAssign := range result.Data {
 		roleId, _ := roleAssign.GetString("role", "id")
 		roleName, _ := roleAssign.GetString("role", "name")
+		roleDomainId, _ := roleAssign.GetString("role", "domain", "id")
+		roleDomainName, _ := roleAssign.GetString("role", "domain", "name")
 
-		var groupById string
-		var groupByName string
+		var groupById, groupByName, groupByDomainId, groupByDomainName string
 
 		if groupBy == "project" {
 			groupById, _ = roleAssign.GetString("scope", "project", "id")
 			groupByName, _ = roleAssign.GetString("scope", "project", "name")
+			groupByDomainId, _ = roleAssign.GetString("scope", "project", "domain", "id")
+			groupByDomainName, _ = roleAssign.GetString("scope", "project", "domain", "name")
 		} else if groupBy == "user" {
 			groupById, _ = roleAssign.GetString("user", "id")
 			groupByName, _ = roleAssign.GetString("user", "name")
+			groupByDomainId, _ = roleAssign.GetString("user", "domain", "id")
+			groupByDomainName, _ = roleAssign.GetString("user", "domain", "name")
 		}
 
 		groupId, _ := roleAssign.GetString("group", "id")
 		groupName, _ := roleAssign.GetString("group", "name")
+		groupDomainId, _ := roleAssign.GetString("group", "domain", "id")
+		groupDomainName, _ := roleAssign.GetString("group", "domain", "name")
 		projPolicies, _ := jsonutils.GetStringArray(roleAssign, "policies", "project")
 		domPolicies, _ := jsonutils.GetStringArray(roleAssign, "policies", "domain")
 		sysPolicies, _ := jsonutils.GetStringArray(roleAssign, "policies", "system")
@@ -319,13 +374,16 @@ func (this *RoleAssignmentManagerV3) GetProjectRole(s *mcclient.ClientSession, i
 
 		if lineIdx < 0 {
 			lineIdx = len(lines)
-			lines = append(lines, sProjectGroupRole{
+			pgr := sProjectGroupRole{
 				Id:   groupById,
 				Name: groupByName,
-			})
+			}
+			pgr.Domain.Id = groupByDomainId
+			pgr.Domain.Name = groupByDomainName
+			lines = append(lines, pgr)
 		}
 
-		lines[lineIdx].add(groupId, groupName, roleId, roleName, projPolicies, domPolicies, sysPolicies)
+		lines[lineIdx].add(groupId, groupName, groupDomainId, groupDomainName, roleId, roleName, roleDomainId, roleDomainName, projPolicies, domPolicies, sysPolicies)
 	}
 
 	lineJson := jsonutils.NewArray()


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：补充project-role接口返回的资源的domain信息

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6
- release/3.5

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area climc