### PR TITLE
fix(region): allow ipmi probe when probe fail

### DIFF
--- a/pkg/compute/models/hosts.go
+++ b/pkg/compute/models/hosts.go
@@ -3982,7 +3982,7 @@ func (self *SHost) AllowPerformIpmiProbe(ctx context.Context,
 }
 
 func (self *SHost) PerformIpmiProbe(ctx context.Context, userCred mcclient.TokenCredential, query jsonutils.JSONObject, data jsonutils.JSONObject) (jsonutils.JSONObject, error) {
-	if utils.IsInStringArray(self.Status, []string{api.BAREMETAL_INIT, api.BAREMETAL_READY, api.BAREMETAL_RUNNING}) {
+	if utils.IsInStringArray(self.Status, []string{api.BAREMETAL_INIT, api.BAREMETAL_READY, api.BAREMETAL_RUNNING, api.BAREMETAL_PROBE_FAIL}) {
 		return nil, self.StartIpmiProbeTask(ctx, userCred, "")
 	}
 	return nil, httperrors.NewInvalidStatusError("Cannot do Ipmi-probe in status %s", self.Status)


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：允许probe fail的时候验证ipmi信息


<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/area region
/cc @zexi 
