### PR TITLE
Automated cherry pick of #10629: feat(region): virtually display the esxiagent of the cached image as a host

### DIFF
--- a/pkg/compute/models/storagecachedimages.go
+++ b/pkg/compute/models/storagecachedimages.go
@@ -199,6 +199,15 @@ func (self *SStoragecachedimage) getExtraDetails(ctx context.Context, out api.St
 		host, _ := storagecache.GetHost()
 		if host != nil {
 			out.Host = host.GetShortDesc(ctx)
+		} else {
+			var err error
+			hostDesc, err := storagecache.GetEsxiAgentHostDesc()
+			if err != nil {
+				log.Errorf("unable to GetEsxiAgentHostDesc of stroagecache: %s", err.Error())
+			}
+			if hostDesc != nil {
+				out.Host = hostDesc
+			}
 		}
 	}
 	cachedImage := self.GetCachedimage()


### PR DESCRIPTION
Cherry pick of #10629 on release/3.7.

#10629: feat(region): virtually display the esxiagent of the cached image as a host