### PR TITLE
Fix the problem of hostwire producted by #9723

### DIFF
--- a/pkg/compute/models/hostwires.go
+++ b/pkg/compute/models/hostwires.go
@@ -55,7 +55,7 @@ func init() {
 type SHostwire struct {
 	SHostJointsBase
 
-	Bridge string `width:"16" charset:"ascii" nullable:"false" list:"domain" update:"domain" create:"domain_required"`
+	Bridge string `width:"64" charset:"ascii" nullable:"false" list:"domain" update:"domain" create:"domain_required"`
 	// 接口名称
 	Interface string `width:"16" charset:"ascii" nullable:"false" list:"domain" update:"domain" create:"domain_required"`
 	// 是否是主地址

--- a/pkg/compute/models/wires.go
+++ b/pkg/compute/models/wires.go
@@ -237,7 +237,7 @@ func (wire *SWire) getHostwireQuery() *sqlchemy.SQuery {
 }
 
 func (wire *SWire) HostCount() (int, error) {
-	q := wire.getHostwireQuery()
+	q := HostwireManager.Query().Equals("wire_id", wire.Id).GroupBy("host_id")
 	return q.CountWithError()
 }
 


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
1. fix(region): de-duplication when obtaining the number of hosts
2. fix(region): expand the bridge field
    由于 esxi 中，bridge 是 dvs 的一个路径，长度为 16 字段会不够用

- [x] 功能、bugfix描述
- [x] 冒烟测试
<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->
/cc @zexi
/area region