### PR TITLE
Automated cherry pick of #10471: fix(apigateway): use info response service type of console endpoints

### DIFF
--- a/pkg/apigateway/handler/auth.go
+++ b/pkg/apigateway/handler/auth.go
@@ -1006,6 +1006,7 @@ func getUserInfo2(s *mcclient.ClientSession, uid string, pid string, loginIp str
 		item := jsonutils.NewDict()
 		item.Add(jsonutils.NewString(ep.Url), "url")
 		item.Add(jsonutils.NewString(ep.Name), "name")
+		item.Add(jsonutils.NewString(ep.Service), "service")
 		menus.Add(item)
 	}
 

--- a/pkg/mcclient/token.go
+++ b/pkg/mcclient/token.go
@@ -26,6 +26,8 @@ import (
 type ExternalService struct {
 	Name string
 	Url  string
+
+	Service string
 }
 
 type Endpoint struct {

--- a/pkg/mcclient/token3.go
+++ b/pkg/mcclient/token3.go
@@ -316,8 +316,11 @@ func (catalog KeystoneServiceCatalogV3) GetServicesByInterface(region string, in
 			if catalog[i].Endpoints[j].RegionId == region &&
 				catalog[i].Endpoints[j].Interface == infType &&
 				len(catalog[i].Endpoints[j].Name) > 0 {
-				srv := ExternalService{Name: catalog[i].Endpoints[j].Name,
-					Url: catalog[i].Endpoints[j].Url}
+				srv := ExternalService{
+					Name:    catalog[i].Endpoints[j].Name,
+					Url:     catalog[i].Endpoints[j].Url,
+					Service: catalog[i].Type,
+				}
 				services = append(services, srv)
 			}
 		}


### PR DESCRIPTION
Cherry pick of #10471 on release/3.7.

#10471: fix(apigateway): use info response service type of console endpoints