### PR TITLE
Automated cherry pick of #10505: fix(baremetal): megactl driver fail to find device by key

### DIFF
--- a/pkg/baremetal/utils/raid/megactl/megactl.go
+++ b/pkg/baremetal/utils/raid/megactl/megactl.go
@@ -626,7 +626,7 @@ func (a StorcliAdaptor) key() string {
 }
 
 func (a *StorcliAdaptor) isComplete() bool {
-	return a.Controller >= 0 && a.key() != ""
+	return a.Controller >= 0 && a.name != "" && a.sn != ""
 }
 
 func (a *StorcliAdaptor) parseLine(l string) {


### PR DESCRIPTION
Cherry pick of #10505 on release/3.6.

#10505: fix(baremetal): megactl driver fail to find device by key