### PR TITLE
fix(keystone): role_assignment effective list ignore groups without user

### DIFF
--- a/pkg/keystone/models/assignments.go
+++ b/pkg/keystone/models/assignments.go
@@ -663,7 +663,7 @@ func (manager *SAssignmentManager) FetchAll(
 			grpproj.Field("project_id"),
 			grpproj.Field("role_id"),
 		)
-		q2 = q2.Join(memberships, sqlchemy.Equals(grpproj.Field("group_id"), memberships.Field("group_id")))
+		q2 = q2.LeftJoin(memberships, sqlchemy.Equals(grpproj.Field("group_id"), memberships.Field("group_id")))
 		if len(userId) > 0 {
 			q2 = q2.Filter(sqlchemy.Equals(memberships.Field("user_id"), userId))
 		}


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:
修正：role_assignment列表加effective参数时忽略了没有用户的组


<!--
- [ ] 功能、bugfix描述
- [ ] 冒烟测试
- [ ] 单元测试编写
-->

**是否需要 backport 到之前的 release 分支**:
- release/3.7
- release/3.6
- release/3.5
- release/3.4

<!--
如果不需要，填写 "NONE".
如果需要，就以下面 item 的格式写 release 分支名，并提交对应的 cherry-pick PR:
- release/3.2
-->

/cc @zexi 
/area keystone
