### PR TITLE
Automated cherry pick of #10455: fix(keystone): allow joint projects across domains by default

### DIFF
--- a/pkg/keystone/models/assignments.go
+++ b/pkg/keystone/models/assignments.go
@@ -30,7 +30,6 @@ import (
 	"yunion.io/x/onecloud/pkg/cloudcommon/db"
 	"yunion.io/x/onecloud/pkg/cloudcommon/policy"
 	"yunion.io/x/onecloud/pkg/httperrors"
-	"yunion.io/x/onecloud/pkg/keystone/options"
 	"yunion.io/x/onecloud/pkg/mcclient"
 	"yunion.io/x/onecloud/pkg/mcclient/auth"
 	"yunion.io/x/onecloud/pkg/util/rbacutils"
@@ -250,9 +249,10 @@ func (manager *SAssignmentManager) ProjectAddUser(ctx context.Context, userCred 
 		return err
 	}
 	if project.DomainId != user.DomainId {
-		if project.DomainId != api.DEFAULT_DOMAIN_ID && !options.Options.AllowJoinProjectsAcrossDomains {
-			return httperrors.NewInputParameterError("join user into project of default domain or identical domain")
-		} else if !db.IsAllowPerform(rbacutils.ScopeSystem, userCred, user, "join-project") {
+		// if project.DomainId != api.DEFAULT_DOMAIN_ID && !options.Options.AllowJoinProjectsAcrossDomains {
+		//	return httperrors.NewInputParameterError("join user into project of default domain or identical domain")
+		// } else
+		if !db.IsAllowPerform(rbacutils.ScopeSystem, userCred, user, "join-project") {
 			return httperrors.NewForbiddenError("not enough privilege")
 		}
 	} else {
@@ -350,9 +350,10 @@ func (manager *SAssignmentManager) projectAddGroup(ctx context.Context, userCred
 		return err
 	}
 	if project.DomainId != group.DomainId {
-		if project.DomainId != api.DEFAULT_DOMAIN_ID && !options.Options.AllowJoinProjectsAcrossDomains {
-			return httperrors.NewInputParameterError("join group into project of default domain or identical domain")
-		} else if !db.IsAllowPerform(rbacutils.ScopeSystem, userCred, group, "join-project") {
+		// if project.DomainId != api.DEFAULT_DOMAIN_ID && !options.Options.AllowJoinProjectsAcrossDomains {
+		// 	return httperrors.NewInputParameterError("join group into project of default domain or identical domain")
+		// } else
+		if !db.IsAllowPerform(rbacutils.ScopeSystem, userCred, group, "join-project") {
 			return httperrors.NewForbiddenError("not enough privilege")
 		}
 	} else {

--- a/pkg/keystone/options/options.go
+++ b/pkg/keystone/options/options.go
@@ -53,7 +53,7 @@ type SKeystoneOptions struct {
 
 	SessionEndpointType string `help:"Client session end point type"`
 
-	AllowJoinProjectsAcrossDomains bool `help:"allow users/groups to join projects across domains" default:"false"`
+	// AllowJoinProjectsAcrossDomains bool `help:"allow users/groups to join projects across domains" default:"false"`
 }
 
 var (


### PR DESCRIPTION
Cherry pick of #10455 on release/3.5.

#10455: fix(keystone): allow joint projects across domains by default