### PR TITLE
Automated cherry pick of #7047: fix: adjust primary key length when sqlchemy utf8 default to utf8mb4

### DIFF
--- a/pkg/keystone/models/configs.go
+++ b/pkg/keystone/models/configs.go
@@ -82,8 +82,8 @@ type SConfigOption struct {
 
 	ResType string `width:"32" charset:"ascii" nullable:"false" default:"identity_provider" primary:"true"`
 	ResId   string `name:"domain_id" width:"64" charset:"ascii" primary:"true"`
-	Group   string `width:"255" charset:"utf8" primary:"true"`
-	Option  string `width:"255" charset:"utf8" primary:"true"`
+	Group   string `width:"191" charset:"utf8" primary:"true"`
+	Option  string `width:"191" charset:"utf8" primary:"true"`
 
 	Value jsonutils.JSONObject `nullable:"false"`
 }

--- a/pkg/keystone/models/nonlocal_users.go
+++ b/pkg/keystone/models/nonlocal_users.go
@@ -51,7 +51,7 @@ type SNonlocalUser struct {
 	db.SModelBase
 
 	DomainId string `width:"64" charset:"ascii" primary:"true"`
-	Name     string `width:"255" charset:"utf8" primary:"true"`
+	Name     string `width:"191" charset:"utf8" primary:"true"`
 	UserId   string `width:"64" charset:"ascii" nullable:"false" index:"true"`
 }
 


### PR DESCRIPTION
Cherry pick of #7047 on release/3.6.

#7047: fix: adjust primary key length when sqlchemy utf8 default to utf8mb4