### PR TITLE
fix(apigateway): use info response service type of console endpoints

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -1006,6 +1006,7 @@ func getUserInfo2(s *mcclient.ClientSession, uid string, pid string, loginIp str
 		item := jsonutils.NewDict()
 		item.Add(jsonutils.NewString(ep.Url), "url")
 		item.Add(jsonutils.NewString(ep.Name), "name")
+		item.Add(jsonutils.NewString(ep.Service), "service")
 		menus.Add(item)
 	}
 

--- a/pkg/mcclient/token.go
+++ b/pkg/mcclient/token.go
@@ -26,6 +26,8 @@ import (
 type ExternalService struct {
 	Name string
 	Url  string
+
+	Service string
 }
 
 type Endpoint struct {

--- a/pkg/mcclient/token3.go
+++ b/pkg/mcclient/token3.go
@@ -316,8 +316,11 @@ func (catalog KeystoneServiceCatalogV3) GetServicesByInterface(region string, in
 			if catalog[i].Endpoints[j].RegionId == region &&
 				catalog[i].Endpoints[j].Interface == infType &&
 				len(catalog[i].Endpoints[j].Name) > 0 {
-				srv := ExternalService{Name: catalog[i].Endpoints[j].Name,
-					Url: catalog[i].Endpoints[j].Url}
+				srv := ExternalService{
+					Name:    catalog[i].Endpoints[j].Name,
+					Url:     catalog[i].Endpoints[j].Url,
+					Service: catalog[i].Type,
+				}
 				services = append(services, srv)
 			}
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：apigateway的userInfo的endpoint列表中携带服务类型

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area apigateway