### PR TITLE
fix(hostman): recycle local disk file when rebuilding root

### DIFF
--- a/pkg/hostman/storageman/diskhandlers/diskhandler.go
+++ b/pkg/hostman/storageman/diskhandlers/diskhandler.go
@@ -71,7 +71,7 @@ func AddDiskHandler(prefix string, app *appsrv.Application) {
 
 		app.AddHandler("POST",
 			fmt.Sprintf("%s/%s/<storageId>/<action>/<diskId>", prefix, keyWord),
-			auth.Authenticate(perfomrDiskActions))
+			auth.Authenticate(performDiskActions))
 		app.AddHandler("GET",
 			fmt.Sprintf("%s/%s/<storageId>/<diskId>/status", prefix, keyWord),
 			auth.Authenticate(getDiskStatus))
@@ -206,7 +206,7 @@ func saveToGlance(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	hostutils.ResponseOk(ctx, w)
 }
 
-func perfomrDiskActions(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+func performDiskActions(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	params, _, body := appsrv.FetchEnv(ctx, w, r)
 	if body == nil {
 		body = jsonutils.NewDict()
@@ -230,7 +230,8 @@ func perfomrDiskActions(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	var disk storageman.IDisk
 	var err error
 
-	if action != "create" {
+	rebuild, _ := body.Bool("disk", "rebuild")
+	if action != "create" || rebuild {
 		disk, err = storage.GetDiskById(diskId)
 		if err != nil {
 			hostutils.Response(ctx, w, httperrors.NewGeneralError(errors.Wrapf(err, "GetDiskById(%s)", diskId)))

--- a/pkg/hostman/storageman/storage_local.go
+++ b/pkg/hostman/storageman/storage_local.go
@@ -192,10 +192,13 @@ func (s *SLocalStorage) DeleteDiskfile(diskpath string) error {
 			destFile = fmt.Sprintf("%s.%d", path.Base(diskpath), time.Now().Unix())
 		)
 		if err := procutils.NewCommand("mkdir", "-p", destDir).Run(); err != nil {
+			log.Errorf("Fail to mkdir %s for recycle: %s", destDir, err)
 			return err
 		}
+		log.Infof("Move deleted disk file %s to recycle %s", diskpath, destDir)
 		return procutils.NewCommand("mv", "-f", diskpath, path.Join(destDir, destFile)).Run()
 	} else {
+		log.Infof("Delete disk file %s immediately", diskpath)
 		return procutils.NewCommand("rm", "-rf", diskpath).Run()
 	}
 }


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：rebuild root时候要把磁盘放入回收站

<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6
- release/3.5
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi @ioito 
/area host