### PR TITLE
fix(log): add filters to baremetal event logs

### DIFF
--- a/pkg/apis/logger/input.go
+++ b/pkg/apis/logger/input.go
@@ -27,6 +27,16 @@ type BaremetalEventListInput struct {
 	Since time.Time `json:"since"`
 	// until
 	Until time.Time `json:"until"`
+	// host_id
+	HostId []string `json:"host_id"`
+	// id
+	Id []int64 `json:"id"`
+	// EventId
+	EventId []string `json:"event_id"`
+	// Type
+	Type []string `json:"type"`
+	// ipmi_ip
+	IpmiIp []string `json:"ipmi_ip"`
 }
 
 type ActionLogListInput struct {

--- a/pkg/logger/models/baremetalevents.go
+++ b/pkg/logger/models/baremetalevents.go
@@ -108,5 +108,30 @@ func (manager *SBaremetalEventManager) ListItemFilter(
 	if !query.Until.IsZero() {
 		q = q.LE("created", query.Until)
 	}
+	if len(query.HostId) == 1 {
+		q = q.Equals("host_id", query.HostId[0])
+	} else if len(query.HostId) > 1 {
+		q = q.In("host_id", query.HostId)
+	}
+	if len(query.Id) == 1 {
+		q = q.Equals("id", query.Id[0])
+	} else if len(query.Id) > 1 {
+		q = q.In("id", query.Id)
+	}
+	if len(query.EventId) == 1 {
+		q = q.Equals("event_id", query.EventId[0])
+	} else if len(query.EventId) > 1 {
+		q = q.In("event_id", query.EventId)
+	}
+	if len(query.Type) == 1 {
+		q = q.Equals("type", query.Type[0])
+	} else if len(query.Type) > 1 {
+		q = q.In("type", query.Type)
+	}
+	if len(query.IpmiIp) == 1 {
+		q = q.Equals("ipmi_ip", query.IpmiIp[0])
+	} else if len(query.IpmiIp) > 1 {
+		q = q.In("ipmi_ip", query.IpmiIp)
+	}
 	return q, nil
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：物理机eventlog增加过滤器

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area log
/cc @zexi 