### PR TITLE
Automated cherry pick of #10650: feat(notify): filter receivers who join the project under the domain where the requester is currently located

### DIFF
--- a/pkg/apis/notify/receiver.go
+++ b/pkg/apis/notify/receiver.go
@@ -113,6 +113,8 @@ type ReceiverListInput struct {
 	EnabledContactType string `json:"enabled_contact_type"`
 
 	VerifiedContactType string `json:"verified_contact_type"`
+
+	ProjectDomainFilter bool `json:"project_domain_filter"`
 }
 
 type ReceiverUpdateInput struct {

--- a/pkg/mcclient/options/notify/receiver.go
+++ b/pkg/mcclient/options/notify/receiver.go
@@ -12,6 +12,7 @@ type ReceiverListOptions struct {
 	UName               string `help:"user name in keystone"`
 	EnabledContactType  string `help:"enabled contact type"`
 	VerifiedContactType string `help:"verified contact type"`
+	ProjectDomainFilter bool   `help:"filter receivers who join the project under the domain where the requester is currently located"`
 }
 
 func (rl *ReceiverListOptions) Params() (jsonutils.JSONObject, error) {


### PR DESCRIPTION
Cherry pick of #10650 on release/3.7.

#10650: feat(notify): filter receivers who join the project under the domain where the requester is currently located